### PR TITLE
fix(client/App): disable save-as on empty tab

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -315,7 +315,7 @@ export class App extends PureComponent {
       return tabShown.promise;
     }
 
-    if (tab !== EMPTY_TAB) {
+    if (!this.isEmptyTab(tab)) {
       const navigationHistory = this.navigationHistory;
 
       if (navigationHistory.get() !== tab) {
@@ -361,6 +361,10 @@ export class App extends PureComponent {
     await this._removeTab(tab);
 
     return true;
+  }
+
+  isEmptyTab = (tab) => {
+    return tab === EMPTY_TAB;
   }
 
   isDirty = (tab) => {
@@ -1488,6 +1492,7 @@ export class App extends PureComponent {
     const Tab = this.getTabComponent(activeTab);
 
     const canSave = this.isUnsaved(activeTab) || this.isDirty(activeTab);
+    const canSaveAs = !this.isEmptyTab(activeTab);
 
     const {
       tabsProvider
@@ -1550,7 +1555,8 @@ export class App extends PureComponent {
                 <Icon name="save" />
               </Button>
               <Button
-                onClick={ this.composeAction('save-as') }
+                disabled={ !canSaveAs }
+                onClick={ canSaveAs ? this.composeAction('save-as') : null }
                 title="Save diagram as..."
               >
                 <Icon name="save-as" />

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -265,6 +265,32 @@ describe('<App>', function() {
       expect(app.state.tabs).to.have.length(1);
     });
 
+
+    it('should not allow user to execute save-as', async function() {
+
+      // given
+      const {
+        app,
+        tree
+      } = createApp(mount);
+
+      const actionSpy = sinon.spy(app, 'triggerAction');
+
+      await app.showTab(EMPTY_TAB);
+
+      const saveAsButton = tree.find('Button[title="Save diagram as..."]').first();
+
+      // assure
+      expect(saveAsButton).to.exist;
+
+      // when
+      saveAsButton.simulate('click');
+
+      // then
+      expect(saveAsButton.prop('disabled')).to.be.true;
+      expect(actionSpy).to.have.not.been.calledWith('save-as');
+    });
+
   });
 
 


### PR DESCRIPTION
This pull request disables the `save-as` toolbar button when the `EmptyTab` is active.

Closes #1282 