### PR TITLE
feat(client/Log): apply native keyboard shortcuts

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1929,6 +1929,7 @@ export class App extends PureComponent {
               layout={ layout.log }
               onClear={ this.clearLog }
               onLayoutChanged={ this.handleLayoutChanged }
+              onUpdateMenu={ this.updateMenu }
             />
 
             <PluginsRoot

--- a/client/src/app/Log.js
+++ b/client/src/app/Log.js
@@ -33,7 +33,8 @@ const DEFAULT_LAYOUT = {
  *   entries={ [ { message, category }, ... ] }
  *   layout={ height, open }
  *   onClear={ () => { } }
- *   onLayoutChanged= () => { } } />
+ *   onLayoutChanged= { () => { } }
+ *   onUpdateMenu = { () => { } } />
  *
  */
 export default class Log extends PureComponent {
@@ -151,6 +152,48 @@ export default class Log extends PureComponent {
     document.execCommand('copy');
   }
 
+  updateMenu = () => {
+
+    const {
+      onUpdateMenu
+    } = this.props;
+
+    const enabled = hasSelection();
+
+    const editMenu = [
+      [
+        {
+          role: 'undo',
+          enabled: false
+        },
+        {
+          role: 'redo',
+          enabled: false
+        },
+      ],
+      [
+        {
+          role: 'copy',
+          enabled
+        },
+        {
+          role: 'cut',
+          enabled: false
+        },
+        {
+          role: 'paste',
+          enabled: false
+        },
+        {
+          role: 'selectAll',
+          enabled: true
+        }
+      ]
+    ];
+
+    onUpdateMenu({ editMenu });
+  }
+
   render() {
 
     const {
@@ -198,6 +241,7 @@ export default class Log extends PureComponent {
               className="entries"
               ref={ this.panelRef }
               onKeyDown={ this.handleKeyDown }
+              onFocus={ this.updateMenu }
             >
               <div className="controls">
                 <button className="copy-button" onClick={ this.handleCopy }>Copy</button>
@@ -252,11 +296,15 @@ export default class Log extends PureComponent {
 // helpers /////////////////////////////////
 
 function selectText(element) {
-  var range, selection;
+  let range, selection;
 
   selection = window.getSelection();
   range = document.createRange();
   range.selectNodeContents(element);
   selection.removeAllRanges();
   selection.addRange(range);
+}
+
+function hasSelection() {
+  return window.getSelection().toString() !== '';
 }

--- a/client/src/app/__tests__/LogSpec.js
+++ b/client/src/app/__tests__/LogSpec.js
@@ -264,7 +264,6 @@ describe('<Log>', function() {
       const handleCopy = spy(instance, 'handleCopy');
 
       // when
-      //
       instance.handleKeyDown({
         keyCode: 65,
         ctrlKey: true,
@@ -274,6 +273,46 @@ describe('<Log>', function() {
       // then
       expect(handleCopy).to.have.been.calledOnce;
     });
+
+
+    it('should update edit menu', async function() {
+
+      // given
+      const onUpdateMenu = spy();
+
+      const {
+        tree
+      } = createLog({
+        open: true,
+        onUpdateMenu
+      }, mount);
+
+      // when
+      tree.find('.entries').simulate('focus');
+
+      // then
+      expect(onUpdateMenu).to.be.calledOnceWithExactly({
+        editMenu: [
+          [
+            { enabled: false, role: 'undo' },
+            { enabled: false, role: 'redo' }
+          ],
+          [
+            { enabled: false, role: 'copy' },
+            { enabled: false, role: 'cut' },
+            { enabled: false, role: 'paste' },
+            { enabled: true, role: 'selectAll' }
+          ]
+        ]
+      });
+    });
+
+
+    /**
+     * @pinussilvestrus :
+     * Currently not possible to test systems clipboard content
+     */
+    it('select selected text on <CTRL+C>');
 
   });
 
@@ -347,6 +386,7 @@ function createLog(options = {}, mountFn = shallow) {
       layout={ layout }
       onClear={ options.onClear || noop }
       onLayoutChanged={ options.onLayoutChanged || noop }
+      onUpdateMenu={ options.onUpdateMenu || noop }
     />
   );
 


### PR DESCRIPTION
Closes #1380 

Enables <CMD+C> copy keyboard shortcut also on mac devices inside the Log panel.