### PR TITLE
Derive default deployment name from the filename

### DIFF
--- a/client/src/plugins/deployment-tool/DeploymentTool.js
+++ b/client/src/plugins/deployment-tool/DeploymentTool.js
@@ -130,8 +130,10 @@ export default class DeploymentTool extends PureComponent {
   }
 
   getDetailsFromUserInput(tab, details) {
+    const initialDetails = this.getInitialDetails(tab, details);
+
     return new Promise(resolve => {
-      const handleClose = (result) => {
+      const handleClose = result => {
 
         this.setState({
           modalState: null
@@ -151,7 +153,7 @@ export default class DeploymentTool extends PureComponent {
       this.setState({
         modalState: {
           tab,
-          details,
+          details: initialDetails,
           handleClose
         }
       });
@@ -185,6 +187,16 @@ export default class DeploymentTool extends PureComponent {
     }
 
     return connectionError;
+  }
+
+  getInitialDetails(tab, providedDetails) {
+    const details = { ...providedDetails };
+
+    if (!details.deploymentName) {
+      details.deploymentName = withoutExtension(tab.name);
+    }
+
+    return details;
   }
 
   getValidatedFields(values) {
@@ -285,4 +297,8 @@ export default class DeploymentTool extends PureComponent {
 // helper ///////
 function isFocusedOnInput(event) {
   return event.type === 'focus' && ['INPUT', 'TEXTAREA'].includes(event.target.tagName);
+}
+
+function withoutExtension(name) {
+  return name.replace(/\.[^.]+$/, '');
 }

--- a/client/src/plugins/deployment-tool/__tests__/DeploymentToolSpec.js
+++ b/client/src/plugins/deployment-tool/__tests__/DeploymentToolSpec.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/* global sinon */
+
+import React from 'react';
+
+import { mount, shallow } from 'enzyme';
+
+import DeploymentTool from '../DeploymentTool';
+import DeploymentDetailsModal from '../DeploymentDetailsModal';
+
+
+describe('<DeploymentTool>', () => {
+
+  it('should render', () => {
+    createDeploymentTool();
+  });
+
+
+  it('should derive the default deployment name from filename', () => {
+
+    // given
+    const { instance } = createDeploymentTool();
+
+    // when
+    const details = instance.getInitialDetails({ name });
+
+    // then
+    expect(details).to.have.property('deploymentName', name);
+  });
+
+
+  describe('#deploy', () => {
+
+    let fetchStub,
+        mounted;
+
+    beforeEach(() => {
+      fetchStub = sinon.stub(window, 'fetch');
+    });
+
+    afterEach(() => {
+      fetchStub.restore();
+
+      if (mounted) {
+        mounted.unmount();
+      }
+    });
+
+
+    it('should derive deployment name from filename', async () => {
+
+      // given
+      const activeTab = createTab({ name: 'foo.bpmn' });
+      const {
+        wrapper,
+        instance
+      } = createDeploymentTool({ activeTab }, mount);
+
+      mounted = wrapper;
+
+      // when
+      instance.deploy();
+
+      await nextTick();
+      wrapper.update();
+
+      // then
+      const modal = wrapper.find(DeploymentDetailsModal).first();
+
+      const onClose = modal.prop('onClose');
+      const deploymentName = modal.find('input[name="deploymentName"]').first().getDOMNode().value;
+
+      expect(deploymentName).to.eql('foo');
+
+      onClose();
+    });
+
+  });
+});
+
+
+
+// helper ////
+function createDeploymentTool({
+  activeTab = createTab(),
+  ...props
+} = {}, render = shallow) {
+  const subscribe = (event, callback) => {
+    event === 'app.activeTabChanged' && callback(activeTab);
+  };
+
+  const triggerAction = event => {
+    switch (event) {
+    case 'save':
+      return activeTab;
+    }
+  };
+
+  const wrapper = render(<DeploymentTool
+    subscribe={ subscribe }
+    triggerAction={ triggerAction }
+    { ...props }
+  />);
+
+  return {
+    wrapper,
+    instance: wrapper.instance()
+  };
+}
+
+function createTab(overrides = {}) {
+  return {
+    id: 42,
+    name: 'foo.bar',
+    type: 'bar',
+    title: 'unsaved',
+    file: {
+      name: 'foo.bar',
+      contents: '',
+      path: null
+    },
+    ...overrides
+  };
+}
+
+function nextTick() {
+  return new Promise(resolve => process.nextTick(() => resolve()));
+}


### PR DESCRIPTION
This PR allows to derive the deployment name from the filename. E.g. for a file called `diagram_1.bpmn` it will set the deployment name to `diagram_1`.

Requires https://github.com/camunda/camunda-modeler/pull/1491