### PR TITLE
Disable node integration

### DIFF
--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -338,7 +338,11 @@ app.createEditorWindow = function() {
   const windowOptions = {
     resizable: true,
     show: false,
-    title: 'Camunda Modeler'
+    title: 'Camunda Modeler',
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      nodeIntegration: false
+    }
   };
 
   if (process.platform === 'linux') {

--- a/app/lib/preload.js
+++ b/app/lib/preload.js
@@ -8,6 +8,30 @@
  * except in compliance with the MIT License.
  */
 
-export function electronRequire(component) {
-  return window.require('electron')[component];
-}
+const {
+  remote,
+  ipcRenderer
+} = require('electron');
+
+const {
+  process,
+  app
+} = remote;
+
+const {
+  platform
+} = process;
+
+/* global window */
+
+window.getAppPreload = function() {
+
+  return {
+    metadata: app.metadata,
+    plugins: app.plugins.getAll(),
+    flags: app.flags.getAll(),
+    ipcRenderer,
+    platform
+  };
+
+};

--- a/client/src/remote/index.js
+++ b/client/src/remote/index.js
@@ -8,8 +8,6 @@
  * except in compliance with the MIT License.
  */
 
-import { electronRequire } from './electron';
-
 import Backend from './Backend';
 import Config from './Config';
 import Dialog from './Dialog';
@@ -19,13 +17,12 @@ import Plugins from './Plugins';
 import Workspace from './Workspace';
 
 const {
-  app,
-  process
-} = electronRequire('remote');
-
-const platform = process.platform;
-
-export const ipcRenderer = electronRequire('ipcRenderer');
+  metadata,
+  flags,
+  platform,
+  plugins: appPlugins,
+  ipcRenderer
+} = window.getAppPreload();
 
 export const backend = new Backend(ipcRenderer, platform);
 
@@ -35,12 +32,13 @@ export const config = new Config(backend);
 
 export const dialog = new Dialog(backend);
 
-export const plugins = new Plugins(app.plugins.getAll());
-
-export const metadata = app.metadata;
-
-export const flags = app.flags.getAll();
+export const plugins = new Plugins(appPlugins);
 
 export const workspace = new Workspace(backend);
 
 export const log = new Log(backend);
+
+export {
+  metadata,
+  flags
+};


### PR DESCRIPTION
This ensures we follow best practices with our electron app and disable the node integration.

As a result, client plug-ins may not freely run code in the scope of the OS. This is a __potential breaking change__.

My few cents are that we should adopt this PR and see if anyone uses this hidden capability. No plug-in should have done that.

Depends on https://github.com/camunda/camunda-modeler/pull/1451 and https://github.com/camunda/camunda-modeler/pull/1452