### PR TITLE
Start Instance Feature

### DIFF
--- a/client/resources/icons/Play.svg
+++ b/client/resources/icons/Play.svg
@@ -1,0 +1,1 @@
+<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="play" class="svg-inline--fa fa-play fa-w-14" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M424.4 214.7L72.4 6.6C43.8-10.3 0 6.1 0 47.9V464c0 37.5 40.7 60.1 72.4 41.3l352-208c31.4-18.5 31.5-64.1 0-82.6z"></path></svg>

--- a/client/src/plugins/camunda-plugin/CamundaPlugin.js
+++ b/client/src/plugins/camunda-plugin/CamundaPlugin.js
@@ -11,22 +11,47 @@
 import React, { PureComponent } from 'react';
 
 import DeploymentTool from './deployment-tool';
+import StartInstanceTool from './start-instance-tool';
 
 /**
  * A plugin to handle both Camunda BPM related tools
  * a) DeploymentTool
- * b) todo(pinussilvestrus): StartInstanceTool (to be implemented),
- * cf. https://github.com/camunda/camunda-modeler/issues/1552
+ * b) StartInstanceTool
  */
 export default class CamundaPlugin extends PureComponent {
 
     deployRef = React.createRef();
 
     render() {
+
+      const deployService = new DeployService(this.deployRef);
+
       return <React.Fragment>
         <DeploymentTool
           ref={ this.deployRef }
           { ...this.props } />
+
+        <StartInstanceTool
+          ref={ this.startInstanceRef }
+          deployService={ deployService }
+          { ...this.props } />
       </React.Fragment>;
     }
+}
+
+class DeployService {
+
+  constructor(ref) {
+    this.deploymentRef = ref;
+  }
+
+  deployWithConfiguration = (...args) => this.current().deployWithConfiguration(...args);
+  getSavedDeployConfiguration = (...args) => this.current().getSavedConfiguration(...args);
+  getDeployConfigurationFromUserInput = (...args) => this.current().getConfigurationFromUserInput(...args);
+  saveDeployConfiguration = (...args) => this.current().saveConfiguration(...args);
+
+  current() {
+    return this.deploymentRef.current;
+  }
+
 }

