### PR TITLE
Only handle import if editor mounted

### DIFF
--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -67,6 +67,7 @@ export class BpmnEditor extends CachedComponent {
   }
 
   componentDidMount() {
+    this._isMounted = true;
 
     const {
       layout
@@ -95,6 +96,8 @@ export class BpmnEditor extends CachedComponent {
   }
 
   componentWillUnmount() {
+    this._isMounted = false;
+
     const {
       modeler
     } = this.getCached();
@@ -106,6 +109,15 @@ export class BpmnEditor extends CachedComponent {
     const propertiesPanel = modeler.get('propertiesPanel');
 
     propertiesPanel.detach();
+  }
+
+
+  ifMounted = (fn) => {
+    return (...args) => {
+      if (this._isMounted) {
+        fn(...args);
+      }
+    };
   }
 
 
@@ -285,7 +297,7 @@ export class BpmnEditor extends CachedComponent {
       });
 
       // TODO(nikku): apply default element templates to initial diagram
-      modeler.importXML(xml, this.handleImport);
+      modeler.importXML(xml, this.ifMounted(this.handleImport));
     }
   }
 

--- a/client/src/app/tabs/cmmn/CmmnEditor.js
+++ b/client/src/app/tabs/cmmn/CmmnEditor.js
@@ -35,6 +35,8 @@ export class CmmnEditor extends CachedComponent {
   }
 
   componentDidMount() {
+    this._isMounted = true;
+
     const {
       modeler
     } = this.getCached();
@@ -52,6 +54,8 @@ export class CmmnEditor extends CachedComponent {
   }
 
   componentWillUnmount() {
+    this._isMounted = false;
+
     const {
       modeler
     } = this.getCached();
@@ -65,6 +69,13 @@ export class CmmnEditor extends CachedComponent {
     propertiesPanel.detach();
   }
 
+  ifMounted = (fn) => {
+    return (...args) => {
+      if (this._isMounted) {
+        fn(...args);
+      }
+    };
+  }
 
   listen(fn) {
     const {
@@ -209,7 +220,7 @@ export class CmmnEditor extends CachedComponent {
       });
 
       // TODO(nikku): apply default element templates to initial diagram
-      modeler.importXML(xml, this.handleImport);
+      modeler.importXML(xml, this.ifMounted(this.handleImport));
     }
   }
 

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -43,6 +43,8 @@ export class DmnEditor extends CachedComponent {
   }
 
   componentDidMount() {
+    this._isMounted = true;
+
     const {
       modeler
     } = this.getCached();
@@ -61,6 +63,8 @@ export class DmnEditor extends CachedComponent {
   }
 
   componentWillUnmount() {
+    this._isMounted = false;
+
     const {
       modeler
     } = this.getCached();
@@ -74,6 +78,14 @@ export class DmnEditor extends CachedComponent {
     if (!this.state.importing) {
       this.checkImport();
     }
+  }
+
+  ifMounted = (fn) => {
+    return (...args) => {
+      if (this._isMounted) {
+        fn(...args);
+      }
+    };
   }
 
   listen(fn) {
@@ -303,7 +315,7 @@ export class DmnEditor extends CachedComponent {
         importing: true
       });
 
-      modeler.importXML(xml, { open: false }, this.handleImport);
+      modeler.importXML(xml, { open: false }, this.ifMounted(this.handleImport));
     } else {
       activeSheet
         && activeSheet.element


### PR DESCRIPTION
Context:

* XML import might finish after editor was unmounted (e.g. scrolling through tabs quickly)
* making sure that import is only handled if editor is mounted fixes this warning

Closes #934