### PR TITLE
chore(client/bpmn): remove unnecessary comment

### DIFF
--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -1514,7 +1514,6 @@ async function renderEditor(xml, options = {}) {
   };
 }
 
-// helper /////////
 function getEvent(events, eventName) {
   return find(events, e => e.type === eventName);
 }


### PR DESCRIPTION
We have `helpers` comment a few lines above ...