### PR TITLE
chore(client/radio): make sure to use valid id for inputs

### DIFF
--- a/client/src/plugins/camunda-plugin/shared/components/Radio.js
+++ b/client/src/plugins/camunda-plugin/shared/components/Radio.js
@@ -41,6 +41,7 @@ export default function Radio(props) {
         <div className="form-check-inline">
           {
             values.map((child) => {
+              const id = toKebabCase(child.label);
               return (
                 <React.Fragment key={ child.label }>
                   <div className={
@@ -52,11 +53,11 @@ export default function Radio(props) {
                       value={ child.value }
                       checked={ isChecked(child.value) }
                       className="custom-control-input"
-                      id={ child.label }
+                      id={ id }
                       tabIndex={ 0 }
                       { ...restProps } />
                     <label
-                      htmlFor={ child.label }
+                      htmlFor={ id }
                       className="custom-control-label">
                       { child.label }
                     </label>
@@ -69,4 +70,22 @@ export default function Radio(props) {
       </div>
     </React.Fragment>
   );
+}
+
+
+
+// helper /////
+/**
+ * Converts text to kebab-case.
+ *
+ * @example
+ * const label = "HTTP Basic";
+ *
+ * // http-basic
+ * const id = toKebabCase(label);
+ *
+ * @param {string} name
+ */
+function toKebabCase(name) {
+  return name.toLowerCase().replace(/\s/g, '-');
 }

--- a/client/src/plugins/camunda-plugin/shared/components/Radio.js
+++ b/client/src/plugins/camunda-plugin/shared/components/Radio.js
@@ -41,7 +41,7 @@ export default function Radio(props) {
         <div className="form-check-inline">
           {
             values.map((child) => {
-              const id = toKebabCase(child.label);
+              const id = 'radio-element-' + toKebabCase(child.label);
               return (
                 <React.Fragment key={ child.label }>
                   <div className={


### PR DESCRIPTION
Before this change, id could take value of "HTTP Basic", which is invalid in HTML5 because of the whitespace.

Cf. https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id