### PR TITLE
fix(project): deep clone git repo for post distro ci stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ jobs:
     - stage: "post distro"
       node_js: node
       language: node_js
+      git:
+        depth: false
       script:
       - npm run send-license-book-summary
     - stage: "nightly build [windows+linux]"


### PR DESCRIPTION
Travis CI clones repository with --depth=50 which may cause it impossible to get previous tag.

I changed the config, but still want to test it locally and that's why it's WIP.