### PR TITLE
feat(editor): generate random definition IDs for new diagrams

### DIFF
--- a/client/lib/app/tabs/bpmn/initial.bpmn
+++ b/client/lib/app/tabs/bpmn/initial.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_{{ ID }}" targetNamespace="http://bpmn.io/schema/bpmn">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" />
   </bpmn:process>

--- a/client/lib/app/tabs/bpmn/provider.js
+++ b/client/lib/app/tabs/bpmn/provider.js
@@ -10,7 +10,7 @@ var initialXML = require('./initial.bpmn');
 
 var BpmnTab = require('./bpmn-tab');
 
-var ids = require('ids')();
+var ids = require('ids')([ 32, 36, 1 ]);
 
 
 /**
@@ -32,11 +32,14 @@ function BpmnProvider(options) {
 
     debug('create BPMN file');
 
+    // make ID ROBUST
+    var xml = initialXML.replace('{{ ID }}', ids.next());
+
     return {
       fileType: 'bpmn',
       name: 'diagram_' + createdFiles + '.bpmn',
       path: isUnsaved.PATH,
-      contents: initialXML,
+      contents: xml,
       isInitial: true
     };
   };

--- a/client/lib/app/tabs/cmmn/initial.cmmn
+++ b/client/lib/app/tabs/cmmn/initial.cmmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<cmmn:definitions xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Test" targetNamespace="http://bpmn.io/schema/cmmn">
+<cmmn:definitions xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_{{ ID }}" targetNamespace="http://bpmn.io/schema/cmmn">
   <cmmn:case id="Case_1">
     <cmmn:casePlanModel id="CasePlanModel_1" name="A CasePlanModel">
       <cmmn:planItem id="PlanItem_1" definitionRef="Task_1" />

--- a/client/lib/app/tabs/cmmn/provider.js
+++ b/client/lib/app/tabs/cmmn/provider.js
@@ -10,7 +10,7 @@ var initialXML = require('./initial.cmmn');
 
 var CmmnTab = require('./cmmn-tab');
 
-var ids = require('ids')();
+var ids = require('ids')([ 32, 36, 1 ]);
 
 
 /**
@@ -32,11 +32,14 @@ function CmmnProvider(options) {
 
     debug('create CMMN file');
 
+    // make ID ROBUST
+    var xml = initialXML.replace('{{ ID }}', ids.next());
+
     return {
       fileType: 'cmmn',
       name: 'diagram_' + createdFiles + '.cmmn',
       path: isUnsaved.PATH,
-      contents: initialXML
+      contents: xml
     };
   };
 


### PR DESCRIPTION
Make sure that new diagrams get random IDs assigned.

This way we prevent clashing in deployments and so on.

Closes #736