### PR TITLE
fix(client/dmn-editor): prevent reattaching properties panel

### DIFF
--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -185,6 +185,8 @@ export class DmnEditor extends CachedComponent {
       onSheetsChanged
     } = this.props;
 
+    const previousView = this.getCached().activeView;
+
     const modeler = this.getModeler();
 
     let activeSheet;
@@ -210,7 +212,9 @@ export class DmnEditor extends CachedComponent {
 
     const activeViewer = modeler.getActiveViewer();
 
-    if (activeViewer) {
+    // only attach properties panel if view is switched
+    if (activeViewer &&
+      (!previousView || previousView.element !== activeView.element)) {
       activeViewer.get('propertiesPanel').attachTo(this.propertiesPanelRef.current);
     }
 
@@ -379,7 +383,6 @@ export class DmnEditor extends CachedComponent {
 
     if (!activeView || activeView.element !== element) {
       this.setCached({
-        activeView: view,
         dirty: dirty || this.getModeler().getStackIdx() !== stackIdx
       });
 

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -202,6 +202,71 @@ describe('<DmnEditor>', function() {
   });
 
 
+  describe('#viewsChanged', function() {
+
+    let instance;
+
+    const view1 = {
+      element: { id: 'foo' },
+      type: 'drd'
+    };
+
+    const view2 = {
+      element: { id: 'bar' },
+      type: 'decisionTable'
+    };
+
+    const views = [view1, view2];
+
+    beforeEach(async function() {
+      instance = (await renderEditor(diagramXML)).instance;
+    });
+
+    it('should reattach properties panel on view switch', async function() {
+
+      // given
+      const modeler = await instance.getModeler();
+
+      const propertiesPanel = modeler.getActiveViewer().get('propertiesPanel');
+
+      const propertiesAttachSpy = sinon.spy(propertiesPanel, 'attachTo');
+
+      // when
+      instance.viewsChanged({
+        activeView: view1,
+        views
+      });
+
+      // then
+      expect(propertiesAttachSpy).to.be.called;
+    });
+
+    it('should NOT reattach properties panel when stay on view', async function() {
+
+      // given
+      const modeler = await instance.getModeler();
+
+      instance.viewsChanged({
+        activeView: view1,
+        views
+      });
+
+      const propertiesPanel = modeler.getActiveViewer().get('propertiesPanel');
+
+      const propertiesAttachSpy = sinon.spy(propertiesPanel, 'attachTo');
+
+      // when
+      instance.viewsChanged({
+        activeView: view1,
+        views
+      });
+
+      // then
+      expect(propertiesAttachSpy).not.to.be.called;
+    });
+  });
+
+
   describe('layout', function() {
 
     it('should open properties panel', async function() {
@@ -534,7 +599,8 @@ async function renderEditor(xml, options = {}) {
     onError,
     onImport,
     onLayoutChanged,
-    onModal
+    onModal,
+    onSheetsChanged
   } = options;
 
   const slotFillRoot = await mount(
@@ -548,6 +614,7 @@ async function renderEditor(xml, options = {}) {
         onImport={ onImport || noop }
         onLayoutChanged={ onLayoutChanged || noop }
         onModal={ onModal || noop }
+        onSheetsChanged={ onSheetsChanged || noop }
         cache={ options.cache || new Cache() }
         layout={ layout || {
           minimap: {


### PR DESCRIPTION
Closes #1100

This fixes the input blurring inside the `dmn-js-properties-panel` by preventing reattaching the properties panel on every element change. Therefore it checks whether the new `dmn-js view` is different from the previous one and only reattaching the properties panel when there is an actual view switch.

What is not part of this PR is the fact we should consider refactoring the way the `views.changed` is fired inside `dmn-js` (https://github.com/bpmn-io/dmn-js/issues/388)