### PR TITLE
Correctly display suggestion to disable plugins

### DIFF
--- a/client/src/app/AppParent.js
+++ b/client/src/app/AppParent.js
@@ -175,7 +175,7 @@ export default class AppParent extends PureComponent {
   }
 
   hasPlugins() {
-    return this.getPlugins().getAll().length;
+    return this.getPlugins().getAppPlugins().length;
   }
 
   togglePlugins = () => {

--- a/client/src/app/__tests__/AppParentSpec.js
+++ b/client/src/app/__tests__/AppParentSpec.js
@@ -761,7 +761,7 @@ describe('<AppParent>', function() {
       });
 
       const plugins = new Plugins({
-        getAll: () => [{}]
+        getAppPlugins: () => [{}]
       });
 
       const { appParent } = createAppParent({

--- a/client/src/app/__tests__/mocks/index.js
+++ b/client/src/app/__tests__/mocks/index.js
@@ -464,7 +464,7 @@ export class Plugins extends Mock {
     return [];
   }
 
-  getAll() {
+  getAppPlugins() {
     return [];
   }
 }


### PR DESCRIPTION
This fixes a problem when error in the app caused an unhandled exception because of renamed `remote/Plugins` method.

Closes https://github.com/camunda/camunda-modeler/issues/1479.