### PR TITLE
Update to electron@3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+#### General
+
+* `CHORE`: update to `electron@3.1.1`
+
 ## 3.0.0-0
 
 _This is a pre-release of the app ported to an entirely new architecture._

--- a/package-lock.json
+++ b/package-lock.json
@@ -3717,9 +3717,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000929",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000929.tgz",
-      "integrity": "sha512-n2w1gPQSsYyorSVYqPMqbSaz1w7o9ZC8VhOEGI9T5MfGDzp7sbopQxG6GaQmYsaq13Xfx/mkxJUWC1Dz3oZfzw=="
+      "version": "1.0.30000930",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000930.tgz",
+      "integrity": "sha512-KD+pw9DderBLB8CGqBzYyFWpnrPVOEjsjargU/CvkNyg60od3cxSPTcTeMPhxJhDbkQPWvOz5BAyBzNl/St9vg=="
     },
     "canvg-browser": {
       "version": "1.0.0",
@@ -6335,9 +6335,9 @@
       "dev": true
     },
     "electron": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-3.0.14.tgz",
-      "integrity": "sha512-1fG9bE0LzL5QXeEq2MC0dHdVO0pbZOnNlVAIyOyJaCFAu/TjLhxQfWj38bFUEojzuVlaR87tZz0iy2qlVZj3sw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-3.1.1.tgz",
+      "integrity": "sha512-ZamfKY9xp8P6/prtBbhOoOsdCaqyArr7GOmgJuBgWY95ZW5nJVP5aA5lLTh8IeVSW1/IM1KyKYPTrTS/RGercQ==",
       "dev": true,
       "requires": {
         "@types/node": "^8.0.24",
@@ -7287,9 +7287,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.103",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.103.tgz",
-      "integrity": "sha512-tObPqGmY9X8MUM8i3MEimYmbnLLf05/QV5gPlkR8MQ3Uj8G8B2govE1U4cQcBYtv3ymck9Y8cIOu4waoiykMZQ=="
+      "version": "1.3.106",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.106.tgz",
+      "integrity": "sha512-eXX45p4q9CRxG0G8D3ZBZYSdN3DnrcZfrFvt6VUr1u7aKITEtRY/xwWzJ/UZcWXa7DMqPu/pYwuZ6Nm+bl0GmA=="
     },
     "elliptic": {
       "version": "6.4.1",
@@ -17105,9 +17105,9 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stream-browserify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
-      "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "decompress": "^4.2.0",
     "del": "^3.0.0",
     "del-cli": "^1.1.0",
-    "electron": "^3.0.14",
+    "electron": "^3.1.1",
     "electron-builder": "~20.28.4",
     "electron-publisher-s3": "^20.17.2",
     "electron-reloader": "^0.2.0",


### PR DESCRIPTION
It could make sense to update to the latest `electron@3.x`, as we are introducing breaking changes anyway. Needs testing on MacOS and Windows.