### PR TITLE
Allow to display custom warning/error category.

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -983,14 +983,14 @@ export class App extends PureComponent {
   /**
    * Propagates errors to parent.
    * @param {Error} error
-   * @param {Tab} [tab]
+   * @param {Tab|string} [categoryOrTab]
    */
-  handleError = (error, tab) => {
+  handleError = (error, categoryOrTab) => {
     const {
       onError
     } = this.props;
 
-    return onError(error, tab);
+    return onError(error, categoryOrTab);
   }
 
   getGlobal = (name) => {
@@ -1008,14 +1008,14 @@ export class App extends PureComponent {
   /**
    * Propagates warnings to parent.
    * @param {Error} error
-   * @param {Tab} [tab]
+   * @param {Tab|string} [categoryOrTab]
    */
-  handleWarning(warning, tab) {
+  handleWarning(warning, categoryOrTab) {
     const {
       onWarning
     } = this.props;
 
-    return onWarning(warning, tab);
+    return onWarning(warning, categoryOrTab);
   }
 
   /**

--- a/client/src/app/__tests__/AppParentSpec.js
+++ b/client/src/app/__tests__/AppParentSpec.js
@@ -435,6 +435,32 @@ describe('<AppParent>', function() {
     });
 
 
+    it('should log client errors with string source attached', async function() {
+
+      // given
+      const backend = new Backend();
+
+      const {
+        appParent
+      } = createAppParent({ globals: { backend } }, mount);
+
+      const app = appParent.getApp();
+      const actionSpy = spy(app, 'triggerAction');
+      const error = createError();
+      const source = 'error-source';
+
+      // when
+      await appParent.handleError(error, source);
+
+      // then
+      expect(actionSpy).to.have.been.calledWith('log', {
+        message: `[${source}] ${error.message}\n${error.stack}`,
+        category: 'error'
+      });
+
+    });
+
+
     it('should log tab errors with file path attached', async function() {
 
       // given
@@ -648,6 +674,34 @@ describe('<AppParent>', function() {
       // then
       expect(actionSpy).to.have.been.calledWith('log', {
         message: warning.message,
+        category: 'warning'
+      });
+
+    });
+
+
+    it('should log client warnings with string source attached', async function() {
+
+      // given
+      const backend = new Backend();
+
+      const {
+        appParent
+      } = createAppParent({ globals: { backend } }, mount);
+
+      const app = appParent.getApp();
+      const actionSpy = spy(app, 'triggerAction');
+      const warning = {
+        message: 'warning'
+      };
+      const source = 'warning-source';
+
+      // when
+      await app.handleWarning(warning, source);
+
+      // then
+      expect(actionSpy).to.have.been.calledWith('log', {
+        message: `[${source}] ${warning.message}`,
         category: 'warning'
       });
 


### PR DESCRIPTION
Simply pass the category as a second argument to `App#handleError`
and `App#handleWarning` callbacks.

This will be useful for logging plugin errors. Might be also used for deployment errors instead of a custom logEntry.