### PR TITLE
Import XML only when it is changed

### DIFF
--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -152,7 +152,7 @@ export class BpmnEditor extends CachedComponent {
   }
 
   componentDidUpdate(prevProps) {
-    this.checkImport(prevProps);
+    this.checkImport();
 
     if (isCacheStateChanged(prevProps, this.props)) {
       this.handleChanged();
@@ -409,16 +409,16 @@ export class BpmnEditor extends CachedComponent {
     return commandStack._stackIdx !== stackIdx;
   }
 
-  async checkImport(prevProps = {}) {
+  checkImport() {
 
-    if (!this.isImportNeeded(prevProps)) {
+    if (!this.isImportNeeded()) {
       return;
     }
 
-    await this.importXML();
+    this.importXML();
   }
 
-  isImportNeeded(prevProps) {
+  isImportNeeded() {
     const {
       importing
     } = this.state;
@@ -435,7 +435,7 @@ export class BpmnEditor extends CachedComponent {
       lastXML
     } = this.getCached();
 
-    return (xml !== prevProps.xml) || (xml !== lastXML);
+    return xml !== lastXML;
   }
 
   async importXML() {

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -775,6 +775,9 @@ describe('<BpmnEditor>', function() {
 
   describe('import', function() {
 
+    afterEach(sinon.restore);
+
+
     it('should import without errors and warnings', function(done) {
 
       // when
@@ -839,6 +842,28 @@ describe('<BpmnEditor>', function() {
           done(error);
         }
       }
+    });
+
+
+    it('should not import when provided xml is the same as the cached one', async function() {
+      // given
+      const isImportNeededSpy = sinon.spy(BpmnEditor.prototype, 'isImportNeeded');
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          lastXML: diagramXML,
+          modeler: new BpmnModeler()
+        }
+      });
+
+      await renderEditor(diagramXML, {
+        cache
+      });
+
+      // then
+      expect(isImportNeededSpy).to.be.called;
+      expect(isImportNeededSpy).to.have.always.returned(false);
     });
 
   });

--- a/client/src/app/tabs/cmmn/CmmnEditor.js
+++ b/client/src/app/tabs/cmmn/CmmnEditor.js
@@ -87,7 +87,7 @@ export class CmmnEditor extends CachedComponent {
   }
 
   componentDidUpdate(prevProps) {
-    this.checkImport(prevProps);
+    this.checkImport();
 
     if (isCachedStateChange(prevProps, this.props)) {
       this.handleChanged();
@@ -252,15 +252,15 @@ export class CmmnEditor extends CachedComponent {
     return commandStack._stackIdx !== stackIdx;
   }
 
-  checkImport(prevProps = {}) {
-    if (!this.isImportNeeded(prevProps)) {
+  checkImport() {
+    if (!this.isImportNeeded()) {
       return;
     }
 
     this.importXML();
   }
 
-  isImportNeeded(prevProps) {
+  isImportNeeded() {
     const {
       importing
     } = this.state;
@@ -277,7 +277,7 @@ export class CmmnEditor extends CachedComponent {
       lastXML
     } = this.getCached();
 
-    return (xml !== prevProps.xml) || (xml !== lastXML);
+    return xml !== lastXML;
   }
 
   importXML() {

--- a/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
+++ b/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
@@ -563,6 +563,9 @@ describe('<CmmnEditor>', function() {
 
   describe('import', function() {
 
+    afterEach(sinon.restore);
+
+
     it('should import without errors and warnings', function(done) {
 
       // when
@@ -627,6 +630,28 @@ describe('<CmmnEditor>', function() {
           done(error);
         }
       }
+    });
+
+
+    it('should not import when provided xml is the same as the cached one', async function() {
+      // given
+      const isImportNeededSpy = sinon.spy(CmmnEditor.prototype, 'isImportNeeded');
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          lastXML: diagramXML,
+          modeler: new CmmnModeler()
+        }
+      });
+
+      await renderEditor(diagramXML, {
+        cache
+      });
+
+      // then
+      expect(isImportNeededSpy).to.be.called;
+      expect(isImportNeededSpy).to.have.always.returned(false);
     });
 
   });

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -98,7 +98,7 @@ export class DmnEditor extends CachedComponent {
   }
 
   componentDidUpdate(prevProps) {
-    this.checkImport(prevProps);
+    this.checkImport();
 
     if (isCachedStateChange(prevProps, this.props)) {
       this.handleChanged();
@@ -360,15 +360,15 @@ export class DmnEditor extends CachedComponent {
     onError(error);
   }
 
-  checkImport(prevProps = {}) {
-    if (!this.isImportNeeded(prevProps)) {
+  checkImport() {
+    if (!this.isImportNeeded()) {
       return;
     }
 
     this.importXML();
   }
 
-  isImportNeeded(prevProps) {
+  isImportNeeded() {
     const {
       importing
     } = this.state;
@@ -385,7 +385,7 @@ export class DmnEditor extends CachedComponent {
       lastXML
     } = this.getCached();
 
-    return (xml !== prevProps.xml) || (xml !== lastXML);
+    return xml !== lastXML;
   }
 
   importXML() {

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -765,6 +765,9 @@ describe('<DmnEditor>', function() {
 
   describe('import', function() {
 
+    afterEach(sinon.restore);
+
+
     it('should import without errors and warnings', function(done) {
 
       // when
@@ -829,6 +832,28 @@ describe('<DmnEditor>', function() {
           done(error);
         }
       }
+    });
+
+
+    it('should not import when provided xml is the same as the cached one', async function() {
+      // given
+      const isImportNeededSpy = sinon.spy(DmnEditor.prototype, 'isImportNeeded');
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          lastXML: diagramXML,
+          modeler: new DmnModeler()
+        }
+      });
+
+      await renderEditor(diagramXML, {
+        cache
+      });
+
+      // then
+      expect(isImportNeededSpy).to.be.called;
+      expect(isImportNeededSpy).to.have.always.returned(false);
     });
 
   });


### PR DESCRIPTION
Removes regression introduced in import refactoring.

![import-check](https://user-images.githubusercontent.com/28307541/53874270-5c0d5280-4002-11e9-844c-842680e6555b.gif)
