### PR TITLE
chore(client): bump camunda-bpm-moddle dependency

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2492,9 +2492,9 @@
       }
     },
     "camunda-bpmn-moddle": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-4.1.2.tgz",
-      "integrity": "sha512-eyrtdo3d9gecD2xExsrNsfEpgkMrmPfj/w9VUqOn6uKn5hpX7lv7RDt4YLjBxwdhPJf+1LTWrmjFKZC0dUB8pw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-4.2.0.tgz",
+      "integrity": "sha512-H69zGH7INadESygOCzuYbHhFX4jWW0nVBRv3d32w21RC539QwYnrF/SswIoTPxeqJftwHGaTqLwRL/WM+kEDvw==",
       "requires": {
         "min-dash": "^3.0.0"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,7 @@
     "bpmn-js": "^5.0.5",
     "bpmn-js-properties-panel": "^0.32.1",
     "bpmn-js-signavio-compat": "^1.2.0",
-    "camunda-bpmn-moddle": "^4.1.2",
+    "camunda-bpmn-moddle": "^4.2.0",
     "camunda-cmmn-moddle": "^1.0.0",
     "camunda-dmn-moddle": "^1.0.0",
     "canvg-browser": "^1.0.0",


### PR DESCRIPTION
Bump to `camunda-bpm-moddle@4.2.0`

Adds support for `camunda:diagramRelationId` property.