### PR TITLE
Properly wire all decision table keyboards shortcuts

### DIFF
--- a/client/src/app/tabs/dmn/getDmnEditMenu.js
+++ b/client/src/app/tabs/dmn/getDmnEditMenu.js
@@ -8,7 +8,8 @@ import {
 } from '../getEditMenu';
 
 function getDecisionTableEntries({
-  hasSelection
+  hasSelection,
+  inputActive
 }) {
   return [
     [
@@ -59,6 +60,21 @@ function getDecisionTableEntries({
         label: 'Remove Clause',
         enabled: hasSelection,
         action: 'removeClause'
+      }
+    ], [
+      {
+        label: 'Select Cell Above',
+        accelerator: 'Shift + Enter',
+        enabled: hasSelection,
+        action: 'selectCellAbove',
+        role: inputActive && 'selectCellAbove'
+      },
+      {
+        label: 'Select Cell Below',
+        accelerator: 'Enter',
+        enabled: hasSelection,
+        action: 'selectCellBelow',
+        role: inputActive && 'selectCellBelow'
       }
     ]
   ];

--- a/client/src/app/tabs/dmn/modeler/DmnModeler.js
+++ b/client/src/app/tabs/dmn/modeler/DmnModeler.js
@@ -12,6 +12,7 @@ import decisionTableAdapterModule from 'dmn-js-properties-panel/lib/adapter/deci
 import literalExpressionAdapterModule from 'dmn-js-properties-panel/lib/adapter/literal-expression';
 
 import propertiesPanelKeyboardBindingsModule from '../../bpmn/modeler/features/properties-panel-keyboard-bindings';
+import decisionTableKeyboardBindingsModule from './features/decision-table-keyboard-bindings';
 
 import camundaModdleDescriptor from 'camunda-dmn-moddle/resources/camunda';
 
@@ -52,6 +53,7 @@ export default class CamundaDmnModeler extends DmnModeler {
         propertiesPanelModule,
         propertiesProviderModule,
         decisionTableAdapterModule,
+        decisionTableKeyboardBindingsModule,
         propertiesPanelKeyboardBindingsModule
       ]),
       literalExpression: mergeModules(literalExpression, [

--- a/client/src/app/tabs/dmn/modeler/features/decision-table-keyboard-bindings/DecisionTableKeyboardBindings.js
+++ b/client/src/app/tabs/dmn/modeler/features/decision-table-keyboard-bindings/DecisionTableKeyboardBindings.js
@@ -1,0 +1,90 @@
+import {
+  isCmd as isCommandOrControl,
+  isKey,
+  isShift
+} from 'diagram-js/lib/features/keyboard/KeyboardUtil';
+
+import {
+  findSelectableAncestor
+} from 'dmn-js-decision-table/lib/features/cell-selection/CellSelectionUtil';
+
+export default class DecisionTableKeyboardBindings {
+  constructor(decisionTable, commandStack, editorActions, eventBus) {
+    this._decisionTable = decisionTable;
+    this._commandStack = commandStack;
+    this._editorActions = editorActions;
+    this._eventBus = eventBus;
+
+    eventBus.on('attach', this._addEventListeners);
+
+    eventBus.on('detach', this._removeEventListeners);
+  }
+
+    _addEventListeners = () => {
+      const container = this._getContainer();
+
+      container.addEventListener('keydown', this.handleKeydown, true);
+    }
+
+    _removeEventListeners = () => {
+      const container = this._getContainer();
+
+      container.removeEventListener('keydown', this.handleKeydown);
+    }
+
+    handleKeydown = event => {
+      const commandStack = this._commandStack;
+      const editorActions = this._editorActions;
+
+      if (isUndo(event)) {
+        commandStack.canUndo() && commandStack.undo();
+
+        event.preventDefault();
+      }
+
+      if (isRedo(event)) {
+        commandStack.canRedo() && commandStack.redo();
+
+        event.preventDefault();
+      }
+
+      if (isSelectCell(event)) {
+        if (!this._hasSelectableAncestor(event.target)) {
+          return;
+        }
+
+        const cmd = isShift(event) ? 'selectCellAbove' : 'selectCellBelow';
+
+        editorActions.trigger(cmd);
+
+        event.preventDefault();
+        event.stopPropagation();
+
+      }
+
+    }
+
+    _getContainer() {
+      return this._decisionTable._container;
+    }
+
+    _hasSelectableAncestor(element) {
+      return findSelectableAncestor(element);
+    }
+}
+
+DecisionTableKeyboardBindings.$inject = [ 'decisionTable', 'commandStack', 'editorActions', 'eventBus' ];
+
+// helpers //////////
+
+function isUndo(event) {
+  return isCommandOrControl(event) && !isShift(event) && isKey(['z', 'Z'], event);
+}
+
+function isRedo(event) {
+  return isCommandOrControl(event) && (isKey(['y', 'Y'], event) || (isKey(['z', 'Z'], event) && isShift(event)));
+}
+
+function isSelectCell(event) {
+  return !isCommandOrControl(event) && isKey(['Enter'], event);
+}

--- a/client/src/app/tabs/dmn/modeler/features/decision-table-keyboard-bindings/__tests__/DecisionTableKeyboardBindingsSpec.js
+++ b/client/src/app/tabs/dmn/modeler/features/decision-table-keyboard-bindings/__tests__/DecisionTableKeyboardBindingsSpec.js
@@ -1,0 +1,207 @@
+/* global sinon */
+
+import Modeler from 'test/mocks/dmn-js/Modeler';
+
+import {
+  assign,
+  isString
+} from 'min-dash';
+
+import DecisionTableKeyboardBindings from '../DecisionTableKeyboardBindings';
+
+const spy = sinon.spy;
+
+describe('DecisionTableKeyboardBindings', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = document.createElement('div');
+  });
+
+  afterEach(function() {
+    sinon.restore();
+  });
+
+
+  it('should undo', function() {
+
+    // given
+    const undoSpy = spy();
+
+    const modeler = createModeler({
+      commandStack: {
+        canUndo: () => true,
+        undo: undoSpy
+      },
+      eventBus: {
+        on: (_, callback) => callback()
+      },
+      decisionTable: {
+        _container: container
+      }
+    });
+
+    const activeViewer = modeler.getActiveViewer();
+
+    const decisionTableKeyboardBindings = activeViewer.get('decisionTable').decisionTableKeyboardBindings;
+
+    const event = createKeyEvent('Z', { ctrlKey: true });
+
+    // when
+    decisionTableKeyboardBindings.handleKeydown(event);
+
+    // then
+    expect(undoSpy).to.have.been.called;
+  });
+
+
+  it('should redo', function() {
+
+    // given
+    const redoSpy = spy();
+
+    const modeler = createModeler({
+      commandStack: {
+        canRedo: () => true,
+        redo: redoSpy
+      },
+      eventBus: {
+        on: (_, callback) => callback()
+      },
+      decisionTable: {
+        _container: container
+      }
+    });
+
+    const activeViewer = modeler.getActiveViewer();
+
+    const decisionTableKeyboardBindings = activeViewer.get('decisionTable').decisionTableKeyboardBindings;
+
+    const event = createKeyEvent('Y', { ctrlKey: true });
+
+    // when
+    decisionTableKeyboardBindings.handleKeydown(event);
+
+    // then
+    expect(redoSpy).to.have.been.called;
+  });
+
+
+  it('should handle selectCellBelow', function() {
+
+    // given
+    const triggerSpy = spy();
+
+    const modeler = createModeler({
+      editorActions: {
+        trigger: triggerSpy,
+      },
+      eventBus: {
+        on: (_, callback) => callback()
+      },
+      decisionTable: {
+        _container: container
+      }
+    });
+
+    const activeViewer = modeler.getActiveViewer();
+
+    const decisionTableKeyboardBindings = activeViewer.get('decisionTable').decisionTableKeyboardBindings;
+
+    const selectableAncestorSpy =
+      sinon.stub(decisionTableKeyboardBindings, '_hasSelectableAncestor').returns(true);
+
+    const event = createKeyEvent('Enter', { ctrlKey: false });
+
+    // when
+    decisionTableKeyboardBindings.handleKeydown(event);
+
+    // then
+    expect(selectableAncestorSpy).to.have.been.called;
+    expect(triggerSpy).to.have.been.calledWith('selectCellBelow');
+
+  });
+
+
+  it('should handle selectCellAbove', function() {
+
+    // given
+    const triggerSpy = spy();
+
+    const modeler = createModeler({
+      editorActions: {
+        trigger: triggerSpy,
+      },
+      eventBus: {
+        on: (_, callback) => callback()
+      },
+      decisionTable: {
+        _container: container
+      }
+    });
+
+    const activeViewer = modeler.getActiveViewer();
+
+    const decisionTableKeyboardBindings = activeViewer.get('decisionTable').decisionTableKeyboardBindings;
+
+    const selectableAncestorSpy =
+      sinon.stub(decisionTableKeyboardBindings, '_hasSelectableAncestor').returns(true);
+
+    const event = createKeyEvent('Enter', {
+      ctrlKey: false,
+      shiftKey: true
+    });
+
+    // when
+    decisionTableKeyboardBindings.handleKeydown(event);
+
+    // then
+    expect(selectableAncestorSpy).to.have.been.called;
+    expect(triggerSpy).to.have.been.calledWith('selectCellAbove');
+
+  });
+
+});
+
+// helpers //////
+
+/**
+ * Create and return a modeler instance with a module that was instanciated with
+ * dependencies.
+ *
+ * @param {Object} Module - Module constructor.
+ * @param {Object} dependencies - Dependencies.
+ *
+ * @returns {Object}
+ */
+function createModeler(dependencies) {
+  return new Modeler({
+    ...dependencies,
+    decisionTable: {
+      ...dependencies.decisionTable,
+      decisionTableKeyboardBindings: new DecisionTableKeyboardBindings(
+        ...DecisionTableKeyboardBindings.$inject.map(name => dependencies[ name ] || {})
+      )
+    }
+  });
+}
+
+/**
+ * Create a fake key event for testing purposes.
+ *
+ * @param {String|Number} key the key or keyCode/charCode
+ * @param {Object} [attrs]
+ *
+ * @return {Event}
+ */
+function createKeyEvent(key, attrs) {
+  var event = document.createEvent('Events') || new document.defaultView.CustomEvent('keyEvent');
+
+  // init and mark as bubbles / cancelable
+  event.initEvent('keydown', false, true);
+
+  var keyAttrs = isString(key) ? { key: key } : { keyCode: key, which: key };
+
+  return assign(event, keyAttrs, attrs || {});
+}

