### PR TITLE
Remove SlotFillRoot from editors' tests

### DIFF
--- a/client/src/app/slot-fill/FillContext.js
+++ b/client/src/app/slot-fill/FillContext.js
@@ -7,6 +7,11 @@
 
 import React from 'react';
 
-const FillContext = React.createContext();
+const defaultValue = {
+  addFill() {},
+  removeFill() {}
+};
+
+const FillContext = React.createContext(defaultValue);
 
 export default FillContext;

--- a/client/src/app/slot-fill/__tests__/FillSpec.js
+++ b/client/src/app/slot-fill/__tests__/FillSpec.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Camunda Services GmbH.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+import { mount } from 'enzyme';
+
+import {
+  Fill,
+} from '..';
+
+
+describe('<Fill>', function() {
+
+  let fill;
+
+  afterEach(() => fill.unmount());
+
+  describe('render', function() {
+
+    it('should render', function() {
+
+      fill = mount(<Fill />);
+
+      expect(fill.instance()).to.exist;
+    });
+  });
+
+});

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -22,8 +22,6 @@ import {
 
 import BpmnModeler from 'test/mocks/bpmn-js/Modeler';
 
-import { SlotFillRoot } from 'src/app/slot-fill';
-
 import diagramXML from './diagram.bpmn';
 import activitiXML from './activiti.bpmn';
 
@@ -1185,37 +1183,33 @@ async function renderEditor(xml, options = {}) {
     getPlugins
   } = options;
 
-  const slotFillRoot = await mount(
-    <SlotFillRoot>
-      <TestEditor
-        id={ id || 'editor' }
-        xml={ xml }
-        activeSheet={ options.activeSheet || { id: 'bpmn' } }
-        onAction={ onAction || noop }
-        onChanged={ onChanged || noop }
-        onError={ onError || noop }
-        onImport={ onImport || noop }
-        onLayoutChanged={ onLayoutChanged || noop }
-        onContentUpdated={ onContentUpdated || noop }
-        onModal={ onModal || noop }
-        onLoadConfig={ onLoadConfig || noop }
-        getPlugins={ getPlugins || (() => []) }
-        cache={ options.cache || new Cache() }
-        layout={ layout || {
-          minimap: {
-            open: false
-          },
-          propertiesPanel: {
-            open: true
-          }
-        } }
-      />
-    </SlotFillRoot>
+  const wrapper = await mount(
+    <TestEditor
+      id={ id || 'editor' }
+      xml={ xml }
+      activeSheet={ options.activeSheet || { id: 'bpmn' } }
+      onAction={ onAction || noop }
+      onChanged={ onChanged || noop }
+      onError={ onError || noop }
+      onImport={ onImport || noop }
+      onLayoutChanged={ onLayoutChanged || noop }
+      onContentUpdated={ onContentUpdated || noop }
+      onModal={ onModal || noop }
+      onLoadConfig={ onLoadConfig || noop }
+      getPlugins={ getPlugins || (() => []) }
+      cache={ options.cache || new Cache() }
+      layout={ layout || {
+        minimap: {
+          open: false
+        },
+        propertiesPanel: {
+          open: true
+        }
+      } }
+    />
   );
 
-  const wrapper = slotFillRoot.find(BpmnEditor);
-
-  const instance = wrapper.instance();
+  const instance = wrapper.find(BpmnEditor).instance();
 
   return {
     instance,

--- a/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
+++ b/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
@@ -31,8 +31,6 @@ import {
   getUndoRedoEntries
 } from '../../getEditMenu';
 
-import { SlotFillRoot } from 'src/app/slot-fill';
-
 import diagramXML from './diagram.cmmn';
 
 const { spy } = sinon;
@@ -846,32 +844,28 @@ function renderEditor(xml, options = {}) {
     onLayoutChanged
   } = options;
 
-  const slotFillRoot = mount(
-    <SlotFillRoot>
-      <TestEditor
-        id={ options.id || 'editor' }
-        xml={ xml }
-        activeSheet={ options.activeSheet || { id: 'cmmn' } }
-        onChanged={ onChanged || noop }
-        onError={ onError || noop }
-        onImport={ onImport || noop }
-        onLayoutChanged={ onLayoutChanged || noop }
-        cache={ options.cache || new Cache() }
-        layout={ layout || {
-          minimap: {
-            open: false
-          },
-          propertiesPanel: {
-            open: true
-          }
-        } }
-      />
-    </SlotFillRoot>
+  const wrapper = mount(
+    <TestEditor
+      id={ options.id || 'editor' }
+      xml={ xml }
+      activeSheet={ options.activeSheet || { id: 'cmmn' } }
+      onChanged={ onChanged || noop }
+      onError={ onError || noop }
+      onImport={ onImport || noop }
+      onLayoutChanged={ onLayoutChanged || noop }
+      cache={ options.cache || new Cache() }
+      layout={ layout || {
+        minimap: {
+          open: false
+        },
+        propertiesPanel: {
+          open: true
+        }
+      } }
+    />
   );
 
-  const wrapper = slotFillRoot.find(CmmnEditor);
-
-  const instance = wrapper.instance();
+  const instance = wrapper.find(CmmnEditor).instance();
 
   return {
     instance,

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -30,8 +30,6 @@ import {
   getUndoRedoEntries
 } from '../../getEditMenu';
 
-import { SlotFillRoot } from 'src/app/slot-fill';
-
 import diagramXML from './diagram.dmn';
 
 const { spy } = sinon;
@@ -988,34 +986,30 @@ async function renderEditor(xml, options = {}) {
     onSheetsChanged
   } = options;
 
-  const slotFillRoot = await mount(
-    <SlotFillRoot>
-      <TestEditor
-        id={ options.id || 'editor' }
-        xml={ xml }
-        activeSheet={ options.activeSheet || { id: 'dmn' } }
-        onChanged={ onChanged || noop }
-        onError={ onError || noop }
-        onImport={ onImport || noop }
-        onLayoutChanged={ onLayoutChanged || noop }
-        onModal={ onModal || noop }
-        onSheetsChanged={ onSheetsChanged || noop }
-        cache={ options.cache || new Cache() }
-        layout={ layout || {
-          minimap: {
-            open: false
-          },
-          propertiesPanel: {
-            open: true
-          }
-        } }
-      />
-    </SlotFillRoot>
+  const wrapper = await mount(
+    <TestEditor
+      id={ options.id || 'editor' }
+      xml={ xml }
+      activeSheet={ options.activeSheet || { id: 'dmn' } }
+      onChanged={ onChanged || noop }
+      onError={ onError || noop }
+      onImport={ onImport || noop }
+      onLayoutChanged={ onLayoutChanged || noop }
+      onModal={ onModal || noop }
+      onSheetsChanged={ onSheetsChanged || noop }
+      cache={ options.cache || new Cache() }
+      layout={ layout || {
+        minimap: {
+          open: false
+        },
+        propertiesPanel: {
+          open: true
+        }
+      } }
+    />
   );
 
-  const wrapper = slotFillRoot.find(DmnEditor);
-
-  const instance = wrapper.instance();
+  const instance = wrapper.find(DmnEditor).instance();
 
   return {
     instance,

--- a/client/src/app/tabs/xml/__tests__/XMLEditorSpec.js
+++ b/client/src/app/tabs/xml/__tests__/XMLEditorSpec.js
@@ -18,8 +18,6 @@ import { XMLEditor } from '../XMLEditor';
 
 import CodeMirror from 'test/mocks/code-mirror/CodeMirror';
 
-import { SlotFillRoot } from 'src/app/slot-fill';
-
 /* global sinon */
 
 const XML = '<xml></xml>';
@@ -215,15 +213,13 @@ function renderEditor(xml, options = {}) {
   } = options;
 
   const slotFillRoot = mount(
-    <SlotFillRoot>
-      <TestEditor
-        id={ id || 'editor' }
-        xml={ xml }
-        activeSheet={ options.activeSheet || { id: 'xml' } }
-        onChanged={ onChanged || noop }
-        cache={ options.cache || new Cache() }
-      />
-    </SlotFillRoot>
+    <TestEditor
+      id={ id || 'editor' }
+      xml={ xml }
+      activeSheet={ options.activeSheet || { id: 'xml' } }
+      onChanged={ onChanged || noop }
+      cache={ options.cache || new Cache() }
+    />
   );
 
   const wrapper = slotFillRoot.find(XMLEditor);


### PR DESCRIPTION
Done via providing default context value for FillContext.
Main benefit of the change is that it's now possible to set props on editor wrappers via enzyme setProps method.

Example:

```javascript
it('should import new XML', async function() {
  // given
  const onImport = sinon.spy();

  // when
  const { wrapper } = await renderEditor(diagramXML, { onImport });

  await wrapper.update();

  wrapper.setProps({ xml: diagramXML + ' ' });

  await wrapper.update();

  // then
  expect(onImport).to.be.calledTwice;
});
```