### PR TITLE
Update checks plugin

### DIFF
--- a/app/lib/config/__tests__/config-spec.js
+++ b/app/lib/config/__tests__/config-spec.js
@@ -322,6 +322,26 @@ describe('Config', function() {
       expect(saveIDSpy).to.have.been.calledOnce;
     });
   });
+
+
+  describe('<os.info>', function() {
+
+    it('should return correct values', function() {
+
+      // given
+      const config = new Config({
+        userPath: 'test'
+      });
+      const os = require('os');
+
+      // when
+      const osInfo = config.get('os.info');
+
+      // then
+      expect(osInfo.platform).to.be.eql(os.platform());
+      expect(osInfo.release).to.be.eql(os.release());
+    });
+  });
 });
 
 

--- a/app/lib/config/index.js
+++ b/app/lib/config/index.js
@@ -13,6 +13,7 @@ const path = require('path');
 const DefaultProvider = require('./providers/DefaultProvider');
 const ElementTemplatesProvider = require('./providers/ElementTemplatesProvider');
 const UUIDProvider = require('./providers/UUIDProvider');
+const OSInfoProvider = require('./providers/OSInfoProvider');
 
 const { isFunction } = require('min-dash');
 
@@ -31,7 +32,8 @@ class Config {
 
     this._providers = {
       'bpmn.elementTemplates': new ElementTemplatesProvider(resourcesPaths),
-      'editor.id': new UUIDProvider(path.join(userPath, '.editorid'))
+      'editor.id': new UUIDProvider(path.join(userPath, '.editorid')),
+      'os.info': new OSInfoProvider()
     };
   }
 

--- a/app/lib/config/providers/OSInfoProvider.js
+++ b/app/lib/config/providers/OSInfoProvider.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+const os = require('os');
+
+/**
+* Provides OS platform/release.
+*/
+class OSInfoProvider {
+
+  get() {
+    return {
+      platform: os.platform(),
+      release: os.release()
+    };
+  }
+}
+
+module.exports = OSInfoProvider;

--- a/client/src/app/plugins/PluginsRoot.js
+++ b/client/src/app/plugins/PluginsRoot.js
@@ -88,6 +88,7 @@ export default class PluginsRoot extends PureComponent {
             subscribe={ subscribe }
             log={ this.log }
             displayNotification={ this.displayNotification }
+            _getGlobal={ app.getGlobal }
           />
         </PluginParent>
       );

--- a/client/src/plugins/update-checks/NewVersionInfoView.js
+++ b/client/src/plugins/update-checks/NewVersionInfoView.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React, { PureComponent } from 'react';
+
+import {
+  Modal
+} from '../../app/primitives';
+
+import {
+  MODAL_TITLE,
+  BUTTON_NEGATIVE,
+  BUTTON_POSITIVE,
+  RELEASE_NOTES_TITLE,
+  INFO_TEXT
+} from './constants';
+
+import css from './NewVersionInfoView.less';
+
+class NewVersionInfoView extends PureComponent {
+  renderHtmlSnippets(releases) {
+    if (!releases) {
+      return null;
+    }
+    return releases.map((release) => {
+      const {
+        version,
+        releaseNoteHTML
+      } = release;
+
+      return (<div
+        className="htmlSnippetItem"
+        key={ version }
+        dangerouslySetInnerHTML={ { __html: releaseNoteHTML } }
+      />);
+    });
+  }
+
+  render() {
+    const {
+      latestVersionInfo,
+      currentVersion,
+      onClose,
+      onGoToDownloadPage
+    } = this.props;
+
+    const {
+      latestVersion,
+      releases
+    } = latestVersionInfo;
+
+    const infoTextProcessed = INFO_TEXT.replace('@@1', latestVersion).replace('@@2', currentVersion);
+
+    return (
+      <Modal className={ css.NewVersionInfo } onClose={ onClose }>
+
+        <Modal.Title>{ MODAL_TITLE }</Modal.Title>
+
+        <Modal.Body>
+          <div className="newVersionInfoText">
+            { infoTextProcessed }
+          </div>
+          <div className="releaseNotesContainer">
+            <b className="releaseNotesTitle"> { RELEASE_NOTES_TITLE } </b>
+            <div className="htmlSnippet">
+              { this.renderHtmlSnippets(releases) }
+            </div>
+          </div>
+        </Modal.Body>
+
+        <Modal.Footer>
+          <div className="formSubmit">
+            <button className="newVersionInfoButtonNegative" onClick={ onClose }> { BUTTON_NEGATIVE } </button>
+            <button className="newVersionInfoButtonPositive" onClick={ onGoToDownloadPage }> { BUTTON_POSITIVE } </button>
+          </div>
+        </Modal.Footer>
+
+      </Modal>
+    );
+  }
+}
+
+export default NewVersionInfoView;

