### PR TITLE
fix(client/BpmnEditor): mark tab as dirty after namespace conversion

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -754,24 +754,6 @@ export class App extends PureComponent {
     };
   }
 
-  /**
-   * Handle if tab content is updated.
-   *
-   * @param {String} new tab content
-   */
-  handleTabContentUpdated = (tab) => (newContent) => {
-
-    if (!newContent) {
-      return;
-    }
-
-    this.updateTab(tab, {
-      file: {
-        contents: newContent
-      }
-    });
-  }
-
   tabSaved(tab, newFile) {
 
     const {
@@ -1491,7 +1473,6 @@ export class App extends PureComponent {
                   tab={ activeTab }
                   layout={ layout }
                   onChanged={ this.handleTabChanged(activeTab) }
-                  onContentUpdated={ this.handleTabContentUpdated(activeTab) }
                   onError={ this.handleTabError(activeTab) }
                   onWarning={ this.handleTabWarning(activeTab) }
                   onShown={ this.handleTabShown(activeTab) }

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -861,50 +861,6 @@ describe('<App>', function() {
   });
 
 
-  describe('#handleTabContentUpdated', function() {
-
-    let app, tab;
-
-    beforeEach(async function() {
-
-      app = createApp().app;
-
-      await app.createDiagram('bpmn');
-
-      tab = app.state.activeTab;
-
-    });
-
-    it('should call #updateTab when new content is given', async function() {
-
-      // given
-      const updateSpy = spy(app, 'updateTab');
-
-      // when
-      app.handleTabContentUpdated(tab)({
-        newContent: '< bar/>'
-      });
-
-      // then
-      expect(updateSpy).to.have.been.called;
-    });
-
-
-    it('should NOT call #updateTab when NO new content given', async function() {
-
-      // given
-      const updateSpy = spy(app, 'updateTab');
-
-      // when
-      app.handleTabContentUpdated(tab)();
-
-      // then
-      expect(updateSpy).to.not.have.been.called;
-    });
-
-  });
-
-
   describe('tab loading', function() {
 
     it('should support life-cycle', async function() {

--- a/client/src/app/tabs/MultiSheetTab.js
+++ b/client/src/app/tabs/MultiSheetTab.js
@@ -183,6 +183,12 @@ export class MultiSheetTab extends CachedComponent {
     }
   }
 
+  handleContentUpdated = xml => {
+    this.setCached({
+      lastXML: xml
+    });
+  }
+
   handleContextMenu = (event, context) => {
 
     const {
@@ -305,8 +311,7 @@ export class MultiSheetTab extends CachedComponent {
       id,
       xml,
       layout,
-      onAction,
-      onContentUpdated
+      onAction
     } = this.props;
 
     if (!sheets) {
@@ -332,7 +337,7 @@ export class MultiSheetTab extends CachedComponent {
             onContextMenu={ this.handleContextMenu }
             onAction={ onAction }
             onChanged={ this.handleChanged }
-            onContentUpdated={ onContentUpdated }
+            onContentUpdated={ this.handleContentUpdated }
             onError={ this.handleError }
             onImport={ this.handleImport }
             onLayoutChanged={ this.handleLayoutChanged }

--- a/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
+++ b/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
@@ -198,17 +198,19 @@ describe('<MultiSheetTab>', function() {
     let instance,
         wrapper;
 
+    const INITIAL_XML = '<foo></foo>';
+
     beforeEach(function() {
       const cache = new Cache();
 
       cache.add('editor', {
         cached: {
-          lastXML: 'foo'
+          lastXML: INITIAL_XML
         }
       });
 
       ({ instance, wrapper } = renderTab({
-        xml: 'foo',
+        xml: INITIAL_XML,
         cache,
         providers: [{
           type: 'foo',
@@ -239,7 +241,7 @@ describe('<MultiSheetTab>', function() {
       const { sheets } = instance.getCached();
 
       // make sure editor returns same XML
-      wrapper.find(DefaultEditor).first().instance().setXML('foo');
+      wrapper.find(DefaultEditor).first().instance().setXML(INITIAL_XML);
 
       // when
       await instance.switchSheet(sheets[1]);
@@ -255,13 +257,33 @@ describe('<MultiSheetTab>', function() {
       const { sheets } = instance.getCached();
 
       // make sure editor returns NOT same XML
-      wrapper.find(DefaultEditor).first().instance().setXML('bar');
+      wrapper.find(DefaultEditor).first().instance().setXML(`${INITIAL_XML}-bar`);
 
       // when
       await instance.switchSheet(sheets[1]);
 
       // then
       expect(instance.isDirty()).to.be.true;
+    });
+
+
+    it('should be dirty after new content is given', async function() {
+
+      // when
+      await instance.handleContentUpdated(`${INITIAL_XML}-bar`);
+
+      // then
+      expect(instance.isDirty()).to.be.true;
+    });
+
+
+    it('should not be dirty after same content is given', async function() {
+
+      // when
+      await instance.handleContentUpdated(INITIAL_XML);
+
+      // then
+      expect(instance.isDirty()).to.be.false;
     });
 
   });


### PR DESCRIPTION
We will no longer handle contents change in App component. It's moved to MultiSheetTab now.

Closes #1122
Closes #403 