### PR TITLE
Fix log error + add generate ID utility

### DIFF
--- a/client/src/app/Log.less
+++ b/client/src/app/Log.less
@@ -53,7 +53,6 @@
   .body {
     overflow: auto;
     position: relative;
-    display: flex;
     border-top: solid 1px #CCC;
     background: #FCFCFC;
   }

--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -8,8 +8,6 @@
  * except in compliance with the MIT License.
  */
 
-import Ids from 'ids';
-
 import bpmnDiagram from './tabs/bpmn/diagram.bpmn';
 import cmmnDiagram from './tabs/cmmn/diagram.cmmn';
 import dmnDiagram from './tabs/dmn/diagram.dmn';
@@ -23,9 +21,10 @@ import { forEach } from 'min-dash';
 
 import parseDiagramType from './util/parseDiagramType';
 
-import Flags from '../util/Flags';
-
-const ids = new Ids([ 32, 36, 1 ]);
+import {
+  Flags,
+  generateId
+} from '../util';
 
 const createdByType = {};
 
@@ -214,7 +213,7 @@ export default class TabsProvider {
   getInitialFileContents(type, options) {
     const rawContents = this.getProvider(type).getInitialContents(options);
 
-    return rawContents && replaceIds(rawContents, ids);
+    return rawContents && replaceIds(rawContents, generateId);
   }
 
   createFile(type, options) {
@@ -267,7 +266,7 @@ export default class TabsProvider {
 
   createTabForFile(file) {
 
-    const id = ids.next();
+    const id = generateId();
 
     const type = this.getTabType(file);
 

--- a/client/src/remote/Backend.js
+++ b/client/src/remote/Backend.js
@@ -8,9 +8,9 @@
  * except in compliance with the MIT License.
  */
 
-import Ids from 'ids';
-
-const ids = new Ids();
+import {
+  generateId
+} from '../util';
 
 
 /**
@@ -34,7 +34,7 @@ export default class Backend {
    */
   send(event, ...args) {
 
-    var id = ids.next();
+    var id = generateId();
 
     return new Promise((resolve, reject) => {
 

--- a/client/src/util/generate-id.js
+++ b/client/src/util/generate-id.js
@@ -8,7 +8,10 @@
  * except in compliance with the MIT License.
  */
 
-export { default as debounce } from './debounce';
-export { default as generateId } from './generate-id';
-export { default as throttle } from './throttle';
-export { default as Flags } from './Flags';
+import Ids from 'ids';
+
+const ids = new Ids([ 32, 36, 1 ]);
+
+export default function generateId() {
+  return ids.next();
+}


### PR DESCRIPTION
This ships two improvements:

* the log controls are no more hidden once the user scrolls:

    ![capture lsXbrC_optimized](https://user-images.githubusercontent.com/58601/68680653-563d1900-0562-11ea-8ab1-f3e3c47bbefd.gif)

* a generic generate ID utility is provided to create IDs consistently in all places where we need them

I've addressed these things while working on https://github.com/camunda/camunda-modeler/issues/1558 but I hope to get them merged before :wink: 