--- a/client/src/plugins/update-checks/NewVersionInfoView.less
+++ b/client/src/plugins/update-checks/NewVersionInfoView.less
@@ -1,0 +1,46 @@
+:local(.NewVersionInfo) {
+  user-select: none;
+
+  h2 {
+    font-weight: normal;
+  }
+
+  font-size: 1.2em;
+
+  button + button {
+    margin-left: 10px;
+  }
+
+  button {
+    padding: 6px 10px;
+  }
+
+  .formSubmit {
+    text-align: right;
+    margin-top: 10px;
+  }
+
+  .releaseNotesContainer {
+    margin-top: 20px;
+  }
+
+  .doNotShowContainer {
+    margin-top: 20px;
+  }
+
+  .doNotShowText {
+    margin-left: 2px;
+  }
+
+  .htmlSnippet {
+    height: 200px;
+    overflow-y: scroll;
+    border: 1px solid gray;
+    margin-top: 10px;
+    padding: 20px;
+  }
+
+  .htmlSnippetItem {
+    margin-bottom: 25px;
+  }
+}

--- a/client/src/plugins/update-checks/UpdateChecks.js
+++ b/client/src/plugins/update-checks/UpdateChecks.js
@@ -1,0 +1,148 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React, { PureComponent } from 'react';
+
+import NewVersionInfoView from './NewVersionInfoView';
+
+import UpdateChecksAPI from './UpdateChecksAPI';
+
+import Flags, { SERVER_INTERACTION, UPDATES_SERVER_URL } from '../../util/Flags';
+
+import Metadata from '../../util/Metadata';
+
+class NoopComponent extends PureComponent {
+  render() {
+    return null;
+  }
+}
+
+const PRIVACY_PREFERENCES_CONFIG_KEY = 'editor.privacyPreferences';
+const LATEST_UPDATE_CHECK_INFO_CONFIG_KEY = 'editor.latestUpdateCheckInfo';
+
+
+const HOURS_DENOMINATOR = 3600000;
+const HOURS_LIMIT = 24;
+
+export default class UpdateChecks extends PureComponent {
+
+  constructor(props) {
+    super(props);
+
+    if (!Flags.get(SERVER_INTERACTION) || !Flags.get(UPDATES_SERVER_URL)) {
+      return new NoopComponent();
+    }
+
+    this.updateChecksAPI = new UpdateChecksAPI();
+
+    this.state = {
+      showModal: false
+    };
+  }
+
+  async componentDidMount() {
+
+    const {
+      config
+    } = this.props;
+
+    const privacyPreferences = await config.get(PRIVACY_PREFERENCES_CONFIG_KEY);
+    if (!privacyPreferences || !privacyPreferences.ENABLE_UPDATE_CHECKS) {
+      this.setState({ checkNotAllowed: true });
+      return;
+    }
+
+    const latestUpdateCheckInfo = await config.get(LATEST_UPDATE_CHECK_INFO_CONFIG_KEY);
+    if (latestUpdateCheckInfo && !this.isTimeExceeded(latestUpdateCheckInfo.latestUpdateTime)) {
+      this.setState({ checkNotNeeded: true });
+      return;
+    }
+
+    await this.checkLatestVersion(latestUpdateCheckInfo);
+  }
+
+  async checkLatestVersion(updatesServerUrl, latestUpdateCheckInfo) {
+
+    this.setState({ isChecking: true });
+
+    const {
+      config,
+      _getGlobal
+    } = this.props;
+
+    const responseJSON = await this.updateChecksAPI.checkLatestVersion(config, _getGlobal, latestUpdateCheckInfo);
+
+    if (!responseJSON.isSuccessful) {
+      this.setState({ isChecking: false, requestError: true });
+      return;
+    }
+
+    const responseBody = responseJSON.response;
+    const latestVersion = responseBody.latestVersion;
+    let newLatestUpdateCheckInfo = latestUpdateCheckInfo ? latestUpdateCheckInfo : {};
+
+    if (latestVersion) {
+      const modelerVersion = 'v' + Metadata.data.version;
+      const downloadURL = responseBody.downloadURL;
+      const releases = responseBody.releases;
+      this.setState({
+        isChecking: false,
+        showModal: true,
+        latestVersionInfo: { latestVersion, downloadURL, releases },
+        currentVersion: modelerVersion
+      });
+      newLatestUpdateCheckInfo.latestCheckedVersion = latestVersion;
+    }
+
+    newLatestUpdateCheckInfo.latestUpdateTime = new Date().getTime();
+    config.set(LATEST_UPDATE_CHECK_INFO_CONFIG_KEY, newLatestUpdateCheckInfo);
+  }
+
+  isTimeExceeded(previousTime) {
+    const now = new Date().getTime();
+    const hoursDiff = Math.abs(now - previousTime) / HOURS_DENOMINATOR;
+    return hoursDiff >= HOURS_LIMIT;
+  }
+
+  onClose = () => {
+    this.setState({
+      showModal: false
+    });
+  }
+
+  onGoToDownloadPage = () => {
+    const {
+      latestVersionInfo
+    } = this.state;
+
+    const {
+      _getGlobal
+    } = this.props;
+
+    _getGlobal('backend').send('external:open-url', { url: latestVersionInfo.downloadURL });
+    this.onClose();
+  }
+
+  render() {
+    const {
+      showModal,
+      latestVersionInfo,
+      currentVersion
+    } = this.state;
+
+    return <React.Fragment>
+      { showModal && <NewVersionInfoView
+        onClose={ this.onClose }
+        onGoToDownloadPage={ this.onGoToDownloadPage }
+        latestVersionInfo={ latestVersionInfo }
+        currentVersion={ currentVersion } /> }
+    </React.Fragment>;
+  }
+}

