### PR TITLE
Eclipse Mars Compatibility (including fix for CAM-4228)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -111,7 +111,7 @@
 	
 	<target name="build.release">
 		<maven basedir="${checkout.release.path}/${checkout.dir}"
-             options="-Pplatform-indigo -Dmaven.test.skip=true -DskipTests=true -X"
+             options="-Pplatform-mars -Dmaven.test.skip=true -DskipTests=true -X"
              goals="clean install"
              resultproperty="maven.build.result" />
 	</target>

--- a/org.camunda.bpm.modeler.tests/.classpath
+++ b/org.camunda.bpm.modeler.tests/.classpath
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="lib/fest-assert-core.jar" sourcepath="lib/fest-assert-core-sources.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/fest-util.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/"/>
+	<classpathentry exported="true" kind="lib" path="lib/fest-util.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/fest-assert-core.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.camunda.bpm.modeler.tests/pom.xml
+++ b/org.camunda.bpm.modeler.tests/pom.xml
@@ -16,14 +16,14 @@
 		<dependency>
 			<groupId>org.easytesting</groupId>
 			<artifactId>fest-assert-core</artifactId>
-			<version>2.0M8</version>
+			<version>2.0M10</version>
 			<scope>test</scope>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.easytesting</groupId>
 			<artifactId>fest-assert-core</artifactId>
-			<version>2.0M8</version>
+			<version>2.0M10</version>
 			<scope>test</scope>
 			<classifier>sources</classifier>
 		</dependency>
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>org.easytesting</groupId>
 			<artifactId>fest-assert-core</artifactId>
-			<version>2.0M8</version>
+			<version>2.0M10</version>
 			<scope>test</scope>
 			<classifier>javadoc</classifier>
 		</dependency>
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>org.easytesting</groupId>
 			<artifactId>fest-util</artifactId>
-			<version>1.2.3</version>
+			<version>1.2.5</version>
 			<scope>test</scope>
 		</dependency>		
 	</dependencies>

--- a/org.camunda.bpm.modeler.tests/src/org/camunda/bpm/modeler/test/integration/AbstractIntegrationTest.java
+++ b/org.camunda.bpm.modeler.tests/src/org/camunda/bpm/modeler/test/integration/AbstractIntegrationTest.java
@@ -3,8 +3,14 @@ package org.camunda.bpm.modeler.test.integration;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
 import org.camunda.bpm.modeler.core.importer.ModelImport;
 import org.camunda.bpm.modeler.test.util.TestHelper;
@@ -13,15 +19,23 @@ import org.camunda.bpm.modeler.test.util.TestHelper.ModelResources;
 import org.camunda.bpm.modeler.test.util.TransactionalExecutionException;
 import org.eclipse.bpmn2.util.Bpmn2Resource;
 import org.eclipse.core.internal.utils.FileUtil;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.xmi.XMLResource;
+import org.eclipse.emf.transaction.Transaction;
+import org.eclipse.emf.transaction.TransactionalEditingDomain;
+import org.eclipse.emf.transaction.impl.TransactionalEditingDomainImpl;
 import org.eclipse.graphiti.dt.IDiagramTypeProvider;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.eclipse.graphiti.mm.pictograms.Diagram;
 import org.eclipse.graphiti.platform.IDiagramContainer;
-import org.eclipse.graphiti.ui.internal.services.GraphitiUiInternal;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
@@ -140,8 +154,9 @@ public class AbstractIntegrationTest {
 				saveOptions.put(resource, saveOption);
 			}
 			
-			GraphitiUiInternal.getEmfService().save(model.getEditingDomain(), saveOptions, null);
-
+			//GraphitiUiInternal.getEmfService().save(model.getEditingDomain(), saveOptions, null);
+			save(model.getEditingDomain(), saveOptions, new NullProgressMonitor());
+			
 			String fileName = "target/" + fileUri;
 			
 			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -157,6 +172,108 @@ public class AbstractIntegrationTest {
 			
 			return outputStream.toString("UTF-8");
 		}
