### PR TITLE
chore(bpmn-modeler): bump disabled collapsed subprocess

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2196,9 +2196,9 @@
       }
     },
     "bpmn-js-disable-collapsed-subprocess": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-disable-collapsed-subprocess/-/bpmn-js-disable-collapsed-subprocess-0.1.0.tgz",
-      "integrity": "sha512-Aw8Q/cuFlRB2L1PRskbZpXMu3WiONwryYeKPE8Ybc53gQrwgNUmYIRMFrZZJEXqPqqJ9HVuUwsubEzJDfZbHzQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bpmn-js-disable-collapsed-subprocess/-/bpmn-js-disable-collapsed-subprocess-0.1.1.tgz",
+      "integrity": "sha512-y68PzBFHCS6tjzabBNqER4cvoBleW+rjdldvgWIt3w58/ejWN53NotSTDXlgZsYQXcrFRi9FHWV5r8zb0OSE7w==",
       "requires": {
         "min-dash": "^3.5.2"
       },

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "@bpmn-io/align-to-origin": "^0.6.0",
     "@bpmn-io/replace-ids": "^0.2.0",
     "bpmn-js": "^6.0.0-beta.0",
-    "bpmn-js-disable-collapsed-subprocess": "^0.1.0",
+    "bpmn-js-disable-collapsed-subprocess": "^0.1.1",
     "bpmn-js-properties-panel": "^0.33.0",
     "bpmn-js-signavio-compat": "^1.2.0",
     "camunda-bpmn-moddle": "^4.3.0",


### PR DESCRIPTION
This update fixes a typo in a label.
