### PR TITLE
Bump to bpmn-js@7.0.1

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "camunda-modeler-client",
-  "version": "4.0.0-alpha.3",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2312,11 +2312,11 @@
       }
     },
     "bpmn-js": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-6.5.1.tgz",
-      "integrity": "sha512-qmxY+vaFndUa4e65WMjSMUVPDz0qAc79JHODJoLXJBklSS5XatUfqzKR6UGfeT7s0IGA7qje1afMVKMz4YJsEw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-7.0.1.tgz",
+      "integrity": "sha512-UHDPCquych4OklVqKqg3xDZbMERKKvX7kU9KqgEhXnIXqkLZSDcnTmISkjTvy6PRhsIN+bu7yEF/Om7BSEw6Og==",
       "requires": {
-        "bpmn-moddle": "^6.0.6",
+        "bpmn-moddle": "^7.0.3",
         "css.escape": "^1.5.1",
         "diagram-js": "^6.6.1",
         "diagram-js-direct-editing": "^1.6.1",
@@ -2329,12 +2329,11 @@
       },
       "dependencies": {
         "min-dom": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.1.2.tgz",
-          "integrity": "sha512-JmI31A4l0G/PeOd1TQcM6U3GNofxJKF9hw2ERta8pCuIFvAIMZNGI4PJT/kbnq6Yh8rvqVTTZLVKyVtuZqqhiQ==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.1.3.tgz",
+          "integrity": "sha512-Lbi1NZjLV9Hg6/bEe2Lfk2Fzsv1MwheR61whqTLP+FxLndYo9TxpksEgM5Kr1khjfCtFTMr0waeEfwIpStkRdw==",
           "requires": {
             "component-event": "^0.1.4",
-            "delegate-events": "^1.1.1",
             "domify": "^1.3.1",
             "indexof": "0.0.1",
             "matches-selector": "^1.2.0"
@@ -2396,13 +2395,13 @@
       }
     },
     "bpmn-moddle": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-6.0.6.tgz",
