### PR TITLE
Serve via file protocol in dev mode, too

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 app/node_modules/
 app/public/
 client/node_modules/
+client/build/
 coverage/
 dist/
 docs/

--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -331,7 +331,7 @@ app.createEditorWindow = function() {
   var url = 'file://' + path.resolve(__dirname + '/../public/index.html');
 
   if (app.developmentMode) {
-    url = 'http://localhost:3000';
+    url = 'file://' + path.resolve(__dirname + '/../../client/build/index.html');
   }
 
   mainWindow.loadURL(url);

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -71,13 +71,7 @@ module.exports = {
     ])
   ],
   // don't bundle shims for node globals
-  node: {
-    dgram: 'empty',
-    fs: 'empty',
-    net: 'empty',
-    tls: 'empty',
-    child_process: 'empty'
-  },
+  node: false,
   devServer: {
     writeToDisk: true
   },

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -79,9 +79,7 @@ module.exports = {
     child_process: 'empty'
   },
   devServer: {
-    headers: {
-      'Access-Control-Allow-Origin': '*'
-    }
+    writeToDisk: true
   },
   devtool: DEV ? 'cheap-module-eval-source-map' : 'source-map'
 };


### PR DESCRIPTION
Serve files in DEV mode via the `file://` protocol, too.

Cf. https://github.com/camunda/camunda-modeler/commit/f9edd19c31c28bdc7f6b6dc8f1e9474fb95a8ec1 for rationale.