### PR TITLE
Remove watermark in prod

### DIFF
--- a/client/src/styles/_base.less
+++ b/client/src/styles/_base.less
@@ -6,3 +6,15 @@ body {
   font-family: Arial, sans-serif;
   font-size: 12px;
 }
+
+.bjs-powered-by {
+  display: none;
+}
+
+.cjs-powered-by {
+  display: none;
+}
+
+.powered-by-logo {
+  display: none;
+}

--- a/resources/plugins/test/style.css
+++ b/resources/plugins/test/style.css
@@ -1,3 +1,7 @@
+.bjs-powered-by {
+  display: block !important;
+}
+
 .bjs-powered-by > img {
   display: none;
 }


### PR DESCRIPTION
Closes #1731

With this commit we remove the logo in BPMN, DMN, CMMN editors (bottom-right corner):

<img width="390" alt="Screenshot 2020-03-17 at 15 57 49" src="https://user-images.githubusercontent.com/15003836/76869157-2e3f2880-6868-11ea-84b4-395fd81ff3bd.png">

Also we're getting rid of this logo in DRD view (top-right):

<img width="451" alt="Screenshot 2020-03-17 at 15 57 33" src="https://user-images.githubusercontent.com/15003836/76869187-3a2aea80-6868-11ea-9fd7-2c11b5c41309.png">

We're keeping the DEV indicator as it helps us distinguishing the prod from dev:

<img width="385" alt="Screenshot 2020-03-17 at 16 00 12" src="https://user-images.githubusercontent.com/15003836/76869338-72322d80-6868-11ea-89af-3fdbd2344aa0.png">

