### PR TITLE
Reference tagged documentation in distribution only

### DIFF
--- a/resources/platform/base/resources/plugins/README.md
+++ b/resources/platform/base/resources/plugins/README.md
@@ -6,5 +6,5 @@ Place plugins into this directory to extend the Camunda Modeler.
 ## Learn More
 
 * [Example Plugins](https://github.com/camunda/camunda-modeler-plugins)
-* [Plugins documentation](https://github.com/camunda/camunda-modeler/tree/master/docs/plugins)
+* [Plugins documentation](https://github.com/camunda/camunda-modeler/tree/${TAG}/docs/plugins)
 * [Plugin Starter Project](https://github.com/camunda/camunda-modeler-plugin-example)

--- a/tasks/after-pack.js
+++ b/tasks/after-pack.js
@@ -12,7 +12,9 @@ const handlers = [
 
 
 async function afterPack(context) {
-  return await handlers.map(h => h(context));
+  return Promise.all(
+    handlers.map(h => h(context))
+  );
 }
 
 module.exports = afterPack;


### PR DESCRIPTION
This builds upon https://github.com/camunda/camunda-modeler/pull/1271 and ensures we only ship tagged links to documentation (not references to `master`).

Closes #1178 