### PR TITLE
DMN Editor plugins

### DIFF
--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -11,7 +11,8 @@
 import React from 'react';
 
 import {
-  assign
+  assign,
+  isFunction
 } from 'min-dash';
 
 import {
@@ -21,6 +22,8 @@ import {
 import {
   debounce
 } from '../../../util';
+
+import configureModeler from './util/configure';
 
 import {
   WithCache,
@@ -648,17 +651,37 @@ export class DmnEditor extends CachedComponent {
     );
   }
 
-  static createCachedState() {
+  static createCachedState(props) {
     const {
       name,
       version
     } = Metadata;
 
-    const modeler = new CamundaDmnModeler({
+    const {
+      getPlugins,
+      onError
+    } = props;
+
+    const {
+      options,
+      warnings
+    } = configureModeler(getPlugins, {
       exporter: {
         name,
         version
-      }
+      },
+    });
+
+    if (warnings.length && isFunction(onError)) {
+      onError(
+        'Problem(s) configuring BPMN editor: \n\t' +
+        warnings.map(error => error.message).join('\n\t') +
+        '\n'
+      );
+    }
+
+    const modeler = new CamundaDmnModeler({
+      ...options
     });
 
     const stackIdx = modeler.getStackIdx();

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -659,8 +659,19 @@ export class DmnEditor extends CachedComponent {
 
     const {
       getPlugins,
+      onAction,
       onError
     } = props;
+
+    // notify interested parties that modeler will be configured
+    const handleMiddlewareExtensions = (middlewares) => {
+      onAction('emit-event', {
+        type: 'dmn.modeler.configure',
+        payload: {
+          middlewares
+        }
+      });
+    };
 
     const {
       options,
@@ -670,11 +681,11 @@ export class DmnEditor extends CachedComponent {
         name,
         version
       },
-    });
+    }, handleMiddlewareExtensions);
 
     if (warnings.length && isFunction(onError)) {
       onError(
-        'Problem(s) configuring BPMN editor: \n\t' +
+        'Problem(s) configuring DMN editor: \n\t' +
         warnings.map(error => error.message).join('\n\t') +
         '\n'
       );
@@ -685,6 +696,14 @@ export class DmnEditor extends CachedComponent {
     });
 
     const stackIdx = modeler.getStackIdx();
+
+    // notify interested parties that modeler was created
+    onAction('emit-event', {
+      type: 'dmn.modeler.created',
+      payload: {
+        modeler
+      }
+    });
 
     return {
       __destroy: () => {

--- a/client/src/app/tabs/dmn/util/__tests__/configureSpec.js
+++ b/client/src/app/tabs/dmn/util/__tests__/configureSpec.js
@@ -1,0 +1,233 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import configureModeler from '../configure';
+
+
+describe('tabs/dmn/util - configure', function() {
+
+  describe('configureModeler', function() {
+
+    describe('should recognize plug-in points', function() {
+
+      it('dmn.modeler.drd.additionalModules', function() {
+
+        // given
+        var module1 = { __id: 1 };
+        var module2 = { __id: 2 };
+        var existingModule = { __id: 'EXISTING' };
+
+        var getPlugins = setupPlugins([
+          [ 'dmn.modeler.drd.additionalModules', module1 ],
+          [ 'dmn.modeler.drd.additionalModules', module2 ]
+        ]);
+
+        // when
+        var {
+          options,
+          warnings
+        } = configureModeler(getPlugins, {
+          drd: {
+            additionalModules: [
+              existingModule
+            ]
+          }
+        });
+
+        // then
+        expect(options).to.eql({
+          drd: {
+            additionalModules: [
+              existingModule,
+              module1,
+              module2
+            ]
+          }
+
+        });
+
+        expect(warnings).to.be.empty;
+      });
+
+
+      it('dmn.modeler.drd.additionalModules', function() {
+
+        // given
+        var module1 = { __id: 1 };
+        var module2 = { __id: 2 };
+        var existingModule = { __id: 'EXISTING' };
+
+        var getPlugins = setupPlugins([
+          [ 'dmn.modeler.decisionTable.additionalModules', module1 ],
+          [ 'dmn.modeler.decisionTable.additionalModules', module2 ]
+        ]);
+
+        // when
+        var {
+          options,
+          warnings
+        } = configureModeler(getPlugins, {
+          decisionTable: {
+            additionalModules: [
+              existingModule
+            ]
+          }
+        });
+
+        // then
+        expect(options).to.eql({
+          decisionTable: {
+            additionalModules: [
+              existingModule,
+              module1,
+              module2
+            ]
+          }
+
+        });
+
+        expect(warnings).to.be.empty;
+      });
+
+
+      it('dmn.modeler.drd.additionalModules', function() {
+
+        // given
+        var module1 = { __id: 1 };
+        var module2 = { __id: 2 };
+        var existingModule = { __id: 'EXISTING' };
+
+        var getPlugins = setupPlugins([
+          [ 'dmn.modeler.literalExpression.additionalModules', module1 ],
+          [ 'dmn.modeler.literalExpression.additionalModules', module2 ]
+        ]);
+
+        // when
+        var {
+          options,
+          warnings
+        } = configureModeler(getPlugins, {
+          literalExpression: {
+            additionalModules: [
+              existingModule
+            ]
+          }
+        });
+
+        // then
+        expect(options).to.eql({
+          literalExpression: {
+            additionalModules: [
+              existingModule,
+              module1,
+              module2
+            ]
+          }
+
+        });
+
+        expect(warnings).to.be.empty;
+      });
+
+
+      it('dmn.modeler.moddleExtension', function() {
+
+        // given
+        var fooExtension = { name: 'foo' };
+        var barExtension = { name: 'bar' };
+
+        var existingExtension = { name: 'existing' };
+
+        var getPlugins = setupPlugins([
+          [ 'dmn.modeler.moddleExtension', fooExtension ],
+          [ 'dmn.modeler.moddleExtension', barExtension ]
+        ]);
+
+        // when
+        var {
+          options,
+          warnings
+        } = configureModeler(getPlugins, {
+          moddleExtensions: {
+            existing: existingExtension
+          }
+        });
+
+        // then
+        expect(options).to.eql({
+          moddleExtensions: {
+            existing: existingExtension,
+            foo: fooExtension,
+            bar: barExtension
+          }
+        });
+
+        expect(warnings).to.be.empty;
+      });
+
+    });
+
+
+    describe('should collect warnings', function() {
+
+      it('dmn.modeler.moddleExtension', function() {
+
+        // given
+        var noNameExtension = { };
+        var existingExtension = { name: 'existing' };
+        var existingOverrideExtension = { name: 'existing' };
+
+        var getPlugins = setupPlugins([
+          [ 'dmn.modeler.moddleExtension', noNameExtension ],
+          [ 'dmn.modeler.moddleExtension', existingOverrideExtension ]
+        ]);
+
+        // when
+        var {
+          options,
+          warnings
+        } = configureModeler(getPlugins, {
+          moddleExtensions: {
+            existing: existingExtension
+          }
+        });
+
+        // then
+        expect(options).to.eql({
+          moddleExtensions: {
+            existing: existingExtension
+          }
+        });
+
+        expect(warnings).to.have.length(2);
+
+        expect(warnings[0].message).to.eql(
+          'dmn.modeler.moddleExtension is missing <name> property'
+        );
+
+        expect(warnings[1].message).to.eql(
+          'dmn.modeler.moddleExtension overrides moddle extension with name <existing>'
+        );
+      });
+
+    });
+
+  });
+
+});
+
+
+// helpers /////////////////////
+
+function setupPlugins(plugins) {
+  return function(type) {
+    return plugins.filter(p => p[0] === type).map(p => p[1]);
+  };
+}

--- a/client/src/app/tabs/dmn/util/configure.js
+++ b/client/src/app/tabs/dmn/util/configure.js
@@ -8,7 +8,9 @@
  * except in compliance with the MIT License.
  */
 
-export default function configureModeler(getPlugins, defaultOptions = {}) {
+export default function configureModeler(
+    getPlugins, defaultOptions = {}, handleMiddlewareExtensions
+) {
 
   const warnings = [];
 
@@ -89,6 +91,10 @@ export default function configureModeler(getPlugins, defaultOptions = {}) {
   let options = {
     ...defaultOptions
   };
+
+  if (typeof handleMiddlewareExtensions === 'function') {
+    handleMiddlewareExtensions(middlewares);
+  }
 
   middlewares.forEach(fn => {
     options = fn(options, logWarning);

--- a/client/src/app/tabs/dmn/util/configure.js
+++ b/client/src/app/tabs/dmn/util/configure.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+export default function configureModeler(getPlugins, defaultOptions = {}) {
+
+  const warnings = [];
+
+  function logWarning(warning) {
+
+    if (typeof warning === 'string') {
+      warning = new Error(warning);
+    }
+
+    warnings.push(warning);
+  }
+
+  function additionalModulesMiddleware(component) {
+
+    return function(options) {
+      const additionalModules = getPlugins(`dmn.modeler.${component}.additionalModules`);
+
+      if (additionalModules.length) {
+        return {
+          ...options,
+          [component]: {
+            ...options[component],
+            additionalModules: [
+              ...((options[component] || {}).additionalModules || []),
+              ...additionalModules
+            ]
+          }
+        };
+      }
+
+      return options;
+    };
+  }
+
+  const middlewares = [
+
+    function moddleExtensionsMiddleware(options, logWarning) {
+      const plugins = getPlugins('dmn.modeler.moddleExtension');
+
+      const moddleExtensions = plugins.reduce((extensions, extension) => {
+        let {
+          name
+        } = extension;
+
+        if (typeof name !== 'string') {
+          logWarning('dmn.modeler.moddleExtension is missing <name> property');
+
+          return extensions;
+        }
+
+        extensions = extensions || {};
+
+        if (name in extensions) {
+          logWarning('dmn.modeler.moddleExtension overrides moddle extension with name <' + name + '>');
+        }
+
+        return {
+          ...extensions,
+          [ name ]: extension
+        };
+      }, options.moddleExtensions);
+
+      if (moddleExtensions) {
+        return {
+          ...options,
+          moddleExtensions
+        };
+      }
+
+      return options;
+    },
+
+    additionalModulesMiddleware('drd'),
+    additionalModulesMiddleware('decisionTable'),
+    additionalModulesMiddleware('literalExpression')
+  ];
+
+  let options = {
+    ...defaultOptions
+  };
+
+  middlewares.forEach(fn => {
+    options = fn(options, logWarning);
+  });
+
+  return {
+    options,
+    warnings
+  };
+}


### PR DESCRIPTION
Closes #1550 

Introduces endpoints to integrate plugins into the DMN Editor

* `dmn.modeler.moddleExtensions`
* `dmn.modeler.drd.additionalModules`
* `dmn.modeler.decisionTable.additionalModules`
* `dmn.modeler.literalExpression.additionalModules` 
* `dmn.modeler.configure` (React Client Extension)
* `dmn.modeler.created` (React Client Extension)

Depends on https://github.com/camunda/camunda-modeler-plugin-helpers/pull/7 (has to be integrated first)

**Aditional Context** 
[Simple Examples](https://github.com/camunda/camunda-modeler/tree/dmn-plugins-examples) (just showcases, not intended to be merged)