--- a/client/src/plugins/update-checks/UpdateChecksAPI.js
+++ b/client/src/plugins/update-checks/UpdateChecksAPI.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import Flags, { UPDATES_SERVER_URL } from '../../util/Flags';
+import Metadata from '../../util/Metadata';
+
+const EDITOR_ID_CONFIG_KEY = 'editor.id';
+const OS_INFO_CONFIG_KEY = 'os.info';
+
+const UPDATE_CHECK_API = 'update-check';
+
+export default class UpdateChecksAPI {
+
+  constructor() {
+
+    this.updatesServerURL = Flags.get(UPDATES_SERVER_URL);
+  }
+
+  async sendRequest(url) {
+    const response = await fetch(url, { method: 'GET' });
+    const responseJSON = await response.json();
+    return responseJSON;
+  }
+
+  formatPlugins(plugins) {
+    return plugins.map((plugin) => {
+      return {
+        name: plugin.name, id: plugin.name
+      };
+    });
+  }
+
+  async checkLatestVersion(config, getGlobal, latestUpdateCheckInfo) {
+
+    try {
+      const editorID = await config.get(EDITOR_ID_CONFIG_KEY);
+      const modelerVersion = 'v' + Metadata.data.version;
+      const newerThan = latestUpdateCheckInfo ? (latestUpdateCheckInfo.latestCheckedVersion) : modelerVersion;
+      const osInfo = await config.get(OS_INFO_CONFIG_KEY);
+      const plugins = this.formatPlugins(getGlobal('plugins').appPlugins);
+
+      const url = new URL(UPDATE_CHECK_API, Flags.get(UPDATES_SERVER_URL));
+      url.searchParams.append('editorID', editorID);
+      url.searchParams.append('newerThan', newerThan);
+      url.searchParams.append('modelerVersion', modelerVersion);
+      url.searchParams.append('os', osInfo.platform);
+      url.searchParams.append('osVersion', osInfo.release);
+      plugins.forEach((plugin) => {
+        url.searchParams.append('plugins[id]', plugin.id);
+        url.searchParams.append('plugins[name]', plugin.name);
+      });
+
+      const responseJSON = await this.sendRequest(url.href);
+      return {
+        isSuccessful: true,
+        response: responseJSON
+      };
+    } catch (err) {
+      return {
+        isSuccessful: false,
+        error: err
+      };
+    }
+  }
+
+}