-      "integrity": "sha512-GbriI2Jt+qiLCaZV/oo9B7PM1fzBz+Mt0ls1irAXEUZek9VMaM71lL0KiN2wCHMcvEVqCMQLMdR9hTW42ji/iQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-7.0.3.tgz",
+      "integrity": "sha512-DylEgndbBNm37v/jEdZTUD1i7XzbpCA5mIAFqkbqof3nYbIOAIycIrkhnRIaBJPvtlxTd3wDdG1ts1IzUfEduA==",
       "requires": {
         "min-dash": "^3.0.0",
         "moddle": "^5.0.1",
-        "moddle-xml": "^8.0.7"
+        "moddle-xml": "^9.0.3"
       },
       "dependencies": {
         "moddle": {
@@ -2414,9 +2413,9 @@
           }
         },
         "moddle-xml": {
-          "version": "8.0.7",
-          "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-8.0.7.tgz",
-          "integrity": "sha512-ynoIED3UwDuvhwpLzSjBX2qXAAgXeMvkjU0xlG2Q9eZGHakNOFJ6TYHEnEOSuaxUrGe3k5c2rZ8jMM7nvlpU7g==",
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-9.0.3.tgz",
+          "integrity": "sha512-3r1c+CA7k9GLqONKtM87DltyLmeWtqz6wbw+SQWNJd66iidmYL4VudN/qpJHt6TP8qxeQrZLTpEYkDQgW6HIDQ==",
           "requires": {
             "min-dash": "^3.0.0",
             "moddle": "^5.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
     "@bpmn-io/dmn-migrate": "^0.4.3",
     "@bpmn-io/replace-ids": "^0.2.0",
     "@sentry/browser": "^5.15.5",
-    "bpmn-js": "^6.5.1",
+    "bpmn-js": "^7.0.1",
     "bpmn-js-disable-collapsed-subprocess": "^0.1.1",
     "bpmn-js-executable-fix": "^0.1.1",
     "bpmn-js-properties-panel": "^0.33.2",

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -165,14 +165,6 @@ export class BpmnEditor extends CachedComponent {
     }
   }
 
-  ifMounted = (fn) => {
-    return (...args) => {
-      if (this._isMounted) {
-        fn(...args);
-      }
-    };
-  }
-
   listen(fn) {
     const modeler = this.getModeler();
 
@@ -470,7 +462,21 @@ export class BpmnEditor extends CachedComponent {
 
     const importedXML = await this.handleNamespace(xml);
 
-    modeler.importXML(importedXML, this.ifMounted(this.handleImport));
+
+    let error = null, warnings = null;
+    try {
+
+      const result = await modeler.importXML(importedXML);
+      warnings = result.warnings;
+    } catch (err) {
+
+      error = err;
+      warnings = err.warnings;
+    }
+
+    if (this._isMounted) {
+      this.handleImport(error, warnings);
+    }
   }
 
   /**

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -529,18 +529,18 @@ export class BpmnEditor extends CachedComponent {
     return generateImage(type, svg);
   }
 
-  exportSVG() {
+  async exportSVG() {
     const modeler = this.getModeler();
 
-    return new Promise((resolve, reject) => {
-      modeler.saveSVG((err, svg) => {
-        if (err) {
-          return reject(err);
-        }
+    try {
 
-        return resolve(svg);
-      });
-    });
+      const { svg } = await modeler.saveSVG();
+
+      return svg;
+    } catch (err) {
+
+      return Promise.reject(err);
+    }
   }
 
   triggerAction = (action, context) => {

--- a/client/src/plugins/camunda-plugin/start-instance-tool/util/isExecutable.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/util/isExecutable.js
@@ -16,24 +16,19 @@ import {
 
 var moddle = new BpmnModdle();
 
-export default function isExecutable(xml) {
+export default async function isExecutable(xml) {
 
-  return new Promise(resolve => {
-    moddle.fromXML(xml, function(err, definitions) {
+  try {
 
-      if (err) {
-        return resolve(false);
-      }
+    const { rootElement } = await moddle.fromXML(xml);
 
-      const {
-        rootElements
-      } = definitions;
+    const { rootElements } = rootElement;
 
-      const hasExecutableProcess = !!find(rootElements, r => r.isExecutable);
+    return !!find(rootElements, r => r.isExecutable);
 
-      resolve(hasExecutableProcess);
+  } catch (err) {
 
-    });
-  });
+    return false;
+  }
 
 }

--- a/client/test/mocks/bpmn-js/Modeler.js
+++ b/client/test/mocks/bpmn-js/Modeler.js
@@ -87,14 +87,22 @@ export default class Modeler {
     };
   }
 
-  importXML(xml, done) {
+  importXML(xml) {
     this.xml = xml;
 
-    const error = xml === 'import-error' ? new Error('error') : null;
+    let error = xml === 'import-error' ? new Error('error') : null;
 
     const warnings = xml === 'import-warnings' ? [ 'warning' ] : [];
 
-    done && done(error, warnings);
+    return new Promise(function(resolve, reject) {
+      if (error) {
+        error.warnings = warnings;
+
+        return reject(error);
+      }
+
+      return resolve({ warnings });
+    });
   }
 
   saveXML(options, done) {

--- a/client/test/mocks/bpmn-js/Modeler.js
+++ b/client/test/mocks/bpmn-js/Modeler.js
@@ -94,7 +94,7 @@ export default class Modeler {
 
     const warnings = xml === 'import-warnings' ? [ 'warning' ] : [];
 
-    return new Promise(function(resolve, reject) {
+    return new Promise((resolve, reject) => {
       if (error) {
         error.warnings = warnings;
 
@@ -105,15 +105,18 @@ export default class Modeler {
     });
   }
 
-  saveXML(options, done) {
+  saveXML(options) {
 
     const xml = this.xml;
 
-    if (xml === 'export-error') {
-      return done(new Error('failed to save xml'));
-    }
+    return new Promise((resolve, reject) => {
 
-    return done(null, xml);
+      if (xml === 'export-error') {
+        return reject(new Error('failed to save xml'));
+      }
+
+      return resolve({ xml });
+    });
   }
 
   saveSVG(done) {

--- a/client/test/mocks/bpmn-js/Modeler.js
+++ b/client/test/mocks/bpmn-js/Modeler.js
@@ -119,13 +119,18 @@ export default class Modeler {
     });
   }
 
-  saveSVG(done) {
+  saveSVG() {
 
-    if (this.xml === 'export-as-error') {
-      return done(new Error('failed to save svg'));
-    }
+    const xml = this.xml;
 
-    return done(null, '<svg />');
+    return new Promise((resolve, reject) => {
+
+      if (xml === 'export-as-error') {
+        return reject(new Error('failed to save svg'));
+      }
+
+      return resolve({ svg: '<svg />' });
+    });
   }
 
   attachTo() {}

--- a/resources/plugins/test/style.css
+++ b/resources/plugins/test/style.css
@@ -2,7 +2,7 @@
   display: block !important;
 }
 
-.bjs-powered-by > img {
+.bjs-powered-by > svg {
   display: none;
 }
 


### PR DESCRIPTION
With this PR we correctly use the awaitable bpmn-js APIs to get rid of callback deprecation warning logs.


---

Closes https://github.com/camunda/camunda-modeler/issues/1775