### PR TITLE
Do not upload Spec files to Sentry

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -140,7 +140,7 @@ function sentryIntegration() {
     new SentryWebpackPlugin({
       release: NODE_ENV === 'production' ? version : 'dev',
       include: '.',
-      ignore: ['node_modules', 'webpack.config.js'],
+      ignore: ['node_modules', 'webpack.config.js', '*Spec.js'],
     })
   ];
 }


### PR DESCRIPTION
Closes #1849

This is an easy fix. You can see it works [here](https://sentry.io/organizations/camunda-modeling/releases/spec-fix-test-release/artifacts/?project=5223041) as this test artifact does not contain any spec file, as opposed to [here](https://sentry.io/organizations/camunda-modeling/releases/4.0.0/artifacts/?project=5223041).

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [x] Corresponds to the concept <!-- link document here -->
* [x] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [x] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [x] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [x] passes Continuous Integration checks
* [x] available as feature branch on GitHub
  * [x] contains the cleaned up commit history
  * [x] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [x] a single commit closes the issue via Closes #issuenr
