### PR TITLE
chore(client/App): refactor saveTab

### DIFF
--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -869,13 +869,13 @@ describe('<App>', function() {
     });
 
 
-    it('should handle save error <save-as>', async function() {
+    it('should handle save error <retry>', async function() {
 
       // given
       await app.createDiagram();
 
       dialog.setShowSaveFileDialogResponse('foo.svg');
-      dialog.setShowSaveFileErrorDialogResponse('save-as');
+      dialog.setShowSaveFileErrorDialogResponse('retry');
 
       const err = new Error('foo');
 
@@ -884,7 +884,7 @@ describe('<App>', function() {
         contents: '<contents>'
       }));
 
-      const saveTabSpy = spy(app, 'saveTab');
+      const saveTabSpy = spy(app, 'saveTabAsFile');
 
       // when
       await app.triggerAction('save-as');


### PR DESCRIPTION
Follow-up of the latest hour-of-code session (cf. https://github.com/bpmn-io/hour-of-code/commit/51b4f8c50aede163527eca85dea74af763edc8f7). It refactors the `App.js#saveTab` functionality to different methods, to make it more understandable. Follows the same approach as #1297. 