### PR TITLE
Track cmmn diagrams

### DIFF
--- a/client/src/app/tabs/cmmn/CmmnEditor.js
+++ b/client/src/app/tabs/cmmn/CmmnEditor.js
@@ -506,11 +506,13 @@ export class CmmnEditor extends CachedComponent {
     );
   }
 
-  static createCachedState() {
+  static createCachedState(props) {
     const {
       name,
       version
     } = Metadata;
+
+    const { onAction } = props;
 
     const modeler = new CamundaCmmnModeler({
       position: 'absolute',
@@ -523,6 +525,14 @@ export class CmmnEditor extends CachedComponent {
     const commandStack = modeler.get('commandStack');
 
     const stackIdx = commandStack._stackIdx;
+
+    // notify interested parties that modeler was created
+    onAction('emit-event', {
+      type: 'cmmn.modeler.created',
+      payload: {
+        modeler
+      }
+    });
 
     return {
       __destroy: () => {

--- a/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
+++ b/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
@@ -873,6 +873,32 @@ describe('<CmmnEditor>', function() {
 
   });
 
+
+  it('should notify when modeler was created', async function() {
+
+    // given
+    const emittedEvents = [];
+    const recordActions = (action, options) => {
+      emittedEvents.push(options);
+    };
+
+    const {
+      instance
+    } = await renderEditor(diagramXML, {
+      onAction: recordActions
+    });
+
+    // when
+    const modeler = instance.getModeler();
+
+    // then
+    expect(emittedEvents.length).to.eql(1);
+
+    const { type, payload } = emittedEvents[0];
+
+    expect(type).to.eql('cmmn.modeler.created');
+    expect(payload.modeler).to.equal(modeler);
+  });
 });
 
 
@@ -884,6 +910,7 @@ const TestEditor = WithCachedState(CmmnEditor);
 
 function renderEditor(xml, options = {}) {
   const {
+    onAction,
     layout,
     onChanged,
     onError,
@@ -896,6 +923,7 @@ function renderEditor(xml, options = {}) {
       id={ options.id || 'editor' }
       xml={ xml }
       activeSheet={ options.activeSheet || { id: 'cmmn' } }
+      onAction={ onAction || noop }
       onChanged={ onChanged || noop }
       onError={ onError || noop }
       onImport={ onImport || noop }

--- a/client/src/plugins/usage-statistics/event-handlers/DiagramOpenEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/DiagramOpenEventHandler.js
@@ -17,11 +17,12 @@ const ELEMENT_TEMPLATES_CONFIG_KEY = 'bpmn.elementTemplates';
 
 const types = {
   BPMN: 'bpmn',
-  DMN: 'dmn'
+  DMN: 'dmn',
+  CMMN: 'cmmn'
 };
 
 // Sends a diagramOpened event to ET with diagram-type: bpmn/dmn payload
-// when a user opens a BPMN or DMN diagram (create a new one or open from file).
+// when a user opens a BPMN, DMN or CMMN diagram (create a new one or open from file).
 export default class DiagramOpenEventHandler extends BaseEventHandler {
 
   constructor(params) {
@@ -42,6 +43,10 @@ export default class DiagramOpenEventHandler extends BaseEventHandler {
 
     subscribe('dmn.modeler.created', () => {
       this.onDiagramOpened(types.DMN);
+    });
+
+    subscribe('cmmn.modeler.created', () => {
+      this.onDiagramOpened(types.CMMN);
     });
   }
 

--- a/client/src/plugins/usage-statistics/event-handlers/__tests__/DiagramOpenEventHandlerSpec.js
+++ b/client/src/plugins/usage-statistics/event-handlers/__tests__/DiagramOpenEventHandlerSpec.js
@@ -40,6 +40,19 @@ describe('<DiagramOpenEventHandler>', () => {
   });
 
 
+  it('should subscribe to cmmn.modeler.created', () => {
+
+    // given
+    const subscribe = sinon.spy();
+
+    // when
+    new DiagramOpenEventHandler({ subscribe });
+
+    // then
+    expect(subscribe.getCall(2).args[0]).to.eql('cmmn.modeler.created');
+  });
+
+
   it('should send with diagram-type: bpmn', async () => {
 
     // given
@@ -166,6 +179,29 @@ describe('<DiagramOpenEventHandler>', () => {
     expect(onSend).to.have.been.calledWith({
       event: 'diagramOpened',
       'diagram-type': 'dmn'
+    });
+  });
+
+
+  it('should send with diagram-type: cmmn', () => {
+
+    // given
+    const subscribe = sinon.spy();
+    const onSend = sinon.spy();
+
+    // when
+    const diagramOpenEventHandler = new DiagramOpenEventHandler({ onSend, subscribe });
+
+    diagramOpenEventHandler.enable();
+
+    const cmmnCallback = subscribe.getCall(2).args[1];
+
+    cmmnCallback();
+
+    // then
+    expect(onSend).to.have.been.calledWith({
+      event: 'diagramOpened',
+      'diagram-type': 'cmmn'
     });
   });
 });

--- a/docs/telemetry/README.md
+++ b/docs/telemetry/README.md
@@ -42,14 +42,16 @@ The `Diagram Opened Event` is sent in following situations:
 
  - User created a new BPMN diagram
  - User created a new DMN diagram
+ - User created a new CMMN diagram
  - User opened an existing BPMN diagram
  - User opened an existing DMN diagram
+ - User opened an existing CMMN diagram
 
 The Diagram Opened Event has the following core structure:
 ```json
 {
   "event": "diagramOpened",
-  "diagram-type": "[bpmn or dmn]"
+  "diagram-type": "[bpmn, dmn or cmmn]"
 }
 ```
 


### PR DESCRIPTION
Closes #1886 

<img width="837" alt="Screenshot 2020-07-21 at 12 00 32" src="https://user-images.githubusercontent.com/15003836/88041135-3b3b9380-cb4a-11ea-92f6-ddb2f0950427.png">

* [x] Corresponds to the concept <!-- link document here -->
* [x] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [x] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [x] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [x] passes Continuous Integration checks
* [x] available as feature branch on GitHub
  * [x] contains the cleaned up commit history
  * [x] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [x] a single commit closes the issue via Closes #issuenr