--- a/client/src/plugins/update-checks/__tests__/NewVersionInfoViewSpec.js
+++ b/client/src/plugins/update-checks/__tests__/NewVersionInfoViewSpec.js
@@ -1,0 +1,152 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+
+import {
+  mount,
+  shallow
+} from 'enzyme';
+
+import {
+  MODAL_TITLE,
+  INFO_TEXT,
+  RELEASE_NOTES_TITLE,
+  BUTTON_NEGATIVE,
+  BUTTON_POSITIVE
+} from '../constants';
+
+import NewVersionInfoView from '../NewVersionInfoView';
+
+/* global sinon */
+const { spy } = sinon;
+
+describe('<NewVersionInfoView>', () => {
+
+  let wrapper;
+
+  beforeEach(() => {
+
+    wrapper = mount(<NewVersionInfoView latestVersionInfo={ {
+      latestVersion: 'v3.7.0',
+      releases: [{
+        version: 'v3.5.0',
+        releaseNoteHTML: 'HTML 1'
+      }, {
+        version: 'v3.6.0',
+        releaseNoteHTML: 'HTML 2'
+      }]
+    } } currentVersion={ 'v3.4.0' } />);
+  });
+
+
+  it('should render', () => {
+
+    shallow(<NewVersionInfoView latestVersionInfo={ {} } />);
+  });
+
+
+  it('should render title', () => {
+
+    const title = wrapper.find('.modal-title');
+
+    expect(title.text()).to.be.eql(MODAL_TITLE);
+  });
+
+
+  it('should render info text', () => {
+
+    const expectedText = INFO_TEXT.replace('@@1', 'v3.7.0').replace('@@2', 'v3.4.0');
+
+    const infoText = wrapper.find('.newVersionInfoText');
+
+    expect(infoText.text()).to.be.eql(expectedText);
+  });
+
+
+  it('should render release notes title', () => {
+
+    const releaseNotesTitle = wrapper.find('.releaseNotesTitle');
+
+    expect(releaseNotesTitle.text().trim()).to.be.eql(RELEASE_NOTES_TITLE);
+  });
+
+
+  it('should render positive button', () => {
+
+    const positiveButton = wrapper.find('.newVersionInfoButtonPositive');
+
+    expect(positiveButton.text().trim()).to.be.eql(BUTTON_POSITIVE);
+  });
+
+
+  it('should render negative button', () => {
+
+    const negativeButton = wrapper.find('.newVersionInfoButtonNegative');
+
+    expect(negativeButton.text().trim()).to.be.eql(BUTTON_NEGATIVE);
+  });
+
+
+  it('should close', () => {
+
+    const onCloseSpy = spy();
+
+    const component = shallow(
+      <NewVersionInfoView latestVersionInfo={ {} } onClose={ onCloseSpy } />
+    );
+
+    const negativeButton = component.find('.newVersionInfoButtonNegative');
+
+    negativeButton.simulate('click');
+
+    expect(onCloseSpy).to.have.been.called;
+  });
+
+
+  it('should go to download page', () => {
+
+    const onGoToDownloadPageSpy = spy();
+
+    const component = shallow(
+      <NewVersionInfoView latestVersionInfo={ {} } onGoToDownloadPage={ onGoToDownloadPageSpy } />
+    );
+
+    const positiveButton = component.find('.newVersionInfoButtonPositive');
+
+    positiveButton.simulate('click');
+
+    expect(onGoToDownloadPageSpy).to.have.been.called;
+  });
+
+
+  it('should render HTML snippets', () => {
+
+    const component = shallow(
+      <NewVersionInfoView latestVersionInfo={ {
+        latestVersion: 'v3.7.0',
+        releases: [
+          {
+            version: 'v3.1.0',
+            releaseNoteHTML: '<b> HTML 1 </b>'
+          }, {
+            version: 'v3.2.0',
+            releaseNoteHTML: '<b> HTML 2 </b>'
+          }
+        ]
+      } } />
+    );
+
+    const htmlSnippet = component.find('.htmlSnippet');
+
+    expect(htmlSnippet.html()).to.contain('<b> HTML 1 </b>');
+    expect(htmlSnippet.html()).to.contain('<b> HTML 2 </b>');
+  });
+});