--- a/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
@@ -30,6 +30,7 @@ import {
 
 const DEPLOYMENT_DETAILS_CONFIG_KEY = 'deployment-tool';
 const ENGINE_ENDPOINTS_CONFIG_KEY = 'camundaEngineEndpoints';
+const PROCESS_DEFINITION_CONFIG_KEY = 'process-definition';
 
 const DEFAULT_ENDPOINT = {
   url: 'http://localhost:8080/engine-rest',
@@ -115,6 +116,9 @@ export default class DeploymentTool extends PureComponent {
     try {
       const deployment = await this.deployWithConfiguration(tab, configuration);
 
+      // (3.2) save deployed process definition
+      await this.saveProcessDefinition(tab, deployment);
+
       await this.handleDeploymentSuccess(tab, deployment);
     } catch (error) {
       await this.handleDeploymentError(tab, error);
@@ -131,6 +135,23 @@ export default class DeploymentTool extends PureComponent {
       title: 'Deployment succeeded',
       duration: 4000
     });
+  }
+
+  async saveProcessDefinition(tab, deployment) {
+
+    if (!deployment || !deployment.deployedProcessDefinition) {
+      return;
+    }
+
+    const {
+      deployedProcessDefinition: processDefinition
+    } = deployment;
+
+    const {
+      config
+    } = this.props;
+
+    return await config.setForFile(tab.file, PROCESS_DEFINITION_CONFIG_KEY, processDefinition);
   }
 
   handleDeploymentError(tab, error) {

--- a/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentToolSpec.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentToolSpec.js
@@ -212,6 +212,36 @@ describe('<DeploymentTool>', () => {
     });
 
 
+    it('should save process definition after deployment', async () => {
+
+      // given
+      const deployedProcessDefinition = { id: 'foo' };
+
+      const config = {
+        setForFile: sinon.spy()
+      };
+
+      const deployStub = sinon.stub().returns({ deployedProcessDefinition });
+
+      const configuration = createConfiguration();
+
+      const activeTab = createTab({ name: 'foo.bpmn' });
+
+      const {
+        instance
+      } = createDeploymentTool({ activeTab, config, deploySpy: deployStub, ...configuration });
+
+      // when
+      await instance.deploy();
+
+      // then
+      expect(config.setForFile).to.have.been.calledTwice;
+
+      // 0: deployment-tool, 1: process-definition
+      expect(config.setForFile.args[1][2]).to.eql(deployedProcessDefinition);
+    });
+
+
     it('should handle deployment error');
 
   });
@@ -312,7 +342,7 @@ class TestDeploymentTool extends DeploymentTool {
 
   // removes CamundaAPI dependency
   deployWithConfiguration(...args) {
-    this.props.deploySpy && this.props.deploySpy(...args);
+    return this.props.deploySpy && this.props.deploySpy(...args);
   }
 
   checkConnection = (...args) => {

--- a/client/src/plugins/camunda-plugin/shared/__tests__/CamundaAPISpec.js
+++ b/client/src/plugins/camunda-plugin/shared/__tests__/CamundaAPISpec.js
@@ -337,6 +337,83 @@ describe('<CamundaAPI>', () => {
 
   });
 
+
+  describe('#startInstance', () => {
+
+    const processDefinition = {
+      id: 'processDefinition'
+    };
+
+    const options = {
+      businessKey: 'businessKey'
+    };
+
+    it('should start process', async () => {
+
+      // given
+      const api = createCamundaAPI({
+        url: 'http://foo'
+      });
+
+      // when
+      fetchSpy.resolves(new Response());
+
+      const result = await api.startInstance(processDefinition, options);
+
+      // then
+      expect(result).to.exist;
+
+      expectFetched(fetchSpy, {
+        url: 'http://foo/process-definition/processDefinition/start'
+      });
+    });
+
+
+    it('should throw when fetch fails', async () => {
+
+      // given
+      const api = createCamundaAPI();
+
+      // when
+      fetchSpy.rejects(new TypeError('Failed to fetch'));
+
+      // when
+      let error;
+
+      try {
+        await api.startInstance(processDefinition, options);
+      } catch (e) {
+        error = e;
+      } finally {
+
+        // then
+        expect(error).to.exist;
+      }
+    });
+
+
+    it('should throw when response is not ok', async () => {
+
+      // given
+      const api = createCamundaAPI();
+
+      fetchSpy.resolves(new Response({ ok: false }));
+
+      // when
+      let error;
+
+      try {
+        await api.startInstance(processDefinition, options);
+      } catch (e) {
+        error = e;
+      }
+
+      // then
+      expect(error).to.exist;
+    });
+
+  });
+
 });
 
 

--- a/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceConfigModal.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceConfigModal.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+
+import { Modal } from '../../../app/primitives';
+
+import css from './StartInstanceConfigModal.less';
+
+import {
+  TextInput
+} from '../shared/components';
+
+import {
+  Field,
+  Formik
+} from 'formik';
+
+export default class StartInstanceConfigModal extends React.PureComponent {
+
+  onClose = (action = 'cancel', data) => this.props.onClose(action, data);
+
+  onCancel = () => this.onClose('cancel');
+
+  onSubmit = (values) => {
+    this.onClose('start', values);
+  }
+
+  render() {
+
+    const {
+      onCancel,
+      onClose,
+      onSubmit
+    } = this;
+
+    const {
+      configuration: values,
+      title
+    } = this.props;
+
+    return (
+      <Modal className={ css.StartInstanceDetailsModal } onClose={ onClose }>
+        <Formik
+          initialValues={ values }
+          onSubmit={ onSubmit }
+        >
+          { form => (
+            <form onSubmit={ form.handleSubmit }>
+
+              <Modal.Title>
+                {
+                  title || 'Start Process Instance'
+                }
+              </Modal.Title>
+
+              <Modal.Body>
+                <p className="intro">
+                  Enter details to start a process instance on the Camunda Engine. Alternatively, you can start a process instance <a href="https://docs.camunda.org/get-started/quick-start/deploy/#start-a-process-instance">via a Rest Client</a>.
+                </p>
+
+                <fieldset>
+                  <legend>
+                    Details
+                  </legend>
+                  <div className="fields">
+                    <Field
+                      name="businessKey"
+                      component={ TextInput }
+                      label="Business Key"
+                      hint="A business key is a domain-specific identifier of a process instance."
+                      autoFocus
+                    />
+                  </div>
+                </fieldset>
+              </Modal.Body>
+              <Modal.Footer>
+                <div className="form-submit">
+
+                  <button
+                    className="btn btn-primary"
+                    type="submit"
+                    disabled={ form.isSubmitting }>
+                  Start
+                  </button>
+
+                  <button
+                    className="btn"
+                    type="button"
+                    onClick={ onCancel }
+                  >
+                  Cancel
+                  </button>
+                </div>
+              </Modal.Footer>
+            </form>
+          )}
+        </Formik>
+      </Modal>
+    );
+  }
+}

--- a/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceConfigModal.less
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceConfigModal.less
@@ -1,0 +1,93 @@
+:local(.StartInstanceDetailsModal) {
+  h2 {
+    font-weight: normal;
+  }
+
+  .intro {
+    margin-bottom: 20px;
+  }
+
+  form {
+    font-size: 1.1em;
+  }
+
+  fieldset {
+    border: solid 1px #E3E3E3;
+    border-radius: 5px;
+    margin: 20px auto;
+    padding: 15px;
+  }
+
+  legend {
+    font-weight: bolder;
+    background: #EEEEEE;
+    border-radius: 5px;
+    padding: 5px 10px;
+  }
+
+  .hint {
+    margin-top: 5px;
+    color: rgb(102, 102, 102);
+  }
+
+  .fields {
+    display: grid;
+    grid-template-columns: 100px auto;
+
+    grid-column-gap: 10px;
+    grid-row-gap: 15px;
+
+    align-items: baseline;
+  }
+
+  .form-submit {
+    text-align: right;
+  }
+ 
+  label {
+    text-align: right;
+    width: 100%;
+    display: inline-block;
+  }
+
+  input,
+  select {
+    width: 100%;
+    padding: 6px;
+
+    font-size: inherit;
+
+    border: 1px solid rgb(204, 204, 204);
+  }
+
+  input.valid {
+    &:not(:focus) {
+      border: 1px solid rgb(82, 178, 21);
+    }
+
+    outline-color: rgb(82, 178, 21);
+  }
+
+  input.invalid {
+    &:not(:focus) {
+      border: 1px solid rgb(255, 0, 0);
+    }
+
+    outline-color: rgb(255, 0, 0);
+  }
+
+  button + button {
+    margin-left: 10px;
+  }
+
+  button {
+    padding: 6px 10px;
+  }
+
+  button:disabled,
+  input:disabled,
+  select:disabled {
+    color: #808080;
+  }
+
+}

--- a/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
@@ -1,0 +1,434 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React, { PureComponent } from 'react';
+
+import PlayIcon from 'icons/Play.svg';
+
+import CamundaAPI from '../shared/CamundaAPI';
+import KeyboardInteractionTrap from '../shared/KeyboardInteractionTrap';
+
+import StartInstanceConfigModal from './StartInstanceConfigModal';
+
+import css from './StartInstanceTool.less';
+
+import { Fill } from '../../../app/slot-fill';
+
+import {
+  DropdownButton,
+  Icon
+} from '../../../app/primitives';
+
+const START_DETAILS_CONFIG_KEY = 'start-instance-tool';
+
+const START_INSTANCE_FAILED = 'Starting process instance failed';
+
+const PROCESS_DEFINITION_CONFIG_KEY = 'process-definition';
+
+export default class StartInstanceTool extends PureComponent {
+
+  state = {
+    modalState: null,
+    activeTab: null
+  }
+
+  START_ACTIONS = [
+    {
+      text: 'Start process instance',
+      onClick: this.startInstance.bind(this)
+    },
+    {
+      text: 'Start process instance with new configuration',
+      onClick: this.startInstance.bind(this, { configure: true })
+    }
+  ];
+
+  componentDidMount() {
+
+    const {
+      subscribe
+    } = this.props;
+
+    subscribe('app.activeTabChanged', ({ activeTab }) => {
+      this.setState({ activeTab });
+    });
+
+  }
+
+  saveActiveTab() {
+    const {
+      triggerAction
+    } = this.props;
+
+    return triggerAction('save');
+  }
+
+  async deploy(tab, configuration) {
+
+    const {
+      deployService
+    } = this.props;
+
+    return await deployService.deployWithConfiguration(tab, configuration);
+  }
+
+  async ensureDeployConfig(tab) {
+
+    const {
+      deployService
+    } = this.props;
+
+    const deployConfig = await deployService.getSavedDeployConfiguration(tab);
+
+    const {
+      configuration: userConfiguration,
+      action
+    } = await deployService.getDeployConfigurationFromUserInput(tab, deployConfig, {
+      title: 'Start Process Instance - Step 1 of 2',
+      intro: 'Specify deployment details to deploy this diagram to Camunda.',
+      primaryAction: 'Next'
+    });
+
+    if (action === 'cancel') {
+      return;
+    }
+
+    await deployService.saveDeployConfiguration(tab, userConfiguration);
+
+    return userConfiguration;
+  }
+
+  async checkConnection(endpoint) {
+
+    const api = new CamundaAPI(endpoint);
+
+    try {
+      await api.checkConnection();
+    } catch (error) {
+      return error;
+    }
+
+    return null;
+  }
+
+  async startInstance(options={}) {
+
+    const {
+      configure
+    } = options;
+
+    const {
+      deployService,
+      displayNotification,
+      log
+    } = this.props;
+
+    // (1) Make sure active tab is saved
+    const tab = await this.saveActiveTab();
+
+    if (!tab) {
+      return;
+    }
+
+    // (2) Ensure deployment config is available
+    let deploymentConfig = await deployService.getSavedDeployConfiguration(tab);
+
+    // (2.1) Check connection to engine
+    const showDeployConfig =
+      !deploymentConfig || await this.checkConnection(deploymentConfig.endpoint);
+
+    if (showDeployConfig) {
+
+      // (2.2) Open Modal to enter deployment configuration
+      deploymentConfig = await this.ensureDeployConfig(tab);
+
+      // (2.2.1) Handle user cancelation
+      if (!deploymentConfig) {
+        return;
+      }
+    }
+
+    // (3) Get start configuration
+    // (3.1) Try to get existing start configuration
+    let startConfiguration = await this.getSavedConfiguration(tab);
+
+    // (3.2) Check if configuration is complete
+    const showStartConfig =
+      configure || !this.canStartWithConfiguration(startConfiguration);
+
+    if (showStartConfig) {
+
+      const uiOptions = {
+        title: !configure ? 'Start Process Instance - Step 2 of 2' : null
+      };
+
+      // (3.3) Open Modal to enter start configuration
+      const {
+        action,
+        configuration: userConfiguration
+      }= await this.getConfigurationFromUserInput(
+        tab,
+        startConfiguration,
+        uiOptions
+      );
+
+      // (3.3.1) Handle user cancelation
+      if (action === 'cancel') {
+        return;
+      }
+
+      startConfiguration = await this.saveConfiguration(tab, userConfiguration);
+    }
+
+    // (4) Trigger deployment
+    try {
+      const deployment = await this.deploy(tab, deploymentConfig);
+
+      // (4.1) Persist process definition
+      await this.saveProcessDefinition(tab, deployment);
+    } catch (error) {
+
+      displayNotification({
+        type: 'error',
+        title: START_INSTANCE_FAILED,
+        content: 'Deployment was not successful. See the log for further details.',
+        duration: 10000
+      });
+      log({ category: 'deploy-error', message: error.problems || error.message });
+
+      return null;
+    }
+
+    // (4.2) Get latest available process definition
+    // * current diagram version OR
+    // * version before if diagram had no changes
+    const processDefinition = await this.getSavedProcessDefinition(tab);
+
+    if (!processDefinition) {
+      displayNotification({
+        type: 'error',
+        title: START_INSTANCE_FAILED,
+        content: 'No executable process available.',
+        duration: 10000
+      });
+
+      return;
+    }
+
+    // (5) Trigger start instance
+    try {
+      const {
+        endpoint
+      } = deploymentConfig;
+
+      const processInstance =
+        await this.startWithConfiguration(startConfiguration, processDefinition, endpoint);
+
+      await this.handleStartSuccess(processInstance, endpoint);
+    } catch (error) {
+      displayNotification({
+        type: 'error',
+        title: START_INSTANCE_FAILED,
+        content: 'See the log for further details.',
+        duration: 10000
+      });
+      log({ category: 'start-instance-error', message: error.problems || error.message });
+    }
+  }
+
+  async saveConfiguration(tab, configuration) {
+    const {
+      config
+    } = this.props;
+
+    await config.setForFile(tab.file, START_DETAILS_CONFIG_KEY, configuration);
+
+    return configuration;
+  }
+
+  canStartWithConfiguration(configuration) {
+
+    if (!configuration) {
+      return false;
+    }
+
+    const {
+      businessKey
+    } = configuration;
+
+    return !!businessKey;
+  }
+
+  async getDefaultConfiguration(providedConfiguration = {}) {
+
+    const startInstance = providedConfiguration || {};
+
+    return {
+      businessKey: 'default',
+      ...startInstance
+    };
+  }
+
+  async getSavedConfiguration(tab) {
+    const {
+      config
+    } = this.props;
+
+    return config.getForFile(tab.file, START_DETAILS_CONFIG_KEY);
+  }
+
+  async getSavedProcessDefinition(tab) {
+    const {
+      config
+    } = this.props;
+
+    return config.getForFile(tab.file, PROCESS_DEFINITION_CONFIG_KEY);
+  }
+
+  async saveProcessDefinition(tab, deployment) {
+    if (!deployment || !deployment.deployedProcessDefinition) {
+      return;
+    }
+
+    const {
+      deployedProcessDefinition: processDefinition
+    } = deployment;
+
+    const {
+      config
+    } = this.props;
+
+    return await config.setForFile(tab.file, PROCESS_DEFINITION_CONFIG_KEY, processDefinition);
+  }
+
+  async getConfigurationFromUserInput(tab, providedConfiguration, uiOptions) {
+    const configuration = await this.getDefaultConfiguration(providedConfiguration);
+
+    return new Promise(resolve => {
+      const handleClose = (action, configuration) => {
+
+        this.setState({
+          modalState: null
+        });
+
+        // contract: if configuration provided, user closed with O.K.
+        // otherwise they canceled it
+        return resolve({ action, configuration });
+      };
+
+      this.setState({
+        modalState: {
+          tab,
+          configuration,
+          handleClose,
+          ...uiOptions
+        }
+      });
+    });
+  }
+
+  startWithConfiguration(configuration, processDefinition, endpoint) {
+
+    const api = new CamundaAPI(endpoint);
+
+    return api.startInstance(processDefinition, configuration);
+  }
+
+  handleStartSuccess(processInstance, endpoint) {
+    const {
+      displayNotification
+    } = this.props;
+
+    const {
+      url
+    } = endpoint;
+
+    displayNotification({
+      type: 'success',
+      title: 'Process instance started successfully',
+      content: <CockpitLink endpointUrl={ url } processInstance={ processInstance } />,
+      duration: 10000
+    });
+  }
+
+  render() {
+    const {
+      activeTab,
+      modalState
+    } = this.state;
+
+    return <React.Fragment>
+
+      { isBpmnTab(activeTab) &&
+      <Fill slot="toolbar" group="8_deploy">
+        <DropdownButton
+          onClick={ this.startInstance.bind(this) }
+          title="Start Current Diagram"
+          className={ css.StartInstanceTool }
+          multiButton
+          items={ this.START_ACTIONS }
+        >
+          <PlayIcon className="icon" />
+        </DropdownButton>
+      </Fill>
+      }
+
+      { modalState &&
+      <KeyboardInteractionTrap triggerAction={ this.props.triggerAction }>
+        <StartInstanceConfigModal
+          configuration={ modalState.configuration }
+          activeTab={ modalState.tab }
+          onClose={ modalState.handleClose }
+          title={ modalState.title }
+        />
+      </KeyboardInteractionTrap>
+      }
+    </React.Fragment>;
+  }
+
+}
+
+
+function CockpitLink(props) {
+  const {
+    endpointUrl,
+    processInstance
+  } = props;
+
+  const {
+    id
+  } = processInstance;
+
+  const baseUrl = getBaseUrl(endpointUrl);
+
+  const cockpitUrl = `${baseUrl}/camunda/app/cockpit/default/#/process-instance/${id}`;
+
+  return (
+    <div className={ css.CockpitLink }>
+      <a href={ cockpitUrl }>
+        Open in Camunda Cockpit
+        <Icon name="open" />
+      </a>
+    </div>
+  );
+}
+
+
+// helpers //////////
+
+function isBpmnTab(tab) {
+  return tab && tab.type === 'bpmn';
+}
+
+function getBaseUrl(url) {
+  const [ protocol,, host ] = url.split('/');
+
+  return `${protocol}//${host}`;
+}

--- a/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.less
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.less
@@ -1,0 +1,15 @@
+:local(.StartInstanceTool) {
+  .icon {
+    width: 14px;
+    height: 14px;
+    padding-top: 3px;
+  }
+}
+
+:local(.CockpitLink) {
+
+  span {
+    padding: 5px
+  }
+
+}

--- a/client/src/plugins/camunda-plugin/start-instance-tool/__tests__/StartInstanceConfigModalSpec.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/__tests__/StartInstanceConfigModalSpec.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+
+import {
+  mount,
+  shallow
+} from 'enzyme';
+
+import StartInstanceConfigModal from '../StartInstanceConfigModal';
+
+describe('<StartInstanceConfigModal>', () => {
+
+  it('should render', () => {
+    createModal();
+  });
+
+
+  it('should render with customizations', () => {
+
+    // given
+    const options = {
+      title: 'title',
+    };
+
+    // when
+    const { wrapper } = createModal(options, mount);
+
+    const titleWrapper = wrapper.find('.modal-title');
+
+    // then
+    expect(titleWrapper.text()).to.eql(options.title);
+  });
+
+});
+
+
+// helpers //////////
+
+function createModal(props={}, renderFn = shallow) {
+
+  const {
+    configuration,
+    onClose,
+    title,
+  } = props;
+
+
+  const wrapper = renderFn(
+    <StartInstanceConfigModal
+      configuration={ configuration || getDefaultConfiguration() }
+      onClose={ onClose || noop }
+      title={ title }
+    />
+  );
+
+  return {
+    wrapper,
+    instance: wrapper.instance()
+  };
+}
+
+function noop() {}
+
+function getDefaultConfiguration() {
+  return {
+    businessKey: 'default'
+  };
+}

--- a/client/src/plugins/camunda-plugin/start-instance-tool/__tests__/StartInstanceToolSpec.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/__tests__/StartInstanceToolSpec.js
@@ -1,0 +1,551 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/* global sinon */
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { Config } from './../../../../app/__tests__/mocks';
+
+import { DeploymentService } from './mocks';
+
+import StartInstanceTool from '../StartInstanceTool';
+
+const START_DETAILS_CONFIG_KEY = 'start-instance-tool';
+
+describe('<StartInstanceTool>', () => {
+
+  it('should render', () => {
+    createStartInstanceTool();
+  });
+
+
+  describe('deploy', () => {
+
+    it('should deploy with saved configuration', async () => {
+
+      // given
+      const deploySpy = sinon.spy();
+
+      const activeTab = createTab({ name: 'foo.bpmn' });
+
+      const deployService = {
+        getSavedDeployConfiguration: () => {
+          return {
+            deployment: { name: 'foo1' },
+            endpoint: {}
+          };
+        },
+        deployWithConfiguration: deploySpy
+      };
+
+      const {
+        instance
+      } = createStartInstanceTool({ activeTab, deployService });
+
+      // when
+      await instance.startInstance();
+
+      // then
+      expect(deploySpy).to.have.been.calledOnce;
+      expect(deploySpy.args[0][1].deployment.name).to.equal('foo1');
+    });
+
+
+    it('should deploy with user configuration', async () => {
+
+      // given
+      const deploySpy = sinon.spy();
+
+      const activeTab = createTab({ name: 'foo.bpmn' });
+
+      const deployService = {
+        deployWithConfiguration: deploySpy
+      };
+
+      const {
+        instance
+      } = createStartInstanceTool({ activeTab, deployService });
+
+      // when
+      await instance.startInstance();
+
+      // then
+      expect(deploySpy).to.have.been.calledOnce;
+      expect(deploySpy.args[0][1].deployment.name).to.equal('foo');
+    });
+
+
+    it('should ask for deployment config on connection error', async () => {
+
+      // given
+      const deploySpy = sinon.spy();
+
+      const connectionStub = sinon.stub().returns(true);
+
+      const activeTab = createTab({ name: 'foo.bpmn' });
+
+      const deployService = {
+        getSavedDeployConfiguration: () => {
+          return {
+            deployment: { name: 'should not use me' },
+            endpoint: {}
+          };
+        },
+        deployWithConfiguration: deploySpy
+      };
+
+      const {
+        instance
+      } = createStartInstanceTool({
+        activeTab,
+        deployService,
+        connectionStub
+      });
+
+      // when
+      await instance.startInstance();
+
+      // then
+      expect(deploySpy).to.have.been.calledOnce;
+      expect(deploySpy.args[0][1].deployment.name).to.equal('foo');
+    });
+
+
+    it('should save deployment configuration', async () => {
+
+      // given
+      const activeTab = createTab({ name: 'foo.bpmn' });
+
+      const saveSpy = sinon.spy();
+
+      const deployService = {
+        saveDeployConfiguration: saveSpy
+      };
+
+      const {
+        instance
+      } = createStartInstanceTool({ activeTab, deployService });
+
+      // when
+      await instance.startInstance();
+
+      // then
+      expect(saveSpy).to.have.been.called;
+      expect(saveSpy.args[0][1].deployment.name).to.equal('foo');
+    });
+
+
+    it('should NOT save deployment configuration if user cancelled', async () => {
+
+      // given
+      const activeTab = createTab({ name: 'foo.bpmn' });
+
+      const saveSpy = sinon.spy();
+
+      const deployService = {
+        getDeployConfigurationFromUserInput: () => {
+          return {
+            action: 'cancel'
+          };
+        },
+        saveDeployConfiguration: saveSpy
+      };
+
+      const {
+        instance
+      } = createStartInstanceTool({ activeTab, deployService });
+
+      // when
+      await instance.startInstance();
+
+      // then
+      expect(saveSpy).not.to.have.been.called;
+    });
+
+
+    it('should save process definition after successful deployment', async () => {
+
+      // given
+      const activeTab = createTab({ name: 'foo.bpmn' });
+
+      const deployedProcessDefinition = { id: 'foo' };
+
+      const config = {
+        setForFile: sinon.spy()
+      };
+
+      const deployService = {
+        deployWithConfiguration: sinon.stub().returns({ deployedProcessDefinition })
+      };
+
+      const {
+        instance
+      } = createStartInstanceTool({
+        activeTab,
+        config,
+        deployService
+      });
+
+      // when
+      await instance.startInstance();
+
+      // then
+      expect(config.setForFile).to.have.been.calledTwice;
+
+      // 0: start-instance-tool, 1: process-definition
+      expect(config.setForFile.args[1][2]).to.eql(deployedProcessDefinition);
+    });
+  });
+
+
+  describe('start instance', () => {
+
+    it('should start instance with saved configuration', async () => {
+
+      // given
+      const startSpy = sinon.spy();
+
+      const activeTab = createTab({ name: 'foo.bpmn' });
+
+      const config = {
+        getForFile: () => {
+          return { businessKey: 'foo' };
+        }
+      };
+
+      const {
+        instance
+      } = createStartInstanceTool({
+        activeTab,
+        config,
+        startSpy
+      });
+
+      // when
+      await instance.startInstance();
+
+      // then
+      expect(startSpy).to.have.been.calledOnce;
+      expect(startSpy.args[0][0].businessKey).to.equal('foo');
+    });
+
+
+    it('should start instance with user configuration', async () => {
+
+      // given
+      const startSpy = sinon.spy();
+
+      const activeTab = createTab({ name: 'foo.bpmn' });
+
+      const userConfiguration = {
+        businessKey: 'bar'
+      };
+
+      const config = {
+        getForFile: () => {
+          return { };
+        }
+      };
+
+      const deployService = {
+        getSavedDeployConfiguration: () => {
+          return {
+            deployment: { name: 'foo' },
+            endpoint: {}
+          };
+        }
+      };
+
+      const {
+        instance
+      } = createStartInstanceTool({
+        activeTab,
+        config,
+        deployService,
+        startSpy,
+        ...userConfiguration,
+      });
+
+      // when
+      await instance.startInstance({ configure: true });
+
+      // then
+      expect(startSpy).to.have.been.calledOnce;
+      expect(startSpy.args[0][0].businessKey).to.equal('bar');
+    });
+
+
+    it('should NOT start instance with no executable process', async () =>{
+
+      // given
+      const startSpy = sinon.spy();
+
+      const activeTab = createTab({ name: 'foo.bpmn' });
+
+      const config = {
+        getForFile: (_, key) => {
+          return key === START_DETAILS_CONFIG_KEY ? { businessKey: 'foo' } : null;
+        }
+      };
+
+      const {
+        instance
+      } = createStartInstanceTool({
+        activeTab,
+        config,
+        startSpy
+      });
+
+      // when
+      await instance.startInstance();
+
+      // then
+      expect(startSpy).not.to.have.been.calledOnce;
+    });
+
+
+    it('should NOT start instance if deployment failed', async () => {
+
+      // given
+      const startSpy = sinon.spy();
+
+      const deployStub = sinon.stub().throws();
+
+      const activeTab = createTab({ name: 'foo.bpmn' });
+
+      const config = {
+        getForFile: () => {
+          return { businessKey: 'foo' };
+        }
+      };
+
+      const deployService = {
+        deployWithConfiguration: deployStub
+      };
+
+      const {
+        instance
+      } = createStartInstanceTool({
+        activeTab,
+        config,
+        deployService,
+        startSpy
+      });
+
+      // when
+      await instance.startInstance();
+
+      // then
+      expect(startSpy).not.to.have.been.calledOnce;
+    });
+
+
+    it('should NOT start instance if user cancelled deployment step', async () => {
+
+      // given
+      const startSpy = sinon.spy();
+
+      const deployService = {
+        getDeployConfigurationFromUserInput: () => {
+          return {
+            action: 'cancel'
+          };
+        }
+      };
+
+      const activeTab = createTab({ name: 'foo.bpmn' });
+
+      const {
+        instance
+      } = createStartInstanceTool({
+        activeTab,
+        deployService,
+        startSpy
+      });
+
+      // when
+      await instance.startInstance();
+
+      // then
+      expect(startSpy).not.to.have.been.calledOnce;
+    });
+
+
+    it('should NOT start instance if user cancelled start step', async () => {
+
+      // given
+      const startSpy = sinon.spy();
+
+      const activeTab = createTab({ name: 'foo.bpmn' });
+
+      const {
+        instance
+      } = createStartInstanceTool({
+        userAction: 'cancel',
+        activeTab,
+        startSpy
+      });
+
+      // when
+      await instance.startInstance();
+
+      // then
+      expect(startSpy).not.to.have.been.calledOnce;
+    });
+
+
+    it('should handle start instance error', async () => {
+
+      // given
+      const startSpy = sinon.stub().throws();
+
+      const logSpy = sinon.spy();
+
+      const activeTab = createTab({ name: 'foo.bpmn' });
+
+      const config = {
+        getForFile: () => {
+          return { businessKey: 'foo' };
+        }
+      };
+
+      const {
+        instance
+      } = createStartInstanceTool({
+        activeTab,
+        config,
+        log: logSpy,
+        startSpy
+      });
+
+      // when
+      await instance.startInstance();
+
+      // then
+      expect(logSpy).to.have.been.calledOnce;
+      expect(logSpy.args[0][0].category).to.eql('start-instance-error');
+    });
+
+  });
+
+
+});
+
+// helpers //////
+class TestStartInstanceTool extends StartInstanceTool {
+
+  /**
+   * @param {object} props
+   * @param {'cancel'|'start'} [props.userAction='start'] user action in configuration modal
+   * @param {object} [props.businessKey] overrides for businessKey configuration
+   */
+  constructor(props) {
+    super(props);
+  }
+
+  // removes CamundaAPI dependency
+  startWithConfiguration(...args) {
+    this.props.startSpy && this.props.startSpy(...args);
+  }
+
+  checkConnection = (...args) => {
+    return this.props.connectionStub && this.props.connectionStub(...args);
+  }
+
+  // closes automatically when modal is opened
+  componentDidUpdate(...args) {
+    super.componentDidUpdate && super.componentDidUpdate(...args);
+
+    const { modalState } = this.state;
+    const {
+      userAction,
+      businessKey
+    } = this.props;
+
+    if (modalState) {
+      const action = userAction || 'start';
+
+      const configuration = action !== 'cancel' && {
+        businessKey: businessKey || modalState.configuration.businessKey
+      };
+
+      modalState.handleClose(action, configuration);
+    }
+  }
+
+}
+
+function createStartInstanceTool({
+  activeTab = createTab(),
+  ...props
+} = {}, render = shallow) {
+  const subscribe = (event, callback) => {
+    event === 'app.activeTabChanged' && callback(activeTab);
+  };
+
+  const triggerAction = event => {
+    switch (event) {
+    case 'save':
+      return activeTab;
+    }
+  };
+
+  const config = new Config({
+    get: (_, defaultValue) => defaultValue,
+    ...props.config
+  });
+
+  const deployService = new DeploymentService({
+    getDeployConfigurationFromUserInput: () => {
+      return {
+        configuration: {
+          deployment: { name: 'foo' },
+          endpoint: {}
+        }
+      };
+    },
+    ...props.deployService
+  });
+
+  const wrapper = render(<TestStartInstanceTool
+    subscribe={ subscribe }
+    triggerAction={ triggerAction }
+    displayNotification={ noop }
+    log={ props.log || noop }
+    { ...props }
+    deployService={ deployService }
+    config={ config }
+  />);
+
+  return {
+    wrapper,
+    instance: wrapper.instance()
+  };
+}
+
+function createTab(overrides = {}) {
+  return {
+    id: 42,
+    name: 'foo.bar',
+    type: 'bar',
+    title: 'unsaved',
+    file: {
+      name: 'foo.bar',
+      contents: '',
+      path: null
+    },
+    ...overrides
+  };
+}
+
+function noop() {}

--- a/client/src/plugins/camunda-plugin/start-instance-tool/__tests__/mocks/index.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/__tests__/mocks/index.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  assign
+} from 'min-dash';
+
+class Mock {
+
+  constructor(overrides = {}) {
+    assign(this, overrides);
+  }
+
+}
+
+export class DeploymentService extends Mock {
+
+  deployWithConfiguration() {}
+
+  getSavedDeployConfiguration() {}
+
+  getDeployConfigurationFromUserInput() {}
+
+  saveDeployConfiguration() {}
+}

