### PR TITLE
962 create a file when new diagram is saved

### DIFF
--- a/app/lib/file-system.js
+++ b/app/lib/file-system.js
@@ -98,6 +98,7 @@ FileSystem.prototype.exportAs = function(diagramFile, filters, callback) {
   });
 };
 
+// TODO(philippfromme): refactor, this method is highly confusing
 FileSystem.prototype.saveAs = function(diagramFile, callback) {
   var dialog = this.dialog,
       self = this;
@@ -106,7 +107,10 @@ FileSystem.prototype.saveAs = function(diagramFile, callback) {
 
   var dialogPath = { filePath: this.getFilePath(diagramFile) };
 
+  // (3) handle dialog response
   function done(error, filePath) {
+
+    // (4) call callback
     if (error) {
       return callback(error);
     }
@@ -124,11 +128,13 @@ FileSystem.prototype.saveAs = function(diagramFile, callback) {
     }
   }
 
+  // (1) open save dialog
   dialog.showDialog('save', assign(createFileDescriptor({
     name: diagramFile.name,
     fileType: fileType
   }), dialogPath), function(error, filePath) {
 
+    // (2) handle dialog response
     if (error) {
       return done(error);
     }

--- a/app/test/spec/file-system-spec.js
+++ b/app/test/spec/file-system-spec.js
@@ -22,7 +22,7 @@ describe('FileSystem', function() {
     });
   });
 
-  after(function() {
+  afterEach(function() {
     try {
       fs.unlinkSync(TEST_FILE_PATH);
     } catch (e) { /** YEA */ }
@@ -116,6 +116,13 @@ describe('FileSystem', function() {
 
 
   describe('readFileStats', function() {
+
+    beforeEach(function(done) {
+      fs.writeFile(TEST_FILE_PATH, '', function(error) {
+        done(error);
+      });
+    });
+
 
     it('should set last modified property on existing file', function() {
       // given

--- a/app/test/spec/file-system-spec.js
+++ b/app/test/spec/file-system-spec.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var fs = require('fs'),
-    os = require('os');
+    os = require('os'),
+    sinon = require('sinon');
 
 var FileSystem = require('../../lib/file-system');
 
@@ -149,6 +150,57 @@ describe('FileSystem', function() {
 
       // then
       expect(statsFile).to.have.property('lastModified').eql(0);
+    });
+
+  });
+
+
+  describe('saveAs', function() {
+
+    it('should save file', function() {
+      // given
+      fileSystem.dialog.showDialog = sinon.stub().callsFake(function(...args) {
+        var callback = args.pop();
+
+        callback(null, TEST_FILE_PATH);
+      });
+
+      var callbackSpy = sinon.spy();
+
+      var file = {
+        contents: 'foo'
+      };
+
+      // when
+      fileSystem.saveAs(file, callbackSpy);
+
+      // then
+      expect(callbackSpy).to.be.called;
+      expect(fs.existsSync(TEST_FILE_PATH)).to.be.true;
+    });
+
+
+    it('should call callback with error if save file dialog was cancelled', function() {
+      // given
+      fileSystem.dialog.showDialog = sinon.stub().callsFake(function(...args) {
+        var callback = args.pop();
+
+        callback();
+      });
+
+      var callbackSpy = sinon.spy();
+
+      var file = {
+        contents: 'foo'
+      };
+
+      // when
+      fileSystem.saveAs(file, callbackSpy);
+
+      // then
+      expect(callbackSpy).to.be.calledOnce;
+      expect(callbackSpy.lastCall.args[0]).to.be.instanceOf(Error);
+      expect(fs.existsSync(TEST_FILE_PATH)).to.be.false;
     });
 
   });


### PR DESCRIPTION
This PR fixes a broken behaviour of `saveAs` button which would not actually save any files.

Closes #962 