### PR TITLE
fix(dmn): set dirty state on views changed

### DIFF
--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -189,6 +189,11 @@ export class DmnEditor extends CachedComponent {
       onSheetsChanged
     } = this.props;
 
+    const {
+      dirty,
+      stackIdx
+    } = this.getCached();
+
     const previousView = this.getCached().activeView;
 
     const modeler = this.getModeler();
@@ -225,6 +230,7 @@ export class DmnEditor extends CachedComponent {
     // must be called last
     this.setCached({
       activeView,
+      dirty: dirty || modeler.getStackIdx() !== stackIdx,
       views
     });
 

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -536,6 +536,36 @@ describe('<DmnEditor>', function() {
       instance = (await renderEditor(diagramXML)).instance;
     });
 
+    it('should save dirty state', async function() {
+
+      // given
+      const dirtySpy = spy(instance, 'isDirty');
+
+      const modeler = await instance.getModeler();
+
+      const commandStack = modeler.getActiveViewer().get('commandStack');
+
+      const oldDirty = instance.getCached().dirty;
+
+      commandStack.execute(2);
+
+      // when
+      instance.viewsChanged({
+        activeView: view1,
+        views
+      });
+
+      const {
+        dirty
+      } = instance.getCached();
+
+      // then
+      expect(dirtySpy).to.have.been.called;
+      expect(dirty).to.be.true;
+      expect(dirty).to.not.equal(oldDirty);
+    });
+
+
     it('should reattach properties panel on view switch', async function() {
 
       // given


### PR DESCRIPTION
This is fixing one problem inside #1228: When making changes inside the drd and switching to another view (e.g. Literal Expression), the dirty state got lost. Therefore with this pull request, we properly set the dirty state when the switch is happening.

Note: the second bug described in #1228 is still happening. 