### PR TITLE
Add timeout to deployment & connection check

### DIFF
--- a/client/src/plugins/deployment-tool/CamundaAPI.js
+++ b/client/src/plugins/deployment-tool/CamundaAPI.js
@@ -10,6 +10,8 @@
 
 import { ConnectionErrorMessages } from './ErrorMessages';
 
+const FETCH_TIMEOUT = 5000;
+
 
 export default class CamundaAPI {
   constructor(baseUrl) {
@@ -106,11 +108,12 @@ export default class CamundaAPI {
     throw new Error('Unknown auth options.');
   }
 
-  async safelyFetch(url, ...args) {
+  async safelyFetch(url, options = {}) {
     let response;
 
     try {
-      response = await fetch(url, ...args);
+      options.signal = options.signal || this.setupTimeoutSignal();
+      response = await fetch(url, options);
     } catch (error) {
       response = {
         url,
@@ -121,6 +124,16 @@ export default class CamundaAPI {
     }
 
     return response;
+  }
+
+  setupTimeoutSignal(timeout = FETCH_TIMEOUT) {
+    const controller = new AbortController();
+
+    const { signal } = controller;
+
+    setTimeout(() => controller.abort(), timeout);
+
+    return signal;
   }
 
   async safelyParse(response) {

--- a/client/src/plugins/deployment-tool/__tests__/CamundaAPISpec.js
+++ b/client/src/plugins/deployment-tool/__tests__/CamundaAPISpec.js
@@ -203,6 +203,51 @@ describe('<CamundaAPI>', () => {
       }
     });
 
+
+    describe('timeout handling', () => {
+
+      let clock;
+
+      before(() => {
+        clock = sinon.useFakeTimers();
+      });
+
+      after(() => clock.restore());
+
+
+      it('should abort request on timeout', async () => {
+
+        // given
+        fetchStub.callsFake((_, { signal }) => {
+          return new Promise(resolve => {
+            for (let i = 0; i < 10; i++) {
+              if (signal && signal.aborted) {
+                throw new Error('timeout');
+              }
+
+              clock.tick(2000);
+            }
+
+            resolve(new Response());
+          });
+        });
+
+        // when
+        let error;
+
+        try {
+          await api.checkConnection();
+        } catch (e) {
+          error = e;
+        } finally {
+
+          // then
+          expect(error).to.exist;
+        }
+      });
+
+    });
+
   });
 
 });


### PR DESCRIPTION
This PR builds on top of https://github.com/camunda/camunda-modeler/pull/1491
It adds a timeout so that the deployment tool doesn't hang in case the server does not handle the request for some reason.
