### PR TITLE
fix(deploy): auto-focus deployment name

### DIFF
--- a/client/src/app/modals/deploy-diagram/View.js
+++ b/client/src/app/modals/deploy-diagram/View.js
@@ -105,6 +105,7 @@ class View extends PureComponent {
                       component={ FormControl }
                       label="Name"
                       validated
+                      autoFocus
                       onFocusChange={ onFocusChange }
                     />
 


### PR DESCRIPTION
Improve the user flow by automatically focusing the
deployment name. This way the user may start typing right away (and is
not forced to manually click the field).

Closes #750