### PR TITLE
Restore warnings hint

### DIFF
--- a/client/src/app/primitives/__tests__/ToastContainerSpec.js
+++ b/client/src/app/primitives/__tests__/ToastContainerSpec.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+
+import {
+  shallow
+} from 'enzyme';
+
+import { ToastContainer } from '..';
+
+
+describe('<ToastContainer>', function() {
+
+  it('should render', function() {
+    shallow(<ToastContainer />);
+  });
+
+
+  it('should render children', function() {
+    const wrapper = shallow((
+      <ToastContainer>
+        <div>
+          { 'Test' }
+        </div>
+      </ToastContainer>
+    ));
+
+    expect(wrapper.contains(<div>{ 'Test' }</div>)).to.be.true;
+  });
+
+});

--- a/client/src/app/primitives/index.js
+++ b/client/src/app/primitives/index.js
@@ -16,3 +16,4 @@ export { default as TabLinks } from './TabLinks';
 export { default as TabContainer } from './TabContainer';
 export { default as Tab } from './Tab';
 export { ModalWrapper } from './modal';
+export { ToastContainer } from './toast';

--- a/client/src/app/primitives/toast/ToastContainer.js
+++ b/client/src/app/primitives/toast/ToastContainer.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+
+import classNames from 'classnames';
+
+import css from './ToastContainer.less';
+
+const TOAST_TYPES = {
+  'alert': css.Alert
+};
+
+const getClassForType = type => {
+  return TOAST_TYPES[type];
+};
+
+const ToastWrapper = props => {
+
+  const {
+    type
+  } = props;
+
+  return (
+    <div className={ classNames(css.ToastContainer, getClassForType(type), props.className) }>
+      { props.children }
+    </div>
+  );
+};
+
+export default ToastWrapper;

--- a/client/src/app/primitives/toast/ToastContainer.less
+++ b/client/src/app/primitives/toast/ToastContainer.less
@@ -1,0 +1,21 @@
+:local(.ToastContainer) {
+
+    text-align: center;
+    top: 100px;
+    left: 0;
+    right: 0;
+    z-index: 10000;
+    position: fixed;
+    margin: 20% auto;
+    height: auto;
+}
+
+:local(.Alert) {
+    text-align: left;
+    margin: 20px auto;
+    display: inline-block;
+    background: #ffffd1;
+    border-radius: 3px;
+    padding: 10px 14px;
+    border: solid 1px #CCC;
+}

--- a/client/src/app/primitives/toast/index.js
+++ b/client/src/app/primitives/toast/index.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+export { default as ToastContainer } from './ToastContainer';

--- a/client/src/app/tabs/MultiSheetTab.js
+++ b/client/src/app/tabs/MultiSheetTab.js
@@ -15,6 +15,8 @@ import {
   TabContainer
 } from '../primitives';
 
+import { ToastConductor } from '../toasts';
+
 import {
   WithCache,
   WithCachedState,
@@ -159,11 +161,34 @@ export class MultiSheetTab extends CachedComponent {
     }
 
     if (warnings && warnings.length) {
+
+      this.openWarningsToast({
+        warnings
+      });
+
       warnings.forEach(warning => {
         this.handleWarning(warning);
       });
     }
   }
