### PR TITLE
fix(client/Log): (re)-enable log copy

### DIFF
--- a/client/src/app/Log.less
+++ b/client/src/app/Log.less
@@ -25,6 +25,13 @@
 
     width: 100%;
     display: block;
+
+  }
+
+  .entry {
+    * {
+      user-select: text;
+    }
   }
 
   .resizer {

--- a/client/src/app/__tests__/LogSpec.js
+++ b/client/src/app/__tests__/LogSpec.js
@@ -185,6 +185,10 @@ describe('<Log>', function() {
         expanded: true
       }, mount);
 
+      const handleCopy = spy(instance, 'handleCopy');
+
+      const handleWindowSelection = spy(window, 'getSelection');
+
       instance.setState({
         focussed: true
       });
@@ -192,8 +196,11 @@ describe('<Log>', function() {
       // when
       const button = tree.find('.copy-button');
 
-      // then
       button.simulate('click');
+
+      // then
+      expect(handleCopy).to.have.been.calledOnce;
+      expect(handleWindowSelection).to.have.been.called;
     });
 
 


### PR DESCRIPTION
Closes #1079

Testing: Unfortunately it seems to be not possible to test the behavior of `window.getSelection`, `selection.addRange` to test the current selection and `navigator.clipboard` or else to test the current clipboard content.