### PR TITLE
chore(client): bump diagram-js-minimap version

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3608,9 +3608,9 @@
       }
     },
     "diagram-js-minimap": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/diagram-js-minimap/-/diagram-js-minimap-1.3.0.tgz",
-      "integrity": "sha512-7rdafQqrth+BlW0IAKDG6AKYDT+mUyRSUSzpRQwGnPVMmFaplZN4vr7hHP86qZRMnkfvLV2MlAEd+8sRl+uRPA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/diagram-js-minimap/-/diagram-js-minimap-2.0.1.tgz",
+      "integrity": "sha512-8MaMisXLNn4BcobNLj84A9kIEvHEF4bVkU5sPCxvHI2z3PrlUGv4Xv7mnmdVULoJD0+7sn6QC1NqYPsblNTNmA==",
       "requires": {
         "css.escape": "^1.5.1",
         "min-dash": "^3.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
     "codemirror": "^5.46.0",
     "debug": "^4.1.1",
     "diagram-js": "^4.0.3",
-    "diagram-js-minimap": "^1.3.0",
+    "diagram-js-minimap": "^2.0.1",
     "diagram-js-origin": "^1.2.0",
     "dmn-js": "^6.3.3",
     "dmn-js-properties-panel": "^0.3.0",


### PR DESCRIPTION
Updates to current `diagram-js-minimap` version.