### PR TITLE
Update dmn-js

### DIFF
--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -53,12 +53,12 @@ This project incorporates components from the projects listed below. The origina
 46.   diagram-js-origin@1.2.0 (https://github.com/bpmn-io/diagram-js-origin)
 47.   diagram-js@3.1.3 (https://github.com/bpmn-io/diagram-js)
 48.   didi@4.0.0 (https://github.com/nikku/didi)
-49.   dmn-js-decision-table@6.2.1 (https://github.com/bpmn-io/dmn-js)
-50.   dmn-js-drd@6.2.1 (https://github.com/bpmn-io/dmn-js)
-51.   dmn-js-literal-expression@6.2.1 (https://github.com/bpmn-io/dmn-js)
+49.   dmn-js-decision-table@6.2.3 (https://github.com/bpmn-io/dmn-js)
+50.   dmn-js-drd@6.2.3 (https://github.com/bpmn-io/dmn-js)
+51.   dmn-js-literal-expression@6.2.3 (https://github.com/bpmn-io/dmn-js)
 52.   dmn-js-properties-panel@0.2.0 (https://github.com/bpmn-io/dmn-js-properties-panel)
-53.   dmn-js-shared@6.2.1
-54.   dmn-js@6.2.1 (https://github.com/bpmn-io/dmn-js)
+53.   dmn-js-shared@6.2.3 (https://github.com/bpmn-io/dmn-js)
+54.   dmn-js@6.2.3 (https://github.com/bpmn-io/dmn-js)
 55.   dmn-moddle@5.0.0 (https://github.com/bpmn-io/dmn-moddle)
 56.   drag-tabs@2.3.0 (https://github.com/bpmn-io/drag-tabs)
 57.   escape-html@1.0.3 (https://github.com/component/escape-html)
@@ -1386,9 +1386,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 END OF didi@4.0.0 NOTICES AND INFORMATION
 
 
-%% dmn-js-decision-table@6.2.1 NOTICES AND INFORMATION BEGIN HERE
+%% dmn-js-decision-table@6.2.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
-Copyright (c) 2015-2017 camunda Services GmbH
+Copyright (c) 2015-present Camunda Services GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in the
@@ -1413,12 +1413,12 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================
-END OF dmn-js-decision-table@6.2.1 NOTICES AND INFORMATION
+END OF dmn-js-decision-table@6.2.3 NOTICES AND INFORMATION
 
 
-%% dmn-js-drd@6.2.1 NOTICES AND INFORMATION BEGIN HERE
+%% dmn-js-drd@6.2.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
-Copyright (c) 2015-2017 camunda Services GmbH
+Copyright (c) 2015-present Camunda Services GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in the
@@ -1443,12 +1443,12 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================
-END OF dmn-js-drd@6.2.1 NOTICES AND INFORMATION
+END OF dmn-js-drd@6.2.3 NOTICES AND INFORMATION
 
 
-%% dmn-js-literal-expression@6.2.1 NOTICES AND INFORMATION BEGIN HERE
+%% dmn-js-literal-expression@6.2.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
-Copyright (c) 2015-2017 camunda Services GmbH
+Copyright (c) 2015-present Camunda Services GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in the
@@ -1473,7 +1473,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================
-END OF dmn-js-literal-expression@6.2.1 NOTICES AND INFORMATION
+END OF dmn-js-literal-expression@6.2.3 NOTICES AND INFORMATION
 
 
 %% dmn-js-properties-panel@0.2.0 NOTICES AND INFORMATION BEGIN HERE
@@ -1503,9 +1503,9 @@ THE SOFTWARE.
 END OF dmn-js-properties-panel@0.2.0 NOTICES AND INFORMATION
 
 
-%% dmn-js-shared@6.2.1 NOTICES AND INFORMATION BEGIN HERE
+%% dmn-js-shared@6.2.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
-Copyright (c) 2015-2017 camunda Services GmbH
+Copyright (c) 2015-present Camunda Services GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in the
@@ -1530,12 +1530,12 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================
-END OF dmn-js-shared@6.2.1 NOTICES AND INFORMATION
+END OF dmn-js-shared@6.2.3 NOTICES AND INFORMATION
 
 
-%% dmn-js@6.2.1 NOTICES AND INFORMATION BEGIN HERE
+%% dmn-js@6.2.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
-Copyright (c) 2015-2017 camunda Services GmbH
+Copyright (c) 2015-present Camunda Services GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in the
@@ -1560,7 +1560,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================
-END OF dmn-js@6.2.1 NOTICES AND INFORMATION
+END OF dmn-js@6.2.3 NOTICES AND INFORMATION
 
 
 %% dmn-moddle@5.0.0 NOTICES AND INFORMATION BEGIN HERE

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3589,24 +3589,24 @@
       "dev": true
     },
     "dmn-js": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/dmn-js/-/dmn-js-6.2.2.tgz",
-      "integrity": "sha512-mDA+Rbtmpb4NXWYtzBseW9+/OB/3RtwVhKSyU+jJwLEZ+02Tlg6vtlVXRBDL7c93kwZcEPpTx/y78N9DVCxYnw==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/dmn-js/-/dmn-js-6.2.3.tgz",
+      "integrity": "sha512-J/cDBDvD7W9GBdtFxFQ73CgMvPdgipF8S6HyHqmRw7TeW5Vrzgo7v5JJ6as03MFGSzFWUsz6bUY9V6uKhMMqCA==",
       "requires": {
-        "dmn-js-decision-table": "^6.2.2",
-        "dmn-js-drd": "^6.2.2",
-        "dmn-js-literal-expression": "^6.2.2",
-        "dmn-js-shared": "^6.2.2"
+        "dmn-js-decision-table": "^6.2.3",
+        "dmn-js-drd": "^6.2.3",
+        "dmn-js-literal-expression": "^6.2.3",
+        "dmn-js-shared": "^6.2.3"
       }
     },
     "dmn-js-decision-table": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/dmn-js-decision-table/-/dmn-js-decision-table-6.2.2.tgz",
-      "integrity": "sha512-i4HZEAcI9yDA/mK8K9tfaME8rRbmfoGxdUFkY//m9bkdPOm2BMccorG1SgT35GfC3nLRpCSx0HlhCqgZ4+qJ/Q==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/dmn-js-decision-table/-/dmn-js-decision-table-6.2.3.tgz",
+      "integrity": "sha512-7zWnNKl/xMHXX4J1rBjmAIItGlMT9YHltcccQH+pxAfmRDAg6sGkER+4aogW5LopUHY4OyAlr9n3ODUJsipvxQ==",
       "requires": {
         "css.escape": "^1.5.1",
         "diagram-js": "^3.1.3",
-        "dmn-js-shared": "^6.2.2",
+        "dmn-js-shared": "^6.2.3",
         "escape-html": "^1.0.3",
         "inferno": "~5.0.5",
         "min-dash": "^3.0.0",
@@ -3616,13 +3616,13 @@
       }
     },
     "dmn-js-drd": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/dmn-js-drd/-/dmn-js-drd-6.2.2.tgz",
-      "integrity": "sha512-vceMx/n6gLk2BNo4ytPLaSj4KNnfQsTxlLVT9JJBzCTaBnz1WXUi7wGz7fmhj6A+8OjcC7F5spx7ZOFlTF0U3Q==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/dmn-js-drd/-/dmn-js-drd-6.2.3.tgz",
+      "integrity": "sha512-59KH1S1ixzFQnR0BQ3/MrILUjbuBN5mHfmNtgwhsuwU8pPBYoiiAEUkKee+x91QlA/c+74Z3gZYwfv/OHcTtOw==",
       "requires": {
         "diagram-js": "^3.1.3",
         "diagram-js-direct-editing": "^1.4.0",
-        "dmn-js-shared": "^6.2.2",
+        "dmn-js-shared": "^6.2.3",
         "inherits": "^2.0.1",
         "min-dash": "^3.0.0",
         "min-dom": "^3.1.1",
@@ -3630,12 +3630,12 @@
       }
     },
     "dmn-js-literal-expression": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/dmn-js-literal-expression/-/dmn-js-literal-expression-6.2.2.tgz",
-      "integrity": "sha512-KTrtW60g6v3h8cgF40j3NhOV2RRjebTSy+4jttoySHHUfyrH9ZPlDFljwEnpTost+b0jKr+LbmezC2pOiK8U4w==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/dmn-js-literal-expression/-/dmn-js-literal-expression-6.2.3.tgz",
+      "integrity": "sha512-le4BVwv0NmksoMoQ9jzB5QDI1l5g62UExg3WDvU868z+Ffvn/brWFs3UwYm5r7I9zvCJ4e8YRZg31rMC11x+WQ==",
       "requires": {
         "diagram-js": "^3.1.3",
-        "dmn-js-shared": "^6.2.2",
+        "dmn-js-shared": "^6.2.3",
         "escape-html": "^1.0.3",
         "inferno": "~5.0.5",
         "min-dash": "^3.0.0",
@@ -3656,9 +3656,9 @@
       }
     },
     "dmn-js-shared": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/dmn-js-shared/-/dmn-js-shared-6.2.2.tgz",
-      "integrity": "sha512-g/Fudl244mLGnTBthK52eRFkHJOPxWFsmS/1z0MdQPhV50T2xolKlfgLID978r03d6RXqjlOVglyX+wCp/QvDg==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/dmn-js-shared/-/dmn-js-shared-6.2.3.tgz",
+      "integrity": "sha512-AzpLzpfD8PAK4DCeeCRwEhfQpceYE2xX6YHd65AHxaYju7+04oWXA1+/pMIBBZ5ZkizKAPr6BqsE6CVRmGSRWQ==",
       "requires": {
         "diagram-js": "^3.1.3",
         "dmn-moddle": "^5.0.0",


### PR DESCRIPTION
Adds repository link, missing from dmn-js-shared.

`THIRD_PARTY_NOTICES` properly diff, too. 

:tada: :balloon: 