### PR TITLE
fix(client): handle undo/redo manually

### DIFF
--- a/client/src/app/KeyboardBindings.js
+++ b/client/src/app/KeyboardBindings.js
@@ -45,6 +45,8 @@ export default class KeyboardBindings {
     this.cut = null;
     this.paste = null;
     this.selectAll = null;
+    this.undo = null;
+    this.redo = null;
 
     if (menu) {
       this.update(menu);
@@ -83,13 +85,19 @@ export default class KeyboardBindings {
       action = getAction(this.paste);
     }
 
-    if (isRedo(event) && isEnabled(this.redo) && !hasRole(this.redo, 'redo')) {
-      action = getAction(this.redo);
-    }
-
     // select all
     if (isSelectAll(event) && isEnabled(this.selectAll) && !hasRole(this.selectAll, 'selectAll')) {
       action = getAction(this.selectAll);
+    }
+
+    // undo
+    if (isUndo(event) && isEnabled(this.undo) && !hasRole(this.undo, 'undo')) {
+      action = getAction(this.undo);
+    }
+
+    // redo
+    if (isRedo(event) && isEnabled(this.redo) && !hasRole(this.redo, 'redo')) {
+      action = getAction(this.redo);
     }
 
     if (action && onAction) {
@@ -103,8 +111,9 @@ export default class KeyboardBindings {
     this.copy = findCopy(menu);
     this.cut = findCut(menu);
     this.paste = findPaste(menu);
-    this.redo = findRedo(menu);
     this.selectAll = findSelectAll(menu);
+    this.undo = findUndo(menu);
+    this.redo = findRedo(menu);
   }
 
   setOnAction(onAction) {
@@ -114,24 +123,35 @@ export default class KeyboardBindings {
 
 // helpers //////////
 
+// Ctrl + C
 function isCopy(event) {
   return isKey(['c', 'C'], event) && isCommandOrControl(event);
 }
 
+// Ctrl + X
 function isCut(event) {
   return isKey(['x', 'X'], event) && isCommandOrControl(event);
 }
 
+// Ctrl + V
 function isPaste(event) {
   return isKey(['v', 'V'], event) && isCommandOrControl(event);
 }
 
-function isRedo(event) {
-  return isKey(['z', 'Z'], event) && isCommandOrControl(event) && isShift(event);
-}
-
+// Ctrl + A
 function isSelectAll(event) {
   return isKey(['a', 'A'], event) && isCommandOrControl(event);
+}
+
+// Ctrl + Z
+function isUndo(event) {
+  return isKey(['z', 'Z'], event) && isCommandOrControl(event) && !isShift(event);
+}
+
+// Ctrl + Y or Ctrl + Shift + Z
+function isRedo(event) {
+  return isCommandOrControl(event) &&
+    (isKey([ 'y', 'Y' ], event) || (isKey(['z', 'Z'], event) && isShift(event)));
 }
 
 /**
@@ -184,6 +204,10 @@ function findCut(menu) {
 
 function findPaste(menu) {
   return find(menu, ({ accelerator }) => isAccelerator(accelerator, 'CommandOrControl+V'));
+}
+
+function findUndo(menu) {
+  return find(menu, ({ accelerator }) => isAccelerator(accelerator, 'CommandOrControl+Z'));
 }
 
 function findRedo(menu) {

--- a/client/src/app/__tests__/KeyboardBindingsSpec.js
+++ b/client/src/app/__tests__/KeyboardBindingsSpec.js
@@ -89,6 +89,65 @@ describe('KeyboardBindings', function() {
   });
 
 
+  it('undo', function() {
+
+    // given
+    event = createKeyEvent('Z', { ctrlKey: true });
+
+    keyboardBindings.update([{
+      accelerator: 'CommandOrControl + Z',
+      action: 'undo'
+    }]);
+
+    // when
+    keyboardBindings._keyHandler(event);
+
+    // then
+    expect(actionSpy).to.have.been.calledWith(null, 'undo');
+  });
+
+
+  describe('redo', function() {
+
+    it('redo (Ctrl + Y)', function() {
+
+      // given
+      event = createKeyEvent('Y', { ctrlKey: true });
+
+      keyboardBindings.update([{
+        accelerator: 'CommandOrControl + Y',
+        action: 'redo'
+      }]);
+
+      // when
+      keyboardBindings._keyHandler(event);
+
+      // then
+      expect(actionSpy).to.have.been.calledWith(null, 'redo');
+    });
+
+
+    it('redo (Ctrl + Shift + Z)', function() {
+
+      // given
+      event = createKeyEvent('Z', { ctrlKey: true, shiftKey: true });
+
+      keyboardBindings.update([{
+        accelerator: 'CommandOrControl + Y',
+        action: 'redo'
+      }]);
+
+      // when
+      keyboardBindings._keyHandler(event);
+
+      // then
+      expect(actionSpy).to.have.been.calledWith(null, 'redo');
+    });
+
+  });
+
+
+
   it('selectAll', function() {
 
     // given
@@ -104,24 +163,6 @@ describe('KeyboardBindings', function() {
 
     // then
     expect(actionSpy).to.have.been.calledWith(null, 'selectAll');
-  });
-
-
-  it('redo', function() {
-
-    // given
-    event = createKeyEvent('Z', { ctrlKey: true, shiftKey: true });
-
-    keyboardBindings.update([{
-      accelerator: 'CommandOrControl + Y',
-      action: 'redo'
-    }]);
-
-    // when
-    keyboardBindings._keyHandler(event);
-
-    // then
-    expect(actionSpy).to.have.been.calledWith(null, 'redo');
   });
 
 

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -180,7 +180,9 @@ export class BpmnEditor extends CachedComponent {
       'attach',
       'elements.copied',
       'propertiesPanel.focusin',
-      'propertiesPanel.focusout'
+      'propertiesPanel.focusout',
+      'directEditing.activate',
+      'directEditing.deactivate'
     ].forEach((event) => {
       modeler[fn](event, this.handleChanged);
     });
@@ -345,6 +347,7 @@ export class BpmnEditor extends CachedComponent {
       copy: !!selectionLength,
       cut: false,
       defaultCopyCutPaste: inputActive,
+      defaultUndoRedo: inputActive,
       dirty,
       distribute: selectionLength > 2,
       editLabel: !inputActive && !!selectionLength,

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -307,6 +307,11 @@ describe('<BpmnEditor>', function() {
 
     it('propertiesPanel.focusout', expectHandleChanged('propertiesPanel.focusout'));
 
+
+    it('propertiesPanel.focusout', expectHandleChanged('directEditing.activate'));
+
+
+    it('propertiesPanel.focusout', expectHandleChanged('directEditing.deactivate'));
   });
 
 
@@ -321,6 +326,8 @@ describe('<BpmnEditor>', function() {
         expect(state).to.include({
           align: false,
           copy: false,
+          defaultCopyCutPaste: false,
+          defaultUndoRedo: false,
           dirty: true,
           distribute: false,
           editLabel: false,

--- a/client/src/app/tabs/bpmn/getBpmnEditMenu.js
+++ b/client/src/app/tabs/bpmn/getBpmnEditMenu.js
@@ -12,6 +12,7 @@ import {
   getCanvasEntries,
   getCopyCutPasteEntries,
   getDefaultCopyCutPasteEntries,
+  getDefaultUndoRedoEntries,
   getDiagramFindEntries,
   getSelectionEntries,
   getToolEntries,
@@ -57,14 +58,21 @@ function getAlignDistributeEntries({
 }
 
 export function getBpmnEditMenu(state) {
-  const { defaultCopyCutPaste } = state;
+  const {
+    defaultCopyCutPaste,
+    defaultUndoRedo
+  } = state;
+
+  const undoRedoEntries = defaultUndoRedo
+    ? getDefaultUndoRedoEntries()
+    : getUndoRedoEntries(state);
 
   const copyCutPasteEntries = defaultCopyCutPaste
     ? getDefaultCopyCutPasteEntries()
     : getCopyCutPasteEntries(state);
 
   return [
-    getUndoRedoEntries(state),
+    undoRedoEntries,
     copyCutPasteEntries,
     getToolEntries(state),
     getAlignDistributeEntries(state),

--- a/client/src/app/tabs/cmmn/CmmnEditor.js
+++ b/client/src/app/tabs/cmmn/CmmnEditor.js
@@ -112,7 +112,9 @@ export class CmmnEditor extends CachedComponent {
       'selection.changed',
       'attach',
       'propertiesPanel.focusin',
-      'propertiesPanel.focusout'
+      'propertiesPanel.focusout',
+      'directEditing.activate',
+      'directEditing.deactivate'
     ].forEach((event) => {
       modeler[fn](event, this.handleChanged);
     });
@@ -199,6 +201,7 @@ export class CmmnEditor extends CachedComponent {
       copy: false,
       cut: false,
       defaultCopyCutPaste: inputActive,
+      defaultUndoRedo: inputActive,
       dirty,
       editLabel: !inputActive && !!selectionLength,
       exportAs: EXPORT_AS,

--- a/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
+++ b/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
@@ -219,6 +219,12 @@ describe('<CmmnEditor>', function() {
 
     it('propertiesPanel.focusout', expectHandleChanged('propertiesPanel.focusout'));
 
+
+    it('propertiesPanel.focusout', expectHandleChanged('directEditing.activate'));
+
+
+    it('propertiesPanel.focusout', expectHandleChanged('directEditing.deactivate'));
+
   });
 
 
@@ -268,6 +274,8 @@ describe('<CmmnEditor>', function() {
 
       expect(changedSpy).to.be.calledOnce;
       expect(changedSpy.firstCall.args[0]).to.include({
+        defaultCopyCutPaste: false,
+        defaultUndoRedo: false,
         dirty: true,
         editLabel: false,
         find: true,

--- a/client/src/app/tabs/cmmn/getCmmnEditMenu.js
+++ b/client/src/app/tabs/cmmn/getCmmnEditMenu.js
@@ -12,6 +12,7 @@ import {
   getCanvasEntries,
   getCopyCutPasteEntries,
   getDefaultCopyCutPasteEntries,
+  getDefaultUndoRedoEntries,
   getDiagramFindEntries,
   getSelectionEntries,
   getToolEntries,
@@ -19,14 +20,21 @@ import {
 } from '../getEditMenu';
 
 export function getCmmnEditMenu(state) {
-  const { defaultCopyCutPaste } = state;
+  const {
+    defaultCopyCutPaste,
+    defaultUndoRedo
+  } = state;
+
+  const undoRedoEntries = defaultUndoRedo
+    ? getDefaultUndoRedoEntries()
+    : getUndoRedoEntries(state);
 
   const copyCutPasteEntries = defaultCopyCutPaste
     ? getDefaultCopyCutPasteEntries()
     : getCopyCutPasteEntries(state);
 
   return [
-    getUndoRedoEntries(state),
+    undoRedoEntries,
     copyCutPasteEntries,
     getToolEntries(state),
     getDiagramFindEntries(state),

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -293,6 +293,7 @@ export class DmnEditor extends CachedComponent {
     if (activeView.type === 'drd') {
       assign(newState, {
         defaultCopyCutPaste: inputActive,
+        defaultUndoRedo: inputActive,
         editLabel: !inputActive && !!selectionLength,
         lassoTool: !inputActive,
         moveCanvas: !inputActive,
@@ -306,6 +307,7 @@ export class DmnEditor extends CachedComponent {
     } else if (activeView.type === 'decisionTable') {
       assign(newState, {
         defaultCopyCutPaste: true,
+        defaultUndoRedo: true,
         hasSelection: activeViewer.get('selection').hasSelection(),
         removeSelected: inputActive,
         selectAll: inputActive
@@ -320,6 +322,7 @@ export class DmnEditor extends CachedComponent {
     } else if (activeView.type === 'literalExpression') {
       assign(newState, {
         defaultCopyCutPaste: true,
+        defaultUndoRedo: true,
         removeSelected: true,
         selectAll: true
       });

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -225,6 +225,8 @@ describe('<DmnEditor>', function() {
 
         // then
         expect(state).to.include({
+          defaultCopyCutPaste: false,
+          defaultUndoRedo: false,
           dirty: true,
           editLabel: false,
           inputActive: false,

--- a/client/src/app/tabs/dmn/getDmnEditMenu.js
+++ b/client/src/app/tabs/dmn/getDmnEditMenu.js
@@ -12,6 +12,7 @@ import {
   getCanvasEntries,
   getCopyCutPasteEntries,
   getDefaultCopyCutPasteEntries,
+  getDefaultUndoRedoEntries,
   getSelectionEntries,
   getToolEntries,
   getUndoRedoEntries
@@ -107,14 +108,21 @@ export function getDmnDrdEditMenu(state) {
 }
 
 export function getDmnDecisionTableEditMenu(state) {
-  const { defaultCopyCutPaste } = state;
+  const {
+    defaultCopyCutPaste,
+    defaultUndoRedo
+  } = state;
+
+  const undoRedoEntries = defaultUndoRedo
+    ? getDefaultUndoRedoEntries()
+    : getUndoRedoEntries(state);
 
   const copyCutPasteEntries = defaultCopyCutPaste
     ? getDefaultCopyCutPasteEntries()
     : getCopyCutPasteEntries(state);
 
   return [
-    getUndoRedoEntries(state),
+    undoRedoEntries,
     copyCutPasteEntries,
     getSelectionEntries(state),
     ...getDecisionTableEntries(state)

--- a/client/src/app/tabs/getEditMenu.js
+++ b/client/src/app/tabs/getEditMenu.js
@@ -222,6 +222,8 @@ export function getToolEntries({
   return menuEntries;
 }
 
+// undo and redo must be handled manually due to a bug in Chromium
+// see https://github.com/electron/electron/issues/3682
 export function getUndoRedoEntries({
   redo,
   undo
@@ -236,6 +238,16 @@ export function getUndoRedoEntries({
     accelerator: 'CommandOrControl+Y',
     enabled: redo,
     action: 'redo'
+  }];
+}
+
+export function getDefaultUndoRedoEntries() {
+  return [{
+    label: 'Undo',
+    role: 'undo'
+  }, {
+    label: 'Redo',
+    role: 'redo'
   }];
 }
 


### PR DESCRIPTION
* handle undo/redo manually (similar to copy/cut/paste)
* update edit menu on `directEditing.activate` and `directEditing.deactivate`
* edit menu entries to trigger native undo/redo OR command stack undo/redo depending on state of editor
* added some comments

Closes #1218