+
+  openWarningsToast = options => {
+    const {
+      warnings
+    } = options;
+
+    this.setCached({
+      warnings
+    });
+
+    this.setToast('WARNINGS');
+  }
+
+  setToast = currentToast => this.setCached({ currentToast })
+
+  closeToast = () => {
+    this.setToast(null);
+  };
 
   /**
    * Open fallback sheet if provided.
@@ -314,7 +339,9 @@ export class MultiSheetTab extends CachedComponent {
     let {
       activeSheet,
       sheets,
-      lastXML
+      lastXML,
+      warnings,
+      currentToast
     } = this.getCached();
 
     let {
@@ -362,6 +389,12 @@ export class MultiSheetTab extends CachedComponent {
           tabs={ sheets }
           activeTab={ activeSheet }
           onSelect={ this.switchSheet } />
+
+        <ToastConductor
+          currentToast={ currentToast }
+          warnings={ warnings }
+          onClose={ this.closeToast }
+        />
 
       </div>
     );

--- a/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
+++ b/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
@@ -43,6 +43,9 @@ describe('<MultiSheetTab>', function() {
 
   describe('#handleImport', function() {
 
+    const error = new Error('error');
+    const warnings = [ 'warning', 'warning' ];
+
     it('should import without errors', function() {
 
       // given
@@ -79,14 +82,34 @@ describe('<MultiSheetTab>', function() {
       });
 
       // when
-      const warnings = [ 'warning', 'warning' ];
-
       instance.handleImport(null, warnings);
 
       // then
       expect(errorSpy).not.to.have.been.called;
       expect(warningSpy).to.have.been.calledTwice;
       expect(warningSpy.alwaysCalledWith('warning')).to.be.true;
+    });
+
+
+    it('should open warnings toast', function() {
+
+      // given
+      const {
+        instance
+      } = renderTab();
+
+      // when
+      instance.handleImport(null, warnings);
+
+      const {
+        warnings: stateWarnings,
+        currentToast
+      } = instance.getCached();
+
+      // then
+      expect(stateWarnings).to.eql(warnings);
+      expect(currentToast).to.eql('WARNINGS');
+
     });
 
 
@@ -106,8 +129,6 @@ describe('<MultiSheetTab>', function() {
       const showImportErrorDialogSpy = spy(instance, 'showImportErrorDialog');
 
       // when
-      const error = new Error('error');
-
       instance.handleImport(error);
 
       // then
@@ -295,6 +316,54 @@ describe('<MultiSheetTab>', function() {
       // then
       expect(instance.isDirty()).to.be.false;
     });
+
+  });
+
+
+  describe('toast handling', function() {
+
+    let instance;
+
+    beforeEach(function() {
+      const rendered = renderTab();
+
+      instance = rendered.instance;
+    });
+
+
+    it('should set toast', function() {
+      // given
+      const fakeToastName = 'toast';
+
+      // when
+      instance.setToast(fakeToastName);
+
+      const {
+        currentToast
+      } = instance.getCached();
+
+      // then
+      expect(currentToast).to.eql(fakeToastName);
+    });
+
+
+    it('should close toast', function() {
+      // given
+      const fakeToastName = 'toast';
+
+      instance.setToast(fakeToastName);
+
+      // when
+      instance.closeToast();
+
+      const {
+        currentToast
+      } = instance.getCached();
+
+      // then
+      expect(currentToast).to.eql(null);
+    });
+
 
   });
 

--- a/client/src/app/toasts/ToastConductor.js
+++ b/client/src/app/toasts/ToastConductor.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+
+import { WarningsToast } from './warnings';
+
+const WARNINGS = 'WARNINGS';
+
+
+const ToastConductor = props => {
+  switch (props.currentToast) {
+  case WARNINGS:
+    return <WarningsToast { ...props } />;
+  default:
+    return null;
+  }
+};
+
+export default ToastConductor;

--- a/client/src/app/toasts/index.js
+++ b/client/src/app/toasts/index.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+export { default as ToastConductor } from './ToastConductor';

--- a/client/src/app/toasts/warnings/WarningsToast.js
+++ b/client/src/app/toasts/warnings/WarningsToast.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React, { PureComponent } from 'react';
+
+import css from './WarningsToast.less';
+
+import {
+  ToastContainer
+} from '../../primitives';
+
+class WarningsToast extends PureComponent {
+
+  render() {
+
+    const {
+      onClose,
+      warnings
+    } = this.props;
+
+    return (
+      <ToastContainer onClose={ onClose } className={ css.WarningsToast } type="alert">
+          Imported with { warningsString(warnings) }. See further information inside the Log. &nbsp;
+
+        <span className='close-warnings' onClick={ onClose }></span>
+      </ToastContainer>);
+  }
+}
+
+export default WarningsToast;
+
+// helpers //////////
+
+function warningsString(warnings) {
+  var count = (warnings || []).length;
+
+  return count + ' warning' + (count !== 1 ? 's' : '');
+}

--- a/client/src/app/toasts/warnings/WarningsToast.less
+++ b/client/src/app/toasts/warnings/WarningsToast.less
@@ -6,7 +6,7 @@
         vertical-align: middle;
         padding: 0 2px;
         margin-left: 3px;
-    
+        cursor: pointer;
         font-size: 18px;
         line-height: 9px;
         vertical-align: middle;

--- a/client/src/app/toasts/warnings/WarningsToast.less
+++ b/client/src/app/toasts/warnings/WarningsToast.less
@@ -1,0 +1,19 @@
+:local(.WarningsToast) {
+    max-width:  400px;
+
+    .close-warnings {
+        display: inline-block;
+        vertical-align: middle;
+        padding: 0 2px;
+        margin-left: 3px;
+    
+        font-size: 18px;
+        line-height: 9px;
+        vertical-align: middle;
+        width: 13px;
+    
+        &:before {
+          content: '×';
+        }
+      }
+}

--- a/client/src/app/toasts/warnings/__tests__/WarningsToastSpec.js
+++ b/client/src/app/toasts/warnings/__tests__/WarningsToastSpec.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+
+import {
+  mount,
+  shallow
+} from 'enzyme';
+
+import { WarningsToast } from '..';
+
+/* global sinon */
+const { spy } = sinon;
+
+describe('<WarningsToast>', function() {
+
+  it('should render', function() {
+    shallow(<WarningsToast />);
+  });
+
+
+  it('should execute onClose', function() {
+
+    // given
+    const closeSpy = spy();
+
+    const wrapper = mount(<WarningsToast
+      onClose={ closeSpy }
+    />);
+
+    const closeButton = wrapper.find('.close-warnings');
+
+    // assure
+    expect(closeButton).to.exist;
+
+    // when
+    closeButton.simulate('click');
+
+    // then
+    expect(closeSpy).to.have.been.called;
+
+  });
+
+});

--- a/client/src/app/toasts/warnings/index.js
+++ b/client/src/app/toasts/warnings/index.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+export { default as WarningsToast } from './WarningsToast';


### PR DESCRIPTION
Closes #1177 

This restores the alert when a diagram is opened with warnings. In comparison with the hint inside the `v.2.2.4` version, it is implemented in a per-tab manner instead inside every editor. I also decided to not restore the 'Open Log' function as it would lead to conflicts with the warning log handling inside the `AppParent`. 

It uses a similar approach as the `ModalConductor`, so it's possible to create different types of toasts in future (e.g. for short notifications, hints etc).

![image](https://user-images.githubusercontent.com/9433996/54192139-93bf4300-44b7-11e9-9491-62f13a811eb7.png)
