### PR TITLE
chore(client): bump min-dash dependency

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,7 @@
     "form-data": "^2.3.1",
     "glob": "^7.0.3",
     "inherits": "^2.0.1",
-    "min-dash": "^3.1.0",
+    "min-dash": "^3.2.0",
     "node-fetch": "^2.1.2",
     "parents": "^1.0.1"
   },

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4760,11 +4760,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4777,15 +4779,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4888,7 +4893,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4898,6 +4904,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4910,17 +4917,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4937,6 +4947,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5009,7 +5020,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5019,6 +5031,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5124,6 +5137,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6976,9 +6990,9 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "min-dash": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.1.0.tgz",
-      "integrity": "sha512-nP58UY9iKd+b6CYivW85+aqgjMXPMd3UAfv5CExiZ8uQBO4LxbY/BWf4rzRjMNtKI9QW21LH80i77mG2Jh96bg=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.2.0.tgz",
+      "integrity": "sha512-iCo8rqY0vlcXF1Dr5grLeRnibcVC0UyDF0Tx0h56sZvvAjeuBKw72gI0Df0KzCOUSxm1hYMVvFWG/wxrjuKJmQ=="
     },
     "min-dom": {
       "version": "3.1.1",

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "dmn-js": "^5.0.0",
     "dmn-js-properties-panel": "^0.1.2",
     "ids": "^0.2.2",
+    "min-dash": "^3.2.0",
     "mitt": "^1.1.3",
     "p-defer": "^1.0.0",
     "p-series": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11466,9 +11466,9 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "min-dash": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.1.0.tgz",
-      "integrity": "sha512-nP58UY9iKd+b6CYivW85+aqgjMXPMd3UAfv5CExiZ8uQBO4LxbY/BWf4rzRjMNtKI9QW21LH80i77mG2Jh96bg=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.2.0.tgz",
+      "integrity": "sha512-iCo8rqY0vlcXF1Dr5grLeRnibcVC0UyDF0Tx0h56sZvvAjeuBKw72gI0Df0KzCOUSxm1hYMVvFWG/wxrjuKJmQ=="
     },
     "min-dom": {
       "version": "3.1.1",


### PR DESCRIPTION
Did a min-dash release to fix broken `{ isUndefined, isDefined }` utilities.

Would be great to merge it soon.