### PR TITLE
Update checks dev improvements

### DIFF
--- a/app/lib/__tests__/flags-spec.js
+++ b/app/lib/__tests__/flags-spec.js
@@ -37,6 +37,27 @@ describe('flags', function() {
 
   });
 
+
+  it('should provide default value', function() {
+
+    // given
+    const flags = new Flags({
+      paths: [
+        absPath('flags/1'),
+        absPath('flags/2')
+      ],
+      overrides: {
+        TWO: 'overridden'
+      }
+    });
+
+    // then
+    expect(flags.get('ONE')).to.equal(true);
+    expect(flags.get('NON_EXISTING')).not.to.exist;
+
+    expect(flags.get('NON_EXISTING', 10000)).to.eql(10000);
+  });
+
 });
 
 

--- a/app/lib/flags.js
+++ b/app/lib/flags.js
@@ -53,8 +53,8 @@ class Flags {
     return this.flags;
   }
 
-  get(key) {
-    return this.flags[key];
+  get(key, defaultValue) {
+    return key in this.flags ? this.flags[key] : defaultValue;
   }
 
 }

--- a/client/src/plugins/update-checks/UpdateChecks.js
+++ b/client/src/plugins/update-checks/UpdateChecks.js
@@ -24,12 +24,16 @@ class NoopComponent extends PureComponent {
   }
 }
 
+const DEFAULT_UPDATE_SERVER_URL = process.env.NODE_ENV === 'production'
+  ? 'https://camunda-modeler-updates.camunda.com/'
+  : 'https://camunda-modeler-update-server-staging.camunda.com';
+
 const PRIVACY_PREFERENCES_CONFIG_KEY = 'editor.privacyPreferences';
 const LATEST_UPDATE_CHECK_INFO_CONFIG_KEY = 'editor.latestUpdateCheckInfo';
 
-
 const HOURS_DENOMINATOR = 3600000;
 const HOURS_LIMIT = 24;
