### PR TITLE
Assign timestamp to nightly build versions

### DIFF
--- a/app/util/get-version.js
+++ b/app/util/get-version.js
@@ -28,8 +28,26 @@ module.exports = function getVersion(pkg, options) {
   var nightly = options.nightly;
 
   if (nightly) {
-    appVersion = semver.inc(appVersion, 'minor') + '-' + nightly;
+    appVersion = semver.inc(appVersion, 'minor') + '-' + nightly + '.' + today();
   }
 
   return appVersion;
 };
+
+function pad(n) {
+  if (n < 10) {
+    return '0' + n;
+  } else {
+    return n;
+  }
+}
+
+function today() {
+  const d = new Date();
+
+  return [
+    d.getFullYear(),
+    pad(d.getMonth() + 1),
+    pad(d.getDate())
+  ].join('');
+}

--- a/tasks/distro.js
+++ b/tasks/distro.js
@@ -26,7 +26,7 @@ const {
 
 // in case of --nightly, update all package versions to the
 // next minor version with the nightly preid. This will
-// result in app and client being versioned like `v1.2.3-nightly.0`.
+// result in app and client being versioned like `v1.2.0-nightly.20191121`.
 
 const nightlyVersion = nightly && getVersion(pkg, {
   nightly: 'nightly'


### PR DESCRIPTION
Closes #1628

Once this PR gets merged, the updates server will be able to compare the recency of nightly builds.