### PR TITLE
fix(client): show open file error dialog if tab couldn't be created

### DIFF
--- a/app/dev.js
+++ b/app/dev.js
@@ -24,6 +24,8 @@ pkg.version = getAppVersion(pkg, {
   nightly: 'dev'
 });
 
+// monkey-patch cli args to not open this file in application
+process.argv = process.argv.filter(arg => !arg.includes('dev.js'));
 
 const app = require('./lib');
 

--- a/app/lib/dialog.js
+++ b/app/lib/dialog.js
@@ -48,7 +48,7 @@ class Dialog {
       name
     } = options;
 
-    this.showDialog({
+    return this.showDialog({
       type: 'error',
       title: 'File Open Error',
       buttons: [

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -356,20 +356,29 @@ describe('<App>', function() {
     });
 
 
-    it('should ignore unrecognized files', async function() {
+    it('should not open unrecognized files', async function() {
 
       // given
-      const {
-        app
-      } = createApp();
+      const dialog = new Dialog();
 
-      const file = createFile('1.unknown');
+      const showSpy = spy(dialog, 'showOpenFileErrorDialog');
+
+      dialog.setShowOpenFileErrorDialogResponse('cancel');
+
+      const { app } = createApp({
+        globals: {
+          dialog
+        }
+      });
+
+      const file = createFile('1.txt');
 
       // when
       const openedTabs = await app.openFiles([ file ]);
 
       // then
       expect(openedTabs).to.be.empty;
+      expect(showSpy).to.have.been.called;
     });
 
 

--- a/client/src/app/drop-zone/DropZone.js
+++ b/client/src/app/drop-zone/DropZone.js
@@ -100,6 +100,14 @@ function DropOverlay() {
 }
 
 
+/**
+ * Checks for droppable items e.g. text/foo, text/plain, application/foo+xml,
+ * application/bpmn, application/cmmn, application/dmn.
+ *
+ * @param {Object} item - Item to be dropped.
+ *
+ * @returns {boolean}
+ */
 export function isDropableItem(item) {
   const { kind, type } = item;
 


### PR DESCRIPTION
* if tab couldn't be created for whatever reason we show a generic error to the user
* add documentation for isDroppableItem

Closes #1314