### PR TITLE
Source maps

### DIFF
--- a/client/src/app/AppParent.js
+++ b/client/src/app/AppParent.js
@@ -25,18 +25,18 @@ export default class AppParent extends Component {
       backend
     } = this.props.globals;
 
-    const result = this.getApp().triggerAction(action, options);
+    let result = Promise.resolve(
+      this.getApp().triggerAction(action, options)
+    );
 
     if (action === 'quit') {
-      Promise.resolve(result).then(
+      result = result.then(
         backend.sendQuitAllowed,
         backend.sendQuitAborted
       );
     }
 
-    if (result && 'catch' in result) {
-      result.catch(() => console.error);
-    }
+    result.catch(this.handleError);
   }
 
   openFiles = (event, files) => {
@@ -129,10 +129,10 @@ export default class AppParent extends Component {
   handleError = (error, tab) => {
 
     if (tab) {
-      return log('tab error', error, tab);
+      return log('tab ERROR', error, tab);
     }
 
-    return log('app error', error);
+    return log('app ERROR', error);
   }
 
   handleWarning = (warning, tab) => {

--- a/client/src/app/__tests__/AppParentSpec.js
+++ b/client/src/app/__tests__/AppParentSpec.js
@@ -136,6 +136,31 @@ describe('<AppParent>', function() {
 
   });
 
+
+  describe('trigger action', function() {
+
+    it('should trigger quit', async function() {
+
+      // given
+      const backend = new Backend();
+
+      const {
+        appParent
+      } = createAppParent({ globals: { backend } }, mount);
+
+      const quitAllowedSpy = spy(backend, 'sendQuitAllowed');
+
+      await appParent.triggerAction({}, 'quit');
+
+      // then
+      expect(quitAllowedSpy).to.have.been.called;
+    });
+
+
+    it('should handle action errors');
+
+  });
+
 });
 
 

--- a/client/src/app/__tests__/mocks/index.js
+++ b/client/src/app/__tests__/mocks/index.js
@@ -332,6 +332,8 @@ export class Backend extends Mock {
 
   sendMenuUpdate() {}
 
+  sendQuitAllowed() {}
+
   on(event, callback) {
     this.listeners[event] = callback.bind(this);
   }

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -82,7 +82,8 @@ module.exports = {
     headers: {
       'Access-Control-Allow-Origin': '*'
     }
-  }
+  },
+  devtool: DEV ? 'cheap-module-eval-source-map' : 'source-map'
 };
 
 


### PR DESCRIPTION
* ensures we ship with source maps so that actual errors are logged with full stack traces
* unifies error logging in `AppParent`