### PR TITLE
chore(client/App): refactor exportAs

### DIFF
--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -1004,13 +1004,13 @@ describe('<App>', function() {
     });
 
 
-    it('should handle export error <export-as>', async function() {
+    it('should handle export error <retry>', async function() {
 
       // given
       await app.createDiagram();
 
       dialog.setShowSaveFileDialogResponse('foo.svg');
-      dialog.setShowSaveFileErrorDialogResponse('export-as');
+      dialog.setShowSaveFileErrorDialogResponse('retry');
 
       const err = new Error('foo');
 
@@ -1019,7 +1019,7 @@ describe('<App>', function() {
         contents: '<contents>'
       }));
 
-      const exportAsSpy = spy(app, 'exportAs');
+      const exportAsSpy = spy(app, 'exportAsFile');
 
       // when
       await app.triggerAction('export-as');


### PR DESCRIPTION
As a follow-up from the [last week's hour of code](https://github.com/bpmn-io/hour-of-code/blob/master/snippets/App_exportAs.md) I refactored the `App.js#exportAs` method, in order to make the export retry more understandable and the whole function(s) more readable (cf. [Single responsibility principle](https://en.wikipedia.org/wiki/Single_responsibility_principle).