### PR TITLE
Do not build for linux 32bit platforms

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -27,7 +27,7 @@
     "target": [
       {
         "target": "tar.gz",
-        "arch": [ "x64", "ia32" ]
+        "arch": [ "x64" ]
       }
     ]
   },


### PR DESCRIPTION
While working on Zeebe Modeler we realized that building some native modules in Electron such as gRPC does not work on Linux 32bit platforms. It turns out that Electron has dropped support for such devices some time ago:

https://www.electronjs.org/blog/linux-32bit-support

It makes sense for us to remove this platform from our build pipeline as well.