### PR TITLE
feat(client/modal): expose title only

### DIFF
--- a/client/src/app/modals/keyboard-shortcuts/View.js
+++ b/client/src/app/modals/keyboard-shortcuts/View.js
@@ -27,9 +27,7 @@ class View extends PureComponent {
     return (
       <Modal className={ css.View } onClose={ onClose }>
 
-        <Modal.Header>
-          <Modal.Title>Keyboard Shortcuts</Modal.Title>
-        </Modal.Header>
+        <Modal.Title>Keyboard Shortcuts</Modal.Title>
 
         <Modal.Body>
           <p>

--- a/client/src/app/primitives/__tests__/ModalSpec.js
+++ b/client/src/app/primitives/__tests__/ModalSpec.js
@@ -39,6 +39,7 @@ describe('<Modal>', function() {
   it('should render children', function() {
     const wrapper = mount((
       <Modal>
+        <Modal.Title><div>{ 'Foo' }</div></Modal.Title>
         <Modal.Body>
           <div>
             { 'Test' }
@@ -47,6 +48,7 @@ describe('<Modal>', function() {
       </Modal>
     ));
 
+    expect(wrapper.contains(<div>{ 'Foo' }</div>)).to.be.true;
     expect(wrapper.contains(<div>{ 'Test' }</div>)).to.be.true;
   });
 

--- a/client/src/app/primitives/modal/Modal.js
+++ b/client/src/app/primitives/modal/Modal.js
@@ -78,8 +78,6 @@ Modal.defaultProps = {
   onClose: () => {}
 };
 
-Modal.Header = Header;
-
 Modal.Body = Body;
 
 Modal.Title = Title;
@@ -92,9 +90,11 @@ Modal.Footer = Footer;
 function Title(props) {
 
   return (
-    <h2 className="modal-title">
-      { props.children }
-    </h2>
+    <div className="modal-header">
+      <h2 className="modal-title">
+        { props.children }
+      </h2>
+    </div>
   );
 }
 
@@ -108,15 +108,6 @@ function Close(props) {
     <span className="close" onClick={ onClick }>
       ×
     </span>
-  );
-}
-
-function Header(props) {
-
-  return (
-    <div className="modal-header">
-      { props.children }
-    </div>
   );
 }
 

--- a/client/src/plugins/deployment-tool/DeploymentDetailsModal.js
+++ b/client/src/plugins/deployment-tool/DeploymentDetailsModal.js
@@ -212,9 +212,7 @@ export default class DeploymentDetailsModal extends React.PureComponent {
         >
           {({ isSubmitting, values }) => (
             <Form>
-              <Modal.Header>
-                <Modal.Title>Deploy Diagram</Modal.Title>
-              </Modal.Header>
+              <Modal.Title>Deploy Diagram</Modal.Title>
 
               <Modal.Body>
                 <p className="intro">


### PR DESCRIPTION
There is not much value in exposing the header, if the only thing a user
should ever customize is the title.

Related to #1558