### PR TITLE
feat(app): set user path via flag

### DIFF
--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -488,13 +488,19 @@ function bootstrapLogging() {
 function bootstrap() {
   const appPath = path.dirname(app.getPath('exe')),
         cwd = process.cwd(),
-        userDesktopPath = app.getPath('userDesktop'),
-        userPath = app.getPath('userData');
+        userDesktopPath = app.getPath('userDesktop');
 
   const {
     files,
     flags: flagOverrides
   } = Cli.parse(process.argv, cwd);
+
+  // (1) user path
+  if (flagOverrides['user-data-dir']) {
+    app.setPath('userData', flagOverrides['user-data-dir']);
+  }
+
+  const userPath = app.getPath('userData');
 
   let resourcesPaths = [
     path.join(appPath, 'resources'),
@@ -508,35 +514,35 @@ function bootstrap() {
     ];
   }
 
-  // (1) config
+  // (2) config
   const config = new Config({
     appPath,
     resourcesPaths,
     userPath
   });
 
-  // (2) flags
+  // (3) flags
   const flags = new Flags({
     paths: resourcesPaths,
     overrides: flagOverrides
   });
 
-  // (3) menu
+  // (4) menu
   const menu = new Menu({
     platform
   });
 
-  // (4) dialog
+  // (5) dialog
   const dialog = new Dialog({
     config,
     electronDialog,
     userDesktopPath
   });
 
-  // (5) workspace
+  // (6) workspace
   new Workspace(config);
 
-  // (6) plugins
+  // (7) plugins
   const pluginsDisabled = flags.get('disable-plugins');
 
   let paths;

--- a/docs/flags/README.md
+++ b/docs/flags/README.md
@@ -27,15 +27,14 @@ Flags passed as command line arguments take precedence over those configured via
 
 ## Available Flags
 
-```json
-{
-  "disable-plugins": false,
-  "disable-adjust-origin": false,
-  "disable-cmmn": false,
-  "disable-dmn": false,
-  "single-instance": false
-}
-```
+| flag | default value |
+| ------------- | ------------- |
+| "disable-plugins"  | false  |
+| "disable-adjust-origin"  | false  |
+| "disable-cmmn" | false |
+| "disable-dmn" | false |
+| "single-instance" | false |
+| "user-data-dir" | [Electron default](../search-paths) |
 
 
 ## Examples

--- a/docs/search-paths/README.md
+++ b/docs/search-paths/README.md
@@ -16,4 +16,6 @@ This is the per-user application data directory which differs across operating s
 
 If you don't know where to find these paths, learn more about Windows [`%APPDATA%`](https://www.howtogeek.com/318177/what-is-the-appdata-folder-in-windows/) and Linux [`$XDG_CONFIG_HOME`](https://wiki.archlinux.org/index.php/XDG_Base_Directory) directories.
 
+It is also possible to change the user data directory. Just use the `--user-data-dir` argument when starting the Camunda Modeler from the command line. Refer to the [flags documentation](../flags) on how to configure the application.
+
 Inside this documentation, we use the `{USER_DATA}` symbol to indicate the User Data Directory.


### PR DESCRIPTION
Adds options to set user path via '--user-path' flag

Example: ./'Camunda Modeler' --user-path="/Users/foo/camunda-modeler"

Closes #1625 