### PR TITLE
fix(client): update lastXML on xml prop change

### DIFF
--- a/client/src/app/tabs/MultiSheetTab.js
+++ b/client/src/app/tabs/MultiSheetTab.js
@@ -316,10 +316,12 @@ export class MultiSheetTab extends CachedComponent {
 
   componentDidMount() {
     const {
-      setCachedState
+      setCachedState,
+      xml
     } = this.props;
 
     let {
+      lastXML,
       sheets
     } = this.getCached();
 
@@ -332,10 +334,25 @@ export class MultiSheetTab extends CachedComponent {
       });
     }
 
+    if (isXMLChange(lastXML, xml)) {
+      this.setCached({
+        lastXML: xml
+      });
+    }
+
+  }
+
+  componentDidUpdate(prevProps) {
+    const { xml } = this.props;
+
+    if (isXMLChange(prevProps.xml, xml)) {
+      this.setCached({
+        lastXML: xml
+      });
+    }
   }
 
   render() {
-
     let {
       activeSheet,
       sheets,

--- a/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
+++ b/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
@@ -41,6 +41,59 @@ describe('<MultiSheetTab>', function() {
   });
 
 
+  describe('xml prop', function() {
+
+    it('update lastXML if xml prop changed (mount)', function() {
+
+      // given
+      const xml = 'foo';
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          lastXML: 'bar'
+        }
+      });
+
+      // when
+      const { instance } = renderTab({
+        xml,
+        cache
+      });
+
+      // then
+      const { lastXML } = instance.getCached();
+
+      expect(lastXML).to.eql(xml);
+    });
+
+
+    it('update lastXML if xml prop changed (update)', function() {
+
+      // given
+      const {
+        instance,
+        wrapper
+      } = renderTab({
+        xml: 'foo'
+      });
+
+      const xml = 'bar';
+
+      // when
+      wrapper.setProps({
+        xml
+      });
+
+      // then
+      const { lastXML } = instance.getCached();
+
+      expect(lastXML).to.equal(xml);
+    });
+  });
+
+
   describe('#handleImport', function() {
 
     const error = new Error('error');
@@ -379,6 +432,7 @@ const TestTab = WithCachedState(MultiSheetTab);
 function renderTab(options = {}) {
   const {
     id,
+    cache,
     xml,
     tab,
     layout,
@@ -392,7 +446,7 @@ function renderTab(options = {}) {
     providers
   } = options;
 
-  const withCachedState = mount(
+  const wrapper = mount(
     <TestTab
       id={ id || 'editor' }
       tab={ tab || defaultTab }
@@ -405,7 +459,7 @@ function renderTab(options = {}) {
       onContextMenu={ onContextMenu || noop }
       onAction={ onAction || noop }
       providers={ providers || defaultProviders }
-      cache={ options.cache || new Cache() }
+      cache={ cache || new Cache() }
       layout={ layout || {
         minimap: {
           open: false
@@ -417,9 +471,9 @@ function renderTab(options = {}) {
     />
   );
 
-  const wrapper = withCachedState.find(MultiSheetTab);
+  const multiSheetTab = wrapper.find(MultiSheetTab);
 
-  const instance = wrapper.instance();
+  const instance = multiSheetTab.instance();
 
   return {
     instance,


### PR DESCRIPTION
Due to [this line](https://github.com/camunda/camunda-modeler/blob/master/client/src/app/tabs/MultiSheetTab.js#L370) in `MultiSheetTab` the cached `lastXML` property must be updated whenever the `xml` prop changes.

Closes #1318