### PR TITLE
Add missing input active properties

### DIFF
--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -362,6 +362,7 @@ export class BpmnEditor extends CachedComponent {
     newState.bpmn = true;
     newState.editable = true;
     newState.elementsSelected = !!selectionLength;
+    newState.inactiveInput = !inputActive;
 
     const contextMenu = getBpmnContextMenu(newState);
 

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -325,6 +325,7 @@ describe('<BpmnEditor>', function() {
           find: true,
           globalConnectTool: true,
           handTool: true,
+          inputActive: false,
           lassoTool: true,
           moveCanvas: true,
           moveToOrigin: true,
@@ -395,6 +396,7 @@ describe('<BpmnEditor>', function() {
       expect(state).to.have.property('bpmn');
       expect(state).to.have.property('editable');
       expect(state).to.have.property('elementsSelected');
+      expect(state).to.have.property('inactiveInput');
     });
 
 

--- a/client/src/app/tabs/cmmn/CmmnEditor.js
+++ b/client/src/app/tabs/cmmn/CmmnEditor.js
@@ -224,6 +224,7 @@ export class CmmnEditor extends CachedComponent {
     newState.cmmn = true;
     newState.editable = true;
     newState.elementsSelected = !!selectionLength;
+    newState.inactiveInput = !inputActive;
 
     const editMenu = getCmmnEditMenu(newState);
     const windowMenu = getCmmnWindowMenu(newState);

--- a/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
+++ b/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
@@ -235,6 +235,7 @@ describe('<CmmnEditor>', function() {
           find: true,
           globalConnectTool: true,
           handTool: true,
+          inputActive: false,
           lassoTool: true,
           moveCanvas: true,
           redo: true,
@@ -299,6 +300,7 @@ describe('<CmmnEditor>', function() {
       expect(state).to.have.property('cmmn');
       expect(state).to.have.property('editable');
       expect(state).to.have.property('elementsSelected');
+      expect(state).to.have.property('inactiveInput');
     });
 
 

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -330,10 +330,11 @@ export class DmnEditor extends CachedComponent {
 
     // ensure backwards compatibility
     // https://github.com/camunda/camunda-modeler/commit/78357e3ed9e6e0255ac8225fbdf451a90457e8bf#diff-bd5be70c4e5eadf1a316c16085a72f0fL17
+    newState.activeEditor = activeView.type;
     newState.dmn = true;
     newState.editable = true;
     newState.elementsSelected = !!selectionLength;
-    newState.activeEditor = activeView.type;
+    newState.inactiveInput = !inputActive;
 
     const windowMenu = getDmnWindowMenu(newState);
 

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -226,6 +226,7 @@ describe('<DmnEditor>', function() {
         expect(state).to.include({
           dirty: true,
           editLabel: false,
+          inputActive: false,
           redo: true,
           removeSelected: false,
           undo: true
@@ -288,6 +289,7 @@ describe('<DmnEditor>', function() {
       expect(state).to.have.property('editable');
       expect(state).to.have.property('elementsSelected');
       expect(state).to.have.property('activeEditor');
+      expect(state).to.have.property('inactiveInput');
     });
 
 


### PR DESCRIPTION
In the current modeler version (`v3.0.0-beta.2`) the [token simulation plugin](https://github.com/bpmn-io/bpmn-js-token-simulation-plugin) is turned on every time the user presses  'T', regardless an input is active. This pull request adds the missing `inactiveInput` property to the `BpmnEditor`, to ensure [the menu item got disabled](https://github.com/bpmn-io/bpmn-js-token-simulation-plugin/blob/master/menu.js#L10). 

It also adds this property to the other editors to ensure backward compatibility.

Closes https://github.com/bpmn-io/bpmn-js-token-simulation-plugin/issues/14.
Relates to https://github.com/camunda/camunda-modeler/issues/1193.