### PR TITLE
Hide old watermark in DMN (dev builds)

### DIFF
--- a/resources/plugins/test/style.css
+++ b/resources/plugins/test/style.css
@@ -6,6 +6,10 @@
   display: none;
 }
 
+.bjs-powered-by > img {
+  display: none;
+}
+
 .bjs-powered-by::before {
   content: url('app-plugins://test/assets/logo.svg');
 }


### PR DESCRIPTION
Fixes this thing in dev builds (`npm run dev`):

<img width="1438" alt="Screenshot 2020-06-16 at 09 51 35" src="https://user-images.githubusercontent.com/15003836/84747401-78df5680-afb7-11ea-94cf-a62506d06bd6.png">

We don't have this problem in normal builds.
