### PR TITLE
fix(menu): disable devtools handler when dialog is open

### DIFF
--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -384,6 +384,11 @@ class MenuBuilder {
       label: 'Toggle DevTools',
       accelerator: 'F12',
       click: (_, browserWindow) => {
+        // TODO: remove when proper handler is added
+        if (!browserWindow) {
+          return;
+        }
+        
         const isDevToolsOpened = browserWindow.isDevToolsOpened();
 
         if (isDevToolsOpened) {


### PR DESCRIPTION
This disables devtools menu handler when no browser window is passed to the callback.
Such situation may appear when a dialog is open and then the button is clicked or
the shortcut is activated.

Closes #1445