### PR TITLE
Clarify search paths in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,3 +14,7 @@ This shows how to use flags to toggle several features
 ### [Plugins](./plugins)
 
 This shows how to use plug into the modeler
+
+### [Search Paths](./search-paths)
+
+This gives an overview about several local data paths

--- a/docs/element-templates/README.md
+++ b/docs/element-templates/README.md
@@ -2,28 +2,24 @@
 
 # Element Templates
 
-Element templates allow you create pre-defined configurations for BPMN elements such as service and user tasks. Once applied via the properties panel they provide configured custom inputs to the user.
+Element templates allow you to create pre-defined configurations for BPMN elements such as service and user tasks. Once applied via the properties panel they provide configured custom inputs to the user.
 
 ![Element template applied](./overview.png)
 
 
 ## Configuring Templates
 
-Element templates are defined as [JSON files](#defining-templates) and are searched for in the `resources/element-templates` folder, relative to the modelers executable _or_ relative to the modelers data directory (see below).
+Element templates are defined as [JSON files](#defining-templates) and are searched for in the `resources/element-templates` folder, relative to the modelers executable _or_ relative to the modelers data directory ([see below](#example-setup)).
 
-Alternatively, they can be stored in a `.camunda/element-templates` directory that resides, relative to the currently opened diagram, anywhere in the diagrams path hierachy.
+Alternatively, they can be stored in a `.camunda/element-templates` directory that resides, relative to the currently opened diagram, anywhere in the diagrams path hierarchy.
 
 New templates will be recognized on diagram reopen or modeler reload/restart.
 
 
 #### Example Setup
 
-The location of the modelers data directory differs across operating systems:
 
-* **Windows**: `%APPDATA%/camunda-modeler`
-* **Mac OS X**: `~/Library/Application Support/camunda-modeler`
-
-On Mac, add a JSON file to the folder `~/Library/Application Support/camunda-modeler/resources/element-templates`, on Windows use the `%APPDATA%/camunda-modeler/resources/element-templates` folder. You may have to create the `resources` and `element-templates` folders.
+Add a JSON file to the `resources/element-templates` sub-folder of your local [`{APP_HOME}`](../search-paths#application-home-directory) or [`{USER_DATA}`](../search-paths#user-data-directory) directory. You may have to create the `resources` and `element-templates` folders  yourself.
 
 For local template discovery, create a `.camunda/element-templates` folder relative in the directory
 or any parent directory of the diagrams you are editing.
@@ -78,7 +74,7 @@ As seen in the code snippet a template consist of a number of important componen
 
 ### Defining Template Properties
 
-With each template you define a number of user-editable fields as well as their mapping to BPMN 2.0 XML as well as Camunda extension elements.
+With each template, you define some user-editable fields as well as their mapping to BPMN 2.0 XML as well as Camunda extension elements.
 
 Let us consider the following example that defines a template for a mail sending task:
 
@@ -164,7 +160,7 @@ All but the _Implementation Type_ are editable by the user through the propertie
 As seen in the example the important attributes in a property definition are:
 
 * `label`: A descriptive text shown with the property
-* `type`: Defining the visual apperance in the properties panel (may be any of `String`, `Text`, `Boolean`, `Dropdown` or `Hidden`)
+* `type`: Defining the visual appearance in the properties panel (may be any of `String`, `Text`, `Boolean`, `Dropdown` or `Hidden`)
 * `value`: An optional default value to be used if the property to be bound is not yet set
 * `binding`: Specifying how the property is mapped to BPMN or Camunda extension elements and attributes (may be any of `property`, `camunda:property`, `camunda:inputParameter`, `camunda:outputParameter`, `camunda:in`, `camunda:out`, `camunda:executionListener`, `camunda:field`)
 * `constraints`: A list of editing constraints to apply to the template
@@ -256,7 +252,7 @@ As of Camunda Modeler `v1.11.0` we support special scoped bindings that allow yo
 
 The example shows how a connector is configured as part of the task.
 On task creation, the connector is created with it and the connector bindings are
-exposed to user in a separate custom fields section.
+exposed to the user in a separate custom fields section.
 
 ![Scoped Custom Fields](./scope-custom-fields.png)
 
@@ -281,7 +277,7 @@ Custom Fields may have a number of constraints associated with them:
 
 ##### Regular Expression
 
-Together with the `pattern` constraint you may define your custom error messages:
+Together with the `pattern` constraint, you may define your custom error messages:
 
 ```json
 ...
@@ -302,7 +298,7 @@ Together with the `pattern` constraint you may define your custom error messages
 ```
 
 
-### Controling Default Entry Visibility
+### Controlling Default Entry Visibility
 
 _TODO_
 
@@ -335,16 +331,16 @@ Other templates may not be applied, once an element is subject to a default temp
 
 ## Development Workflow
 
-When creating custom element templates the modeler will give you detailed validation error messages.
+When creating custom element templates, the modeler will give you detailed validation error messages.
 
 Templates will be loaded on application load and reload. To reload the application with updated templates, open the developer tools `F12` and press `CtrlOrCmd+R`. This will clear all unsaved diagrams **!**
 
 
 ## Supported BPMN Types
 
-Currently element templates may be used on the following BPMN elements:
+Currently, element templates may be used on the following BPMN elements:
 
-* `bpmn:Activity` (including tasks, service tasks and others)
+* `bpmn:Activity` (including tasks, service tasks, and others)
 * `bpmn:SequenceFlow` (for maintaining `condition`)
 * `bpmn:Process`
 

--- a/docs/flags/README.md
+++ b/docs/flags/README.md
@@ -12,7 +12,7 @@ You may configure flags in a `flags.json` file or pass them via CLI.
 
 ### Configure in `flags.json`
 
-Place a `flags.json` file inside the `{APP_HOME}/resources` or `{USER_DATA}/resources` directory to persist them.
+Place a `flags.json` file inside the `resources` folder of your local [`{USER_DATA}`](../search-paths#user-data-directory) or [`{APP_HOME}`](../search-paths#application-home-directory) directory to persist them.
 
 ### Configure via CLI
 

--- a/docs/flags/README.md
+++ b/docs/flags/README.md
@@ -32,7 +32,8 @@ Flags passed as command line arguments take precedence over those configured via
   "disable-plugins": false,
   "disable-adjust-origin": false,
   "disable-cmmn": false,
-  "disable-dmn": false
+  "disable-dmn": false,
+  "single-instance": false
 }
 ```
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -9,12 +9,11 @@ Plugins allow you to change the appearance and behavior of the Camunda Modeler a
 
 ## Plugging into the Camunda Modeler
 
-You can plug into the modeler in order to change its appearance, add new menu entries or extend the modeling tools for [BPMN](https://github.com/bpmn-io/bpmn-js), [CMMN](https://github.com/bpmn-io/cmmn-js) and [DMN](https://github.com/bpmn-io/dmn-js). Adding a plugin is as easy as putting the files into the directory `{MODELER_LOCATION}/resources/plugins`.
-On macOS, the application searches for plugins in the directory `/Users/{USER_NAME}/Library/Application Support/camunda-modeler/resources/plugins`.
+You can plug into the modeler in order to change its appearance, add new menu entries or extend the modeling tools for [BPMN](https://github.com/bpmn-io/bpmn-js), [CMMN](https://github.com/bpmn-io/cmmn-js) and [DMN](https://github.com/bpmn-io/dmn-js). Adding a plugin is as easy as putting the files into the `resources/plugins` sub-folder of your local [`{APP_HOME}`](../search-paths#application-home-directory) or [`{USER_DATA}`](../search-paths#user-data-directory)  directory.
 
 So let's dive into how to add your own plugins.
 
-Regardless of the type of your plugin you have to export it as a [Node.js module](https://nodejs.org/api/modules.html). In order for the modeler to recognize your plugin the filename must be `index.js`.
+Regardless of the type of your plugin, you have to export it as a [Node.js module](https://nodejs.org/api/modules.html). For the modeler to recognize your plugin, the filename must be `index.js`.
 
 Example:
 
@@ -82,9 +81,9 @@ module.exports = {
 
 You can use a Node.js module here since the modeler is built with [Electron](https://electron.atom.io/) which uses [Node.js](https://nodejs.org/en/).
 
-For more information on how the modelers menu works have a look at its implementation [here](https://github.com/camunda/camunda-modeler/blob/master/app/lib/menu/menu-builder.js).
+For more information on how the modeler's menu works, have a look at its implementation [here](https://github.com/camunda/camunda-modeler/blob/master/app/lib/menu/menu-builder.js).
 
-### Extend the modeling tools for BPMN, CMMN and DMN
+### Extend the modeling tools for BPMN, CMMN, and DMN
 
 > Currently you can only extend bpmn-js
 
@@ -149,7 +148,7 @@ Finally, put the folder into the `resources/plugins` directory relative to your 
 
 ### Development Workflow
 
-When creating a plugin you can place the directory containing your plugin in the aforementioned `resources/plugins` directory.
+When creating a plugin, you can place the directory containing your plugin in the aforementioned `resources/plugins` directory.
 
 Plugins will be loaded on application startup (menu plugins) or reload (style and modeling tool plugins). To reload the application, open the developer tools F12 and press `CtrlOrCmd + R`. This will clear all unsaved diagrams!
 

--- a/docs/search-paths/README.md
+++ b/docs/search-paths/README.md
@@ -1,0 +1,19 @@
+# Search Paths
+
+Inside the modeler we look inside different search paths to retrieve persistent application data or additional user resources, e.g. loading [Plugins](../plugins) or [Element Templates](../element-templates). The directories orientate on the [standard electron paths](https://github.com/electron/electron/blob/master/docs/api/app.md#appgetpathname).
+
+## Application Home Directory
+
+This is the installation directory of the application executable. Inside this documentation, we use the `{APP_HOME}` symbol to indicate the Application Home Directory.
+
+## User Data Directory 
+
+This is the per-user application data directory which differs across operating systems:
+
+* **Windows**: `%APPDATA%/camunda-modeler`
+* **Linux**: `$XDG_CONFIG_HOME/camunda-modeler` or `~/.config/camunda-modeler`
+* **macOS**: `~/Library/Application Support/camunda-modeler`
+
+If you don't know where to find these paths, learn more about Windows [`%APPDATA%`](https://www.howtogeek.com/318177/what-is-the-appdata-folder-in-windows/) and Linux [`$XDG_CONFIG_HOME`](https://wiki.archlinux.org/index.php/XDG_Base_Directory) directories.
+
+Inside this documentation, we use the `{USER_DATA}` symbol to indicate the User Data Directory.


### PR DESCRIPTION
Previously we used to state out the `search-paths` (e.g. `%AppData/camunda-modeler` for Windows) in every single part of the documentation. This led to confusion since we did always in a different form.

This pull request adds clear documentation for the `search-paths`. Furthermore, it links to it in every other place where the search paths are needed by the `{APP_HOME}` and `{USER_DATA}` identifier.

I also run the documentation through Grammarly to add some improvements in grammar and fix some typos.

Closes #1220 

Note: I was about to link the `search-paths` directly in the paths, so like

 [`{APP_HOME}`](../search-paths#application-home-directory)`/resources/plugins`

But as you can see the GitHub markdown flavor always adds space after the link, which looks dirty. Therefore I just put the links inside another sentence.