### PR TITLE
Integrate primary/secondary buttons to privacy-settings and updates-check modals

### DIFF
--- a/client/src/plugins/privacy-preferences/PrivacyPreferencesView.js
+++ b/client/src/plugins/privacy-preferences/PrivacyPreferencesView.js
@@ -100,13 +100,13 @@ class PrivacyPreferencesView extends PureComponent {
 
         <Modal.Footer>
           <div className="form-submit">
-            <button className="privacyPreferencesSave" type="submit" onClick={ () => {
+            <button className="btn btn-primary" type="submit" onClick={ () => {
               onSaveAndClose(this.state);
             } }>
               { OK_BUTTON_TEXT }
             </button>
             { hasCancel && (
-              <button className="privacyPreferencesCancel" type="submit" onClick={ onClose }>
+              <button className="btn" type="submit" onClick={ onClose }>
                 { CANCEL_BUTTON_TEXT }
               </button>
             ) }

--- a/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesSpec.js
+++ b/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesSpec.js
@@ -103,7 +103,7 @@ describe('<PrivacyPreferences>', () => {
     } } subscribe={ () => {} } />);
 
     await wrapper.update();
-    wrapper.find('.privacyPreferencesSave').first().simulate('click');
+    wrapper.find('.btn-primary').first().simulate('click');
     expect(setSpy).to.have.been.called;
   });
 
@@ -152,7 +152,7 @@ describe('<PrivacyPreferences>', () => {
 
     await subscribeFunc();
     await wrapper.update();
-    wrapper.find('.privacyPreferencesCancel').first().simulate('click');
+    wrapper.find('.btn').at(1).simulate('click');
     expect(setSpy).to.not.have.been.called;
   });
 });

--- a/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesViewSpec.js
+++ b/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesViewSpec.js
@@ -85,7 +85,7 @@ describe('<PrivacyPreferencesView>', function() {
 
     it('should not render cancel button if prop not set', function() {
 
-      const cancel = wrapper.find('.privacyPreferencesCancel');
+      const cancel = wrapper.find('.btn').at(1);
 
       expect(cancel).to.have.lengthOf(0);
     });
@@ -95,7 +95,7 @@ describe('<PrivacyPreferencesView>', function() {
 
       wrapper = mount(<PrivacyPreferencesView hasCancel={ true } />);
 
-      const cancel = wrapper.find('.privacyPreferencesCancel');
+      const cancel = wrapper.find('.btn').at(1);
 
       expect(cancel).to.have.lengthOf(1);
     });
@@ -181,7 +181,7 @@ describe('<PrivacyPreferencesView>', function() {
         <PrivacyPreferencesView preferences={ currentPreferences } onSaveAndClose={ onSaveAndClose } />
       );
 
-      const saveButton = wrapper.find('.privacyPreferencesSave').first();
+      const saveButton = wrapper.find('.btn-primary').first();
       saveButton.simulate('click');
       expect(onSaveAndClose).to.have.been.calledWith(currentPreferences);
     });
@@ -199,7 +199,7 @@ describe('<PrivacyPreferencesView>', function() {
           onSaveAndClose={ onSaveAndClose } />
       );
 
-      const cancelButton = wrapper.find('.privacyPreferencesCancel').first();
+      const cancelButton = wrapper.find('.btn').at(1);
       cancelButton.simulate('click');
       expect(onSaveAndClose).to.not.have.been.called;
     });

--- a/client/src/plugins/update-checks/NewVersionInfoView.js
+++ b/client/src/plugins/update-checks/NewVersionInfoView.js
@@ -80,8 +80,8 @@ class NewVersionInfoView extends PureComponent {
 
         <Modal.Footer>
           <div className="formSubmit">
-            <button className="newVersionInfoButtonNegative" onClick={ onClose }> { BUTTON_NEGATIVE } </button>
-            <button className="newVersionInfoButtonPositive" onClick={ onGoToDownloadPage }> { BUTTON_POSITIVE } </button>
+            <button className="btn btn-primary" onClick={ onGoToDownloadPage }> { BUTTON_POSITIVE } </button>
+            <button className="btn" onClick={ onClose }> { BUTTON_NEGATIVE } </button>
           </div>
         </Modal.Footer>
 

--- a/client/src/plugins/update-checks/__tests__/NewVersionInfoViewSpec.js
+++ b/client/src/plugins/update-checks/__tests__/NewVersionInfoViewSpec.js
@@ -81,7 +81,7 @@ describe('<NewVersionInfoView>', () => {
 
   it('should render positive button', () => {
 
-    const positiveButton = wrapper.find('.newVersionInfoButtonPositive');
+    const positiveButton = wrapper.find('.btn-primary');
 
     expect(positiveButton.text().trim()).to.be.eql(BUTTON_POSITIVE);
   });
@@ -89,7 +89,7 @@ describe('<NewVersionInfoView>', () => {
 
   it('should render negative button', () => {
 
-    const negativeButton = wrapper.find('.newVersionInfoButtonNegative');
+    const negativeButton = wrapper.find('.btn').at(1);
 
     expect(negativeButton.text().trim()).to.be.eql(BUTTON_NEGATIVE);
   });
@@ -103,7 +103,7 @@ describe('<NewVersionInfoView>', () => {
       <NewVersionInfoView latestVersionInfo={ {} } onClose={ onCloseSpy } />
     );
 
-    const negativeButton = component.find('.newVersionInfoButtonNegative');
+    const negativeButton = component.find('.btn').at(1);
 
     negativeButton.simulate('click');
 
@@ -119,7 +119,7 @@ describe('<NewVersionInfoView>', () => {
       <NewVersionInfoView latestVersionInfo={ {} } onGoToDownloadPage={ onGoToDownloadPageSpy } />
     );
 
-    const positiveButton = component.find('.newVersionInfoButtonPositive');
+    const positiveButton = component.find('.btn-primary');
 
     positiveButton.simulate('click');
 


### PR DESCRIPTION
This PR integrates primary and secondary button classes into privacy-settings and updates-check modals so that once we implement these css classes, these modals would be aligned with deployment related modals.