### PR TITLE
fix(client/xml-editor): restore copy, cut and paste menu entries

### DIFF
--- a/client/src/app/tabs/xml/getXMLEditMenu.js
+++ b/client/src/app/tabs/xml/getXMLEditMenu.js
@@ -32,9 +32,30 @@ function getXMLFindEntries() {
   }];
 }
 
+function getXMLCopyCutPasteEntries() {
+  return [
+    {
+      label: 'Cut',
+      accelerator: 'CmdOrCtrl+X',
+      role: 'cut'
+    },
+    {
+      label: 'Copy',
+      accelerator: 'CmdOrCtrl+C',
+      role: 'copy'
+    },
+    {
+      label: 'Paste',
+      accelerator: 'CmdOrCtrl+V',
+      role: 'paste'
+    }
+  ];
+}
+
 export function getXMLEditMenu(state) {
   return [
     getUndoRedoEntries(state),
+    getXMLCopyCutPasteEntries(),
     getXMLFindEntries()
   ];
 }


### PR DESCRIPTION
This also restores the actual actions on Mac.

Closes #868
Closes #814 

Related to [SUPPORT-6136](https://app.camunda.com/jira/browse/SUPPORT-6136)

Needs manual testing. Please test on Windows if the actions still work as supposed.
