### PR TITLE
Normalize Sentry events

### DIFF
--- a/app/lib/util/__tests__/error-tracking-spec.js
+++ b/app/lib/util/__tests__/error-tracking-spec.js
@@ -111,8 +111,12 @@ describe('error-tracking', function() {
     // when
     errorTracking.start(Sentry, 'v2', config, flags, renderer);
 
+    const params = sentryInitSpy.getCall(0).args[0];
+
     // then
-    expect(sentryInitSpy).to.have.been.calledWith({ dsn: 'SOME_SENTRY_DSN', release: 'v2' });
+    expect(params.dsn).to.eql('SOME_SENTRY_DSN');
+    expect(params.release).to.eql('v2');
+    expect(params.beforeSend).to.exist;
   });
 
 
@@ -129,8 +133,10 @@ describe('error-tracking', function() {
     // when
     errorTracking.start(Sentry, 'v2', config, flags, renderer);
 
+    const params = sentryInitSpy.getCall(0).args[0];
+
     // then
-    expect(sentryInitSpy).to.have.been.calledWith({ dsn: 'FLAG_SENTRY_DSN', release: 'v2' });
+    expect(params.dsn).to.eql('FLAG_SENTRY_DSN');
   });
 
 

--- a/client/src/plugins/error-tracking/ErrorTracking.js
+++ b/client/src/plugins/error-tracking/ErrorTracking.js
@@ -197,11 +197,12 @@ export default class ErrorTracking extends PureComponent {
 
   normalizeEventPath = (event) => {
     try {
-
       const { exception, request } = event;
       const { values } = exception;
 
-      request.url = normalizeUrl(request.url);
+      if (request) {
+        request.url = normalizeUrl(request.url);
+      }
 
       values.forEach((exceptionVal) => {
         const { stacktrace } = exceptionVal;
@@ -215,8 +216,8 @@ export default class ErrorTracking extends PureComponent {
       return event;
     } catch (err) {
 
-      // Don't loose the actual event in case things go wrong
-      return event;
+      this.props.log(err);
+      return null;
     }
   }
 

--- a/client/src/plugins/error-tracking/__tests__/ErrorTrackingSpec.js
+++ b/client/src/plugins/error-tracking/__tests__/ErrorTrackingSpec.js
@@ -366,30 +366,30 @@ describe('<ErrorTracking>', () => {
 
     it('should normalize Windows paths', () => {
 
-      return normalizationTest('/C:/Users/user/test-user/Desktop/Camunda/resources/app.asar/public/');
+      return expectNormalization('/C:/Users/user/test-user/Desktop/Camunda/resources/app.asar/public/');
     });
 
 
     it('should normalize Linux paths', () => {
 
-      return normalizationTest('/home/testuser/Aplications/camunda-modeler-4.0.0-linux-x64/resources/app.asar/public/');
+      return expectNormalization('/home/testuser/Aplications/camunda-modeler-4.0.0-linux-x64/resources/app.asar/public/');
     });
 
 
     it('should normalize Mac paths', () => {
 
-      return normalizationTest('/Applications/Camunda Modeler.app/Contents/Resources/app.asar/public/');
+      return expectNormalization('/Applications/Camunda Modeler.app/Contents/Resources/app.asar/public/');
     });
 
 
     it('should normalize dev paths', () => {
 
-      return normalizationTest('webpack-internal:///./src/plugins/camunda-plugin/deployment-tool/');
+      return expectNormalization('webpack-internal:///./src/plugins/camunda-plugin/deployment-tool/');
     });
   });
 });
 
-async function normalizationTest(prefix) {
+async function expectNormalization(prefix) {
 
   // given
   const url = prefix + '2.2.js';

--- a/client/src/plugins/error-tracking/__tests__/ErrorTrackingSpec.js
+++ b/client/src/plugins/error-tracking/__tests__/ErrorTrackingSpec.js
@@ -174,11 +174,13 @@ describe('<ErrorTracking>', () => {
     // when
     await instance.componentDidMount();
 
+    const args = sentryInitSpy.getCall(0).args;
+
     // then
-    expect(sentryInitSpy).to.have.been.calledWith({
-      dsn: 'TEST_DSN',
-      release: '3.5.0'
-    });
+    expect(args).to.have.length(1);
+
+    expect(args[0].dsn).to.eql('TEST_DSN');
+    expect(args[0].release).to.eql('3.5.0');
   });
 
 

--- a/client/src/plugins/error-tracking/__tests__/ErrorTrackingSpec.js
+++ b/client/src/plugins/error-tracking/__tests__/ErrorTrackingSpec.js
@@ -370,6 +370,12 @@ describe('<ErrorTracking>', () => {
     });
 
 
+    it('should normalize Windows paths with backslash', () => {
+
+      return expectNormalization('C:\\Users\\user\\test-user\\Desktop\\Camunda\\resources\\app.asar\\public\\');
+    });
+
+
     it('should normalize Linux paths', () => {
 
       return expectNormalization('/home/testuser/Aplications/camunda-modeler-4.0.0-linux-x64/resources/app.asar/public/');


### PR DESCRIPTION
__Which issue does this PR address?__

Closes #1831

**Best way to test this works**
Since we don't have this problem for dev builds, we need to create a buggy artifact to test this. Follow these steps:

1. Inject `SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG` and `SENTRY_PROJECT` environment variables. They should be accessible from `client/webpack.config.js` These values can be found on our Sentry page. Ping @oguzeroglu if you don't know how to get those.
2. We don't want to pollute existing sourcemaps, so we need to change [this line](https://github.com/camunda/camunda-modeler/blob/c002e72af5c0147444af28edd1787e14def83fb8/client/webpack.config.js#L141) to `release: 'testRelease'`. For the same reason, change [this line](https://github.com/camunda/camunda-modeler/blob/c002e72af5c0147444af28edd1787e14def83fb8/client/src/plugins/error-tracking/ErrorTracking.js#L84) to `release: 'testRelease'` as well.
3. Inject a `throw new Error('TEST ERROR');` somewhere inside the client code. I usually inject this into the top of`DeploymentConfigModal#onClose` so that an exception is thrown every time I try to close the deployment modal.
4. `npm run build`
5. Reproduce the bug using the built artifact (by trying to close the deployment modal).
6. Go to Sentry, find the related error. Verify that Sentry shows correctly where the error occured and this warning does not exist:
<img width="929" alt="Screenshot 2020-06-24 at 13 19 00" src="https://user-images.githubusercontent.com/15003836/85546539-49ff5b00-b61d-11ea-8481-8da29bf5f1df.png">

For questions ping @oguzeroglu.

**Why this error happens**
Unlike bpmn.io demo website, Camunda Modeler errors do not come from a static source. The error URL depends on where the users installed the app. That's why Sentry is unable to match uploaded sourcemaps to URL of exceptions.

Example:
Uploaded sourcemap: `public/2.2.js`
Error comes from: `/Users/Desktop/test/Camunda Modeler/app.asar/public/2.2.js`

That's why we need to normalize the URLs.

See [this comment](https://github.com/camunda/camunda-modeler/issues/1831#issuecomment-648676209).

Note that the official Electron Sentry SDK uses a similar technique to overcome this problem. Due to the fact that users may turn off the error tracking option on the run, we've chosen not to use the sentry-electron package, since it does not provide us such flexibility (we use sentry-browser and sentry-node libraries instead)

<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [x] Corresponds to the concept <!-- link document here -->
* [x] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [x] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [x] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [x] passes Continuous Integration checks
* [x] available as feature branch on GitHub
  * [x] contains the cleaned up commit history
  * [x] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [x] a single commit closes the issue via Closes #issuenr
