### PR TITLE
chore(client): bump dmn-js version

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3564,24 +3564,24 @@
       "dev": true
     },
     "dmn-js": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/dmn-js/-/dmn-js-6.2.1.tgz",
-      "integrity": "sha512-ZoQyVPk5dpyo2kJ9NxknjLNS/k1wuyvWfXwaIosnZ+jzfr+sP4YcCkLvzTD+y+d0TN2FwFz4Abt0Kp7bCAHJAQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/dmn-js/-/dmn-js-6.2.2.tgz",
+      "integrity": "sha512-mDA+Rbtmpb4NXWYtzBseW9+/OB/3RtwVhKSyU+jJwLEZ+02Tlg6vtlVXRBDL7c93kwZcEPpTx/y78N9DVCxYnw==",
       "requires": {
-        "dmn-js-decision-table": "^6.2.1",
-        "dmn-js-drd": "^6.2.1",
-        "dmn-js-literal-expression": "^6.2.1",
-        "dmn-js-shared": "^6.2.1"
+        "dmn-js-decision-table": "^6.2.2",
+        "dmn-js-drd": "^6.2.2",
+        "dmn-js-literal-expression": "^6.2.2",
+        "dmn-js-shared": "^6.2.2"
       }
     },
     "dmn-js-decision-table": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/dmn-js-decision-table/-/dmn-js-decision-table-6.2.1.tgz",
-      "integrity": "sha512-wU+8ijX0S34r1EdLd7TidOHBsbGZz1SLSosJ2wGZQvrgYN3Jm1ubf+A1ETWDGsd3RFeuTuTGjuYpBmdrltr0YA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/dmn-js-decision-table/-/dmn-js-decision-table-6.2.2.tgz",
+      "integrity": "sha512-i4HZEAcI9yDA/mK8K9tfaME8rRbmfoGxdUFkY//m9bkdPOm2BMccorG1SgT35GfC3nLRpCSx0HlhCqgZ4+qJ/Q==",
       "requires": {
         "css.escape": "^1.5.1",
         "diagram-js": "^3.1.3",
-        "dmn-js-shared": "^6.2.1",
+        "dmn-js-shared": "^6.2.2",
         "escape-html": "^1.0.3",
         "inferno": "~5.0.5",
         "min-dash": "^3.0.0",
@@ -3591,13 +3591,13 @@
       }
     },
     "dmn-js-drd": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/dmn-js-drd/-/dmn-js-drd-6.2.1.tgz",
-      "integrity": "sha512-zjrNBgz6o9wI9TpS+3vnOx3No15m/MVnDpx7FRP5dm9TAvH/1sRz1rbh7vX+5FPky0zz8eT/ntzKVQZq7hQ7HQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/dmn-js-drd/-/dmn-js-drd-6.2.2.tgz",
+      "integrity": "sha512-vceMx/n6gLk2BNo4ytPLaSj4KNnfQsTxlLVT9JJBzCTaBnz1WXUi7wGz7fmhj6A+8OjcC7F5spx7ZOFlTF0U3Q==",
       "requires": {
         "diagram-js": "^3.1.3",
         "diagram-js-direct-editing": "^1.4.0",
-        "dmn-js-shared": "^6.2.1",
+        "dmn-js-shared": "^6.2.2",
         "inherits": "^2.0.1",
         "min-dash": "^3.0.0",
         "min-dom": "^3.1.1",
@@ -3605,12 +3605,12 @@
       }
     },
     "dmn-js-literal-expression": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/dmn-js-literal-expression/-/dmn-js-literal-expression-6.2.1.tgz",
-      "integrity": "sha512-8UA+NT0h9R4EuoUQ2RgEfSYAgwp++H5G9s8el92oGykMW7WPxzT410IJ8MRZtibLa9DPG9/aa2gLoV9DTHF4gw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/dmn-js-literal-expression/-/dmn-js-literal-expression-6.2.2.tgz",
+      "integrity": "sha512-KTrtW60g6v3h8cgF40j3NhOV2RRjebTSy+4jttoySHHUfyrH9ZPlDFljwEnpTost+b0jKr+LbmezC2pOiK8U4w==",
       "requires": {
         "diagram-js": "^3.1.3",
-        "dmn-js-shared": "^6.2.1",
+        "dmn-js-shared": "^6.2.2",
         "escape-html": "^1.0.3",
         "inferno": "~5.0.5",
         "min-dash": "^3.0.0",
@@ -3631,9 +3631,9 @@
       }
     },
     "dmn-js-shared": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/dmn-js-shared/-/dmn-js-shared-6.2.1.tgz",
-      "integrity": "sha512-lVu4wX9rMlQ0KWf/5uj+7rZHl6NwSNkya9ov85vw3LekUj8XivIIBec0ZELz8DkREHhvpU4Dagh+vRbot4Og1w==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/dmn-js-shared/-/dmn-js-shared-6.2.2.tgz",
+      "integrity": "sha512-g/Fudl244mLGnTBthK52eRFkHJOPxWFsmS/1z0MdQPhV50T2xolKlfgLID978r03d6RXqjlOVglyX+wCp/QvDg==",
       "requires": {
         "diagram-js": "^3.1.3",
         "dmn-moddle": "^5.0.0",
@@ -4983,14 +4983,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5005,20 +5003,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5135,8 +5130,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5148,7 +5142,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5163,7 +5156,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5171,14 +5163,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5197,7 +5187,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5278,8 +5267,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5291,7 +5279,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5413,7 +5400,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,7 @@
     "diagram-js": "^3.1.2",
     "diagram-js-minimap": "^1.3.0",
     "diagram-js-origin": "^1.2.0",
-    "dmn-js": "^6.2.0",
+    "dmn-js": "^6.2.2",
     "dmn-js-properties-panel": "^0.2.0",
     "drag-tabs": "^2.2.0",
     "formik": "^1.3.2",


### PR DESCRIPTION
`<= v6.2.1` did not properly destroy child viewers.

Cf. bpmn-io/dmn-js#392