+
 
 export default class UpdateChecks extends PureComponent {
 
@@ -40,7 +44,9 @@ export default class UpdateChecks extends PureComponent {
       return new NoopComponent();
     }
 
-    this.updateChecksAPI = new UpdateChecksAPI(Flags.get(UPDATES_SERVER_URL));
+    const updateServerUrl = Flags.get(UPDATES_SERVER_URL, DEFAULT_UPDATE_SERVER_URL);
+
+    this.updateChecksAPI = new UpdateChecksAPI(updateServerUrl);
 
     this.state = {
       showModal: false

--- a/client/src/plugins/update-checks/UpdateChecks.js
+++ b/client/src/plugins/update-checks/UpdateChecks.js
@@ -14,7 +14,7 @@ import NewVersionInfoView from './NewVersionInfoView';
 
 import UpdateChecksAPI from './UpdateChecksAPI';
 
-import Flags, { DISABLE_SERVER_INTERACTION } from '../../util/Flags';
+import Flags, { DISABLE_SERVER_INTERACTION, FORCE_UPDATE_CHECKS, UPDATES_SERVER_URL } from '../../util/Flags';
 
 import Metadata from '../../util/Metadata';
 
@@ -40,7 +40,7 @@ export default class UpdateChecks extends PureComponent {
       return new NoopComponent();
     }
 
-    this.updateChecksAPI = new UpdateChecksAPI();
+    this.updateChecksAPI = new UpdateChecksAPI(Flags.get(UPDATES_SERVER_URL));
 
     this.state = {
       showModal: false
@@ -60,7 +60,8 @@ export default class UpdateChecks extends PureComponent {
     }
 
     const latestUpdateCheckInfo = await config.get(LATEST_UPDATE_CHECK_INFO_CONFIG_KEY);
-    if (latestUpdateCheckInfo && !this.isTimeExceeded(latestUpdateCheckInfo.latestUpdateTime)) {
+
+    if (!Flags.get(FORCE_UPDATE_CHECKS) && latestUpdateCheckInfo && !this.isTimeExceeded(latestUpdateCheckInfo.latestUpdateTime)) {
       this.setState({ checkNotNeeded: true });
       return;
     }

--- a/client/src/plugins/update-checks/UpdateChecksAPI.js
+++ b/client/src/plugins/update-checks/UpdateChecksAPI.js
@@ -14,9 +14,19 @@ const EDITOR_ID_CONFIG_KEY = 'editor.id';
 const OS_INFO_CONFIG_KEY = 'os.info';
 
 const UPDATE_CHECK_API = 'update-check';
-const UPDATES_SERVER_URL = 'https://camunda-modeler-updates.camunda.com/';
+const PROD_UPDATES_SERVER_URL = 'https://camunda-modeler-updates.camunda.com/';
+const DEV_UPDATES_SERVER_URL = 'http://camunda-modeler-update-server-staging.camunda.com';
 
 export default class UpdateChecksAPI {
+
+  constructor(updatesServerURLFlagValue) {
+
+    if (updatesServerURLFlagValue) {
+      this.updatesServerURL = updatesServerURLFlagValue;
+    } else {
+      this.updatesServerURL = __ENVIRONMENT__ === 'development' ? DEV_UPDATES_SERVER_URL : PROD_UPDATES_SERVER_URL;
+    }
+  }
 
   async sendRequest(url) {
     const response = await fetch(url, { method: 'GET' });
@@ -41,7 +51,7 @@ export default class UpdateChecksAPI {
       const osInfo = await config.get(OS_INFO_CONFIG_KEY);
       const plugins = this.formatPlugins(getGlobal('plugins').appPlugins);
 
-      const url = new URL(UPDATE_CHECK_API, UPDATES_SERVER_URL);
+      const url = new URL(UPDATE_CHECK_API, this.updatesServerURL);
       url.searchParams.append('editorID', editorID);
       url.searchParams.append('newerThan', newerThan);
       url.searchParams.append('modelerVersion', modelerVersion);

--- a/client/src/plugins/update-checks/UpdateChecksAPI.js
+++ b/client/src/plugins/update-checks/UpdateChecksAPI.js
@@ -14,18 +14,11 @@ const EDITOR_ID_CONFIG_KEY = 'editor.id';
 const OS_INFO_CONFIG_KEY = 'os.info';
 
 const UPDATE_CHECK_API = 'update-check';
-const PROD_UPDATES_SERVER_URL = 'https://camunda-modeler-updates.camunda.com/';
-const DEV_UPDATES_SERVER_URL = 'http://camunda-modeler-update-server-staging.camunda.com';
 
 export default class UpdateChecksAPI {
 
-  constructor(updatesServerURLFlagValue) {
-
-    if (updatesServerURLFlagValue) {
-      this.updatesServerURL = updatesServerURLFlagValue;
-    } else {
-      this.updatesServerURL = __ENVIRONMENT__ === 'development' ? DEV_UPDATES_SERVER_URL : PROD_UPDATES_SERVER_URL;
-    }
+  constructor(endpointUrl) {
+    this.endpointUrl = endpointUrl;
   }
 
   async sendRequest(url) {
@@ -51,7 +44,7 @@ export default class UpdateChecksAPI {
       const osInfo = await config.get(OS_INFO_CONFIG_KEY);
       const plugins = this.formatPlugins(getGlobal('plugins').appPlugins);
 
-      const url = new URL(UPDATE_CHECK_API, this.updatesServerURL);
+      const url = new URL(UPDATE_CHECK_API, this.endpointUrl);
       url.searchParams.append('editorID', editorID);
       url.searchParams.append('newerThan', newerThan);
       url.searchParams.append('modelerVersion', modelerVersion);

--- a/client/src/util/Flags.js
+++ b/client/src/util/Flags.js
@@ -18,8 +18,8 @@ class Flags {
     this.data = data;
   }
 
-  get(key) {
-    return this.data[key];
+  get(key, defaultValue) {
+    return key in this.data ? this.data[key] : defaultValue;
   }
 
   reset = () => {

--- a/client/src/util/Flags.js
+++ b/client/src/util/Flags.js
@@ -37,3 +37,5 @@ export const DISABLE_ADJUST_ORIGIN = 'disable-adjust-origin';
 export const DISABLE_PLUGINS = 'disable-plugins';
 export const RELAUNCH = 'relaunch';
 export const DISABLE_SERVER_INTERACTION = 'disable-server-interaction';
+export const UPDATES_SERVER_URL = 'updates-server-url';
+export const FORCE_UPDATE_CHECKS = 'force-update-checks';

--- a/client/src/util/__tests__/FlagsSpec.js
+++ b/client/src/util/__tests__/FlagsSpec.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import FlagsSingleton from '../Flags';
+
+const Flags = FlagsSingleton.__proto__.constructor;
+
+
+describe('Flags', function() {
+
+  describe('init', function() {
+
+    it('should properly initialize', function() {
+
+      // given
+      const flags = new Flags();
+      const data = {
+        name: 'name'
+      };
+
+      // when
+      flags.init(data);
+
+      // then
+      expect(flags.get('name')).to.eql(data.name);
+      expect(flags.get('non-existing')).not.to.exist;
+      expect(flags.get('non-exising', 1000)).to.eql(1000);
+
+    });
+
+  });
+
+});

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -12,8 +12,14 @@
 
 const path = require('path');
 
-const DEV = process.env.NODE_ENV === 'development';
+const NODE_ENV = process.env.NODE_ENV || 'development';
+
+const DEV = NODE_ENV === 'development';
 const LICENSE_CHECK = process.env.LICENSE_CHECK;
+
+const {
+  DefinePlugin
+} = require('webpack');
 
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
@@ -89,6 +95,9 @@ module.exports = {
   },
   plugins: [
     new CaseSensitivePathsPlugin(),
+    new DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(NODE_ENV)
+    }),
     new CopyWebpackPlugin([
       {
         from: './public',

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Camunda Modeler for BPMN, DMN and CMMN, based on bpmn.io",
   "scripts": {
     "app:auto-test": "npm run app:test -- --watch",
-    "app:dev": "electron ./app/dev.js resources/diagram/simple.bpmn",
+    "app:dev": "electron ./app/dev.js --force-update-checks resources/diagram/simple.bpmn",
     "app:test": "nyc --reporter lcov --exclude \"app/test/**\" --exclude \"app/**/__tests__\" mocha --require ./app/test/expect \"app/**/*-spec.js\"",
     "client:build": "(cd client && npm run build)",
     "client:auto-test": "(cd client && npm run auto-test)",


### PR DESCRIPTION
This PR addresses these issues to make things easier for us developers to play with Updates Check features:

1)  Introduce `updates-server-url` flag
3) Introduce `force-update-checks` flag to disable wait-for-another-day rule for update checks. Using this flag, update checks requests are sent anytime the editor is refreshed. This flag is enabled by default for dev builds and is not documented as it is not intended for production usage.
