### PR TITLE
Disable collapsing sub process

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2195,6 +2195,21 @@
         }
       }
     },
+    "bpmn-js-disable-collapsed-subprocess": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-disable-collapsed-subprocess/-/bpmn-js-disable-collapsed-subprocess-0.1.0.tgz",
+      "integrity": "sha512-Aw8Q/cuFlRB2L1PRskbZpXMu3WiONwryYeKPE8Ybc53gQrwgNUmYIRMFrZZJEXqPqqJ9HVuUwsubEzJDfZbHzQ==",
+      "requires": {
+        "min-dash": "^3.5.2"
+      },
+      "dependencies": {
+        "min-dash": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.5.2.tgz",
+          "integrity": "sha512-YVbJZUtnzT5QsgJUp9H9uyJTW6NJgswFqI27RI/+MSox860uIjaGMbSQBftEzbMXiJVRG24hpoIh3SG666SHgA=="
+        }
+      }
+    },
     "bpmn-js-properties-panel": {
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-0.33.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "@bpmn-io/align-to-origin": "^0.6.0",
     "@bpmn-io/replace-ids": "^0.2.0",
     "bpmn-js": "^6.0.0-beta.0",
+    "bpmn-js-disable-collapsed-subprocess": "^0.1.0",
     "bpmn-js-properties-panel": "^0.33.0",
     "bpmn-js-signavio-compat": "^1.2.0",
     "camunda-bpmn-moddle": "^4.3.0",

--- a/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
+++ b/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
@@ -33,6 +33,8 @@ import camundaModdleExtension from 'camunda-bpmn-moddle/lib';
 import propertiesPanelModule from 'bpmn-js-properties-panel';
 import propertiesProviderModule from 'bpmn-js-properties-panel/lib/provider/camunda';
 
+import disableCollapsedSubprocessModule from 'bpmn-js-disable-collapsed-subprocess';
+
 
 import 'bpmn-js-properties-panel/styles/properties.less';
 
@@ -75,7 +77,8 @@ const extensionModules = [
   propertiesPanelKeyboardBindingsModule,
   propertiesPanelModule,
   propertiesProviderModule,
-  signavioCompatModule
+  signavioCompatModule,
+  disableCollapsedSubprocessModule
 ];
 
 CamundaBpmnModeler.prototype._modules = [


### PR DESCRIPTION
This commit adds a bpmn-js plugin that disables modeling
actions that allowed to collapse sub process. It is done
due to lacking support for collapsed sub process with
children in other Camunda tools: Cockpit and Cawemo.

BREAKING CHANGES

* Sub Process cannot be collapsed anymore.

Closes #1486

<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

Closes #