+
+		// --------------------------------------------------------------------
+		// replacement for EmfService.save(...)
+		private Set<Resource> save(final TransactionalEditingDomain editingDomain, final Map<Resource, Map<?, ?>> options,
+				IProgressMonitor monitor) {
+
+			final Map<URI, Throwable> failedSaves = new HashMap<URI, Throwable>();
+			final Set<Resource> savedResources = new HashSet<Resource>();
+			final IWorkspaceRunnable wsRunnable = new IWorkspaceRunnable() {
+				public void run(final IProgressMonitor monitor) throws CoreException {
+
+					final Runnable runnable = new Runnable() {
+						public void run() {
+							Transaction parentTx;
+							if (editingDomain != null
+									&& (parentTx = ((TransactionalEditingDomainImpl) editingDomain).getActiveTransaction()) != null) {
+								do {
+									if (!parentTx.isReadOnly()) {
+										throw new IllegalStateException(
+												"saveInWorkspaceRunnable() called from within a command (likely to produce deadlock)"); //$NON-NLS-1$
+									}
+								} while ((parentTx = ((TransactionalEditingDomainImpl) editingDomain).getActiveTransaction().getParent()) != null);
+							}
+
+							final EList<Resource> resources = editingDomain.getResourceSet().getResources();
+							// Copy list to an array to prevent ConcurrentModificationExceptions
+							// during the saving of the dirty resources
+							Resource[] resourcesArray = new Resource[resources.size()];
+							resourcesArray = resources.toArray(resourcesArray);
+							for (int i = 0; i < resourcesArray.length; i++) {
+								// In case resource modification tracking is switched on, 
+								// we can check if a resource has been modified, so that we only need to save
+								// really changed resources; otherwise we need to save all resources in the set
+								final Resource resource = resourcesArray[i];
+								/*
+								 * Bug 371513 - Added check for isLoaded(): a
+								 * resource that has not yet been loaded (possibly
+								 * after a reload triggered by a change in another
+								 * editor) has no content yet; saving such a
+								 * resource will simply erase _all_ content from the
+								 * resource on the disk (including the diagram). -->
+								 * a not yet loaded resource must not be saved
+								 */
+								if ((!resource.isTrackingModification() || resource.isModified()) && resource.isLoaded()) {
+									try {
+										resource.save(options.get(resource));
+										savedResources.add(resource);
+									} catch (final Throwable t) {
+										failedSaves.put(resource.getURI(), t);
+									}
+								}
+							}
+						}
+					};
+
+					try {
+						editingDomain.runExclusive(runnable);
+					} catch (final InterruptedException e) {
+						throw new RuntimeException(e);
+					}
+				}
+			};
+			try {
+				ResourcesPlugin.getWorkspace().run(wsRunnable, null);
+				if (!failedSaves.isEmpty()) {
+					throw new WrappedException(createMessage(failedSaves), new RuntimeException());
+				}
+			} catch (final CoreException e) {
+				final Throwable cause = e.getStatus().getException();
+				if (cause instanceof RuntimeException) {
+					throw (RuntimeException) cause;
+				}
+				throw new RuntimeException(e);
+			}
+
+			return savedResources;
+		}
+
+		private String createMessage(Map<URI, Throwable> failedSaves) {
+			final StringBuilder buf = new StringBuilder("The following resources could not be saved:"); //$NON-NLS-1$
+			for (final Entry<URI, Throwable> entry : failedSaves.entrySet()) {
+				buf.append("\nURI: ").append(entry.getKey().toString()).append(", cause: \n").append(getExceptionAsString(entry.getValue())); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+			return buf.toString();
+		}
+		
+		private String getExceptionAsString(Throwable t) {
+			final StringWriter stringWriter = new StringWriter();
+			final PrintWriter printWriter = new PrintWriter(stringWriter);
+			t.printStackTrace(printWriter);
+			final String result = stringWriter.toString();
+			try {
+				stringWriter.close();
+			} catch (final IOException e) {
+				// $JL-EXC$ ignore
+			}
+			printWriter.close();
+			return result;
+		}
+
+		// end replacement of EmfService.save(...)
+		// --------------------------------------------------------------------
 
 		public void close() {
 			if (editor != null) {

--- a/org.camunda.bpm.modeler.updatesite.feature/associate.properties
+++ b/org.camunda.bpm.modeler.updatesite.feature/associate.properties
@@ -1,2 +1,2 @@
 # associate site(s) - use comma to separate list - to add to the resulting repo 
-associate.sites=http://download.eclipse.org/modeling/mdt/bpmn2/updates/milestones/S20130822/
+associate.sites=http://download.eclipse.org/modeling/mdt/bpmn2/updates/mars/1.2.0/

--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/runtime/engine/model/impl/CallActivityImpl.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/runtime/engine/model/impl/CallActivityImpl.java
@@ -184,6 +184,8 @@ public class CallActivityImpl extends org.eclipse.bpmn2.impl.CallActivityImpl im
 				return getCalledElementBinding();
 			case ModelPackage.CALL_ACTIVITY__CALLED_ELEMENT_VERSION:
 				return getCalledElementVersion();
+			case ModelPackage.CALL_ACTIVITY__CALLED_ELEMENT_REF:
+				return getCalledElementRef();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}

--- a/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/diagram/editor/Bpmn2EditorUpdateBehavior.java
+++ b/org.camunda.bpm.modeler/src/org/camunda/bpm/modeler/ui/diagram/editor/Bpmn2EditorUpdateBehavior.java
@@ -26,6 +26,7 @@ import org.eclipse.emf.workspace.WorkspaceEditingDomainFactory;
 import org.eclipse.emf.workspace.util.WorkspaceSynchronizer.Delegate;
 import org.eclipse.graphiti.ui.editor.DefaultUpdateBehavior;
 import org.eclipse.graphiti.ui.editor.DiagramBehavior;
+import org.eclipse.graphiti.ui.editor.IDiagramEditorInput;
 import org.eclipse.graphiti.ui.internal.editor.GFWorkspaceCommandStackImpl;
 
 /**
@@ -83,7 +84,7 @@ public class Bpmn2EditorUpdateBehavior extends DefaultUpdateBehavior {
 	}
 
 	@Override
-	public void createEditingDomain() {
+	public void createEditingDomain(IDiagramEditorInput input) {
 		TransactionalEditingDomain editingDomain = createResourceSetAndEditingDomain();
 		initializeEditingDomain(editingDomain);
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -21,37 +21,23 @@
 	</licenses>
 
 	<properties>
-		<tycho-version>0.17.0</tycho-version>
+		<tycho-version>0.23.0</tycho-version>
 	</properties>
 
 	<profiles>
 		<profile>
-			<id>platform-kepler</id>
+			<id>platform-mars</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 				<property>
 					<name>platform-version-name</name>
-					<value>kepler</value>
+					<value>mars</value>
 				</property>
 			</activation>
 			<properties>
-				<eclipse-site>http://download.eclipse.org/releases/kepler</eclipse-site>
-				<platform-version>[4.3)</platform-version>
-				<platform-version-name>kepler</platform-version-name>
-			</properties>
-		</profile>
-		<profile>
-			<id>platform-indigo</id>
-			<activation>
-				<property>
-					<name>platform-version-name</name>
-					<value>indigo</value>
-				</property>
-			</activation>
-			<properties>
-				<eclipse-site>http://download.eclipse.org/releases/indigo</eclipse-site>
-				<platform-version>[3.7,3.8)</platform-version>
-				<platform-version-name>indigo</platform-version-name>
+				<eclipse-site>http://download.eclipse.org/releases/mars</eclipse-site>
+				<platform-version>[4.5)</platform-version>
+				<platform-version-name>mars</platform-version-name>
 			</properties>
 		</profile>
 	</profiles>
@@ -72,7 +58,7 @@
 
 		<repository>
 			<id>eclipse-bpmn2</id>
-			<url>http://download.eclipse.org/modeling/mdt/bpmn2/updates/milestones/S20130822/</url>
+			<url>http://download.eclipse.org/modeling/mdt/bpmn2/updates/mars/1.2.0/</url>
 			<layout>p2</layout>
 		</repository>
 	</repositories>


### PR DESCRIPTION
Hey guys,

the integrated development environment is an essential success factor when working with camunda BPM. Unfortunately the camunda BPM plugin only works without errors when using the way too old Eclipse Kepler edition :-1: 

So I decided to fix CAM-4228 and build an Eclipse Mars compatible plugin version. :+1: 

Hope this helps to get an official new Eclipse Plugin released soon!? A lot of people are waiting for that...

Cheers
Gunnar von der Beck
(Accso - Accelerated Solutions GmbH)

P.S.: you should create a new branch for that as the fix is not backward compatible!