### PR TITLE
fix(ci): rewrite test stage condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ jobs:
         npm run build -- --win --publish --on-demand --region=$AWS_ON_DEMAND_REGION
 stages:
   - name: test
-    if: type == api AND env(SKIP_TESTS) != "true"
+    if: type != api OR env(SKIP_TESTS) != "true"
   - name: "pre distro"
     if: tag =~ ^v\d
   - name: "distro"


### PR DESCRIPTION
Test stage should run for all build which are not triggered via API and for API-triggered builds where SKIP_TESTS is not set to `true`.

This was broken via https://github.com/camunda/camunda-modeler/commit/c0d933c2b228771e2dd1a9865b4f0781bb3f85c9 🙈 

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
