### PR TITLE
Cloud connect plugin compatibility

### DIFF
--- a/app/lib/config/index.js
+++ b/app/lib/config/index.js
@@ -28,10 +28,10 @@ class Config {
       userPath
     } = options;
 
-    this._defaultProvider = new DefaultProvider(path.join(userPath, 'config.json'));
+    const defaultProvider = this._defaultProvider = new DefaultProvider(path.join(userPath, 'config.json'));
 
     this._providers = {
-      'bpmn.elementTemplates': new ElementTemplatesProvider(resourcesPaths),
+      'bpmn.elementTemplates': new ElementTemplatesProvider(resourcesPaths, defaultProvider),
       'editor.id': new UUIDProvider(path.join(userPath, '.editorid')),
       'os.info': new OSInfoProvider()
     };

--- a/app/lib/config/providers/ElementTemplatesProvider.js
+++ b/app/lib/config/providers/ElementTemplatesProvider.js
@@ -22,8 +22,9 @@ const log = require('../../log')('app:config:element-templates');
  * Get element templates.
  */
 class ElementTemplatesProvider {
-  constructor(paths) {
+  constructor(paths, defaultProvider) {
     this._paths = paths;
+    this._defaultProvider = defaultProvider;
   }
 
   /**
@@ -42,7 +43,10 @@ class ElementTemplatesProvider {
       ...this._paths
     ];
 
-    return getTemplates(paths);
+    return [
+      ...getTemplates(paths),
+      ...this._defaultProvider.get('elementTemplates', [])
+    ];
   }
 }
 

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -132,12 +132,10 @@ export class BpmnEditor extends CachedComponent {
     propertiesPanel.attachTo(this.propertiesPanelRef.current);
 
 
-    if (this.shouldLoadTemplates()) {
-      try {
-        await this.loadTemplates();
-      } catch (error) {
-        this.handleError({ error });
-      }
+    try {
+      await this.loadTemplates();
+    } catch (error) {
+      this.handleError({ error });
     }
 
     this.checkImport();
@@ -192,14 +190,6 @@ export class BpmnEditor extends CachedComponent {
     modeler[fn]('minimap.toggle', this.handleMinimapToggle);
   }
 
-  shouldLoadTemplates() {
-    const {
-      templatesLoaded
-    } = this.getCached();
-
-    return !templatesLoaded;
-  }
-
   async loadTemplates() {
     const { getConfig } = this.props;
 
@@ -211,9 +201,15 @@ export class BpmnEditor extends CachedComponent {
 
     templatesLoader.setTemplates(templates);
 
-    this.setCached({
-      templatesLoaded: true
-    });
+    const propertiesPanel = modeler.get('propertiesPanel', false);
+
+    if (propertiesPanel) {
+      const currentElement = propertiesPanel._current && propertiesPanel._current.element;
+
+      if (currentElement) {
+        propertiesPanel.update(currentElement);
+      }
+    }
   }
 
   undo = () => {
@@ -603,6 +599,10 @@ export class BpmnEditor extends CachedComponent {
       context = {
         value: 'fit-viewport'
       };
+    }
+
+    if (action === 'elementTemplates.reload') {
+      return this.loadTemplates();
     }
 
     // TODO(nikku): handle all editor actions

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -977,7 +977,7 @@ describe('<BpmnEditor>', function() {
     });
 
 
-    it('should not reload templates if it once succeeded', async function() {
+    it('should reload templates on action triggered', async function() {
 
       // given
       const getConfigSpy = sinon.spy(),
@@ -1001,91 +1001,17 @@ describe('<BpmnEditor>', function() {
         getConfig: getConfigSpy
       });
 
-      instance.componentWillUnmount();
-      await instance.componentDidMount();
+      const propertiesPanel = instance.getModeler().get('propertiesPanel');
 
-      // expect
-      expect(getConfigSpy).to.be.calledOnce;
-      expect(getConfigSpy).to.be.calledWith('bpmn.elementTemplates');
-      expect(elementTemplatesLoaderStub.setTemplates).to.be.calledOnce;
-    });
+      const updateSpy = spy(propertiesPanel, 'update');
 
-
-    it('should retry loading templates on mount if they could not be loaded', async function() {
-
-      // given
-      const getConfigStub = sinon.stub(),
-            elementTemplatesLoaderStub = sinon.stub({ setTemplates() {} });
-
-      getConfigStub.onFirstCall()
-        .rejects()
-        .onSecondCall()
-        .resolves();
-
-      const cache = new Cache();
-
-      cache.add('editor', {
-        cached: {
-          modeler: new BpmnModeler({
-            modules: {
-              elementTemplatesLoader: elementTemplatesLoaderStub
-            }
-          })
-        }
-      });
-
-      // when
-      const { instance } = await renderEditor(diagramXML, {
-        cache,
-        getConfig: getConfigStub
-      });
-
-      instance.componentWillUnmount();
-      await instance.componentDidMount();
-
-      // expect
-      expect(getConfigStub).to.be.calledTwice;
-      expect(getConfigStub).to.be.calledWith('bpmn.elementTemplates');
-      expect(elementTemplatesLoaderStub.setTemplates).to.be.calledOnce;
-    });
-
-
-    it('should retry loading templates on mount if they could not be set', async function() {
-
-      // given
-      const getConfigSpy = sinon.spy(),
-            elementTemplatesLoaderStub = sinon.stub({ setTemplates() {} });
-
-      elementTemplatesLoaderStub.setTemplates.onFirstCall()
-        .throwsException()
-        .onSecondCall()
-        .returns();
-
-      const cache = new Cache();
-
-      cache.add('editor', {
-        cached: {
-          modeler: new BpmnModeler({
-            modules: {
-              elementTemplatesLoader: elementTemplatesLoaderStub
-            }
-          })
-        }
-      });
-
-      // when
-      const { instance } = await renderEditor(diagramXML, {
-        cache,
-        getConfig: getConfigSpy
-      });
-
-      instance.componentWillUnmount();
-      await instance.componentDidMount();
+      await instance.triggerAction('elementTemplates.reload');
 
       // expect
       expect(getConfigSpy).to.be.calledTwice;
-      expect(getConfigSpy).to.be.calledWith('bpmn.elementTemplates');
+      expect(getConfigSpy).to.be.always.calledWith('bpmn.elementTemplates');
       expect(elementTemplatesLoaderStub.setTemplates).to.be.calledTwice;
+      expect(updateSpy).to.have.been.called;
     });
 
 

--- a/client/test/mocks/bpmn-js/Modeler.js
+++ b/client/test/mocks/bpmn-js/Modeler.js
@@ -44,9 +44,17 @@ class CommandStack {
 }
 
 class PropertiesPanel {
+  constructor() {
+    this._current = {
+      element: {}
+    };
+  }
+
   attachTo() {}
 
   detach() {}
+
+  update() {}
 }
 
 export default class Modeler {


### PR DESCRIPTION
Adds two things that are necessary for the new cloud connect plugin to work:

* load element templates from default config file
* action that triggers BPMN editor to reload element templates and update properties panel

Related to https://github.com/bpmn-io/internal-docs/issues/121