### PR TITLE
Support macOS (OSX) sign

### DIFF
--- a/tasks/distro.js
+++ b/tasks/distro.js
@@ -66,6 +66,9 @@ module.exports = function(grunt) {
 
     if (platform === 'darwin') {
       options.name = 'Camunda Modeler';
+      if (grunt.option('sign')) {
+        options.osxSign = grunt.option('sign');
+      }
     }
 
     if (platform === 'win32') {


### PR DESCRIPTION
Hi, I supported macOS (OSX) sign.

Usage: 

```sh
# case use identity name
npm run all --sign "Developer ID Application: XXXXX Inc. (XXXXX)"
# case use identity
npm run all --sign "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
```

You can check identities by `security find-identity` command.

When you want to get more information, please check https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#osxsign.

Fixed https://github.com/camunda/camunda-modeler/issues/612