--- a/client/src/plugins/update-checks/__tests__/UpdateChecksSpec.js
+++ b/client/src/plugins/update-checks/__tests__/UpdateChecksSpec.js
@@ -1,0 +1,311 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+
+import Flags, { UPDATES_SERVER_URL, SERVER_INTERACTION } from '../../../util/Flags';
+import Metadata from '../../../util/Metadata';
+
+import {
+  shallow
+} from 'enzyme';
+
+import UpdateChecks from '../UpdateChecks';
+
+const PRIVACY_PREFERENCES_CONFIG_KEY = 'editor.privacyPreferences';
+const LATEST_UPDATE_CHECK_INFO_CONFIG_KEY = 'editor.latestUpdateCheckInfo';
+const EDITOR_ID_CONFIG_KEY = 'editor.id';
+const OS_INFO_CONFIG_KEY = 'os.info';
+
+describe('<UpdateChecks>', () => {
+
+  beforeEach(() => {
+    Flags.init({
+      [ SERVER_INTERACTION ]: true,
+      [ UPDATES_SERVER_URL]: 'http://test-url.com'
+    });
+    Metadata.init({ name: 'test-name', version: '3.5.0' });
+  });
+
+
+  afterEach(() => {
+    Flags.reset();
+    Metadata.init({});
+  });
+
+
+  it('should render', () => {
+    shallow(<UpdateChecks />);
+  });
+
+
+  it('should not be initialized if SERVER_INTERACTION flag missing', () => {
+
+    Flags.init({
+      [ UPDATES_SERVER_URL]: 'http://test-url.com'
+    });
+
+    const component = shallow(<UpdateChecks />);
+
+    expect(component.state()).to.be.null;
+  });
+
+
+  it('should not be initialized if UPDATES_SERVER_URL flag missing', () => {
+
+    Flags.init({
+      [ SERVER_INTERACTION ]: true
+    });
+
+    const component = shallow(<UpdateChecks />);
+
+    expect(component.state()).to.be.null;
+  });
+
+
+  it('should be initialized if flags not missing', () => {
+
+    const component = shallow(<UpdateChecks />);
+
+    expect(component.state('showModal')).to.be.false;
+  });
+
+
+  it('should be in checkNotAllowed state if privacy preference non existent', async () => {
+
+    const component = shallow(<UpdateChecks config={ {
+      get(key) {
+        return new Promise((resolve, reject) => {
+          if (key === PRIVACY_PREFERENCES_CONFIG_KEY) {
+            resolve(null);
+          }
+        });
+      }
+    } } />);
+
+    await waitForNPromises(component, 1);
+
+    expect(component.state().checkNotAllowed).to.be.true;
+
+  });
+
+
+  it('should be in checkNotAllowed state if ENABLE_UPDATE_CHECKS preference is false', async () => {
+
+    const component = shallow(<UpdateChecks config={ {
+      get(key) {
+        return new Promise((resolve, reject) => {
+          if (key === PRIVACY_PREFERENCES_CONFIG_KEY) {
+            resolve({
+              ENABLE_UPDATE_CHECKS: false
+            });
+          }
+        });
+      }
+    } } />);
+
+    await waitForNPromises(component, 1);
+
+    expect(component.state().checkNotAllowed).to.be.true;
+  });
+
+
+  it('should be in isChecking state if ENABLE_UPDATE_CHECKS preference is true', async () => {
+
+    const component = shallow(<UpdateChecks config={ {
+      get(key) {
+        return new Promise((resolve, reject) => {
+          if (key === PRIVACY_PREFERENCES_CONFIG_KEY) {
+            resolve({
+              ENABLE_UPDATE_CHECKS: true
+            });
+          } else if (key === LATEST_UPDATE_CHECK_INFO_CONFIG_KEY) {
+            resolve(null);
+          }
+        });
+      }
+    } } />);
+
+    await waitForNPromises(component, 2);
+
+    expect(component.state().isChecking).to.be.true;
+  });
+
+
+  it('should be in checkNotNeeded state if last update check time not exceeded', async () => {
+
+    const component = shallow(<UpdateChecks config={ {
+      get(key) {
+        return new Promise((resolve, reject) => {
+          if (key === LATEST_UPDATE_CHECK_INFO_CONFIG_KEY) {
+            resolve({ latestUpdateTime: new Date().getTime() });
+          } else {
+            resolve({
+              ENABLE_UPDATE_CHECKS: true
+            });
+          }
+        });
+      }
+    } } />);
+
+    await waitForNPromises(component, 2);
+
+    expect(component.state().checkNotNeeded).to.be.true;
+  });
+
+
+  it('should check latest version with correct url', async () => {
+
+    const component = getUpdateCheckerComponent();
+
+    let requestedURL = '';
+
+    mockServerResponse(component, {}, (url) => {
+      requestedURL = url;
+    });
+
+    await waitForNPromises(component, 4);
+
+    expect(requestedURL).to.be.eql('http://test-url.com/update-check?editorID=test-id&newerThan=v3.5.0&modelerVersion=v3.5.0&os=window&osVersion=98&plugins%5Bid%5D=plugin1&plugins%5Bname%5D=plugin1&plugins%5Bid%5D=plugin2&plugins%5Bname%5D=plugin2');
+  });
+
+
+  it('should update latest update check config for empty server response', async () => {
+
+    let setValue = {};
+
+    const onConfigSet = (key, value) => {
+      setValue = value;
+    };
+
+    const component = getUpdateCheckerComponent({ onConfigSet: onConfigSet });
+
+    mockServerResponse(component, {});
+
+    await waitForNPromises(component, 5);
+
+    expect(setValue.latestUpdateTime).to.exist;
+  });
+
+
+  it('should update latest update check config based on server response', async () => {
+
+    let setValue = {};
+
+    const onConfigSet = (key, value) => {
+      setValue = value;
+    };
+
+    const component = getUpdateCheckerComponent({ onConfigSet: onConfigSet });
+
+    mockServerResponse(component, {
+      latestVersion: 'v3.7.0',
+      downloadURL: 'test-download-url',
+      releases: []
+    });
+
+    await waitForNPromises(component, 5);
+
+    expect(setValue.latestCheckedVersion).to.be.eql('v3.7.0');
+  });
+
+
+  it('should not show modal for empty server response', async () => {
+
+    const component = getUpdateCheckerComponent();
+
+    mockServerResponse(component, {});
+
+    await waitForNPromises(component, 5);
+
+    expect(component.state().showModal).to.be.false;
+  });
+
+
+  it('should show modal for positive server response', async () => {
+
+    const component = getUpdateCheckerComponent();
+
+    mockServerResponse(component, {
+      latestVersion: 'v3.7.0',
+      downloadURL: 'test-download-url',
+      releases: []
+    });
+
+    await waitForNPromises(component, 5);
+
+    expect(component.state().showModal).to.be.true;
+  });
+
+
+  it('should be in requestError state if server connection fails', async () => {
+
+    const component = getUpdateCheckerComponent();
+
+    component.instance().updateChecksAPI.sendRequest = () => {
+      throw new Error('These things happen.');
+    };
+
+    await waitForNPromises(component, 4);
+
+    expect(component.state().requestError).to.be.true;
+  });
+});
+
+const getUpdateCheckerComponent = (confs) => {
+  return shallow(<UpdateChecks config={ {
+    get(key) {
+      return new Promise((resolve, reject) => {
+        if (key === LATEST_UPDATE_CHECK_INFO_CONFIG_KEY) {
+          resolve({ latestUpdateTime: 0, latestCheckedVersion: 'v3.5.0' });
+        } else if (key === PRIVACY_PREFERENCES_CONFIG_KEY) {
+          resolve({
+            ENABLE_UPDATE_CHECKS: true
+          });
+        } else if (key === EDITOR_ID_CONFIG_KEY) {
+          resolve('test-id');
+        } else if (key === OS_INFO_CONFIG_KEY) {
+          resolve({ platform: 'window', release: '98' });
+        }
+      });
+    },
+    set(key, value) {
+      if (confs && confs.onConfigSet) {
+        confs.onConfigSet(key, value);
+      }
+    }
+  } } _getGlobal={ (key) => {
+    if (key === 'plugins') {
+      return {
+        appPlugins: [
+          { name: 'plugin1', id: 'pluginID1' },
+          { name: 'plugin2', id: 'pluginID2' }
+        ]
+      };
+    }
+  } } />);
+};
+
+const waitForNPromises = async (component, n) => {
+  for (let i = 0; i < n; i ++) {
+    await component.update();
+  }
+};
+
+const mockServerResponse = (component, resp, callback) => {
+  component.instance().updateChecksAPI.sendRequest = (url) => {
+    if (callback) {
+      callback(url);
+    }
+    return new Promise((resolve, reject) => {
+      resolve(resp);
+    });
+  };
+};

