### PR TITLE
fix(dmn-edit-menu): handle undo and redo entries without default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 ## Unreleased
 
 ___Note:__ Yet to be released changes appear here._
+* `FIX`: fix broken keyboard shortcuts and menu entries for Undo & Redo in decision tables ([#1843](https://github.com/camunda/camunda-modeler/issues/1843))
 
 ## 4.2.0
 

--- a/client/src/app/tabs/dmn/getDmnEditMenu.js
+++ b/client/src/app/tabs/dmn/getDmnEditMenu.js
@@ -13,7 +13,6 @@ import {
   getCopyCutPasteEntries,
   getAlignDistributeEntries,
   getDefaultCopyCutPasteEntries,
-  getDefaultUndoRedoEntries,
   getSelectionEntries,
   getToolEntries,
   getUndoRedoEntries
@@ -61,21 +60,14 @@ export function getDmnDrdEditMenu(state) {
 }
 
 export function getDmnDecisionTableEditMenu(state) {
-  const {
-    defaultCopyCutPaste,
-    defaultUndoRedo
-  } = state;
-
-  const undoRedoEntries = defaultUndoRedo
-    ? getDefaultUndoRedoEntries()
-    : getUndoRedoEntries(state);
+  const { defaultCopyCutPaste } = state;
 
   const copyCutPasteEntries = defaultCopyCutPaste
     ? getDefaultCopyCutPasteEntries()
     : getCopyCutPasteEntries(state);
 
   return [
-    undoRedoEntries,
+    getUndoRedoEntries(state),
     copyCutPasteEntries,
     getSelectionEntries(state),
     ...getDecisionTableEntries(state)


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

closes #1843

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [X] Corresponds to the concept: see #1843
* [X] Corresponds to the design: applied existing design which is also used [here](https://github.com/camunda/camunda-modeler/blob/develop/client/src/app/tabs/dmn/getDmnEditMenu.js#L46)

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr

__Additional context__

Discovered during analysis of this PR and probably caused in same module: #1912 