### PR TITLE
Unified buttons

### DIFF
--- a/client/public/style.css
+++ b/client/public/style.css
@@ -1,3 +1,18 @@
+/* global color definitions */
+:root {
+  --blue-base: #4d90ff;
+  --blue-darken-48: #005df7;
+  --blue-darken-55: #1a70ff;
+  --blue-darken-62: #3c85ff;
+  --blue-lighten-75: #80b0ff;
+  --blue-lighten-82: #a2c5ff;
+
+  --silver-base: #f8f8f8;
+  --silver-darken-80: #cdcdcd;
+  --silver-darken-87: #dedede;
+  --silver-darken-94: #efefef;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -81,3 +96,73 @@ body:not(.loading) > .loader {
 }
 
 /* </animation> */
+
+
+/* <buttons> */
+
+.btn {
+  min-width: 92px;
+  height: 30px;
+  border-radius: 3px;
+  font-size: 13px;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: normal;
+  letter-spacing: normal;
+  text-align: center;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+
+.btn-primary {
+  color: #fdfdfe;
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.2);
+  border: solid 1px var(--blue-darken-62);
+  background-color: var(--blue-base);
+}
+
+.btn-primary:hover {
+  border: solid 1px var(--blue-darken-55);
+  background-color: var(--blue-darken-62);
+}
+
+.btn-primary:active {
+  border: solid 1px var(--blue-darken-48);
+  background-color: var(--blue-darken-55);
+}
+
+.btn-primary:disabled {
+  box-shadow: none;
+  border: solid 1px var(--blue-lighten-82);
+  background-color: var(--blue-lighten-75);
+  color: rgba(253, 253, 254, 0.8);
+}
+
+.btn-secondary {
+  color: #535353;
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.1);
+  border: solid 1px var(--silver-darken-80);
+  background-color: var(--silver-base);
+}
+
+.btn-secondary:hover {
+  background-color: var(--silver-darken-94);
+}
+
+.btn-secondary:active {
+  background-color: var(--silver-darken-87);
+}
+
+.btn-secondary:disabled {
+  box-shadow: none;
+  border: solid 1px var(--silver-darken-87);
+  background-color: var(--silver-base);
+  color: rgba(83, 83, 83, 0.5);
+}
+
+.btn + .btn {
+  margin-left: 10px;
+}
+
+/* </buttons>

--- a/client/src/app/EmptyTab.js
+++ b/client/src/app/EmptyTab.js
@@ -39,12 +39,12 @@ export default class EmptyTab extends PureComponent {
       <Tab className={ css.EmptyTab }>
         <p className="create-buttons">
           <span>Create a </span>
-          <button className="create-bpmn" onClick={ () => onAction('create-bpmn-diagram') }>BPMN diagram</button>
+          <button className="create-bpmn btn btn-secondary" onClick={ () => onAction('create-bpmn-diagram') }>BPMN diagram</button>
           {
             !Flags.get(DISABLE_DMN) && (
               <Fragment>
                 <span> or </span>
-                <button onClick={ () => onAction('create-dmn-diagram') }>DMN diagram</button>
+                <button className="btn btn-secondary" onClick={ () => onAction('create-dmn-diagram') }>DMN diagram</button>
               </Fragment>
             )
           }

--- a/client/src/app/EmptyTab.less
+++ b/client/src/app/EmptyTab.less
@@ -9,10 +9,6 @@
 
     button {
       margin: 0.5em;
-      padding: 0.5em;
-
-      font-size: 12px;
-      color: #444;
     }
   }
 }

--- a/client/src/app/modals/keyboard-shortcuts/View.js
+++ b/client/src/app/modals/keyboard-shortcuts/View.js
@@ -51,7 +51,9 @@ class View extends PureComponent {
         </Modal.Body>
 
         <Modal.Footer>
-          <button onClick={ onClose }>Close</button>
+          <div className="buttonDiv">
+            <button className="btn btn-primary" onClick={ onClose }>Close</button>
+          </div>
         </Modal.Footer>
       </Modal>
     );

--- a/client/src/app/modals/keyboard-shortcuts/View.less
+++ b/client/src/app/modals/keyboard-shortcuts/View.less
@@ -7,4 +7,9 @@
     padding: 5px 10px;
     font-family: monospace;
   }
+
+  .buttonDiv {
+    text-align: right;
+    margin-top: 10px;
+  }
 }

--- a/client/src/plugins/camunda-plugin/deployment-tool/DeploymentConfigModal.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/DeploymentConfigModal.js
@@ -325,19 +325,19 @@ export default class DeploymentConfigModal extends React.PureComponent {
                 <div className="form-submit">
 
                   <button
-                    type="submit"
-                    className="btn btn-primary"
-                    disabled={ form.isSubmitting }
-                  >
-                    { primaryAction || 'Deploy' }
-                  </button>
-
-                  <button
                     type="button"
                     className="btn btn-secondary"
                     onClick={ () => onClose('cancel') }
                   >
                     Cancel
+                  </button>
+
+                  <button
+                    type="submit"
+                    className="btn btn-primary"
+                    disabled={ form.isSubmitting }
+                  >
+                    { primaryAction || 'Deploy' }
                   </button>
 
                 </div>

--- a/client/src/plugins/camunda-plugin/deployment-tool/DeploymentConfigModal.less
+++ b/client/src/plugins/camunda-plugin/deployment-tool/DeploymentConfigModal.less
@@ -83,15 +83,6 @@
     outline-color: rgb(255, 0, 0);
   }
 
-  button + button {
-    margin-left: 10px;
-  }
-
-  button {
-    padding: 6px 10px;
-  }
-
-  button:disabled,
   input:disabled,
   select:disabled {
     color: #808080;

--- a/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceConfigModal.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceConfigModal.js
@@ -83,20 +83,19 @@ export default class StartInstanceConfigModal extends React.PureComponent {
               </Modal.Body>
               <Modal.Footer>
                 <div className="form-submit">
-
-                  <button
-                    className="btn btn-primary"
-                    type="submit"
-                    disabled={ form.isSubmitting }>
-                  Start
-                  </button>
-
                   <button
                     className="btn btn-secondary"
                     type="button"
                     onClick={ onCancel }
                   >
                   Cancel
+                  </button>
+
+                  <button
+                    className="btn btn-primary"
+                    type="submit"
+                    disabled={ form.isSubmitting }>
+                  Start
                   </button>
                 </div>
               </Modal.Footer>

--- a/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceConfigModal.less
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceConfigModal.less
@@ -43,7 +43,7 @@
   .form-submit {
     text-align: right;
   }
- 
+
   label {
     text-align: right;
     width: 100%;
@@ -76,15 +76,6 @@
     outline-color: rgb(255, 0, 0);
   }
 
-  button + button {
-    margin-left: 10px;
-  }
-
-  button {
-    padding: 6px 10px;
-  }
-
-  button:disabled,
   input:disabled,
   select:disabled {
     color: #808080;

--- a/client/src/plugins/privacy-preferences/PrivacyPreferencesView.js
+++ b/client/src/plugins/privacy-preferences/PrivacyPreferencesView.js
@@ -100,16 +100,16 @@ class PrivacyPreferencesView extends PureComponent {
 
         <Modal.Footer>
           <div className="form-submit">
-            <button className="btn btn-primary" type="submit" onClick={ () => {
-              onSaveAndClose(this.state);
-            } }>
-              { OK_BUTTON_TEXT }
-            </button>
             { hasCancel && (
               <button className="btn btn-secondary" type="submit" onClick={ onClose }>
                 { CANCEL_BUTTON_TEXT }
               </button>
             ) }
+            <button className="btn btn-primary" type="submit" onClick={ () => {
+              onSaveAndClose(this.state);
+            } }>
+              { OK_BUTTON_TEXT }
+            </button>
           </div>
         </Modal.Footer>
 

--- a/client/src/plugins/privacy-preferences/PrivacyPreferencesView.less
+++ b/client/src/plugins/privacy-preferences/PrivacyPreferencesView.less
@@ -6,14 +6,6 @@
 
   font-size: 1.2em;
 
-  button + button {
-    margin-left: 10px;
-  }
-
-  button {
-    padding: 6px 10px;
-  }
-
   a {
     text-decoration: none;
   }

--- a/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesSpec.js
+++ b/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesSpec.js
@@ -152,7 +152,7 @@ describe('<PrivacyPreferences>', () => {
 
     await subscribeFunc();
     await wrapper.update();
-    wrapper.find('.btn').at(1).simulate('click');
+    wrapper.find('.btn-secondary').simulate('click');
     expect(setSpy).to.not.have.been.called;
   });
 });

--- a/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesViewSpec.js
+++ b/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesViewSpec.js
@@ -199,7 +199,7 @@ describe('<PrivacyPreferencesView>', function() {
           onSaveAndClose={ onSaveAndClose } />
       );
 
-      const cancelButton = wrapper.find('.btn').at(1);
+      const cancelButton = wrapper.find('.btn-secondary');
       cancelButton.simulate('click');
       expect(onSaveAndClose).to.not.have.been.called;
     });

--- a/client/src/plugins/update-checks/NewVersionInfoView.js
+++ b/client/src/plugins/update-checks/NewVersionInfoView.js
@@ -80,8 +80,8 @@ class NewVersionInfoView extends PureComponent {
 
         <Modal.Footer>
           <div className="formSubmit">
-            <button className="btn btn-primary" onClick={ onGoToDownloadPage }> { BUTTON_POSITIVE } </button>
             <button className="btn btn-secondary" onClick={ onClose }> { BUTTON_NEGATIVE } </button>
+            <button className="btn btn-primary" onClick={ onGoToDownloadPage }> { BUTTON_POSITIVE } </button>
           </div>
         </Modal.Footer>
 

--- a/client/src/plugins/update-checks/__tests__/NewVersionInfoViewSpec.js
+++ b/client/src/plugins/update-checks/__tests__/NewVersionInfoViewSpec.js
@@ -89,7 +89,7 @@ describe('<NewVersionInfoView>', () => {
 
   it('should render negative button', () => {
 
-    const negativeButton = wrapper.find('.btn').at(1);
+    const negativeButton = wrapper.find('.btn-secondary');
 
     expect(negativeButton.text().trim()).to.be.eql(BUTTON_NEGATIVE);
   });
@@ -103,7 +103,7 @@ describe('<NewVersionInfoView>', () => {
       <NewVersionInfoView latestVersionInfo={ {} } onClose={ onCloseSpy } />
     );
 
-    const negativeButton = component.find('.btn').at(1);
+    const negativeButton = component.find('.btn-secondary');
 
     negativeButton.simulate('click');
 


### PR DESCRIPTION
I renamed the modal-buttons branch to unified-buttons, as it is more correct.

**Empty page:**
<img width="632" alt="Screenshot 2020-01-14 at 15 39 26" src="https://user-images.githubusercontent.com/15003836/72353276-115d6c00-36e4-11ea-9f95-8ba86967e895.png">

**Privacy prefs:**
<img width="775" alt="Screenshot 2020-01-14 at 15 39 44" src="https://user-images.githubusercontent.com/15003836/72353300-1e7a5b00-36e4-11ea-9441-e92310ae738d.png">

**Deploy diagram:**
<img width="624" alt="Screenshot 2020-01-14 at 15 40 14" src="https://user-images.githubusercontent.com/15003836/72353323-2e923a80-36e4-11ea-8a46-f0b674d49067.png">

**Start process instance [Step 1]:**
<img width="694" alt="Screenshot 2020-01-14 at 15 40 33" src="https://user-images.githubusercontent.com/15003836/72353359-3f42b080-36e4-11ea-80b7-91cfc6c72515.png">

**Start process instance [Step2]:**
<img width="663" alt="Screenshot 2020-01-14 at 15 41 10" src="https://user-images.githubusercontent.com/15003836/72353385-4ec1f980-36e4-11ea-9715-28d10ff0b873.png">

**Update checks modal:**
<img width="660" alt="Screenshot 2020-01-14 at 15 41 59" src="https://user-images.githubusercontent.com/15003836/72353487-71eca900-36e4-11ea-864a-a65584bc994b.png">
