### PR TITLE
fix(app): activate edit menu if provided only

### DIFF
--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -36,23 +36,31 @@ class MenuBuilder {
   }
 
   build() {
-    return this.appendFileMenu(new this.constructor(this.options)
-      .appendNewFile()
-      .appendOpen()
-      .appendSeparator()
-      .appendSwitchTab()
-      .appendSaveFile()
-      .appendSaveAsFile()
-      .appendSaveAllFiles()
-      .appendSeparator()
-      .appendExportAs()
-      .appendCloseTab()
-      .appendSeparator()
-      .appendQuit()
-      .get())
-      .appendEditMenu()
-      .appendWindowMenu()
-      .appendHelpMenu();
+    this.appendFileMenu(
+      new MenuBuilder(this.options)
+        .appendNewFile()
+        .appendOpen()
+        .appendSeparator()
+        .appendSwitchTab()
+        .appendSaveFile()
+        .appendSaveAsFile()
+        .appendSaveAllFiles()
+        .appendSeparator()
+        .appendExportAs()
+        .appendCloseTab()
+        .appendSeparator()
+        .appendQuit()
+        .get()
+    );
+
+    if ('editMenu' in this.options.state) {
+      this.appendEditMenu();
+    }
+
+    this.appendWindowMenu();
+    this.appendHelpMenu();
+
+    return this;
   }
 
   buildContextMenu() {
@@ -289,7 +297,7 @@ class MenuBuilder {
   }
 
   getEditMenu(menuItems) {
-    const builder = new this.constructor(this.options);
+    const builder = new MenuBuilder(this.options);
 
     menuItems.forEach((menuItem, index) => {
       if (Array.isArray(menuItem)) {


### PR DESCRIPTION
* ensures we only show the edit menu, if the
  client provides it
* the empty tab does not provide it, thus
  it is disabled without a tab open

Closes #1070