### PR TITLE
Add moveCanvas and moveSelection editMenu actions for drd

### DIFF
--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -20,6 +20,15 @@ import { SlotFillRoot } from 'src/app/slot-fill';
 import diagramXML from './diagram.bpmn';
 import activitiXML from './activiti.bpmn';
 
+import {
+  getCanvasEntries,
+  getCopyCutPasteEntries,
+  getDiagramFindEntries,
+  getSelectionEntries,
+  getToolEntries,
+  getUndoRedoEntries
+} from '../../getEditMenu';
+
 const { spy } = sinon;
 
 
@@ -276,6 +285,143 @@ describe('<BpmnEditor>', function() {
 
       // when
       instance.handleChanged();
+    });
+
+
+    describe('edit menu', function() {
+
+      const includesEntryDeeply = (editMenu, label) => {
+        return editMenu.filter(entries => {
+          return entries.some(e => e.label === label);
+        }).length > 0;
+      };
+
+      it('should provide und/redo entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          const editMenuEntries = getUndoRedoEntries(state);
+
+          // then
+          expect(state.editMenu).to.deep.include(editMenuEntries);
+
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
+
+      it('should provide copy/paste entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          const editMenuEntries = getCopyCutPasteEntries(state);
+
+          // then
+          expect(state.editMenu).to.deep.include(editMenuEntries);
+
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
+
+      it('should provide tool entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          const editMenuEntries = getToolEntries(state);
+
+          // then
+          expect(state.editMenu).to.deep.include(editMenuEntries);
+
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
+
+      it('should provide find entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          const editMenuEntries = getDiagramFindEntries(state);
+
+          // then
+          expect(state.editMenu).to.deep.include(editMenuEntries);
+
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
+
+      it('should provide selection + canvas entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          const editMenuEntries = [
+            ...getCanvasEntries(state),
+            ...getSelectionEntries(state)
+          ];
+
+          // then
+          expect(state.editMenu).to.deep.include(editMenuEntries);
+
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
+
+      it('should provide align/distribute entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          // then
+          expect(includesEntryDeeply(state.editMenu, 'Align Elements')).to.be.true;
+          expect(includesEntryDeeply(state.editMenu, 'Distribute Elements')).to.be.true;
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
     });
 
   });

--- a/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
+++ b/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
@@ -15,6 +15,15 @@ import {
 
 import CmmnModeler from 'test/mocks/cmmn-js/Modeler';
 
+import {
+  getCanvasEntries,
+  getCopyCutPasteEntries,
+  getDiagramFindEntries,
+  getSelectionEntries,
+  getToolEntries,
+  getUndoRedoEntries
+} from '../../getEditMenu';
+
 import { SlotFillRoot } from 'src/app/slot-fill';
 
 import diagramXML from './diagram.cmmn';
@@ -256,6 +265,117 @@ describe('<CmmnEditor>', function() {
 
       // when
       instance.handleChanged();
+    });
+
+    describe('edit menu', function() {
+
+      it('should provide und/redo entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          const editMenuEntries = getUndoRedoEntries(state);
+
+          // then
+          expect(state.editMenu).to.deep.include(editMenuEntries);
+
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
+
+      it('should provide copy/paste entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          const editMenuEntries = getCopyCutPasteEntries(state);
+
+          // then
+          expect(state.editMenu).to.deep.include(editMenuEntries);
+
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
+
+      it('should provide tool entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          const editMenuEntries = getToolEntries(state);
+
+          // then
+          expect(state.editMenu).to.deep.include(editMenuEntries);
+
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
+
+      it('should provide find entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          const editMenuEntries = getDiagramFindEntries(state);
+
+          // then
+          expect(state.editMenu).to.deep.include(editMenuEntries);
+
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
+
+      it('should provide selection + canvas entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          const editMenuEntries = [
+            ...getCanvasEntries(state),
+            ...getSelectionEntries(state)
+          ];
+
+          // then
+          expect(state.editMenu).to.deep.include(editMenuEntries);
+
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
     });
 
   });

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -15,6 +15,14 @@ import {
 
 import DmnModeler from 'test/mocks/dmn-js/Modeler';
 
+import {
+  getCanvasEntries,
+  getCopyCutPasteEntries,
+  getSelectionEntries,
+  getToolEntries,
+  getUndoRedoEntries
+} from '../../getEditMenu';
+
 import { SlotFillRoot } from 'src/app/slot-fill';
 
 import diagramXML from './diagram.dmn';
@@ -247,6 +255,197 @@ describe('<DmnEditor>', function() {
 
       // when
       instance.handleChanged();
+    });
+
+
+    describe('edit menu', function() {
+
+      it('should provide und/redo entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          const editMenuEntries = getUndoRedoEntries(state);
+
+          // then
+          expect(state.editMenu).to.deep.include(editMenuEntries);
+
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
+
+      it('should provide copy/paste entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          const editMenuEntries = getCopyCutPasteEntries(state);
+
+          // then
+          expect(state.editMenu).to.deep.include(editMenuEntries);
+
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
+
+      it('should provide selection entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          const editMenuEntries = getSelectionEntries(state);
+
+          // then
+          expect(state.editMenu).to.deep.include(editMenuEntries);
+
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
+
+      describe('drd', function() {
+
+        it('should provide tool entries', async function() {
+
+          // given
+          const changedSpy = (state) => {
+
+            const editMenuEntries = getToolEntries(state);
+
+            // then
+            expect(state.editMenu).to.deep.include(editMenuEntries);
+
+          };
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          // when
+          instance.handleChanged();
+        });
+
+
+        it('should provide canvas entries', async function() {
+
+          // given
+          const changedSpy = (state) => {
+
+            const editMenuEntries = getCanvasEntries(state);
+
+            // then
+            expect(state.editMenu).to.deep.include(editMenuEntries);
+
+          };
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          // when
+          instance.handleChanged();
+        });
+      });
+
+
+      describe('decision table', function() {
+
+        const includesEntryDeeply = (editMenu, label) => {
+          return editMenu.filter(entries => {
+            return entries.some(e => e.label === label);
+          }).length > 0;
+        };
+
+        it('should provide rule entries', async function() {
+
+          // given
+          const changedSpy = (state) => {
+
+            // then
+            expect(includesEntryDeeply(state.editMenu, 'Add Rule')).to.be.true;
+            expect(includesEntryDeeply(state.editMenu, 'Remove Clause')).to.be.true;
+
+          };
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          const modeler = instance.getModeler();
+          modeler.open({ type: 'decisionTable' });
+
+          // when
+          instance.handleChanged();
+        });
+
+
+        it('should provide clause entries', async function() {
+
+          // given
+          const changedSpy = (state) => {
+
+            // then
+            expect(includesEntryDeeply(state.editMenu, 'Add Clause')).to.be.true;
+            expect(includesEntryDeeply(state.editMenu, 'Remove Clause')).to.be.true;
+
+          };
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          const modeler = instance.getModeler();
+          modeler.open({ type: 'decisionTable' });
+
+          // when
+          instance.handleChanged();
+        });
+
+
+        it('should provide select cell entries', async function() {
+
+          // given
+          const changedSpy = (state) => {
+
+            // then
+            expect(includesEntryDeeply(state.editMenu, 'Select Cell Above')).to.be.true;
+            expect(includesEntryDeeply(state.editMenu, 'Select Cell Below')).to.be.true;
+
+          };
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          const modeler = instance.getModeler();
+          modeler.open({ type: 'decisionTable' });
+
+          // when
+          instance.handleChanged();
+        });
+
+      });
+
     });
 
   });

--- a/client/src/app/tabs/dmn/getDmnEditMenu.js
+++ b/client/src/app/tabs/dmn/getDmnEditMenu.js
@@ -1,5 +1,6 @@
 
 import {
+  getCanvasEntries,
   getCopyCutPasteEntries,
   getDefaultCopyCutPasteEntries,
   getSelectionEntries,
@@ -91,6 +92,7 @@ export function getDmnDrdEditMenu(state) {
     getUndoRedoEntries(state),
     copyCutPasteEntries,
     getToolEntries(state),
+    getCanvasEntries(state),
     getSelectionEntries(state)
   ];
 }

--- a/client/test/mocks/dmn-js/Modeler.js
+++ b/client/test/mocks/dmn-js/Modeler.js
@@ -60,6 +60,9 @@ class Viewer {
       selection: {
         get() {
           return [];
+        },
+        hasSelection() {
+          return false;
         }
       },
       sheet: {


### PR DESCRIPTION
Closes #1146 

- Add missing editMenu entries for `moveCanvas` and `moveSelection` for DMN drd tab
- Add test coverage for edit menu entries for `DmnEditor`, `CmmnEditor`, `BpmnEditor`

Note #1148 also adds editMenu entries for the `DmnEditor`. Therefore it might be a good idea adding some test coverage there after this pr is merged.