### PR TITLE
976 refactor empty file and unrecognized file dialog

### DIFF
--- a/app/lib/dialog.js
+++ b/app/lib/dialog.js
@@ -201,28 +201,6 @@ Dialog.prototype.getDialogOptions = function(type, options) {
         ].join('\n')
       };
     },
-    emptyFile: function(options) {
-      ensureOptions([ 'fileType', 'name' ], options);
-
-      var type = options.fileType.toUpperCase();
-
-      return {
-        type: 'question',
-        title: [
-          'Empty ',
-          type,
-          ' file'
-        ].join(''),
-        buttons: [
-          { id: 'cancel', label: 'Cancel' },
-          { id: 'create', label: 'Create' }
-        ],
-        message: [
-          'The file "' + options.name + '" is empty.',
-          'Would you like to create a new ' + type + ' diagram?'
-        ].join('\n')
-      };
-    },
     error: getDialog('error'),
     warning: getDialog('warning'),
     info: getDialog('info')

--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -127,12 +127,6 @@ if (config.get('single-instance', true)) {
 
 // client life-cycle //////////////////
 
-renderer.on('dialog:unrecognized-file', function(file, done) {
-  dialog.showDialog('unrecognizedFile', { name: file.name });
-
-  done(null);
-});
-
 renderer.on('dialog:reimport-warning', function(done) {
 
   dialog.showDialog('reimportWarning', done);
@@ -175,13 +169,6 @@ renderer.on('dialog:saving-denied', function(done) {
 
 renderer.on('dialog:content-changed', function(done) {
   dialog.showDialog('contentChanged', done);
-});
-
-renderer.on('dialog:empty-file', function(options, done) {
-  dialog.showDialog('emptyFile', {
-    fileType: options.fileType,
-    name: options.name
-  }, done);
 });
 
 renderer.on('deploy', function(data, done) {

--- a/app/test/spec/dialog-spec.js
+++ b/app/test/spec/dialog-spec.js
@@ -86,33 +86,6 @@ describe('Dialog', function() {
   });
 
 
-  it('should show empty file dialog', function(done) {
-
-    // given
-    electronDialog.setResponse(1); // 'Create' button
-
-    // when
-    dialog.showDialog('emptyFile', {
-      fileType: 'bpmn',
-      name: 'foo.bpmn'
-    }, function(err, result) {
-      var dialogArgs = getDialogArgs(electronDialog.showMessageBox);
-
-      expect(result).to.equal('create');
-
-      expect(electronDialog.showMessageBox).to.have.been.called;
-
-      expect(dialogArgs.title).to.equal('Empty BPMN file');
-      expect(dialogArgs.message).to.equal([
-        'The file "foo.bpmn" is empty.',
-        'Would you like to create a new BPMN diagram?'
-      ].join('\n'));
-
-      done();
-    });
-  });
-
-
   it('should show message dialog -> close', function(done) {
 
     // given

--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -64,6 +64,16 @@ export default class TabsProvider {
 
   }
 
+  getProviderNames() {
+
+    var names = [];
+    for (var key in this.providers) {
+      this.providers[key].name ? names.push(this.providers[key].name) : '';
+    }
+
+    return names;
+  }
+
   getProvider(type) {
     return (this.providers[type] || noopProvider);
   }

--- a/client/src/app/__tests__/mocks/index.js
+++ b/client/src/app/__tests__/mocks/index.js
@@ -77,6 +77,18 @@ export class TabsProvider {
 
       return Promise.resolve({ default: FakeTab });
     };
+
+    this.providers = {
+      bpmn: {
+        name: 'BPMN',
+      },
+      cmnn: {
+        name: 'CMMN'
+      },
+      dmn: {
+        name: 'DMN'
+      }
+    };
   }
 
   createTab(type) {
@@ -100,8 +112,26 @@ export class TabsProvider {
     };
   }
 
+  getProvider(type) {
+    return this.providers[type];
+  }
+
+  getProviderNames() {
+    var names = [];
+    for (var key in this.providers) {
+      this.providers[key].name ? names.push(this.providers[key].name) : '';
+    }
+
+    return names;
+  }
+
   getTabComponent(type) {
     return this.resolveTab(type);
+  }
+
+
+  getInitialFileContents() {
+    return '<contents>';
   }
 
 }
@@ -121,6 +151,9 @@ export class Dialog extends Mock {
 
     this.askSaveResponse = null;
     this.openFileResponse = null;
+    this.showResponse = null;
+    this.showUnrecognizedFileErrorDialogResponse = null;
+    this.showEmptyFileDialogResponse = null;
   }
 
   setAskSaveResponse(response) {
@@ -135,6 +168,18 @@ export class Dialog extends Mock {
     this.openFileResponse = response;
   }
 
+  setShowResponse(response) {
+    this.showResponse = response;
+  }
+
+  setShowUnrecognizedFileErrorDialogResponse(response) {
+    this.showUnrecognizedFileErrorDialogResponse = response;
+  }
+
+  setShowEmptyFileDialogResponse(response) {
+    this.showEmptyFileDialogResponse = response;
+  }
+
   askSave() {
     return this.askSaveResponse;
   }
@@ -145,6 +190,18 @@ export class Dialog extends Mock {
 
   openFile() {
     return this.openFileResponse;
+  }
+
+  show() {
+    return this.showResponse;
+  }
+
+  showUnrecognizedFileErrorDialog() {
+    return this.showUnrecognizedFileErrorDialogResponse;
+  }
+
+  showEmptyFileDialog() {
+    return this.showEmptyFileDialogResponse;
   }
 }
 

--- a/client/src/app/tabs/MultiSheetTab.js
+++ b/client/src/app/tabs/MultiSheetTab.js
@@ -109,26 +109,11 @@ export class MultiSheetTab extends CachedComponent {
       type
     } = tab;
 
-    // TODO(philippfromme): where to put this?
-    const answer = await onAction('show-dialog', {
-      type: 'error',
-      title: 'Import Error',
-      message: 'Ooops!',
-      buttons: [{
-        id: 'close',
-        label: 'Close'
-      }, {
-        id: 'ask-in-forum',
-        label: 'Ask in Forum'
-      }],
-      detail: [
-        error.message,
-        '',
-        'Do you believe "' + name + '" is valid ' + type.toUpperCase() + ' diagram?',
-        '',
-        'Post this error with your diagram in our forum for help.'
-      ].join('\n')
-    });
+    const answer = await onAction('show-dialog', getErrorDialog({
+      error,
+      name,
+      type
+    }));
 
     if (answer === 'ask-in-forum') {
       onAction('open-external-url', {
@@ -345,5 +330,33 @@ export class MultiSheetTab extends CachedComponent {
 
 }
 
-
 export default WithCache(WithCachedState(MultiSheetTab));
+
+
+// helper //////////
+
+function getErrorDialog({
+  error,
+  name,
+  type
+}) {
+  return {
+    type: 'error',
+    title: 'Import Error',
+    message: 'Ooops!',
+    buttons: [{
+      id: 'close',
+      label: 'Close'
+    }, {
+      id: 'ask-in-forum',
+      label: 'Ask in Forum'
+    }],
+    detail: [
+      error.message,
+      '',
+      'Do you believe "' + name + '" is valid ' + type.toUpperCase() + ' diagram?',
+      '',
+      'Post this error with your diagram in our forum for help.'
+    ].join('\n')
+  };
+}

--- a/client/src/remote/Dialog.js
+++ b/client/src/remote/Dialog.js
@@ -26,4 +26,54 @@ export default class Dialog {
     return this.backend.send('dialog:show', options);
   }
 
+  showUnrecognizedFileErrorDialog = async (options) => {
+    const {
+      file,
+      types
+    } = options;
+
+    const typesString = types.reduce((string, type, index) => {
+      const isLast = index === types.length - 1;
+
+      const seperator = isLast ? ' or' : ',';
+
+      return string.concat(`${ seperator } ${ type.toUpperCase() }`);
+    });
+
+    await this.show({
+      type: 'error',
+      title: 'Unrecognized file format',
+      buttons: [
+        { id: 'cancel', label: 'Close' }
+      ],
+      message: 'The file "' + file.name + '" is not a' + typesString + ' file.'
+    });
+  }
+
+  showEmptyFileDialog = async (options) => {
+    const {
+      file,
+      type
+    } = options;
+
+    const typeUpperCase = type.toUpperCase();
+
+    return this.show({
+      type: 'info',
+      title: [
+        'Empty ',
+        typeUpperCase,
+        ' file'
+      ].join(''),
+      buttons: [
+        { id: 'cancel', label: 'Cancel' },
+        { id: 'create', label: 'Create' }
+      ],
+      message: [
+        'The file "' + file.name + '" is empty.',
+        'Would you like to create a new ' + typeUpperCase + ' diagram?'
+      ].join('\n')
+    });
+  }
+
 }

--- a/client/src/remote/__tests__/DialogSpec.js
+++ b/client/src/remote/__tests__/DialogSpec.js
@@ -1,0 +1,101 @@
+import Dialog from '../Dialog';
+
+import { Backend } from '../../app/__tests__/mocks';
+
+describe('dialog', function() {
+
+  it('#show', function() {
+
+    // given
+    const sendSpy = (type, opts) => {
+
+      // then
+      expect(type).to.equal('dialog:show');
+
+      expect(opts).to.eql(options);
+    };
+
+    const backend = new Backend({ send: sendSpy });
+    const dialog = new Dialog(backend);
+
+    const options = {
+      type: 'info',
+      title: 'Foo',
+      message: 'Foo!',
+      buttons: [
+        { id: 'foo', label: 'Foo' }
+      ]
+    };
+
+    // when
+    dialog.show(options);
+  });
+
+
+  it('#showUnrecognizedFileErrorDialog', function() {
+
+    // given
+    const sendSpy = (type, opts) => {
+
+      // then
+      expect(type).to.equal('dialog:show');
+
+      expect(opts).to.eql({
+        type: 'error',
+        title: 'Unrecognized file format',
+        buttons: [
+          { id: 'cancel', label: 'Close' }
+        ],
+        message: 'The file "foo" is not a foo, bar or baz file.'
+      });
+    };
+
+    const backend = new Backend({ send: sendSpy });
+    const dialog = new Dialog(backend);
+
+    const options = {
+      file: {
+        name: 'foo'
+      },
+      types: [ 'foo', 'bar', 'baz' ]
+    };
+
+    // when
+    dialog.showUnrecognizedFileErrorDialog(options);
+  });
+
+
+  it('#showEmptyFileDialog', function() {
+
+    // given
+    const sendSpy = (type, opts) => {
+
+      // then
+      expect(type).to.equal('dialog:show');
+
+      expect(opts).to.eql({
+        type: 'info',
+        title: 'Empty FOO file',
+        buttons: [
+          { id: 'cancel', label: 'Cancel' },
+          { id: 'create', label: 'Create' }
+        ],
+        message: 'The file "foo" is empty.\nWould you like to create a new FOO diagram?'
+      });
+    };
+
+    const backend = new Backend({ send: sendSpy });
+    const dialog = new Dialog(backend);
+
+    const options = {
+      file: {
+        name: 'foo'
+      },
+      type: 'foo'
+    };
+
+    // when
+    dialog.showEmptyFileDialog(options);
+  });
+
+});


### PR DESCRIPTION
Closes #976 
Closes #975 

Since the unrecognized file dialog is related to the empty file handling, I've just combine the refactoring of both dialogs in this pull request. 

- Restore empty file dialog
- Restore unrecognized file dialog
- Remove harcoded dialogs [1]

[1] the hardcoded `unrecognized-file` dialog is used in [another event](https://github.com/camunda/camunda-modeler/blob/next/app/lib/index.js#L311) as well. This should be refactored in another place, e.g. in #971 