--- a/client/src/app/tabs/dmn/modeler/features/decision-table-keyboard-bindings/index.js
+++ b/client/src/app/tabs/dmn/modeler/features/decision-table-keyboard-bindings/index.js
@@ -1,0 +1,6 @@
+import DecisionTableKeyboardBindings from './DecisionTableKeyboardBindings';
+
+export default {
+  __init__: [ 'decisionTableKeyboardBindings' ],
+  decisionTableKeyboardBindings: [ 'type', DecisionTableKeyboardBindings ]
+};


### PR DESCRIPTION
Closes #1061 

Following keyboard bindings were already being implemented, they were not integrated inside the dmn-js [Keyboard feature](https://github.com/bpmn-io/dmn-js/blob/master/packages/dmn-js-decision-table/src/features/keyboard/Keyboard.js):

- TAB / SHIFT + TAB navigate cells (horizontally)
- CTRL+ENTER adds a new line in the cell

Following keyboard bindings are integrated by a39223f:

- Undo / Redo works as expected, via command stack operation
- ENTER / SHIFT + ENTER navigate cells (vertically)

62f4c1a also restores the edit menu entries for `selectCellBelow` and `selectCellAbove` as it was before in `camunda-modeler` version `v2.2.4`.

During the integration, I encountered a problem regarding missing keyboard bindings inside the dmn diagram editor. I opened an according issue (#1146). 

**Note for reviewer:** We will have to recheck the keyboard bindings against windows (@pinussilvestrus) and linux (@barmac) before merging.