### PR TITLE
Display fills in a stable order

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1681,7 +1681,7 @@ export class App extends PureComponent {
 
             <Toolbar />
 
-            <Fill name="toolbar" group="general">
+            <Fill name="toolbar" group="1_general">
               <DropdownButton
                 title="Create diagram"
                 items={ [
@@ -1718,7 +1718,7 @@ export class App extends PureComponent {
               </Button>
             </Fill>
 
-            <Fill name="toolbar" group="save">
+            <Fill name="toolbar" group="2_save">
               <Button
                 disabled={ !canSave }
                 onClick={ canSave ? this.composeAction('save') : null }
@@ -1735,7 +1735,7 @@ export class App extends PureComponent {
               </Button>
             </Fill>
 
-            <Fill name="toolbar" group="editor">
+            <Fill name="toolbar" group="3_editor">
               <Button
                 disabled={ !tabState.undo }
                 onClick={ this.composeAction('undo') }
@@ -1753,7 +1753,7 @@ export class App extends PureComponent {
             </Fill>
 
             {
-              tabState.exportAs && <Fill name="toolbar" group="export">
+              tabState.exportAs && <Fill name="toolbar" group="4_export">
                 <Button
                   title="Export as image"
                   onClick={ this.composeAction('export-as') }

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1681,7 +1681,7 @@ export class App extends PureComponent {
 
             <Toolbar />
 
-            <Fill name="toolbar" group="1_general">
+            <Fill slot="toolbar" group="1_general">
               <DropdownButton
                 title="Create diagram"
                 items={ [
@@ -1718,7 +1718,7 @@ export class App extends PureComponent {
               </Button>
             </Fill>
 
-            <Fill name="toolbar" group="2_save">
+            <Fill slot="toolbar" group="2_save">
               <Button
                 disabled={ !canSave }
                 onClick={ canSave ? this.composeAction('save') : null }
@@ -1735,7 +1735,7 @@ export class App extends PureComponent {
               </Button>
             </Fill>
 
-            <Fill name="toolbar" group="3_editor">
+            <Fill slot="toolbar" group="3_editor">
               <Button
                 disabled={ !tabState.undo }
                 onClick={ this.composeAction('undo') }
@@ -1753,7 +1753,7 @@ export class App extends PureComponent {
             </Fill>
 
             {
-              tabState.exportAs && <Fill name="toolbar" group="4_export">
+              tabState.exportAs && <Fill slot="toolbar" group="4_export">
                 <Button
                   title="Export as image"
                   onClick={ this.composeAction('export-as') }

--- a/client/src/app/Toolbar.js
+++ b/client/src/app/Toolbar.js
@@ -18,7 +18,7 @@ export default class Toolbar extends PureComponent {
   render() {
     return (
       <div className={ css.Toolbar }>
-        <Slot name="toolbar" group={ groupButtons } separator={ (key) => <Separator key={ key } /> } />
+        <Slot name="toolbar" separator={ (key) => <Separator key={ key } /> } />
       </div>
     );
   }
@@ -28,46 +28,4 @@ function Separator(props) {
   return (
     <span className={ 'separator' } { ...props }></span>
   );
-}
-
-
-function groupButtons(buttonFills) {
-
-  const defaultGroups = [
-    'general',
-    'save',
-    'editor',
-    'export'
-  ];
-
-  const groups = [];
-
-  const groupsById = {};
-
-  defaultGroups.forEach(function(groupName) {
-
-    const group = [];
-
-    groupsById[groupName] = group;
-    groups.push(group);
-  });
-
-  buttonFills.forEach(function(button) {
-
-    const groupName = button.props.group || '__default';
-
-    let group = groupsById[groupName];
-
-    if (!group) {
-      group = [];
-      groupsById[groupName] = group;
-      groups.push(group);
-    }
-
-    group.push(button);
-  });
-
-  return groups.filter(function(group) {
-    return group.length;
-  });
 }

--- a/client/src/app/slot-fill/Slot.js
+++ b/client/src/app/slot-fill/Slot.js
@@ -53,7 +53,7 @@ export default class Slot extends PureComponent {
         ({ fills }) => {
 
           const filtered = fills.filter(fill => {
-            return fill.props.name === name;
+            return fill.props.slot === name;
           });
 
           const cropped = limit ? filtered.slice(0, limit) : filtered;

--- a/client/src/app/slot-fill/__tests__/SlotFillSpec.js
+++ b/client/src/app/slot-fill/__tests__/SlotFillSpec.js
@@ -158,7 +158,7 @@ describe('slot-fill', function() {
     it('should update fill', function() {
       var slotFillRoot = ReactDOM.render(
         <SlotFillRoot>
-          <Fill name="foo">
+          <Fill slot="foo">
             <RenderButtons />
           </Fill>
           <Slot name="foo" />
@@ -194,7 +194,7 @@ describe('slot-fill', function() {
       // when
       var slotFillRoot = ReactDOM.render(
         <SlotFillRoot>
-          <Fill name="foo">
+          <Fill slot="foo">
             <div className="fill" />
           </Fill>
           <div className="slot">
@@ -218,7 +218,7 @@ describe('slot-fill', function() {
 
         // given
         var unorderedFills = [ '1_a', '2_b', '3_a', 'foo', '2_a' ].map(id => (
-          <Fill name="foo" group={ id } key={ id }>
+          <Fill slot="foo" group={ id } key={ id }>
             <div className="fill" id={ id } />
           </Fill>
         ));
@@ -255,13 +255,13 @@ describe('slot-fill', function() {
         // when
         var slotFillRoot = ReactDOM.render(
           <SlotFillRoot>
-            <Fill name="foo" group="1_a" priority={ -1 }>
+            <Fill slot="foo" group="1_a" priority={ -1 }>
               <div className="fill" id="low_priority" />
             </Fill>
-            <Fill name="foo" group="1_a">
+            <Fill slot="foo" group="1_a">
               <div className="fill" id="no_priority" />
             </Fill>
-            <Fill name="foo" group="1_a" priority={ 100 }>
+            <Fill slot="foo" group="1_a" priority={ 100 }>
               <div className="fill" id="high_priority" />
             </Fill>
             <div className="slot">

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -672,7 +672,7 @@ export class BpmnEditor extends CachedComponent {
 
         <Loader hidden={ !importing } />
 
-        <Fill name="toolbar" group="color">
+        <Fill name="toolbar" group="5_color">
           <DropdownButton
             title="Set element color"
             disabled={ !this.state.setColor }
@@ -695,7 +695,7 @@ export class BpmnEditor extends CachedComponent {
           </DropdownButton>
         </Fill>
 
-        <Fill name="toolbar" group="align">
+        <Fill name="toolbar" group="6_align">
           <Button
             title="Align elements left"
             disabled={ !this.state.align }
@@ -739,7 +739,7 @@ export class BpmnEditor extends CachedComponent {
           </Button>
         </Fill>
 
-        <Fill name="toolbar" group="distribute">
+        <Fill name="toolbar" group="7_distribute">
           <Button
             title="Distribute elements horizontally"
             disabled={ !this.state.distribute }
@@ -756,7 +756,7 @@ export class BpmnEditor extends CachedComponent {
           </Button>
         </Fill>
 
-        <Fill name="toolbar" group="deploy">
+        <Fill name="toolbar" group="8_deploy">
           <Button
             onClick={ this.props.onModal.bind(null, 'DEPLOY_DIAGRAM') }
             title="Deploy Current Diagram"

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -672,7 +672,7 @@ export class BpmnEditor extends CachedComponent {
 
         <Loader hidden={ !importing } />
 
-        <Fill name="toolbar" group="5_color">
+        <Fill slot="toolbar" group="5_color">
           <DropdownButton
             title="Set element color"
             disabled={ !this.state.setColor }
@@ -695,7 +695,7 @@ export class BpmnEditor extends CachedComponent {
           </DropdownButton>
         </Fill>
 
-        <Fill name="toolbar" group="6_align">
+        <Fill slot="toolbar" group="6_align">
           <Button
             title="Align elements left"
             disabled={ !this.state.align }
@@ -739,7 +739,7 @@ export class BpmnEditor extends CachedComponent {
           </Button>
         </Fill>
 
-        <Fill name="toolbar" group="7_distribute">
+        <Fill slot="toolbar" group="7_distribute">
           <Button
             title="Distribute elements horizontally"
             disabled={ !this.state.distribute }
@@ -756,7 +756,7 @@ export class BpmnEditor extends CachedComponent {
           </Button>
         </Fill>
 
-        <Fill name="toolbar" group="8_deploy">
+        <Fill slot="toolbar" group="8_deploy">
           <Button
             onClick={ this.props.onModal.bind(null, 'DEPLOY_DIAGRAM') }
             title="Deploy Current Diagram"

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -639,7 +639,7 @@ export class DmnEditor extends CachedComponent {
 
         <Loader hidden={ !importing } />
 
-        <Fill name="toolbar" group="8_deploy">
+        <Fill slot="toolbar" group="8_deploy">
           <Button
             onClick={ this.props.onModal.bind(null, 'DEPLOY_DIAGRAM') }
             title="Deploy Current Diagram"

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -639,7 +639,7 @@ export class DmnEditor extends CachedComponent {
 
         <Loader hidden={ !importing } />
 
-        <Fill name="toolbar" group="deploy">
+        <Fill name="toolbar" group="8_deploy">
           <Button
             onClick={ this.props.onModal.bind(null, 'DEPLOY_DIAGRAM') }
             title="Deploy Current Diagram"

--- a/client/src/plugins/deployment-tool/DeploymentTool.js
+++ b/client/src/plugins/deployment-tool/DeploymentTool.js
@@ -18,7 +18,7 @@ export default class DeploymentTool extends PureComponent {
 
     return (
       <React.Fragment>
-        <Fill name="toolbar" group="extension">
+        <Fill slot="toolbar" group="extension">
           🤩
         </Fill>
       </React.Fragment>


### PR DESCRIPTION
Fills are now ordered alphabetically by group name and take
a new property `priority` with 0 as default which is used
to determine the order within a group. The higher the priority,
the earlier the Fill is displayed.

Closes #1492