### PR TITLE
feat(app): allow reading file as buffer

### DIFF
--- a/app/lib/file-system.js
+++ b/app/lib/file-system.js
@@ -38,18 +38,18 @@ const ENCODING_BASE64 = 'base64',
  *
  * @param {string} filePath - Filepath.
  * @param {Object} [options] - Options.
- * @param {string} [options.encoding] - Encoding.
+ * @param {string|false} [options.encoding] - Encoding. Set to false to receive Buffer.
  *
  * @return {Object}
  */
 module.exports.readFile = function(filePath, options = {}) {
   let { encoding } = options;
 
-  if (!encoding) {
+  if (!encoding && encoding !== false) {
     encoding = ENCODING_UTF8;
   }
 
-  const fileContents = fs.readFileSync(filePath, encoding);
+  const fileContents = encoding ? fs.readFileSync(filePath, encoding) : fs.readFileSync(filePath);
 
   return createFile({
     path: filePath,

--- a/app/test/spec/file-system-spec.js
+++ b/app/test/spec/file-system-spec.js
@@ -99,6 +99,23 @@ describe('FileSystem', function() {
     });
 
 
+    it('should read file (encoding=false)', function() {
+
+      // given
+      const fooPath = getTestFilePath('foo.file');
+
+      writeFile(fooPath, { contents: 'foo' });
+
+      // when
+      const file = readFile(fooPath, {
+        encoding: false
+      });
+
+      // then
+      expect(file.contents).to.eql(Buffer.from('foo'));
+    });
+
+
     it('should throw an error', function() {
 
       // given


### PR DESCRIPTION
This adds an ability to get the file contents as buffer, and then operate with it freely.

During the Camunda Summer Hackdays (cf. https://github.com/pinussilvestrus/excel-to-dmn-plugin), I found it helpful if plugins could get file contents as a buffer, and no encoding has to be given. 

Currently, every time when reading a file, you get the encoded file contents, even you did not specify it. Sometimes file contents might be encoded in a format, which [Node.js does not support](https://stackoverflow.com/a/14551669), e.g. when working with Excel files.

__Which issue does this PR address?__

_None_. Just a suggestion for better file reading support for plugins.

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
