### PR TITLE
fix(app): re-activate app on <open-file>

### DIFF
--- a/app/lib/platform/mac-os/index.js
+++ b/app/lib/platform/mac-os/index.js
@@ -75,6 +75,12 @@ function MacOSPlatform(app) {
   function checkAppWindow() {
     if (!app.mainWindow) {
       app.createEditorWindow();
+    } else {
+      if (app.mainWindow.isMinimized()) {
+        app.mainWindow.restore();
+      }
+
+      app.mainWindow.focus();
     }
   }
 

--- a/app/lib/platform/mac-os/index.js
+++ b/app/lib/platform/mac-os/index.js
@@ -85,7 +85,7 @@ function MacOSPlatform(app) {
   app.on('ready', function() {
     app.on('activate', checkAppWindow);
     app.on('app:parse-cmd', checkAppWindow);
-    app.on('app:open-file', checkAppWindow);
+    app.on('open-file', checkAppWindow);
   });
 
 }


### PR DESCRIPTION
This should fix a regression introduced in https://github.com/camunda/camunda-modeler/commit/64431481b6f6935e09d5052ff176f7bc5c9f4d12.

The event `app:open-file` is no longer emitted.