### PR TITLE
chore(deploy): use given tab on <deployTab>

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1571,6 +1571,10 @@ export class App extends PureComponent {
       return this.saveAllTabs();
     }
 
+    if (action === 'save-tab') {
+      return this.saveTab(options.tab);
+    }
+
     if (action === 'save') {
       return this.saveTab(activeTab);
     }

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -833,6 +833,36 @@ describe('<App>', function() {
     });
 
 
+    it('should save any tab', async function() {
+
+      // given
+      const file1 = createFile('diagram_1.bpmn');
+      const file2 = createFile('diagram_2.bpmn');
+
+      const [ tab1 ] = await app.openFiles([ file1, file2 ]);
+
+      // when
+      app.setState({
+        ...app.setDirty(tab1) // inactive tab
+      });
+
+      await app.triggerAction('save-tab', { tab: tab1 });
+
+      // then
+      expect(writeFileSpy).to.have.been.calledWith(
+        file1.path,
+        {
+          ...file1,
+          contents: 'CONTENTS'
+        },
+        {
+          encoding: 'utf8',
+          fileType: 'bpmn'
+        }
+      );
+    });
+
+
     it('should save as existing tab', async function() {
 
       // given

--- a/client/src/plugins/deployment-tool/DeploymentTool.js
+++ b/client/src/plugins/deployment-tool/DeploymentTool.js
@@ -41,17 +41,17 @@ export default class DeploymentTool extends PureComponent {
   }
 
   componentDidMount() {
-    this.props.subscribe('app.activeTabChanged', activeTab => {
+    this.props.subscribe('app.activeTabChanged', ({ activeTab }) => {
       this.setState({ activeTab });
     });
   }
 
-  saveTab() {
+  saveTab = (tab) => {
     const {
       triggerAction
     } = this.props;
 
-    return triggerAction('save');
+    return triggerAction('save-tab', { tab });
   }
 
   deploy = () => {
@@ -82,10 +82,10 @@ export default class DeploymentTool extends PureComponent {
 
   async deployTab(tab) {
 
-    // (1.2) Open save file dialog if dirty
-    tab = await this.saveTab();
+    // (1) Open save file dialog if dirty
+    tab = await this.saveTab(tab);
 
-    // (1.3) Cancel deploy if file save cancelled
+    // (1.1) Cancel deploy if file save cancelled
     if (!tab) {
       return;
     }

--- a/client/src/plugins/deployment-tool/__tests__/DeploymentToolSpec.js
+++ b/client/src/plugins/deployment-tool/__tests__/DeploymentToolSpec.js
@@ -152,7 +152,7 @@ function createDeploymentTool({
 
   const triggerAction = event => {
     switch (event) {
-    case 'save':
+    case 'save-tab':
       return activeTab;
     }
   };


### PR DESCRIPTION
Instead of ignoring the <tab> param and using the <activeTab> in the <deployTab> functionality, this ensures to actually using the given tab.

Follow up of Hour of Code, cf. https://github.com/bpmn-io/hour-of-code/blob/master/snippets/DeploymentTool_deployTab.md
