### PR TITLE
chore(app): make dialogs actual modal windows

### DIFF
--- a/app/lib/dialog.js
+++ b/app/lib/dialog.js
@@ -247,6 +247,7 @@ Dialog.prototype.showDialog = function(type, opts, done) {
   }
 
   var dialog = this.dialog,
+      browserWindow = this.browserWindow,
       dialogOptions = this.getDialogOptions(type, opts),
       buttons = dialogOptions.buttons;
 
@@ -282,19 +283,26 @@ Dialog.prototype.showDialog = function(type, opts, done) {
   }
 
   if (type === 'open') {
-    dialog.showOpenDialog(dialogOptions, dialogCallback);
+    dialog.showOpenDialog(browserWindow, dialogOptions, dialogCallback);
 
   } else
   if (type === 'save' || type === 'exportAs') {
-    dialog.showSaveDialog(dialogOptions, dialogCallback);
+    dialog.showSaveDialog(browserWindow, dialogOptions, dialogCallback);
 
   } else {
-    dialog.showMessageBox(dialogOptions, dialogCallback);
+    dialog.showMessageBox(browserWindow, dialogOptions, dialogCallback);
   }
 };
 
 Dialog.prototype.showGeneralErrorDialog = function() {
   var dialog = this.dialog;
 
-  dialog.showErrorBox('Error', 'There was an internal error.' + '\n' + 'Please try again.');
+  dialog.showErrorBox(
+    'Error',
+    'There was an internal error.' + '\n' + 'Please try again.'
+  );
+};
+
+Dialog.prototype.setActiveWindow = function(browserWindow) {
+  this.browserWindow = browserWindow;
 };

--- a/app/lib/file-system.js
+++ b/app/lib/file-system.js
@@ -19,7 +19,8 @@ var FILE_PROPERTIES = ['path', 'name', 'contents', 'lastModified', 'fileType'];
 /**
  * Interface for handling files.
  *
- * @param  {Object} browserWindow   Main browser window
+ * @param {Object} options
+ * @param {Dialog} options.dialog
  */
 function FileSystem(options) {
   ensureOptions([ 'dialog' ], options);

--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -229,6 +229,7 @@ renderer.on('client-config:get', function(...args) {
 });
 
 renderer.on('file:save-as', function(diagramFile, done) {
+
   saveCallback(fileSystem.saveAs, diagramFile, done);
 });
 
@@ -360,9 +361,12 @@ app.createEditorWindow = function() {
     title: 'Camunda Modeler'
   });
 
+  dialog.setActiveWindow(mainWindow);
+
   mainWindow.maximize();
 
   mainWindow.loadURL('file://' + path.resolve(__dirname + '/../../public/index.html'));
+
 
   // handling case when user clicks on window close button
   mainWindow.on('close', function(e) {
@@ -371,6 +375,8 @@ app.createEditorWindow = function() {
     if (app.quitAllowed) {
       // dereferencing main window and resetting client state
       app.mainWindow = null;
+      dialog.setActiveWindow(null);
+
       app.clientReady = false;
 
       return console.log('Main window closed');

--- a/app/test/helper/mock/electron-dialog.js
+++ b/app/test/helper/mock/electron-dialog.js
@@ -14,15 +14,15 @@ function ElectronDialog() {
     this.response = fileOrError;
   };
 
-  this.showOpenDialog = function(opts, callback) {
+  this.showOpenDialog = function(browserWindow, opts, callback) {
     callback(this.response);
   };
 
-  this.showSaveDialog = function(opts, callback) {
+  this.showSaveDialog = function(browserWindow, opts, callback) {
     callback(this.response);
   };
 
-  this.showMessageBox = function(opts, callback) {
+  this.showMessageBox = function(browserWindow, opts, callback) {
     callback(this.response);
   };
 

--- a/app/test/spec/dialog-spec.js
+++ b/app/test/spec/dialog-spec.js
@@ -12,7 +12,7 @@ var USER_PATH = '/users/bpmn.io/',
 
 
 function getDialogArgs(method) {
-  return method.args[0][0];
+  return method.args[0][1];
 }
 
 describe('Dialog', function() {


### PR DESCRIPTION
This uses the browserWindow option to make dialogs actual modal windows.

As a result the menu on the parent window is no longer clickable and
does not receive key strokes. In my opinion this should be the desired behavior.