### PR TITLE
chore(export): scale pixel images by factor 3

### DIFF
--- a/client/karma.config.js
+++ b/client/karma.config.js
@@ -92,7 +92,7 @@ module.exports = function(karma) {
             use: 'babel-loader'
           },
           {
-            test: /\.(css|bpmn|cmmn|dmn|less|xml|png)$/,
+            test: /\.(css|bpmn|cmmn|dmn|less|xml|png|svg)$/,
             use: 'raw-loader'
           }
         ]

--- a/client/src/app/util/__tests__/diagram.svg
+++ b/client/src/app/util/__tests__/diagram.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- created with bpmn-js / http://bpmn.io -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="48" height="48" viewBox="167.00001525878906 96 48 48" version="1.1"><g class="djs-group"><g class="djs-element djs-shape selected" data-element-id="StartEvent_1" style="display: block;" transform="translate(173 102)"><g class="djs-visual"><circle cx="18" cy="18" r="18" style="stroke: black; stroke-width: 2px; fill: white; fill-opacity: 0.95;"/></g><rect x="0" y="0" width="36" height="36" class="djs-hit" style="fill: none; stroke-opacity: 0; stroke: white; stroke-width: 15px;"/><rect x="-6" y="-6" width="48" height="48" class="djs-outline" style="fill: none;"/></g></g></svg>

--- a/client/src/app/util/__tests__/generateImageSpec.js
+++ b/client/src/app/util/__tests__/generateImageSpec.js
@@ -1,0 +1,24 @@
+import generateImage from '../generateImage';
+
+var types = [
+  'png',
+  'jpeg'
+];
+
+
+describe('util - generateImage', function() {
+
+  const svg = require('./diagram.svg');
+
+  types.forEach(function(type) {
+
+    it('should export <' + type + '>', function() {
+
+      const image = generateImage(type, svg);
+
+      expect(image).to.exist;
+    });
+
+  });
+
+});

--- a/client/src/app/util/generateImage.js
+++ b/client/src/app/util/generateImage.js
@@ -6,6 +6,7 @@ const ENCODINGS = [
   'image/jpeg'
 ];
 
+const SCALE = 3;
 
 export default function generateImage(type, svg) {
   const encoding = 'image/' + type;
@@ -18,6 +19,11 @@ export default function generateImage(type, svg) {
   }
 
   canvas = document.createElement('canvas');
+
+
+  svg = svg.replace(/width="([^"]+)" height="([^"]+)"/, function(_, widthStr, heightStr) {
+    return `width="${parseInt(widthStr, 10) * SCALE}" height="${parseInt(heightStr, 10) * SCALE}"`;
+  });
 
   canvg(canvas, svg);
 


### PR DESCRIPTION
Ends up with better to read diagrams while ensuring
diagram sizes are still O.K. (4.5MB for a huge diagram).

Closes #486