### PR TITLE
fix(parse-file-type): correctly detect type

### DIFF
--- a/client/lib/app/util/parse-file-type.js
+++ b/client/lib/app/util/parse-file-type.js
@@ -10,13 +10,47 @@ var TYPES = {
   cmmn: 'http://www.omg.org/spec/CMMN'
 };
 
+var defintionsNoPrefix = /[<\s]+(?:Definitions|definitions)\s+/,
+    namespaceNoPrefix = /xmlns="([^"]*)"/,
+    defintionsPrefix = /[<\s]+(.*):(?:Definitions|definitions)\s+/;
+
 
 module.exports = function parseType(file) {
 
-  var type = null;
+  var contents = file.contents,
+      type = null,
+      matches,
+      matchedNamespace,
+      namespacePrefix;
 
-  forEach(TYPES, function(ns, t) {
-    if (file.contents.indexOf(ns) !== -1) {
+  // no prefix e.g. <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  if (defintionsNoPrefix.test(contents)) {
+    matches = contents.match(namespaceNoPrefix);
+
+    if (matches && matches[1]) {
+      matchedNamespace = matches[1];
+    }
+  }
+
+  // prefix e.g. <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  if (defintionsPrefix.test(contents)) {
+    matches = contents.match(defintionsPrefix);
+
+    if (matches && matches[1]) {
+
+      // dynamically create regex based on matched prefix
+      namespacePrefix = new RegExp(`xmlns:${ matches[1] }="([^"]*)"`);
+
+      matches = contents.match(namespacePrefix);
+
+      if (matches && matches[1]) {
+        matchedNamespace = matches[1];
+      }
+    }
+  }
+
+  forEach(TYPES, function(uri, t) {
+    if (matchedNamespace && matchedNamespace.indexOf(uri) !== -1) {
       type = t;
     }
   });

--- a/client/test/fixtures/basic.cmmn11.xml
+++ b/client/test/fixtures/basic.cmmn11.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cmmn:definitions xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0n29yop" targetNamespace="http://bpmn.io/schema/cmmn">
+  <cmmn:case id="Case_1">
+    <cmmn:casePlanModel id="CasePlanModel_1" name="A CasePlanModel">
+      <cmmn:planItem id="PlanItem_1" definitionRef="Task_1" />
+      <cmmn:task id="Task_1" />
+    </cmmn:casePlanModel>
+  </cmmn:case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram id="_5a66685b-5f57-4e2f-b1d1-acca4fae04b2">
+      <cmmndi:Size xsi:type="dc:Dimension" width="500" height="500" />
+      <cmmndi:CMMNShape id="DI_CasePlanModel_1" cmmnElementRef="CasePlanModel_1">
+        <dc:Bounds x="114" y="63" width="534" height="389" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="PlanItem_1_di" cmmnElementRef="PlanItem_1">
+        <dc:Bounds x="150" y="96" width="100" height="80" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+    </cmmndi:CMMNDiagram>
+  </cmmndi:CMMNDI>
+</cmmn:definitions>

--- a/client/test/fixtures/bpmnWithDmnUri.xml
+++ b/client/test/fixtures/bpmnWithDmnUri.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1" />
+    <bpmn:task id="Task_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="353" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/client/test/spec/util/parse-file-type-spec.js
+++ b/client/test/spec/util/parse-file-type-spec.js
@@ -5,6 +5,8 @@ var parseFileType = require('app/util/parse-file-type');
 
 var files = {
   bpmn: require('test/fixtures/basic.bpmn20.xml'),
+  bpmnWithDmnUri: require('test/fixtures/bpmnWithDmnUri.xml'),
+  cmmn: require('test/fixtures/basic.cmmn11.xml'),
   dmn: require('test/fixtures/basic.dmn11.xml'),
   nyan: require('test/fixtures/nyan_cat.png'),
   random: require('test/fixtures/random.xml')
@@ -26,6 +28,30 @@ describe('util - parse file type', function() {
 
     // then
     expect(notation).to.equal('bpmn');
+  });
+
+
+  it('should identify bpmn file regardless of dmn uri', function() {
+    // given
+    var bpmnFile = getFile('bpmnWithDmnUri');
+
+    // when
+    var notation = parseFileType({ contents: bpmnFile });
+
+    // then
+    expect(notation).to.equal('bpmn');
+  });
+
+
+  it('should identify cmmn file', function() {
+    // given
+    var dmnFile = getFile('cmmn');
+
+    // when
+    var notation = parseFileType({ contents: dmnFile });
+
+    // then
+    expect(notation).to.equal('cmmn');
   });
 
 


### PR DESCRIPTION
* detection failed as soon as uri of another type was in file
* type is now detected by checking namespace of root element

Closes #944