--- a/client/src/plugins/update-checks/constants.js
+++ b/client/src/plugins/update-checks/constants.js
@@ -8,12 +8,12 @@
  * except in compliance with the MIT License.
  */
 
-import CamundaPlugin from './camunda-plugin';
-import PrivacyPreferences from './privacy-preferences';
-import UpdateChecks from './update-checks';
+export const MODAL_TITLE = 'A Camunda Modeler Update is Available';
 
-export default [
-  CamundaPlugin,
-  PrivacyPreferences,
-  UpdateChecks
-];
+export const BUTTON_NEGATIVE = 'Not right now';
+
+export const BUTTON_POSITIVE = 'Go to download page';
+
+export const RELEASE_NOTES_TITLE = 'Release notes:';
+
+export const INFO_TEXT = 'Camunda Modeler @@1 is now available--you have @@2. Would you like to download it now?';

--- a/client/src/plugins/update-checks/index.js
+++ b/client/src/plugins/update-checks/index.js
@@ -8,12 +8,4 @@
  * except in compliance with the MIT License.
  */
 
-import CamundaPlugin from './camunda-plugin';
-import PrivacyPreferences from './privacy-preferences';
-import UpdateChecks from './update-checks';
-
-export default [
-  CamundaPlugin,
-  PrivacyPreferences,
-  UpdateChecks
-];
+export { default } from './UpdateChecks';

