### PR TITLE
Pub sub for privacy preferences in error tracking

### DIFF
--- a/client/src/plugins/error-tracking/ErrorTracking.js
+++ b/client/src/plugins/error-tracking/ErrorTracking.js
@@ -25,7 +25,6 @@ const NON_EXISTENT_EDITOR_ID = 'NON_EXISTENT_EDITOR_ID';
 
 const log = debug('ErrorTracking');
 
-const ONE_MINUTE_MS = 1000 * 60;
 
 // DSN is set to Travis as an env variable, passed to client via WebPack DefinePlugin
 const DEFINED_SENTRY_DSN = process.env.SENTRY_DSN;
@@ -39,9 +38,6 @@ export default class ErrorTracking extends PureComponent {
     this.SENTRY_DSN = Flags.get(SENTRY_DSN) || DEFINED_SENTRY_DSN;
 
     // Setting this here so that we can mock later if necessary.
-    this.SCHEDULE_TIME = ONE_MINUTE_MS;
-
-    // Setting this here so that we can mock later if necessary.
     this._sentry = Sentry;
 
     this._isInitialized = false;
@@ -52,11 +48,10 @@ export default class ErrorTracking extends PureComponent {
     // check scheduling
     if (!Flags.get(DISABLE_REMOTE_INTERACTION)) {
 
-      // If remove interaction is not disabled via flags:
+      // If remote interaction is not disabled via flags:
       // -> The user may turn on / off error reporting on the run
       // -> The user may never actually restart the modeler.
-      // That's why we'll schedule a check and turn on / off Sentry if necessary.
-      this.scheduleCheck();
+      this.props.subscribe('privacy-preferences.changed', this.handlePrivacyPreferencesChanged);
     }
 
     // initialization
@@ -181,11 +176,8 @@ export default class ErrorTracking extends PureComponent {
     }
   }
 
-  scheduleCheck() {
-    setTimeout(() => {
-      this.recheckSentry();
-      this.scheduleCheck();
-    }, this.SCHEDULE_TIME);
+  handlePrivacyPreferencesChanged = () => {
+    this.recheckSentry();
   }
 
   render() {

--- a/client/src/plugins/error-tracking/ErrorTracking.js
+++ b/client/src/plugins/error-tracking/ErrorTracking.js
@@ -177,7 +177,7 @@ export default class ErrorTracking extends PureComponent {
   }
 
   handlePrivacyPreferencesChanged = () => {
-    this.recheckSentry();
+    return this.recheckSentry();
   }
 
   render() {

--- a/client/src/plugins/error-tracking/__tests__/ErrorTrackingSpec.js
+++ b/client/src/plugins/error-tracking/__tests__/ErrorTrackingSpec.js
@@ -139,21 +139,6 @@ describe('<ErrorTracking>', () => {
   });
 
 
-  it('should schedule check', async () => {
-
-    // given
-    const scheduleCheck = sinon.spy();
-
-    const { instance } = createErrorTracking({ scheduleCheck });
-
-    // when
-    await instance.componentDidMount();
-
-    // then
-    expect(scheduleCheck).to.have.been.called;
-  });
-
-
   it('should not schedule check if DISABLE_REMOTE_INTERACTION flag is set', async () => {
 
     // given
@@ -237,8 +222,7 @@ describe('<ErrorTracking>', () => {
     await instance.componentDidMount();
 
     // then
-    expect(subscribeSpy).to.have.been.called;
-    expect(subscribeSpy.getCall(0).args[0]).to.eql('app.error-handled');
+    expect(subscribeSpy).to.have.been.calledWith('app.error-handled');
   });
 
 
@@ -260,7 +244,7 @@ describe('<ErrorTracking>', () => {
     // when
     await instance.componentDidMount();
 
-    const callback = subscribeSpy.getCall(0).args[1];
+    const callback = subscribeSpy.getCall(2).args[1];
 
     callback(handledError);
 
@@ -302,16 +286,11 @@ describe('<ErrorTracking>', () => {
 
     areCrashReportsEnabled = true;
 
-    return new Promise((resolve) => {
+    await instance.handlePrivacyPreferencesChanged();
 
-      setTimeout(() => {
-
-        expect(initializeSentrySpy).to.have.been.called;
-        expect(backendSendSpy).to.have.been.calledWith('errorTracking:turnedOn');
-
-        return resolve();
-      }, 100);
-    });
+    // then
+    expect(initializeSentrySpy).to.have.been.called;
+    expect(backendSendSpy).to.have.been.calledWith('errorTracking:turnedOn');
   });
 
 
@@ -349,16 +328,11 @@ describe('<ErrorTracking>', () => {
 
     areCrashReportsEnabled = false;
 
-    return new Promise((resolve) => {
+    await instance.handlePrivacyPreferencesChanged();
 
-      setTimeout(() => {
-
-        expect(sentryCloseSpy).to.have.been.called;
-        expect(backendSendSpy).to.have.been.calledWith('errorTracking:turnedOff');
-
-        return resolve();
-      }, 100);
-    });
+    // then
+    expect(sentryCloseSpy).to.have.been.called;
+    expect(backendSendSpy).to.have.been.calledWith('errorTracking:turnedOff');
   });
 });
 

--- a/client/src/plugins/privacy-preferences/PrivacyPreferences.js
+++ b/client/src/plugins/privacy-preferences/PrivacyPreferences.js
@@ -67,8 +67,14 @@ export default class PrivacyPreferences extends PureComponent {
   }
 
   onSaveAndClose = (preferences) => {
-    this.props.config.set(CONFIG_KEY, preferences);
+    this.props.config.set(CONFIG_KEY, preferences)
+      .then(() => this.emit('privacy-preferences.changed', preferences));
+
     this.onClose();
+  }
+
+  emit(event, payload) {
+    this.props.triggerAction('emit-event', { type: event, payload });
   }
 
   render() {

--- a/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesSpec.js
+++ b/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesSpec.js
@@ -98,7 +98,10 @@ describe('<PrivacyPreferences>', () => {
         });
       },
       set() {
-        setSpy();
+        return new Promise((resolve, reject) => {
+          setSpy();
+          resolve(null);
+        });
       }
     } } subscribe={ () => {} } />);
 


### PR DESCRIPTION
An example of how we could subscribe to privacy preferences changes. Thus, we are able to enable/disable crash reports as soon as user enables/disables them.

This might also be helpful for future analytics module.