### PR TITLE
fix(client/editors): prevent import when props did not update

### DIFF
--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -154,7 +154,7 @@ export class BpmnEditor extends CachedComponent {
   }
 
   componentDidUpdate(prevProps) {
-    this.checkImport();
+    this.checkImport(prevProps);
 
     if (isCacheStateChanged(prevProps, this.props)) {
       this.handleChanged();
@@ -405,16 +405,16 @@ export class BpmnEditor extends CachedComponent {
     return commandStack._stackIdx !== stackIdx;
   }
 
-  checkImport() {
+  checkImport(prevProps) {
 
-    if (!this.isImportNeeded()) {
+    if (!this.isImportNeeded(prevProps)) {
       return;
     }
 
     this.importXML();
   }
 
-  isImportNeeded() {
+  isImportNeeded(prevProps) {
     const {
       importing
     } = this.state;
@@ -426,6 +426,10 @@ export class BpmnEditor extends CachedComponent {
     const {
       xml
     } = this.props;
+
+    if (prevProps && prevProps.xml === xml) {
+      return false;
+    }
 
     const {
       lastXML

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -891,6 +891,26 @@ describe('<BpmnEditor>', function() {
       expect(isImportNeededSpy).to.have.always.returned(false);
     });
 
+
+    it('should not import when props did not changed', async function() {
+      // given
+      const {
+        instance
+      } = await renderEditor(diagramXML);
+
+      const isImportNeededSpy = sinon.spy(instance, 'isImportNeeded');
+
+      // when
+      await instance.componentDidUpdate({
+        xml: diagramXML
+      });
+
+      // then
+      expect(isImportNeededSpy).to.be.called;
+      expect(isImportNeededSpy).to.have.always.returned(false);
+
+    });
+
   });
 
 

--- a/client/src/app/tabs/cmmn/CmmnEditor.js
+++ b/client/src/app/tabs/cmmn/CmmnEditor.js
@@ -87,7 +87,7 @@ export class CmmnEditor extends CachedComponent {
   }
 
   componentDidUpdate(prevProps) {
-    this.checkImport();
+    this.checkImport(prevProps);
 
     if (isCachedStateChange(prevProps, this.props)) {
       this.handleChanged();
@@ -252,15 +252,15 @@ export class CmmnEditor extends CachedComponent {
     return commandStack._stackIdx !== stackIdx;
   }
 
-  checkImport() {
-    if (!this.isImportNeeded()) {
+  checkImport(prevProps) {
+    if (!this.isImportNeeded(prevProps)) {
       return;
     }
 
     this.importXML();
   }
 
-  isImportNeeded() {
+  isImportNeeded(prevProps) {
     const {
       importing
     } = this.state;
@@ -272,6 +272,10 @@ export class CmmnEditor extends CachedComponent {
     const {
       xml
     } = this.props;
+
+    if (prevProps && prevProps.xml === xml) {
+      return false;
+    }
 
     const {
       lastXML

--- a/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
+++ b/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
@@ -628,6 +628,26 @@ describe('<CmmnEditor>', function() {
       expect(isImportNeededSpy).to.have.always.returned(false);
     });
 
+
+    it('should not import when props did not changed', async function() {
+      // given
+      const {
+        instance
+      } = await renderEditor(diagramXML);
+
+      const isImportNeededSpy = sinon.spy(instance, 'isImportNeeded');
+
+      // when
+      await instance.componentDidUpdate({
+        xml: diagramXML
+      });
+
+      // then
+      expect(isImportNeededSpy).to.be.called;
+      expect(isImportNeededSpy).to.have.always.returned(false);
+
+    });
+
   });
 
 

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -98,7 +98,7 @@ export class DmnEditor extends CachedComponent {
   }
 
   componentDidUpdate(prevProps) {
-    this.checkImport();
+    this.checkImport(prevProps);
 
     if (isCachedStateChange(prevProps, this.props)) {
       this.handleChanged();
@@ -360,15 +360,15 @@ export class DmnEditor extends CachedComponent {
     onError(error);
   }
 
-  checkImport() {
-    if (!this.isImportNeeded()) {
+  checkImport(prevProps) {
+    if (!this.isImportNeeded(prevProps)) {
       return;
     }
 
     this.importXML();
   }
 
-  isImportNeeded() {
+  isImportNeeded(prevProps) {
     const {
       importing
     } = this.state;
@@ -380,6 +380,10 @@ export class DmnEditor extends CachedComponent {
     const {
       xml
     } = this.props;
+
+    if (prevProps && prevProps.xml === xml) {
+      return false;
+    }
 
     const {
       lastXML

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -831,6 +831,26 @@ describe('<DmnEditor>', function() {
       expect(isImportNeededSpy).to.have.always.returned(false);
     });
 
+
+    it('should not import when props did not changed', async function() {
+      // given
+      const {
+        instance
+      } = await renderEditor(diagramXML);
+
+      const isImportNeededSpy = sinon.spy(instance, 'isImportNeeded');
+
+      // when
+      await instance.componentDidUpdate({
+        xml: diagramXML
+      });
+
+      // then
+      expect(isImportNeededSpy).to.be.called;
+      expect(isImportNeededSpy).to.have.always.returned(false);
+
+    });
+
   });
 
 


### PR DESCRIPTION
Closes #1298

While the past refactoring of import handling inside all editors, we removed the `xml-change-check` when the editors trigger an update. This pull request re-adds it, to ensure no old xml is imported.