### PR TITLE
fix(client): pass dirty tabs as prop to tab links

### DIFF
--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -367,14 +367,14 @@ describe('<App>', function() {
       const {
         activeTab,
         tabs,
-        dirtyTabs
+        unsavedTabs
       } = app.state;
 
       expect(tabs).to.have.length(1);
       expect(tabs).to.eql([ tab ]);
       expect(activeTab).to.eql(tab);
 
-      expect(dirtyTabs).to.have.property(tab.id, true);
+      expect(unsavedTabs).to.have.property(tab.id, true);
     });
 
 
@@ -516,6 +516,10 @@ describe('<App>', function() {
             saveTabSpy = spy(app, 'saveTab');
 
       const tab = await app.createDiagram();
+
+      app.setState({
+        ...app.setDirty(tab)
+      });
 
       dialog.setShowCloseFileDialogResponse('discard');
 
@@ -2135,13 +2139,13 @@ describe('<App>', function() {
     });
 
 
-    it('should be dirty after creating a diagram', async function() {
+    it('should NOT be dirty after creating a diagram', async function() {
 
       // when
       const tab = await app.createDiagram();
 
       // then
-      expect(app.isDirty(tab)).to.be.true;
+      expect(app.isDirty(tab)).to.be.false;
     });
 
 
@@ -2163,17 +2167,13 @@ describe('<App>', function() {
       // given
       const tab = await app.createDiagram();
 
-      console.log(tab);
-
       dialog.setShowSaveFileDialogResponse('diagram_1.bpmn');
 
       // when
       await app.triggerAction('save');
 
       // then
-      setTimeout(() => {
-        expect(app.isDirty(tab)).to.be.false;
-      }, 100);
+      expect(app.isDirty(tab)).to.be.false;
     });
 
   });

--- a/client/src/app/primitives/TabLinks.js
+++ b/client/src/app/primitives/TabLinks.js
@@ -93,12 +93,21 @@ export default class TabLinks extends PureComponent {
     onMoveTab(tab, newIndex);
   }
 
+  isDirty = (tab) => {
+    const {
+      dirtyTabs,
+      unsavedTabs
+    } = this.props;
+
+    return (dirtyTabs && !!dirtyTabs[ tab.id ]) ||
+           (unsavedTabs && !!unsavedTabs[ tab.id ]);
+  }
+
   render() {
 
     const {
       activeTab,
       tabs,
-      isDirty,
       onSelect,
       onContextMenu,
       onClose,
@@ -113,13 +122,15 @@ export default class TabLinks extends PureComponent {
         <div className="tabs-container">
           {
             tabs.map(tab => {
+              const dirty = this.isDirty(tab);
+
               return (
                 <span
                   key={ tab.id }
                   data-tab-id={ tab.id }
                   className={ classNames('tab', {
                     active: tab === activeTab,
-                    dirty: isDirty && isDirty(tab)
+                    dirty
                   }) }
                   onClick={ () => onSelect(tab, event) }
                   onContextMenu={ (event) => (onContextMenu || noop)(tab, event) }

--- a/client/src/app/primitives/__tests__/TabLinksSpec.js
+++ b/client/src/app/primitives/__tests__/TabLinksSpec.js
@@ -11,10 +11,54 @@ import {
   defaultTabs
 } from './mocks';
 
+const [
+  tab1,
+  tab2,
+  tab3,
+  tab4
+] = defaultTabs;
+
 const { spy } = sinon;
 
 
 describe('<TabLinks>', function() {
+
+  describe('dirty state', function() {
+
+    it('should be dirty if dirty OR unsaved', function() {
+
+      // given
+      const {
+        tabLinks
+      } = renderTabLinks({
+        dirtyTabs: {
+          tab1: false,
+          tab2: false,
+          tab3: true,
+          tab4: true
+        },
+        unsavedTabs: {
+          tab1: false,
+          tab2: true,
+          tab3: false,
+          tab4: true
+        }
+      });
+
+      // when
+      const tab1Dirty = tabLinks.isDirty(tab1),
+            tab2Dirty = tabLinks.isDirty(tab2),
+            tab3Dirty = tabLinks.isDirty(tab3),
+            tab4Dirty = tabLinks.isDirty(tab4);
+
+      // then
+      expect(tab1Dirty).to.be.false;
+      expect(tab2Dirty).to.be.true;
+      expect(tab3Dirty).to.be.true;
+      expect(tab4Dirty).to.be.true;
+    });
+
+  });
 
   describe('scrolling', function() {
 
@@ -79,7 +123,9 @@ function renderTabLinks(options = {}) {
     activeTab,
     tabs,
     onMoveTab,
-    onSelect
+    onSelect,
+    dirtyTabs,
+    unsavedTabs
   } = options;
 
   const tree = mount(
@@ -87,7 +133,9 @@ function renderTabLinks(options = {}) {
       activeTab={ activeTab || defaultActiveTab }
       tabs={ tabs || defaultTabs }
       onMoveTab={ onMoveTab || noop }
-      onSelect={ onSelect || noop } />
+      onSelect={ onSelect || noop }
+      dirtyTabs={ dirtyTabs || {} }
+      unsavedTabs={ unsavedTabs || {} } />
   );
 
   const tabLinks = tree.instance();

--- a/client/src/app/primitives/__tests__/mocks/index.js
+++ b/client/src/app/primitives/__tests__/mocks/index.js
@@ -8,5 +8,13 @@ export const defaultTabs = [
   {
     id: 'tab2',
     name: 'tab2.tab'
+  },
+  {
+    id: 'tab3',
+    name: 'tab3.tab'
+  },
+  {
+    id: 'tab4',
+    name: 'tab4.tab'
   }
 ];


### PR DESCRIPTION
* seperate concepts of unsaved and dirty tabs
* pass maps of unsaved and dirty tabs instead of callback
* maps will be re-created whenever there's a relevant change

Closes #1117 