### PR TITLE
1187 diagram discovery

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1560,7 +1560,11 @@ export class App extends PureComponent {
                 onMoveTab={ this.moveTab }
                 onContextMenu={ this.openTabLinksMenu }
                 onClose={ this.handleCloseTab }
-                onCreate={ this.composeAction('create-bpmn-diagram') }
+                placeholder={ {
+                  label: '+',
+                  title: 'New BPMN diagram',
+                  onClick: this.composeAction('create-bpmn-diagram')
+                } }
                 draggable
                 scrollable
               />

--- a/client/src/app/primitives/TabLinks.js
+++ b/client/src/app/primitives/TabLinks.js
@@ -122,7 +122,7 @@ export default class TabLinks extends PureComponent {
       onSelect,
       onContextMenu,
       onClose,
-      onCreate,
+      placeholder,
       className
     } = this.props;
 
@@ -167,14 +167,15 @@ export default class TabLinks extends PureComponent {
           }
 
           {
-            onCreate && <span
-              key="empty-tab"
-              className={ classNames('tab ignore', {
+            placeholder && <span
+              key="__placeholder"
+              className={ classNames('tab placeholder ignore', {
                 active: tabs.length === 0
               }) }
-              onClick={ () => onCreate() }
+              onClick={ placeholder.onClick }
+              title={ placeholder.title }
             >
-              +
+              { placeholder.label }
             </span>
           }
         </div>

--- a/client/src/app/primitives/TabLinks.js
+++ b/client/src/app/primitives/TabLinks.js
@@ -139,6 +139,7 @@ export default class TabLinks extends PureComponent {
                 <span
                   key={ tab.id }
                   data-tab-id={ tab.id }
+                  title={ tab.title }
                   className={ classNames('tab', {
                     active: tab === activeTab,
                     dirty
@@ -151,6 +152,7 @@ export default class TabLinks extends PureComponent {
                   {
                     onClose && <span
                       className="close"
+                      title="Close Tab"
                       onClick={ e => {
                         e.preventDefault();
                         e.stopPropagation();

--- a/client/src/app/primitives/__tests__/TabLinksSpec.js
+++ b/client/src/app/primitives/__tests__/TabLinksSpec.js
@@ -61,6 +61,24 @@ describe('<TabLinks>', function() {
   });
 
 
+  describe('title', function() {
+
+    it('should display tab title', function() {
+
+      const {
+        tree
+      } = renderTabLinks();
+
+      // when
+      const node = tree.find('.tab[data-tab-id="tab1"]').getDOMNode();
+
+      // then
+      expect(node.title).to.eql(tab1.title);
+    });
+
+  });
+
+
   describe('scrolling', function() {
 
     it('should handle scroll', function() {

--- a/client/src/app/primitives/__tests__/TabLinksSpec.js
+++ b/client/src/app/primitives/__tests__/TabLinksSpec.js
@@ -79,6 +79,52 @@ describe('<TabLinks>', function() {
   });
 
 
+  describe('placeholder', function() {
+
+    it('should display empty tab handle', function() {
+
+      const clickSpy = spy();
+
+      const placeholder = {
+        onClick: clickSpy,
+        title: 'CREATE STUFF',
+        label: '+'
+      };
+
+      const {
+        tree
+      } = renderTabLinks({ placeholder });
+
+      // when
+      const tab = tree.find('.tab.placeholder');
+
+      // then
+      expect(tab.exists()).to.be.true;
+
+      // and when
+      tab.simulate('click');
+
+      // then
+      expect(clickSpy).to.have.been.calledOnce;
+    });
+
+
+    it('should hide empty tab handle', function() {
+
+      const {
+        tree
+      } = renderTabLinks();
+
+      // when
+      const tab = tree.find('.tab.placeholder');
+
+      // then
+      expect(tab.exists()).to.be.false;
+    });
+
+  });
+
+
   describe('scrolling', function() {
 
     it('should handle scroll', function() {
@@ -168,7 +214,8 @@ function renderTabLinks(options = {}) {
     onMoveTab,
     onSelect,
     dirtyTabs,
-    unsavedTabs
+    unsavedTabs,
+    placeholder
   } = options;
 
   const tree = mount(
@@ -178,7 +225,8 @@ function renderTabLinks(options = {}) {
       onMoveTab={ onMoveTab || noop }
       onSelect={ onSelect || noop }
       dirtyTabs={ dirtyTabs || {} }
-      unsavedTabs={ unsavedTabs || {} } />
+      unsavedTabs={ unsavedTabs || {} }
+      placeholder={ placeholder } />
   );
 
   const tabLinks = tree.instance();

--- a/client/src/app/primitives/__tests__/mocks/index.js
+++ b/client/src/app/primitives/__tests__/mocks/index.js
@@ -1,6 +1,7 @@
 export const defaultActiveTab = {
   id: 'tab1',
-  name: 'tab1.tab'
+  name: 'tab1.tab',
+  title: 'tab1'
 };
 
 export const defaultTabs = [

--- a/client/src/remote/Backend.js
+++ b/client/src/remote/Backend.js
@@ -8,9 +8,9 @@ const ids = new Ids();
  */
 export default class Backend {
 
-  constructor(ipcRenderer, process) {
+  constructor(ipcRenderer, platform) {
     this.ipcRenderer = ipcRenderer;
-    this.process = process;
+    this.platform = platform;
   }
 
   /**
@@ -79,7 +79,6 @@ export default class Backend {
   }
 
   getPlatform() {
-    return this.process.platform;
+    return this.platform;
   }
-
 }

--- a/client/src/remote/__tests__/BackendSpec.js
+++ b/client/src/remote/__tests__/BackendSpec.js
@@ -1,21 +1,18 @@
 import Backend from '../Backend';
 
 import {
-  IpcRenderer,
-  Process
+  IpcRenderer
 } from './mocks';
 
 describe('backend', function() {
 
   let backend,
-      ipcRenderer,
-      process;
+      ipcRenderer;
 
   beforeEach(function() {
     ipcRenderer = new IpcRenderer();
-    process = new Process();
 
-    backend = new Backend(ipcRenderer, process);
+    backend = new Backend(ipcRenderer, 'foo');
   });
 
 
@@ -48,16 +45,13 @@ describe('backend', function() {
   });
 
 
-  it('should return platform darwin', function() {
-
-    // given
-    process.setPlatform('darwin');
+  it('should return platform <foo>', function() {
 
     // when
     const platform = backend.getPlatform();
 
     // then
-    expect(platform).to.equal('darwin');
+    expect(platform).to.equal('foo');
   });
 
 });

--- a/client/src/remote/__tests__/mocks/index.js
+++ b/client/src/remote/__tests__/mocks/index.js
@@ -25,13 +25,3 @@ export class IpcRenderer {
     this.listener = callback;
   }
 }
-
-export class Process {
-  constructor() {
-    this.platform = null;
-  }
-
-  setPlatform(platform) {
-    this.platform = platform;
-  }
-}

--- a/client/src/remote/index.js
+++ b/client/src/remote/index.js
@@ -13,11 +13,11 @@ const {
   process
 } = electronRequire('remote');
 
+const platform = process.platform;
+
 export const ipcRenderer = electronRequire('ipcRenderer');
 
-export { process };
-
-export const backend = new Backend(ipcRenderer, process);
+export const backend = new Backend(ipcRenderer, platform);
 
 export const fileSystem = new FileSystem(backend);
 


### PR DESCRIPTION
Closes #1187

---

__Note to Reviewer:__ This deliberately excludes the convenience feature of representing the user home as `~` on Mac OS and Linux. We must internally represent files as absolut paths but display them to the user in a localized manner, something that we cannot simply / quickly implement right now.