### PR TITLE
Fix dmn modeler dragging layout

### DIFF
--- a/client/src/app/tabs/dmn/DmnEditor.less
+++ b/client/src/app/tabs/dmn/DmnEditor.less
@@ -11,7 +11,7 @@
     }
   }
 
-  .top {
+  &>.top {
     padding: 10px;
 
     .button {
@@ -36,7 +36,7 @@
 
   }
 
-  .bottom {
+  &>.bottom {
     display: flex;
     flex: 1;
     flex-direction: row;
@@ -46,7 +46,7 @@
     flex: 1;
     position: relative;
   }
-  
+
   .diagram:not(.drd) {
     margin-right: 10px;
     margin-bottom: 10px;


### PR DESCRIPTION
This fixes class name clashes as both .top and .bottom classes
are used in dmn-js.

Related to #1898

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
