### PR TITLE
feat(app): mark tab created from empty file as dirty

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -508,16 +508,14 @@ export class App extends Component {
 
     if (response == 'create') {
 
-      // TODO(philippfromme): fix dirty state
       let tab = this.addTab(
-        tabsProvider.createTabForFile(file)
+        tabsProvider.createTabForFile({
+          ...file,
+          contents: tabsProvider.getInitialFileContents(fileType)
+        })
       );
 
-      tab = await this.updateTab(tab, {
-        file: {
-          contents: tabsProvider.getInitialFileContents(fileType)
-        }
-      });
+      this.markAsDirty(tab);
 
       await this.selectTab(tab);
 
@@ -676,20 +674,11 @@ export class App extends Component {
   handleTabChanged = (tab) => (properties = {}) => {
 
     let {
-      dirtyTabs,
       tabState
     } = this.state;
 
     if ('dirty' in properties) {
-
-      const newDirtyTabs = {
-        ...dirtyTabs,
-        [tab.id]: properties.dirty
-      };
-
-      this.setState({
-        dirtyTabs: newDirtyTabs
-      });
+      this.markAsDirty(tab, properties.dirty);
     }
 
     tabState = {
@@ -702,6 +691,22 @@ export class App extends Component {
     });
 
     this.updateMenu(tabState);
+  }
+
+  markAsDirty(tab, dirty = true) {
+
+    let {
+      dirtyTabs
+    } = this.state;
+
+    const newDirtyTabs = {
+      ...dirtyTabs,
+      [tab.id]: dirty
+    };
+
+    this.setState({
+      dirtyTabs: newDirtyTabs
+    });
   }
 
   /**

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -280,12 +280,15 @@ describe('<App>', function() {
       // then
       const {
         activeTab,
-        tabs
+        tabs,
+        dirtyTabs
       } = app.state;
 
       expect(tabs).to.have.length(1);
       expect(tabs).to.eql([ tab ]);
       expect(activeTab).to.eql(tab);
+
+      expect(dirtyTabs).to.have.property(tab.id, true);
     });
 
 


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

Gets rid of a `TODO` in the app.