--- a/client/src/plugins/camunda-plugin/start-instance-tool/index.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/index.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+export { default } from './StartInstanceTool.js';


### PR DESCRIPTION
Closes #1552 
Depends on #1616 

-----

This enables starting process instanced from the Modeler. To do that, it used a `deployService` to re-use certain methods from the `DeploymentTool`. 

* deployWithConfiguration
* getSavedDeployConfiguration
* getDeployConfigurationFromUserInput
* saveDeployConfiguration

The primary action will always be to directly start a process instance with the given configuration. It will ensure to always start the *latest available process definition*. The engine returns no `deployedProcessDefinition` if the diagram had no changes. In this case, the tool will use the latest known process definition (saved in config).

When nothing has configured so far (first-time use), it acts like a Two-Step-Modal to do following actions:

1. Get deployment config from user
2. Get start config from user
3. Deploy diagram
4. Start process instance

![Kapture 2019-11-28 at 12 40 18](https://user-images.githubusercontent.com/9433996/69803836-7cf38480-11dd-11ea-9ab8-34438dce67f6.gif)

**Error Cases**

(1) Error while deploying

![Kapture 2019-11-28 at 12 44 13](https://user-images.githubusercontent.com/9433996/69803846-811fa200-11dd-11ea-94f4-d1a8d4556e7b.gif)

(2) Error while starting

![Kapture 2019-11-28 at 12 45 56](https://user-images.githubusercontent.com/9433996/69803853-854bbf80-11dd-11ea-9e9f-c530f453f288.gif)

(3) No executable process

![Kapture 2019-11-28 at 12 48 41](https://user-images.githubusercontent.com/9433996/69803858-8977dd00-11dd-11ea-826e-997474c6f12c.gif)
