### PR TITLE
chore(codecov): remove appveyor configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,3 @@ comment: off
 parsers:
   javascript:
     enable_partials: yes
-
-codecov:
-  ci:
-    - !appveyor


### PR DESCRIPTION
It's unnecessary after we dropped Appveyor: 8f24e98aba2e88148fd40e5bc459eb81627408fd

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
