### PR TITLE
Don't use Enzyme in ErrorTracking tests

### DIFF
--- a/client/src/plugins/error-tracking/__tests__/ErrorTrackingSpec.js
+++ b/client/src/plugins/error-tracking/__tests__/ErrorTrackingSpec.js
@@ -29,7 +29,7 @@ describe('<ErrorTracking>', () => {
 
   it('should render', () => {
 
-    createErrorTracking();
+    shallow(<ErrorTracking />);
   });
 
 
@@ -38,7 +38,7 @@ describe('<ErrorTracking>', () => {
     // given
     const initializeSentry = sinon.spy();
 
-    const { instance } = createErrorTracking({ initializeSentry });
+    const instance = createErrorTracking({ initializeSentry });
 
     // when
     await instance.componentDidMount();
@@ -53,7 +53,7 @@ describe('<ErrorTracking>', () => {
     // given
     const initializeSentry = sinon.spy();
 
-    const { instance } = createErrorTracking({ initializeSentry, dsn: 'TEST_DSN' });
+    const instance = createErrorTracking({ initializeSentry, dsn: 'TEST_DSN' });
 
     // when
     await instance.componentDidMount();
@@ -68,7 +68,7 @@ describe('<ErrorTracking>', () => {
     // given
     const initializeSentry = sinon.spy();
 
-    const { instance } = createErrorTracking({
+    const instance = createErrorTracking({
       initializeSentry, dsn: 'TEST_DSN',
       configValues: { 'editor.privacyPreferences': { ENABLE_CRASH_REPORTS: false } }
     });
@@ -86,7 +86,7 @@ describe('<ErrorTracking>', () => {
     // given
     const initializeSentry = sinon.spy();
 
-    const { instance } = createErrorTracking({
+    const instance = createErrorTracking({
       initializeSentry,
       dsn: 'TEST_DSN',
       configValues: { 'editor.privacyPreferences': { ENABLE_CRASH_REPORTS: true } }
@@ -108,7 +108,7 @@ describe('<ErrorTracking>', () => {
     });
 
     // when
-    const { instance } = createErrorTracking();
+    const instance = createErrorTracking();
 
     // then
     expect(instance.SENTRY_DSN).to.eql('custom-sentry-dsn');
@@ -124,7 +124,7 @@ describe('<ErrorTracking>', () => {
 
     const initializeSentry = sinon.spy();
 
-    const { instance } = createErrorTracking({
+    const instance = createErrorTracking({
       initializeSentry,
       dsn: 'TEST_DSN',
       configValues: { 'editor.privacyPreferences': { ENABLE_CRASH_REPORTS: true } }
@@ -148,7 +148,7 @@ describe('<ErrorTracking>', () => {
 
     const scheduleCheck = sinon.spy();
 
-    const { instance } = createErrorTracking({ scheduleCheck });
+    const instance = createErrorTracking({ scheduleCheck });
 
     // when
     await instance.componentDidMount();
@@ -165,7 +165,7 @@ describe('<ErrorTracking>', () => {
 
     const sentryInitSpy = sinon.spy();
 
-    const { instance } = createErrorTracking({
+    const instance = createErrorTracking({
       sentryInitSpy,
       dsn: 'TEST_DSN',
       configValues: { 'editor.privacyPreferences': { ENABLE_CRASH_REPORTS: true } }
@@ -187,7 +187,7 @@ describe('<ErrorTracking>', () => {
     // given
     const setTagSpy = sinon.spy();
 
-    const { instance } = createErrorTracking({
+    const instance = createErrorTracking({
       setTagSpy,
       dsn: 'TEST_DSN',
       configValues: {
@@ -212,7 +212,7 @@ describe('<ErrorTracking>', () => {
     // given
     const subscribeSpy = sinon.spy();
 
-    const { instance } = createErrorTracking({
+    const instance = createErrorTracking({
       subscribeSpy,
       dsn: 'TEST_DSN',
       configValues: { 'editor.privacyPreferences': { ENABLE_CRASH_REPORTS: true } }
@@ -234,7 +234,7 @@ describe('<ErrorTracking>', () => {
     const sentryCaptureExceptionSpy = sinon.spy();
     const subscribeSpy = sinon.spy();
 
-    const { instance } = createErrorTracking({
+    const instance = createErrorTracking({
       sentryCaptureExceptionSpy,
       subscribeSpy,
       dsn: 'TEST_DSN',
@@ -244,7 +244,7 @@ describe('<ErrorTracking>', () => {
     // when
     await instance.componentDidMount();
 
-    const callback = subscribeSpy.getCall(2).args[1];
+    const callback = subscribeSpy.getCall(1).args[1];
 
     callback(handledError);
 
@@ -261,7 +261,7 @@ describe('<ErrorTracking>', () => {
     const backendSendSpy = sinon.spy();
     const initializeSentrySpy = sinon.spy();
 
-    const { instance } = createErrorTracking({
+    const instance = createErrorTracking({
       backendSendSpy,
       initializeSentry: initializeSentrySpy,
       keepScheduleAsItIs: true,
@@ -302,7 +302,7 @@ describe('<ErrorTracking>', () => {
     const backendSendSpy = sinon.spy();
     const sentryCloseSpy = sinon.spy();
 
-    const { instance } = createErrorTracking({
+    const instance = createErrorTracking({
       backendSendSpy,
       sentryCloseSpy,
       keepScheduleAsItIs: true,
@@ -342,7 +342,7 @@ describe('<ErrorTracking>', () => {
     const setTagSpy = sinon.spy();
     const plugins = [ { name: 'test' } ];
 
-    const { instance } = createErrorTracking({
+    const instance = createErrorTracking({
       plugins,
       setTagSpy,
       dsn: 'TEST_DSN',
@@ -387,11 +387,11 @@ function createErrorTracking(props={}) {
     }
   };
 
-  const component = shallow(
-    <ErrorTracking
-      _getGlobal={ _getGlobal }
-      subscribe={ subscribe }
-      config={ {
+  const instance = new ErrorTracking(
+    {
+      _getGlobal,
+      subscribe,
+      config: {
         get: (key) => {
 
           if (props.configGet) {
@@ -402,11 +402,9 @@ function createErrorTracking(props={}) {
             resolve(configValues[key] || null);
           });
         }
-      } }
-    />
+      }
+    }
   );
-
-  const instance = component.instance();
 
   if (!props.keepScheduleAsItIs) {
     instance.scheduleCheck = props.scheduleCheck || function() {};
@@ -445,5 +443,5 @@ function createErrorTracking(props={}) {
     }
   };
 
-  return { component, instance };
+  return instance;
 }

--- a/client/src/plugins/usage-statistics/__tests__/UsageStatisticsSpec.js
+++ b/client/src/plugins/usage-statistics/__tests__/UsageStatisticsSpec.js
@@ -10,6 +10,10 @@
 
 /* global sinon */
 
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
 import UsageStatistics from '../UsageStatistics';
 import BaseEventHandler from '../event-handlers/BaseEventHandler';
 
@@ -30,7 +34,7 @@ describe('<UsageStatistics>', () => {
 
   it('should render', () => {
 
-    createUsageStatistics();
+    shallow(<UsageStatistics subscribe={ () => {} } />);
   });
 
 


### PR DESCRIPTION
In this PR, we get rid of Enzyme in ErrorTracking tests since this plugin does not render anything.

We did the same in [UsageStatistics](https://github.com/camunda/camunda-modeler/commit/87f6e8bf8783ec7ef18782b206f505180013ef52) plugin.

__Definition of Done__

* [x] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [x] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [x] passes Continuous Integration checks
* [x] available as feature branch on GitHub
  * [x] contains the cleaned up commit history
  * [x] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
