### PR TITLE
Mitigate file Save As issue

### DIFF
--- a/app/lib/dialog.js
+++ b/app/lib/dialog.js
@@ -71,6 +71,13 @@ class Dialog {
     // remove extension
     name = path.parse(name).name;
 
+    // add default extension as specified by filter
+    // this prevents users on Linux to run into export / save-as issues,
+    // cf. https://github.com/camunda/camunda-modeler/issues/1699
+    if (filters && filters[0] && filters[0].extensions && filters[0].extensions[0]) {
+      name = name + '.' + filters[0].extensions[0];
+    }
+
     let { defaultPath } = options;
 
     if (!defaultPath) {

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1487,7 +1487,14 @@ export class App extends PureComponent {
 
     const exportType = getFileTypeFromExtension(exportPath);
 
-    const { encoding } = provider.exports ? provider.exports[ exportType ] : ENCODING_UTF8;
+    // handle missing extension / export type as abortion
+    // this ensures file export does not fail on Linux,
+    // cf. https://github.com/camunda/camunda-modeler/issues/1699
+    if (provider.exports && !provider.exports[exportType]) {
+      return false;
+    }
+
+    const { encoding } = provider.exports && provider.exports[ exportType ] || ENCODING_UTF8;
 
     return {
       encoding,
@@ -1510,6 +1517,7 @@ export class App extends PureComponent {
 
         return exportOptions ? await this.exportAsFile(exportOptions) : false;
       } catch (err) {
+        console.error('Tab export failed', err);
 
         const response = await this.askForSaveRetry(tab, err, getExportFileErrorDialog);
 

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -1119,6 +1119,23 @@ describe('<App>', function() {
       expect(writeFileSpy).to.have.been.calledTwice;
     });
 
+
+    it('should handle missing export extension', async function() {
+
+      // given
+      await app.createDiagram();
+
+      dialog.setShowSaveFileDialogResponse('foo');
+
+      // when
+      await app.triggerAction('export-as');
+
+      // then
+      expect(showSaveFileDialogSpy).to.have.been.called;
+
+      expect(writeFileSpy).not.to.have.been.called;
+    });
+
   });
 
 


### PR DESCRIPTION
A few issues fixed:

* We append the default file extension
* We do not fail if the dialog accidentally returns a file without recognizable extension
* We do not shadow export errors but print them to the console at least

Closes #1699 

---

Please double check if that does not break anything on MacOS (as I believe we removed the extension deliberately during `Save As...` at some point).

* [x] Works on Linux
* [x] Works on MacOS
* [ ] Works on Windows