### PR TITLE
fix(client): use correct type param to empty file dialog

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -409,7 +409,7 @@ export class App extends Component {
 
     const response = await dialog.showEmptyFileDialog({
       file,
-      fileType
+      type: fileType
     });
 
     if (response == 'create') {

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -277,6 +277,34 @@ describe('<App>', function() {
     });
 
 
+    it('should open empty file with correct options', async function() {
+
+      // given
+      const dialog = new Dialog();
+
+      dialog.setShowEmptyFileDialogResponse('create');
+
+      const showSpy = spy(dialog, 'showEmptyFileDialog');
+
+      const { app } = createApp({
+        globals: {
+          dialog
+        }
+      });
+
+      const file1 = createFile('1.bpmn', null, '');
+
+      // when
+      await app.openEmptyFile(file1);
+
+      // then
+      expect(showSpy).to.have.been.calledWith({
+        file: file1,
+        type: 'bpmn'
+      });
+    });
+
+
     it('should NOT open empty TXT file', async function() {
 
       // given


### PR DESCRIPTION
- fixes the throwed exception on open empty files
- adds test for correct function call

Closes #1036 