### PR TITLE
Update state on direct editing cancel/complete

### DIFF
--- a/client/lib/app/editor/bpmn-editor.js
+++ b/client/lib/app/editor/bpmn-editor.js
@@ -353,7 +353,9 @@ BpmnEditor.prototype.getModeler = function() {
     this.modeler.on([
       'commandStack.changed',
       'selection.changed',
-      'elements.copied'
+      'elements.copied',
+      'directEditing.activate',
+      'directEditing.deactivate'
     ], this.updateState, this);
 
     // add importing flag (high priority)

--- a/client/lib/app/editor/cmmn-editor.js
+++ b/client/lib/app/editor/cmmn-editor.js
@@ -277,7 +277,9 @@ CmmnEditor.prototype.getModeler = function() {
     // hook up with modeler change events
     this.modeler.on([
       'commandStack.changed',
-      'selection.changed'
+      'selection.changed',
+      'directEditing.activate',
+      'directEditing.deactivate'
     ], this.updateState, this);
 
     // add importing flag (high priority)

--- a/client/lib/app/editor/dmn-editor.js
+++ b/client/lib/app/editor/dmn-editor.js
@@ -206,9 +206,6 @@ DmnEditor.prototype.getModeler = function() {
       this.initialState.importing = false;
     });
 
-    // hook up with modeler change events
-    // TODO(nikku): hook up with change events?
-
     var updateState = (options = {}) => (event) => {
       this.updateState(options, event);
     };
@@ -218,6 +215,8 @@ DmnEditor.prototype.getModeler = function() {
     this.modeler.on('view.contentChanged', updateState({ contentChanged: true }));
 
     this.modeler.on('view.selectionChanged', updateState());
+
+    this.modeler.on('view.directEditingChanged', updateState());
 
     // log editor errors
     // log errors into log

--- a/client/lib/app/editor/dmn/CamundaDmnEditor.js
+++ b/client/lib/app/editor/dmn/CamundaDmnEditor.js
@@ -16,6 +16,10 @@ export default class CamundaDmnEditor extends DmnJS {
         this._emit('view.selectionChanged', event);
       });
 
+      viewer.on([ 'directEditing.activate', 'directEditing.deactivate' ], event => {
+        this._emit('view.directEditingChanged', event);
+      });
+
       viewer.on('error', ({ error }) => {
         this._emit('error', {
           viewer,


### PR DESCRIPTION
Makes sure `EDIT` menu is updated on both direct editing cancel and complete.