--- a/client/src/util/Flags.js
+++ b/client/src/util/Flags.js
@@ -37,3 +37,4 @@ export const DISABLE_ADJUST_ORIGIN = 'disable-adjust-origin';
 export const DISABLE_PLUGINS = 'disable-plugins';
 export const RELAUNCH = 'relaunch';
 export const SERVER_INTERACTION = 'server-interaction';
+export const UPDATES_SERVER_URL = 'updates-server-url';


### PR DESCRIPTION
Closes #1545

To test this, pull the [Camunda Modeler Updates Server](https://github.com/camunda/camunda-modeler-update-server), start the server with **test mode**: `npm run testMode`, this would let server respond with a test response rather than an empty response.

Run camunda modeler with:
`--server-interaction --updates-server-url=http://localhost:8050`

**Tip**
While testing it makes sense to comment out [this line](https://github.com/camunda/camunda-modeler/blob/3b9eecfa3d269b1beeab9bc0b6071f9f1150ac66/client/src/plugins/update-checks/UpdateChecks.js#L63) as we don't want to wait for another day to make the popup visible again :)

In the testMode, the Modeler should show something like this:

<img width="904" alt="Screenshot 2019-11-28 at 16 31 00" src="https://user-images.githubusercontent.com/15003836/69818205-893b0a00-11fc-11ea-9a54-8355bf9da328.png">

**Go to download page** button should go to camunda.com