### PR TITLE
License header

### DIFF
--- a/app/dev.js
+++ b/app/dev.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const log = require('./lib/log')('app:dev');

--- a/app/lib/__tests__/cli-spec.js
+++ b/app/lib/__tests__/cli-spec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const Cli = require('../cli');

--- a/app/lib/__tests__/flags-spec.js
+++ b/app/lib/__tests__/flags-spec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const path = require('path');

--- a/app/lib/cli.js
+++ b/app/lib/cli.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/client-config/__tests__/client-config-spec.js
+++ b/app/lib/client-config/__tests__/client-config-spec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const ClientConfig = require('..');

--- a/app/lib/client-config/index.js
+++ b/app/lib/client-config/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/client-config/providers/element-templates-provider.js
+++ b/app/lib/client-config/providers/element-templates-provider.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/client-config/providers/find-templates.js
+++ b/app/lib/client-config/providers/find-templates.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const fs = require('fs');

--- a/app/lib/client-config/providers/none-provider.js
+++ b/app/lib/client-config/providers/none-provider.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/config.js
+++ b/app/lib/config.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const fs = require('fs');

--- a/app/lib/deployer.js
+++ b/app/lib/deployer.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/dialog.js
+++ b/app/lib/dialog.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/file-system.js
+++ b/app/lib/file-system.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/flags.js
+++ b/app/lib/flags.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const {

--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const {

--- a/app/lib/log/__test__/log-spec.js
+++ b/app/lib/log/__test__/log-spec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const sinon = require('sinon');

--- a/app/lib/log/index.js
+++ b/app/lib/log/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 module.exports = require('./log');

--- a/app/lib/log/log.js
+++ b/app/lib/log/log.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const { format } = require('util');

--- a/app/lib/log/transports/client.js
+++ b/app/lib/log/transports/client.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 class ClientTransport {

--- a/app/lib/log/transports/console.js
+++ b/app/lib/log/transports/console.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 class ConsoleTransport {

--- a/app/lib/log/transports/file.js
+++ b/app/lib/log/transports/file.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const { Console } = require('console');

--- a/app/lib/log/transports/index.js
+++ b/app/lib/log/transports/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 module.exports = {

--- a/app/lib/menu/index.js
+++ b/app/lib/menu/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const Menu = require('./menu');

--- a/app/lib/menu/mac-os/index.js
+++ b/app/lib/menu/mac-os/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 module.exports = require('./mac-menu-builder');

--- a/app/lib/menu/mac-os/mac-menu-builder.js
+++ b/app/lib/menu/mac-os/mac-menu-builder.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/menu/menu.js
+++ b/app/lib/menu/menu.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/platform/index.js
+++ b/app/lib/platform/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/platform/linux/index.js
+++ b/app/lib/platform/linux/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/platform/mac-os/index.js
+++ b/app/lib/platform/mac-os/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/platform/windows/index.js
+++ b/app/lib/platform/windows/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/plugins.js
+++ b/app/lib/plugins.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const path = require('path');

--- a/app/lib/util/__tests__/files-spec.js
+++ b/app/lib/util/__tests__/files-spec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const path = require('path');

--- a/app/lib/util/browser-open.js
+++ b/app/lib/util/browser-open.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const { shell } = require('electron');

--- a/app/lib/util/ensure-opts.js
+++ b/app/lib/util/ensure-opts.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/util/files.js
+++ b/app/lib/util/files.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const glob = require('glob');

--- a/app/lib/util/filter-extensions.js
+++ b/app/lib/util/filter-extensions.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/util/has-property.js
+++ b/app/lib/util/has-property.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/util/renderer.js
+++ b/app/lib/util/renderer.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/util/require-platform.js
+++ b/app/lib/util/require-platform.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/lib/workspace.js
+++ b/app/lib/workspace.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const {

--- a/app/test/expect.js
+++ b/app/test/expect.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/test/fixtures/plugins/register/plugins/broken-menu/index.js
+++ b/app/test/fixtures/plugins/register/plugins/broken-menu/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 module.exports = {

--- a/app/test/fixtures/plugins/register/plugins/broken-menu/menu.js
+++ b/app/test/fixtures/plugins/register/plugins/broken-menu/menu.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 module.exports = require('./missing');

--- a/app/test/fixtures/plugins/register/plugins/broken/index.js
+++ b/app/test/fixtures/plugins/register/plugins/broken/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 module.exports = require('./missing');

--- a/app/test/fixtures/plugins/register/plugins/ghost-paths/index.js
+++ b/app/test/fixtures/plugins/register/plugins/ghost-paths/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 module.exports = {

--- a/app/test/fixtures/plugins/register/plugins/missing-descriptor/index.js
+++ b/app/test/fixtures/plugins/register/plugins/missing-descriptor/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 module.exports = {};

--- a/app/test/fixtures/plugins/register/plugins/ok-duplicate/index.js
+++ b/app/test/fixtures/plugins/register/plugins/ok-duplicate/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 // attempts duplicate registration of 'OK' name

--- a/app/test/fixtures/plugins/register/plugins/ok/index.js
+++ b/app/test/fixtures/plugins/register/plugins/ok/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 module.exports = {

--- a/app/test/fixtures/plugins/register/plugins/with-script/index.js
+++ b/app/test/fixtures/plugins/register/plugins/with-script/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 module.exports = {

--- a/app/test/fixtures/plugins/register/plugins/with-script/script.js
+++ b/app/test/fixtures/plugins/register/plugins/with-script/script.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 console.log('hello world');

--- a/app/test/fixtures/plugins/register/plugins/with-style/index.js
+++ b/app/test/fixtures/plugins/register/plugins/with-style/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 module.exports = {

--- a/app/test/fixtures/plugins/register/plugins/wrong/depth/index.js
+++ b/app/test/fixtures/plugins/register/plugins/wrong/depth/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 module.exports = {

--- a/app/test/fixtures/plugins/with-asset/plugins/plugin/index.js
+++ b/app/test/fixtures/plugins/with-asset/plugins/plugin/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 module.exports = {

--- a/app/test/helper/mock/config.js
+++ b/app/test/helper/mock/config.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/test/helper/mock/electron-app.js
+++ b/app/test/helper/mock/electron-app.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/test/helper/mock/electron-dialog.js
+++ b/app/test/helper/mock/electron-dialog.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/test/helper/mock/electron-menu-item.js
+++ b/app/test/helper/mock/electron-menu-item.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/test/helper/mock/electron-menu.js
+++ b/app/test/helper/mock/electron-menu.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/test/helper/mock/fetch.js
+++ b/app/test/helper/mock/fetch.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 var RESPONSE_OK = { mocked: true };

--- a/app/test/helper/mock/form-data.js
+++ b/app/test/helper/mock/form-data.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 function FormData() {

--- a/app/test/helper/mock/fs.js
+++ b/app/test/helper/mock/fs.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 module.exports = {

--- a/app/test/spec/deployer-spec.js
+++ b/app/test/spec/deployer-spec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/test/spec/dialog-spec.js
+++ b/app/test/spec/dialog-spec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/test/spec/file-system-spec.js
+++ b/app/test/spec/file-system-spec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/test/spec/menu/menu-builder-spec.js
+++ b/app/test/spec/menu/menu-builder-spec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/test/spec/plugins-spec.js
+++ b/app/test/spec/plugins-spec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/test/util/spy-on.js
+++ b/app/test/util/spy-on.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/app/util/get-version.js
+++ b/app/util/get-version.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/client/karma.config.js
+++ b/client/karma.config.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 var coverage = process.env.COVERAGE;

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/AppParent.js
+++ b/client/src/app/AppParent.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/EmptyTab.js
+++ b/client/src/app/EmptyTab.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent, Fragment } from 'react';

--- a/client/src/app/History.js
+++ b/client/src/app/History.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /**

--- a/client/src/app/KeyboardBindings.js
+++ b/client/src/app/KeyboardBindings.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import {

--- a/client/src/app/Log.js
+++ b/client/src/app/Log.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import Ids from 'ids';

--- a/client/src/app/Toolbar.js
+++ b/client/src/app/Toolbar.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/__tests__/AppParentSpec.js
+++ b/client/src/app/__tests__/AppParentSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { Component } from 'react';

--- a/client/src/app/__tests__/EmptyTabSpec.js
+++ b/client/src/app/__tests__/EmptyTabSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/__tests__/HistorySpec.js
+++ b/client/src/app/__tests__/HistorySpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import History from '../History';

--- a/client/src/app/__tests__/KeyboardBindingsSpec.js
+++ b/client/src/app/__tests__/KeyboardBindingsSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/app/__tests__/LogSpec.js
+++ b/client/src/app/__tests__/LogSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/__tests__/TabsProviderSpec.js
+++ b/client/src/app/__tests__/TabsProviderSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import TabsProvider from '../TabsProvider';

--- a/client/src/app/__tests__/mocks/index.js
+++ b/client/src/app/__tests__/mocks/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import { Component } from 'react';

--- a/client/src/app/cached/Cache.js
+++ b/client/src/app/cached/Cache.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import {

--- a/client/src/app/cached/CacheContext.js
+++ b/client/src/app/cached/CacheContext.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/cached/CachedComponent.js
+++ b/client/src/app/cached/CachedComponent.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import { PureComponent } from 'react';

--- a/client/src/app/cached/WithCache.js
+++ b/client/src/app/cached/WithCache.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/cached/WithCachedState.js
+++ b/client/src/app/cached/WithCachedState.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/cached/__tests__/CacheSpec.js
+++ b/client/src/app/cached/__tests__/CacheSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/app/cached/__tests__/CachedComponentSpec.js
+++ b/client/src/app/cached/__tests__/CachedComponentSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/app/cached/__tests__/WitchCachedStateSpec.js
+++ b/client/src/app/cached/__tests__/WitchCachedStateSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/cached/__tests__/WithCacheSpec.js
+++ b/client/src/app/cached/__tests__/WithCacheSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/cached/index.js
+++ b/client/src/app/cached/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default as Cache } from './Cache';

--- a/client/src/app/drop-zone/DropZone.js
+++ b/client/src/app/drop-zone/DropZone.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/drop-zone/__tests__/DropZoneSpec.js
+++ b/client/src/app/drop-zone/__tests__/DropZoneSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/app/drop-zone/index.js
+++ b/client/src/app/drop-zone/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { DropZone } from './DropZone';

--- a/client/src/app/index.js
+++ b/client/src/app/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default as App } from './App';

--- a/client/src/app/modals/ModalConductor.js
+++ b/client/src/app/modals/ModalConductor.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/modals/deploy-diagram/AuthTypes.js
+++ b/client/src/app/modals/deploy-diagram/AuthTypes.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const AuthTypes = {

--- a/client/src/app/modals/deploy-diagram/DeployDiagramModal.js
+++ b/client/src/app/modals/deploy-diagram/DeployDiagramModal.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/modals/deploy-diagram/View.js
+++ b/client/src/app/modals/deploy-diagram/View.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/modals/deploy-diagram/__tests__/DeployDiagramModalSpec.js
+++ b/client/src/app/modals/deploy-diagram/__tests__/DeployDiagramModalSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/app/modals/deploy-diagram/error-messages/getCamundaBpmErrorMessage.js
+++ b/client/src/app/modals/deploy-diagram/error-messages/getCamundaBpmErrorMessage.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const ERROR_MESSAGE = {

--- a/client/src/app/modals/deploy-diagram/error-messages/getNetworkErrorMessage.js
+++ b/client/src/app/modals/deploy-diagram/error-messages/getNetworkErrorMessage.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const ERROR_MESSAGE = {

--- a/client/src/app/modals/deploy-diagram/error-messages/getStatusCodeErrorMessage.js
+++ b/client/src/app/modals/deploy-diagram/error-messages/getStatusCodeErrorMessage.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const ERROR_MESSAGE = {

--- a/client/src/app/modals/deploy-diagram/error-messages/index.js
+++ b/client/src/app/modals/deploy-diagram/error-messages/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import getCamundaBpmErrorMessage from './getCamundaBpmErrorMessage';

--- a/client/src/app/modals/deploy-diagram/getEditMenu.js
+++ b/client/src/app/modals/deploy-diagram/getEditMenu.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export default function getEditMenu(enabled) {

--- a/client/src/app/modals/deploy-diagram/index.js
+++ b/client/src/app/modals/deploy-diagram/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default as DeployDiagramModal } from './DeployDiagramModal';

--- a/client/src/app/modals/index.js
+++ b/client/src/app/modals/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default as ModalConductor } from './ModalConductor';

--- a/client/src/app/modals/keyboard-shortcuts/KeyboardShortcutsModal.js
+++ b/client/src/app/modals/keyboard-shortcuts/KeyboardShortcutsModal.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/modals/keyboard-shortcuts/View.js
+++ b/client/src/app/modals/keyboard-shortcuts/View.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/modals/keyboard-shortcuts/__tests__/KeyboardShortcutsModalSpec.js
+++ b/client/src/app/modals/keyboard-shortcuts/__tests__/KeyboardShortcutsModalSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/modals/keyboard-shortcuts/getShortcuts.js
+++ b/client/src/app/modals/keyboard-shortcuts/getShortcuts.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const keyboardBinding = (binding, modifierKey) => {

--- a/client/src/app/modals/keyboard-shortcuts/index.js
+++ b/client/src/app/modals/keyboard-shortcuts/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default as KeyboardShortcutsModal } from './KeyboardShortcutsModal';

--- a/client/src/app/primitives/Button.js
+++ b/client/src/app/primitives/Button.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/primitives/DropdownButton.js
+++ b/client/src/app/primitives/DropdownButton.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/primitives/Loader.js
+++ b/client/src/app/primitives/Loader.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/primitives/Tab.js
+++ b/client/src/app/primitives/Tab.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/primitives/TabContainer.js
+++ b/client/src/app/primitives/TabContainer.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/primitives/TabLinks.js
+++ b/client/src/app/primitives/TabLinks.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/primitives/__tests__/ButtonSpec.js
+++ b/client/src/app/primitives/__tests__/ButtonSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/app/primitives/__tests__/DropdownButtonSpec.js
+++ b/client/src/app/primitives/__tests__/DropdownButtonSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/app/primitives/__tests__/IconSpec.js
+++ b/client/src/app/primitives/__tests__/IconSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/primitives/__tests__/ModalWrapperSpec.js
+++ b/client/src/app/primitives/__tests__/ModalWrapperSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/app/primitives/__tests__/TabLinksSpec.js
+++ b/client/src/app/primitives/__tests__/TabLinksSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/app/primitives/__tests__/mocks/index.js
+++ b/client/src/app/primitives/__tests__/mocks/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export const defaultActiveTab = {

--- a/client/src/app/primitives/icon/Icon.js
+++ b/client/src/app/primitives/icon/Icon.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/primitives/icon/index.js
+++ b/client/src/app/primitives/icon/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default as Icon } from './Icon';

--- a/client/src/app/primitives/index.js
+++ b/client/src/app/primitives/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default as Button } from './Button';

--- a/client/src/app/primitives/modal/ModalWrapper.js
+++ b/client/src/app/primitives/modal/ModalWrapper.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/primitives/modal/index.js
+++ b/client/src/app/primitives/modal/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default as ModalWrapper } from './ModalWrapper';

--- a/client/src/app/slot-fill/Fill.js
+++ b/client/src/app/slot-fill/Fill.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/slot-fill/FillContext.js
+++ b/client/src/app/slot-fill/FillContext.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/slot-fill/Slot.js
+++ b/client/src/app/slot-fill/Slot.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent, Fragment } from 'react';

--- a/client/src/app/slot-fill/SlotContext.js
+++ b/client/src/app/slot-fill/SlotContext.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/slot-fill/SlotFillRoot.js
+++ b/client/src/app/slot-fill/SlotFillRoot.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/slot-fill/WithContext.js
+++ b/client/src/app/slot-fill/WithContext.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/slot-fill/__tests__/FillSpec.js
+++ b/client/src/app/slot-fill/__tests__/FillSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/slot-fill/__tests__/SlotFillSpec.js
+++ b/client/src/app/slot-fill/__tests__/SlotFillSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { Component } from 'react';

--- a/client/src/app/slot-fill/index.js
+++ b/client/src/app/slot-fill/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default as Fill } from './Fill';

--- a/client/src/app/tabs/EditorTab.js
+++ b/client/src/app/tabs/EditorTab.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/tabs/ErrorTab.js
+++ b/client/src/app/tabs/ErrorTab.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/tabs/MultiSheetTab.js
+++ b/client/src/app/tabs/MultiSheetTab.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/tabs/PropertiesContainer.js
+++ b/client/src/app/tabs/PropertiesContainer.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { PureComponent } from 'react';

--- a/client/src/app/tabs/__tests__/EditorTabSpec.js
+++ b/client/src/app/tabs/__tests__/EditorTabSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
+++ b/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/app/tabs/__tests__/PropertiesContainerSpec.js
+++ b/client/src/app/tabs/__tests__/PropertiesContainerSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/app/tabs/__tests__/mocks/index.js
+++ b/client/src/app/tabs/__tests__/mocks/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { Component } from 'react';

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React, { Component } from 'react';

--- a/client/src/app/tabs/bpmn/BpmnTab.js
+++ b/client/src/app/tabs/bpmn/BpmnTab.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import BpmnEditor from './BpmnEditor';

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/app/tabs/bpmn/__tests__/DiagramSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/DiagramSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 describe('tabs/bpmn', function() {

--- a/client/src/app/tabs/bpmn/getBpmnContextMenu.js
+++ b/client/src/app/tabs/bpmn/getBpmnContextMenu.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 function getCopyPasteEntries({

--- a/client/src/app/tabs/bpmn/getBpmnEditMenu.js
+++ b/client/src/app/tabs/bpmn/getBpmnEditMenu.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import {

--- a/client/src/app/tabs/bpmn/getBpmnWindowMenu.js
+++ b/client/src/app/tabs/bpmn/getBpmnWindowMenu.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export default function getBpmnWindowMenu(state) {

--- a/client/src/app/tabs/bpmn/index.js
+++ b/client/src/app/tabs/bpmn/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default } from './BpmnTab';

--- a/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
+++ b/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import BpmnModeler from 'bpmn-js/lib/Modeler';

--- a/client/src/app/tabs/bpmn/modeler/features/apply-default-templates/__tests__/applyDefaultTemplatesSpec.js
+++ b/client/src/app/tabs/bpmn/modeler/features/apply-default-templates/__tests__/applyDefaultTemplatesSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/app/tabs/bpmn/modeler/features/apply-default-templates/applyDefaultTemplates.js
+++ b/client/src/app/tabs/bpmn/modeler/features/apply-default-templates/applyDefaultTemplates.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import {

--- a/client/src/app/tabs/bpmn/modeler/features/apply-default-templates/index.js
+++ b/client/src/app/tabs/bpmn/modeler/features/apply-default-templates/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import applyDefaultTemplates from './applyDefaultTemplates';

--- a/client/src/app/tabs/bpmn/modeler/features/executable-fix/executable-fix.js
+++ b/client/src/app/tabs/bpmn/modeler/features/executable-fix/executable-fix.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/client/src/app/tabs/bpmn/modeler/features/executable-fix/index.js
+++ b/client/src/app/tabs/bpmn/modeler/features/executable-fix/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 module.exports = {

--- a/client/src/app/tabs/bpmn/modeler/features/global-clipboard/index.js
+++ b/client/src/app/tabs/bpmn/modeler/features/global-clipboard/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/PropertiesPanelKeyoardBindings.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/PropertiesPanelKeyoardBindings.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import {

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/__tests__/PropertiesPanelKeyboardBindingsSpec.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/__tests__/PropertiesPanelKeyboardBindingsSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/index.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import PropertiesPanelKeyboardBindings from './PropertiesPanelKeyoardBindings';

--- a/client/src/app/tabs/bpmn/modeler/index.js
+++ b/client/src/app/tabs/bpmn/modeler/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default } from './BpmnModeler';

--- a/client/src/app/tabs/bpmn/util/__tests__/namespaceSpec.js
+++ b/client/src/app/tabs/bpmn/util/__tests__/namespaceSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import {

--- a/client/src/app/tabs/bpmn/util/namespace.js
+++ b/client/src/app/tabs/bpmn/util/namespace.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import BpmnModdle from 'bpmn-moddle';

--- a/client/src/app/tabs/cmmn/CmmnEditor.js
+++ b/client/src/app/tabs/cmmn/CmmnEditor.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/tabs/cmmn/CmmnTab.js
+++ b/client/src/app/tabs/cmmn/CmmnTab.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import CmmnEditor from './CmmnEditor';

--- a/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
+++ b/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/app/tabs/cmmn/__tests__/DiagramSpec.js
+++ b/client/src/app/tabs/cmmn/__tests__/DiagramSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 describe('tabs/cmmn', function() {

--- a/client/src/app/tabs/cmmn/getCmmnEditMenu.js
+++ b/client/src/app/tabs/cmmn/getCmmnEditMenu.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import {

--- a/client/src/app/tabs/cmmn/getCmmnWindowMenu.js
+++ b/client/src/app/tabs/cmmn/getCmmnWindowMenu.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export default function getCmmnWindowMenu(state) {

--- a/client/src/app/tabs/cmmn/index.js
+++ b/client/src/app/tabs/cmmn/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default } from './CmmnTab';

--- a/client/src/app/tabs/cmmn/modeler/CmmnModeler.js
+++ b/client/src/app/tabs/cmmn/modeler/CmmnModeler.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import CmmnModeler from 'cmmn-js/lib/Modeler';

--- a/client/src/app/tabs/cmmn/modeler/index.js
+++ b/client/src/app/tabs/cmmn/modeler/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default } from './CmmnModeler';

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/tabs/dmn/DmnTab.js
+++ b/client/src/app/tabs/dmn/DmnTab.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import DmnEditor from './DmnEditor';

--- a/client/src/app/tabs/dmn/__tests__/DiagramSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DiagramSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 describe('tabs/dmn', function() {

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/app/tabs/dmn/__tests__/DmnModelerSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnModelerSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import DmnModeler from '../modeler';

--- a/client/src/app/tabs/dmn/getDmnEditMenu.js
+++ b/client/src/app/tabs/dmn/getDmnEditMenu.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import {

--- a/client/src/app/tabs/dmn/getDmnWindowMenu.js
+++ b/client/src/app/tabs/dmn/getDmnWindowMenu.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export default function getBpmnWindowMenu(state) {

--- a/client/src/app/tabs/dmn/index.js
+++ b/client/src/app/tabs/dmn/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default } from './DmnTab';

--- a/client/src/app/tabs/dmn/modeler/DmnModeler.js
+++ b/client/src/app/tabs/dmn/modeler/DmnModeler.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import DmnModeler from 'dmn-js/lib/Modeler';

--- a/client/src/app/tabs/dmn/modeler/features/decision-table-keyboard/DecisionTableKeyboard.js
+++ b/client/src/app/tabs/dmn/modeler/features/decision-table-keyboard/DecisionTableKeyboard.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import { inherits } from 'util';

--- a/client/src/app/tabs/dmn/modeler/features/decision-table-keyboard/__tests__/DecisionTableKeyboardSpec.js
+++ b/client/src/app/tabs/dmn/modeler/features/decision-table-keyboard/__tests__/DecisionTableKeyboardSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import DecisionTableKeyboard from '../DecisionTableKeyboard';

--- a/client/src/app/tabs/dmn/modeler/features/decision-table-keyboard/index.js
+++ b/client/src/app/tabs/dmn/modeler/features/decision-table-keyboard/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import EditorActions from 'dmn-js-decision-table/lib/features/editor-actions';

--- a/client/src/app/tabs/dmn/modeler/index.js
+++ b/client/src/app/tabs/dmn/modeler/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default } from './DmnModeler';

--- a/client/src/app/tabs/getEditMenu.js
+++ b/client/src/app/tabs/getEditMenu.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import Flags, { DISABLE_ADJUST_ORIGIN } from '../../util/Flags';

--- a/client/src/app/tabs/xml/CodeMirror.js
+++ b/client/src/app/tabs/xml/CodeMirror.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import CodeMirror from 'codemirror';

--- a/client/src/app/tabs/xml/XMLEditor.js
+++ b/client/src/app/tabs/xml/XMLEditor.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/tabs/xml/__tests__/XMLEditorSpec.js
+++ b/client/src/app/tabs/xml/__tests__/XMLEditorSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/app/tabs/xml/getXMLEditMenu.js
+++ b/client/src/app/tabs/xml/getXMLEditMenu.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import {

--- a/client/src/app/tabs/xml/getXMLWindowMenu.js
+++ b/client/src/app/tabs/xml/getXMLWindowMenu.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export default function getXMLWindowMenu() {

--- a/client/src/app/tabs/xml/index.js
+++ b/client/src/app/tabs/xml/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default } from './XMLEditor';

--- a/client/src/app/util/__tests__/executeOnceSpec.js
+++ b/client/src/app/util/__tests__/executeOnceSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import executeOnce from '../executeOnce';

--- a/client/src/app/util/__tests__/generateImageSpec.js
+++ b/client/src/app/util/__tests__/generateImageSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import generateImage from '../generateImage';

--- a/client/src/app/util/__tests__/parseDiagramTypeSpec.js
+++ b/client/src/app/util/__tests__/parseDiagramTypeSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import parseDiagramType from '../parseDiagramType';

--- a/client/src/app/util/dragger.js
+++ b/client/src/app/util/dragger.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import dragTabs from 'drag-tabs';

--- a/client/src/app/util/executeOnce.js
+++ b/client/src/app/util/executeOnce.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /**

--- a/client/src/app/util/generateImage.js
+++ b/client/src/app/util/generateImage.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import canvg from 'canvg-browser';

--- a/client/src/app/util/parseDiagramType.js
+++ b/client/src/app/util/parseDiagramType.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/client/src/app/util/scroller.js
+++ b/client/src/app/util/scroller.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import scrollTabs from 'scroll-tabs';

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import React from 'react';

--- a/client/src/remote/Backend.js
+++ b/client/src/remote/Backend.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import Ids from 'ids';

--- a/client/src/remote/Config.js
+++ b/client/src/remote/Config.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const GET_CLIENT_CONFIG = 'client-config:get';

--- a/client/src/remote/Dialog.js
+++ b/client/src/remote/Dialog.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import { assign } from 'min-dash';

--- a/client/src/remote/FileSystem.js
+++ b/client/src/remote/FileSystem.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /**

--- a/client/src/remote/Log.js
+++ b/client/src/remote/Log.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export default class Log {

--- a/client/src/remote/Plugins.js
+++ b/client/src/remote/Plugins.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import { filter } from 'min-dash';

--- a/client/src/remote/Workspace.js
+++ b/client/src/remote/Workspace.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /**

--- a/client/src/remote/__tests__/BackendSpec.js
+++ b/client/src/remote/__tests__/BackendSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import Backend from '../Backend';

--- a/client/src/remote/__tests__/DialogSpec.js
+++ b/client/src/remote/__tests__/DialogSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import Dialog from '../Dialog';

--- a/client/src/remote/__tests__/FileSystemSpec.js
+++ b/client/src/remote/__tests__/FileSystemSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import FileSystem from '../FileSystem';

--- a/client/src/remote/__tests__/PluginsSpec.js
+++ b/client/src/remote/__tests__/PluginsSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /* global sinon */

--- a/client/src/remote/__tests__/mocks/index.js
+++ b/client/src/remote/__tests__/mocks/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export class IpcRenderer {

--- a/client/src/remote/electron.js
+++ b/client/src/remote/electron.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export function electronRequire(component) {

--- a/client/src/remote/index.js
+++ b/client/src/remote/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import { electronRequire } from './electron';

--- a/client/src/util/Flags.js
+++ b/client/src/util/Flags.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 class Flags {

--- a/client/src/util/Metadata.js
+++ b/client/src/util/Metadata.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const NOT_INITIALIZED = 'NOT_INITIALIZED';

--- a/client/src/util/__tests__/MetadataSpec.js
+++ b/client/src/util/__tests__/MetadataSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import MetadataSingleton from '../Metadata';

--- a/client/src/util/debounce.js
+++ b/client/src/util/debounce.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import {

--- a/client/src/util/dom/__tests__/draggerSpec.js
+++ b/client/src/util/dom/__tests__/draggerSpec.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import draggerFactory from '../dragger';

--- a/client/src/util/dom/dragger.js
+++ b/client/src/util/dom/dragger.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import {

--- a/client/src/util/dom/isInput.js
+++ b/client/src/util/dom/isInput.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export function isInput(element) {

--- a/client/src/util/index.js
+++ b/client/src/util/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export { default as debounce } from './debounce';

--- a/client/src/util/throttle.js
+++ b/client/src/util/throttle.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 /**

--- a/client/test/all.js
+++ b/client/test/all.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import { configure } from 'enzyme';

--- a/client/test/helper/index.js
+++ b/client/test/helper/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export function insertCSS(name, css) {

--- a/client/test/mocks/bpmn-js/Modeler.js
+++ b/client/test/mocks/bpmn-js/Modeler.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import { assign } from 'min-dash';

--- a/client/test/mocks/cmmn-js/Modeler.js
+++ b/client/test/mocks/cmmn-js/Modeler.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import { assign } from 'min-dash';

--- a/client/test/mocks/code-mirror/CodeMirror.js
+++ b/client/test/mocks/code-mirror/CodeMirror.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 export default function create(options = {}) {

--- a/client/test/mocks/dmn-js/Modeler.js
+++ b/client/test/mocks/dmn-js/Modeler.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import { assign } from 'min-dash';

--- a/client/test/suite.js
+++ b/client/test/suite.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 import { configure } from 'enzyme';

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/package-lock.json
+++ b/package-lock.json
@@ -5198,9 +5198,9 @@
       }
     },
     "eslint-plugin-camunda-licensed": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-camunda-licensed/-/eslint-plugin-camunda-licensed-0.4.1.tgz",
-      "integrity": "sha512-zLoIE4OTZHRIY3Wby3QGkWcMpoesU5ZR49MhW6A47t6KiNW2vfn7ahUe2EdTlUDY3N/PXeECgkZLFWgJWUcAzg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-camunda-licensed/-/eslint-plugin-camunda-licensed-0.4.2.tgz",
+      "integrity": "sha512-o5GS7lfus4vHeFbITp55w+tkXugXWFX2cy3yVWTXJqtqKAfsAeDg9znqpGpjHijUhVJ7dwdaQAALM7EFnt4diw==",
       "dev": true,
       "requires": {
         "eslint-plugin-license-header": "^0.1.2"
@@ -6231,8 +6231,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6256,15 +6255,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6281,22 +6278,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6427,8 +6421,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6442,7 +6435,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6459,7 +6451,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6468,15 +6459,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6497,7 +6486,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6586,8 +6574,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6601,7 +6588,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6697,8 +6683,7 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6740,7 +6725,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6762,7 +6746,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6811,15 +6794,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "electron-reloader": "^0.2.0",
     "eslint": "^5.13.0",
     "eslint-plugin-bpmn-io": "^0.6.1",
-    "eslint-plugin-camunda-licensed": "^0.4.1",
+    "eslint-plugin-camunda-licensed": "^0.4.2",
     "eslint-plugin-import": "^2.16.0",
     "execa": "^1.0.0",
     "lerna": "^3.10.8",

--- a/resources/plugins/test/index.js
+++ b/resources/plugins/test/index.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 module.exports = {

--- a/tasks/after-pack.js
+++ b/tasks/after-pack.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const handlers = [

--- a/tasks/after-pack/add-platform-files.js
+++ b/tasks/after-pack/add-platform-files.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const fs = require('fs');

--- a/tasks/after-pack/add-version.js
+++ b/tasks/after-pack/add-version.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const fs = require('fs');

--- a/tasks/after-pack/register-archive-hook.js
+++ b/tasks/after-pack/register-archive-hook.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const del = require('del').sync;

--- a/tasks/distro.js
+++ b/tasks/distro.js
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const argv = require('mri')(process.argv);

--- a/tasks/license-book.js
+++ b/tasks/license-book.js
@@ -1,8 +1,11 @@
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 'use strict';

--- a/tasks/test-distro.js
+++ b/tasks/test-distro.js
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 
 /**
- * Copyright (c) Camunda Services GmbH.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
  */
 
 const argv = require('yargs').argv;


### PR DESCRIPTION
Up to now we did not use the offical Camunda MIT license header.

This fixes the issue and adapts the official, Elastic style version.