### PR TITLE
fix(app): allow well-known files to be dropped

### DIFF
--- a/client/src/app/drop-zone/DropZone.js
+++ b/client/src/app/drop-zone/DropZone.js
@@ -45,8 +45,7 @@ export class DropZone extends React.PureComponent {
   isDragAllowed(event) {
     const { dataTransfer } = event;
 
-    return Array.from(dataTransfer.items)
-      .some(({ kind, type }) => type === '' && kind === 'file');
+    return Array.from(dataTransfer.items).some(isDropableItem);
   }
 
   handleDragLeave = event => {
@@ -98,4 +97,15 @@ function DropOverlay() {
       </div>
     </div>
   );
+}
+
+
+export function isDropableItem(item) {
+  const { kind, type } = item;
+
+  if (kind !== 'file') {
+    return false;
+  }
+
+  return /^(text\/.*|application\/([^+]*\+)?xml|application\/(cmmn|bpmn|dmn))?$/.test(type);
 }

--- a/client/src/app/drop-zone/__tests__/DropZoneSpec.js
+++ b/client/src/app/drop-zone/__tests__/DropZoneSpec.js
@@ -16,7 +16,11 @@ import {
   shallow
 } from 'enzyme';
 
-import { DropZone } from '../DropZone';
+import {
+  DropZone,
+  isDropableItem
+} from '../DropZone';
+
 
 describe('<DropZone>', function() {
 
@@ -220,6 +224,58 @@ describe('<DropZone>', function() {
 
 });
 
+
+describe('DropZone - isDropableItem', function() {
+
+  function item(kind, type) {
+    return { kind, type };
+  }
+
+
+  it('should detect droppable file types', function() {
+
+    // given
+    const droppables = [
+      item('file', ''),
+      item('file', 'text/plain'),
+      item('file', 'application/xml'),
+      item('file', 'application/rss+xml'),
+      item('file', 'application/bpmn+xml'),
+      item('file', 'application/cmmn'),
+      item('file', 'application/dmn'),
+      item('file', 'application/bpmn'),
+      item('file', 'text/xml')
+    ];
+
+
+    // then
+    droppables.forEach((item) => {
+      if (!isDropableItem(item)) {
+        throw new Error(`expected ${JSON.stringify(item)} to be droppable`);
+      }
+    });
+
+  });
+
+
+  it('should detect non-droppable file types', function() {
+
+    // given
+    const nonDroppables = [
+      item('foo', 'application/xml'),
+      item('file', 'application/png+image')
+    ];
+
+    // then
+    nonDroppables.forEach((item) => {
+      if (isDropableItem(item)) {
+        throw new Error(`expected ${JSON.stringify(item)} to be non-droppable`);
+      }
+    });
+
+  });
+
+});
 
 
 // helper /////


### PR DESCRIPTION
On my OS (Linux) files with known extensions (TXT or XML) get type set
to the actual mime-type.

This prevents dropping these files, as we previously matched for an
empty file type only (assuming that the OS does not know about BPMN,
CMMN and DMN files).

This PR improves the situation. If the OS reports a well-known type
(or a text typethat may contain a diagram), allow dragging over.