### PR TITLE
fix(ci): run codecov after success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,8 @@ jobs:
     - stage: test
       name: Test on Linux
       script:
-      - |
-        COVERAGE=1 npm run all -- --x64 --no-compress
-        npx codecov
+      - COVERAGE=1 npm run all -- --x64 --no-compress
+      after_success: npx codecov
     - stage: test
       name: Test on Windows
       os: windows


### PR DESCRIPTION
Proof that job fails when tests fail (no codecov): https://travis-ci.org/github/camunda/camunda-modeler/jobs/694307743
Proof that it uploads codecov on build success: https://travis-ci.org/github/camunda/camunda-modeler/jobs/694309470#L2069

Closes #1820 

