### PR TITLE
Enable privacy preferences and update checks by default

### DIFF
--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -540,7 +540,7 @@ class MenuBuilder {
         label: 'Report Issue',
         click: () => browserOpen('https://github.com/camunda/camunda-modeler/issues/new/choose')
       },
-      ... (app.flags && app.flags.get('server-interaction')) ? [
+      ... (app.flags && !app.flags.get('disable-server-interaction')) ? [
         getSeparatorTemplate(),
         {
           label: 'Privacy Preferences',

--- a/client/src/plugins/privacy-preferences/PrivacyPreferences.js
+++ b/client/src/plugins/privacy-preferences/PrivacyPreferences.js
@@ -12,7 +12,7 @@ import React, { PureComponent } from 'react';
 
 import PrivacyPreferencesView from './PrivacyPreferencesView';
 
-import Flags, { SERVER_INTERACTION } from '../../util/Flags';
+import Flags, { DISABLE_SERVER_INTERACTION } from '../../util/Flags';
 
 const CONFIG_KEY = 'editor.privacyPreferences';
 
@@ -26,8 +26,7 @@ export default class PrivacyPreferences extends PureComponent {
 
   constructor(props) {
     super(props);
-
-    if (!Flags.get(SERVER_INTERACTION)) {
+    if (Flags.get(DISABLE_SERVER_INTERACTION)) {
       return new NoopComponent();
     }
   }

--- a/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesSpec.js
+++ b/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesSpec.js
@@ -17,26 +17,12 @@ import {
   shallow
 } from 'enzyme';
 
-import Flags, { SERVER_INTERACTION } from '../../../util/Flags';
-
 import PrivacyPreferences from '../PrivacyPreferences';
 
 // eslint-disable-next-line no-undef
 const { spy } = sinon;
 
 describe('<PrivacyPreferences>', () => {
-
-  beforeEach(() => {
-    Flags.init({
-      [ SERVER_INTERACTION ]: true
-    });
-  });
-
-
-  afterEach(() => {
-    Flags.reset();
-  });
-
 
   it('should render', async () => {
 

--- a/client/src/plugins/update-checks/UpdateChecks.js
+++ b/client/src/plugins/update-checks/UpdateChecks.js
@@ -14,7 +14,7 @@ import NewVersionInfoView from './NewVersionInfoView';
 
 import UpdateChecksAPI from './UpdateChecksAPI';
 
-import Flags, { SERVER_INTERACTION, UPDATES_SERVER_URL } from '../../util/Flags';
+import Flags, { DISABLE_SERVER_INTERACTION } from '../../util/Flags';
 
 import Metadata from '../../util/Metadata';
 
@@ -36,7 +36,7 @@ export default class UpdateChecks extends PureComponent {
   constructor(props) {
     super(props);
 
-    if (!Flags.get(SERVER_INTERACTION) || !Flags.get(UPDATES_SERVER_URL)) {
+    if (Flags.get(DISABLE_SERVER_INTERACTION)) {
       return new NoopComponent();
     }
 
@@ -65,10 +65,10 @@ export default class UpdateChecks extends PureComponent {
       return;
     }
 
-    await this.checkLatestVersion(latestUpdateCheckInfo);
+    this.checkLatestVersion(latestUpdateCheckInfo);
   }
 
-  async checkLatestVersion(updatesServerUrl, latestUpdateCheckInfo) {
+  async checkLatestVersion(latestUpdateCheckInfo) {
 
     this.setState({ isChecking: true });
 
@@ -78,7 +78,6 @@ export default class UpdateChecks extends PureComponent {
     } = this.props;
 
     const responseJSON = await this.updateChecksAPI.checkLatestVersion(config, _getGlobal, latestUpdateCheckInfo);
-
     if (!responseJSON.isSuccessful) {
       this.setState({ isChecking: false, requestError: true });
       return;

--- a/client/src/plugins/update-checks/UpdateChecksAPI.js
+++ b/client/src/plugins/update-checks/UpdateChecksAPI.js
@@ -8,20 +8,15 @@
  * except in compliance with the MIT License.
  */
 
-import Flags, { UPDATES_SERVER_URL } from '../../util/Flags';
 import Metadata from '../../util/Metadata';
 
 const EDITOR_ID_CONFIG_KEY = 'editor.id';
 const OS_INFO_CONFIG_KEY = 'os.info';
 
 const UPDATE_CHECK_API = 'update-check';
+const UPDATES_SERVER_URL = 'https://camunda-modeler-updates.camunda.com/';
 
 export default class UpdateChecksAPI {
-
-  constructor() {
-
-    this.updatesServerURL = Flags.get(UPDATES_SERVER_URL);
-  }
 
   async sendRequest(url) {
     const response = await fetch(url, { method: 'GET' });
@@ -46,7 +41,7 @@ export default class UpdateChecksAPI {
       const osInfo = await config.get(OS_INFO_CONFIG_KEY);
       const plugins = this.formatPlugins(getGlobal('plugins').appPlugins);
 
-      const url = new URL(UPDATE_CHECK_API, Flags.get(UPDATES_SERVER_URL));
+      const url = new URL(UPDATE_CHECK_API, UPDATES_SERVER_URL);
       url.searchParams.append('editorID', editorID);
       url.searchParams.append('newerThan', newerThan);
       url.searchParams.append('modelerVersion', modelerVersion);

--- a/client/src/plugins/update-checks/__tests__/UpdateChecksSpec.js
+++ b/client/src/plugins/update-checks/__tests__/UpdateChecksSpec.js
@@ -10,7 +10,7 @@
 
 import React from 'react';
 
-import Flags, { UPDATES_SERVER_URL, SERVER_INTERACTION } from '../../../util/Flags';
+import Flags, { DISABLE_SERVER_INTERACTION } from '../../../util/Flags';
 import Metadata from '../../../util/Metadata';
 
 import {
@@ -27,10 +27,6 @@ const OS_INFO_CONFIG_KEY = 'os.info';
 describe('<UpdateChecks>', () => {
 
   beforeEach(() => {
-    Flags.init({
-      [ SERVER_INTERACTION ]: true,
-      [ UPDATES_SERVER_URL]: 'http://test-url.com'
-    });
     Metadata.init({ name: 'test-name', version: '3.5.0' });
   });
 
@@ -46,10 +42,10 @@ describe('<UpdateChecks>', () => {
   });
 
 
-  it('should not be initialized if SERVER_INTERACTION flag missing', () => {
+  it('should not be initialized if DISABLE_SERVER_INTERACTION flag existent', () => {
 
     Flags.init({
-      [ UPDATES_SERVER_URL]: 'http://test-url.com'
+      [ DISABLE_SERVER_INTERACTION ]: true
     });
 
     const component = shallow(<UpdateChecks />);
@@ -58,19 +54,8 @@ describe('<UpdateChecks>', () => {
   });
 
 
-  it('should not be initialized if UPDATES_SERVER_URL flag missing', () => {
 
-    Flags.init({
-      [ SERVER_INTERACTION ]: true
-    });
-
-    const component = shallow(<UpdateChecks />);
-
-    expect(component.state()).to.be.null;
-  });
-
-
-  it('should be initialized if flags not missing', () => {
+  it('should be initialized if DISABLE_SERVER_INTERACTION flag missing', () => {
 
     const component = shallow(<UpdateChecks />);
 
@@ -158,22 +143,6 @@ describe('<UpdateChecks>', () => {
     await waitForNPromises(component, 2);
 
     expect(component.state().checkNotNeeded).to.be.true;
-  });
-
-
-  it('should check latest version with correct url', async () => {
-
-    const component = getUpdateCheckerComponent();
-
-    let requestedURL = '';
-
-    mockServerResponse(component, {}, (url) => {
-      requestedURL = url;
-    });
-
-    await waitForNPromises(component, 4);
-
-    expect(requestedURL).to.be.eql('http://test-url.com/update-check?editorID=test-id&newerThan=v3.5.0&modelerVersion=v3.5.0&os=window&osVersion=98&plugins%5Bid%5D=plugin1&plugins%5Bname%5D=plugin1&plugins%5Bid%5D=plugin2&plugins%5Bname%5D=plugin2');
   });
 
 

--- a/client/src/util/Flags.js
+++ b/client/src/util/Flags.js
@@ -36,5 +36,4 @@ export const DISABLE_DMN = 'disable-dmn';
 export const DISABLE_ADJUST_ORIGIN = 'disable-adjust-origin';
 export const DISABLE_PLUGINS = 'disable-plugins';
 export const RELAUNCH = 'relaunch';
-export const SERVER_INTERACTION = 'server-interaction';
-export const UPDATES_SERVER_URL = 'updates-server-url';
+export const DISABLE_SERVER_INTERACTION = 'disable-server-interaction';


### PR DESCRIPTION
Closes #1641

This PR enables privacy preferences and update checks by default. Also introduces --disable-server-interaction flag to disable privacy preference settings and update checks features (which is of course false by default).