### PR TITLE
chore(coverage): upload combined report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ jobs:
       language: node_js
       script:
       - COVERAGE=1 npm run all -- --x64 --no-compress
-      - npx codecov -f client/coverage/lcov.info -F client
-      - npx codecov -f coverage/lcov.info -F app
+      - npx codecov
     - stage: "distro [windows+linux]"
       os: linux
       services: docker


### PR DESCRIPTION
This is a follow up to https://github.com/camunda/camunda-modeler/pull/1140 that ensures all coverage reports are correctly processed.

```
It seems like there is no way to split apart
client and app components in the coverage report.

Does not make too much of a difference anyway °_°.
```