### PR TITLE
Element Template Modal UX Fixes

### DIFF
--- a/client/src/app/primitives/__tests__/ModalSpec.js
+++ b/client/src/app/primitives/__tests__/ModalSpec.js
@@ -142,4 +142,79 @@ describe('<Modal>', function() {
 
   });
 
+
+  describe('<Modal.Title>', function() {
+
+    it('should render', function() {
+      wrapper = mount(<Modal.Title />);
+    });
+
+
+    it('should render with custom props', function() {
+
+      // given
+      const onClickSpy = sinon.spy();
+
+      // when
+      wrapper = mount(<Modal.Title className="foo" onClick={ onClickSpy } />);
+
+      wrapper.simulate('click');
+
+      // then
+      expect(wrapper.getDOMNode().classList.contains('foo')).to.be.true;
+      expect(onClickSpy).to.have.been.called;
+    });
+
+  });
+
+
+  describe('<Modal.Body>', function() {
+
+    it('should render', function() {
+      wrapper = mount(<Modal.Body />);
+    });
+
+
+    it('should render with custom props', function() {
+
+      // given
+      const onClickSpy = sinon.spy();
+
+      // when
+      wrapper = mount(<Modal.Body className="foo" onClick={ onClickSpy } />);
+
+      wrapper.simulate('click');
+
+      // then
+      expect(wrapper.getDOMNode().classList.contains('foo')).to.be.true;
+      expect(onClickSpy).to.have.been.called;
+    });
+
+  });
+
+
+  describe('<Modal.Footer>', function() {
+
+    it('should render', function() {
+      wrapper = mount(<Modal.Footer />);
+    });
+
+
+    it('should render with custom props', function() {
+
+      // given
+      const onClickSpy = sinon.spy();
+
+      // when
+      wrapper = mount(<Modal.Footer className="foo" onClick={ onClickSpy } />);
+
+      wrapper.simulate('click');
+
+      // then
+      expect(wrapper.getDOMNode().classList.contains('foo')).to.be.true;
+      expect(onClickSpy).to.have.been.called;
+    });
+
+  });
+
 });

--- a/client/src/app/primitives/modal/Modal.js
+++ b/client/src/app/primitives/modal/Modal.js
@@ -86,18 +86,22 @@ Modal.Footer = Footer;
 
 
 function Title(props) {
+  const {
+    children,
+    className,
+    ...rest
+  } = props;
 
   return (
-    <div className="modal-header">
+    <div className={ classNames('modal-header', className) } { ...rest }>
       <h2 className="modal-title">
-        { props.children }
+        { children }
       </h2>
     </div>
   );
 }
 
 function Close(props) {
-
   const {
     onClick
   } = props;
@@ -110,16 +114,28 @@ function Close(props) {
 }
 
 function Body(props) {
+  const {
+    children,
+    className,
+    ...rest
+  } = props;
+
   return (
-    <div className="modal-body">
-      { props.children }
+    <div className={ classNames('modal-body', className) } { ...rest }>
+      { children }
     </div>
   );
 }
 
 function Footer(props) {
+  const {
+    children,
+    className,
+    ...rest
+  } = props;
+
   return (
-    <div className="modal-footer">
+    <div className={ classNames('modal-footer', className) } { ...rest }>
       { props.children }
     </div>
   );

--- a/client/src/plugins/element-templates-modal/components/ElementTemplatesModalView.js
+++ b/client/src/plugins/element-templates-modal/components/ElementTemplatesModalView.js
@@ -56,9 +56,17 @@ class ElementTemplatesView extends PureComponent {
 
     const selectedElementType = await triggerAction('getSelectedElementType');
 
-    elementTemplates = elementTemplates.filter(({ appliesTo }) => {
-      return appliesTo.includes(selectedElementType);
-    });
+    elementTemplates = elementTemplates
+      .filter(({ appliesTo }) => {
+        return appliesTo.includes(selectedElementType);
+      })
+      .sort((a, b) => {
+        if (a.name.toLowerCase() < b.name.toLowerCase()) {
+          return -1;
+        } else {
+          return 1;
+        }
+      });
 
     const selectedElementAppliedElementTemplate = await triggerAction('getSelectedElementAppliedElementTemplate');
 

--- a/client/src/plugins/element-templates-modal/components/ElementTemplatesModalView.js
+++ b/client/src/plugins/element-templates-modal/components/ElementTemplatesModalView.js
@@ -38,6 +38,7 @@ class ElementTemplatesView extends PureComponent {
         tags: [],
         search: ''
       },
+      scroll: false,
       selected: null
     };
   }
@@ -140,6 +141,10 @@ class ElementTemplatesView extends PureComponent {
     });
   }
 
+  onScroll = ({ target }) => {
+    this.setState({ scroll: target.scrollTop > 0 });
+  }
+
   render() {
     const { onClose } = this.props;
 
@@ -148,6 +153,7 @@ class ElementTemplatesView extends PureComponent {
       elementTemplates,
       expanded,
       filter,
+      scroll,
       selected
     } = this.state;
 
@@ -164,8 +170,8 @@ class ElementTemplatesView extends PureComponent {
 
         <Modal.Title>Catalog</Modal.Title>
 
-        <Modal.Body>
-          <div className="header">
+        <Modal.Body onScroll={ this.onScroll }>
+          <div className={ classNames('header', { 'header--scroll': scroll }) }>
             <h2 className="header__title">Templates</h2>
             <div className="header__filter">
               <Input className="header__filter-item" value={ filter.search } onChange={ this.onSearchChange } />

--- a/client/src/plugins/element-templates-modal/components/ElementTemplatesModalView.js
+++ b/client/src/plugins/element-templates-modal/components/ElementTemplatesModalView.js
@@ -33,6 +33,7 @@ class ElementTemplatesView extends PureComponent {
     this.state = {
       applied: null,
       elementTemplates: [],
+      elementTemplatesFiltered: [],
       expanded: null,
       filter: {
         tags: [],
@@ -73,6 +74,7 @@ class ElementTemplatesView extends PureComponent {
 
     this.setState({
       elementTemplates,
+      elementTemplatesFiltered: elementTemplates,
       applied: selectedElementAppliedElementTemplate
     });
   }
@@ -122,22 +124,29 @@ class ElementTemplatesView extends PureComponent {
   onSearchChange = search => {
     const { filter } = this.state;
 
-    this.setState({
-      filter: {
-        ...filter,
-        search
-      }
+    this.setFilter({
+      ...filter,
+      search
     });
   }
 
   onTagsChange = tags => {
     const { filter } = this.state;
 
+    this.setFilter({
+      ...filter,
+      tags
+    });
+  }
+
+  setFilter = filter => {
+    const { elementTemplates } = this.state;
+
+    const elementTemplatesFiltered = filterElementTemplates(elementTemplates, filter);
+
     this.setState({
-      filter: {
-        ...filter,
-        tags
-      }
+      elementTemplatesFiltered,
+      filter
     });
   }
 
@@ -151,6 +160,7 @@ class ElementTemplatesView extends PureComponent {
     const {
       applied,
       elementTemplates,
+      elementTemplatesFiltered,
       expanded,
       filter,
       scroll,
@@ -163,7 +173,7 @@ class ElementTemplatesView extends PureComponent {
 
     const tagCounts = getTagCounts(elementTemplates);
 
-    const filteredElementTemplates = filterElementTemplates(elementTemplates, filter);
+    const canApply = elementTemplatesFiltered.find(({ id }) => id === selected);
 
     return (
       <Modal className={ css.ElementTemplatesModalView } onClose={ onClose }>
@@ -185,8 +195,8 @@ class ElementTemplatesView extends PureComponent {
 
           <ul className="element-templates-list">
             {
-              filteredElementTemplates.length
-                ? filteredElementTemplates.map(elementTemplate => {
+              elementTemplatesFiltered.length
+                ? elementTemplatesFiltered.map(elementTemplate => {
                   const { id } = elementTemplate;
 
                   return (
@@ -203,7 +213,7 @@ class ElementTemplatesView extends PureComponent {
                 : null
             }
             {
-              !filteredElementTemplates.length ? (
+              !elementTemplatesFiltered.length ? (
                 <ElementTemplatesListItemEmpty />
               ) : null
             }
@@ -212,16 +222,17 @@ class ElementTemplatesView extends PureComponent {
 
         <Modal.Footer>
           <div className="form-submit">
-            <button className="btn btn-secondary" type="submit" onClick={ onClose }>
+            <button className="btn btn-secondary button--cancel" type="submit" onClick={ onClose }>
               Cancel
             </button>
-            {
-              true && (
-                <button disabled={ isNil(selected) } className="btn btn-primary" type="submit" onClick={ this.onApply }>
-                  Apply
-                </button>
-              )
-            }
+            <button
+              disabled={ !canApply }
+              className="btn btn-primary button--apply"
+              type="submit"
+              onClick={ this.onApply }
+            >
+              Apply
+            </button>
           </div>
         </Modal.Footer>
 

--- a/client/src/plugins/element-templates-modal/components/ElementTemplatesModalView.js
+++ b/client/src/plugins/element-templates-modal/components/ElementTemplatesModalView.js
@@ -377,6 +377,14 @@ function getTagCounts(elementTemplates) {
   }, {});
 }
 
+function leftPad(string, length, character) {
+  while (string.length < length) {
+    string = `${ character }${ string }`;
+  }
+
+  return string;
+}
+
 function getDate(elementTemplate) {
   const { metadata } = elementTemplate;
 
@@ -384,5 +392,13 @@ function getDate(elementTemplate) {
     return;
   }
 
-  return new Date(metadata.updated).toLocaleDateString('en-US').split('/').reverse().join('-');
+  const dateUpdated = new Date(metadata.updated);
+
+  const year = dateUpdated.getFullYear();
+
+  const month = leftPad(String(dateUpdated.getMonth() + 1), 2, '0');
+
+  const date = leftPad(String(dateUpdated.getDate()), 2, '0');
+
+  return `${ year }-${ month }-${ date }`;
 }

--- a/client/src/plugins/element-templates-modal/components/ElementTemplatesModalView.js
+++ b/client/src/plugins/element-templates-modal/components/ElementTemplatesModalView.js
@@ -244,8 +244,15 @@ class ElementTemplatesView extends PureComponent {
 export default ElementTemplatesView;
 
 export class ElementTemplatesListItem extends React.PureComponent {
-  constructor(props) {
-    super(props);
+  onSelect = ({ target }) => {
+    const { onSelect } = this.props;
+
+    // Do not select on description expand click
+    if (target.classList.contains('element-templates-list__item-description-expand')) {
+      return;
+    }
+
+    onSelect();
   }
 
   render() {
@@ -253,7 +260,6 @@ export class ElementTemplatesListItem extends React.PureComponent {
       applied,
       elementTemplate,
       expanded,
-      onSelect,
       onToggleExpanded,
       selected
     } = this.props;
@@ -292,7 +298,7 @@ export class ElementTemplatesListItem extends React.PureComponent {
           { 'element-templates-list__item--selectable': id !== applied },
           { 'element-templates-list__item--selected': id === selected }
         )
-      } onClick={ id !== applied && id !== selected ? onSelect : null }>
+      } onClick={ id !== applied && id !== selected ? this.onSelect : null }>
         <div className="element-templates-list__item-header">
           <span className="element-templates-list__item-name">{ name }</span>
           {

--- a/client/src/plugins/element-templates-modal/components/ElementTemplatesModalView.less
+++ b/client/src/plugins/element-templates-modal/components/ElementTemplatesModalView.less
@@ -1,10 +1,28 @@
 :local(.ElementTemplatesModalView) {
+  .modal-body {
+    padding: 0;
+
+    min-height: 50vh;
+  }
+
   .header {
     display: flex;
-
+    position: sticky;
+    top: 0;
+    
     flex-direction: row;
 
-    margin: 0 0 16px 0;
+    align-items: center;
+    
+    padding: 16px 20px 16px 20px;
+
+    border-bottom: solid 1px transparent;
+
+    background-color: var(--silver-lighten-99);
+  }
+
+  .header--scroll {
+    border-bottom: solid 1px var(--silver-darken-87);
   }
 
   .header__title {
@@ -29,7 +47,7 @@
 
   .element-templates-list {
     margin: 0;
-    padding: 0;
+    padding: 0 20px 20px 20px;
   }
   
   .element-templates-list__item {

--- a/client/src/plugins/element-templates-modal/components/Input.less
+++ b/client/src/plugins/element-templates-modal/components/Input.less
@@ -72,10 +72,4 @@
 
     color: var(--blue-darken-48);
   }
-
-  .input__text:focus + .input__clear:hover {
-    background-color: var(--blue-darken-48);
-
-    color: var(--color-ffffff);
-  }
 }

--- a/client/src/plugins/element-templates-modal/components/__tests__/ElementTemplatesViewSpec.js
+++ b/client/src/plugins/element-templates-modal/components/__tests__/ElementTemplatesViewSpec.js
@@ -67,6 +67,25 @@ describe('<ElementTemplatesView>', function() {
     });
 
 
+    it('should get element templates sorted alphabetically', async function() {
+
+      // given
+      const {
+        instance,
+        wrapper
+      } = await createElementTemplatesModalView();
+
+      // when
+      await instance.getElementTemplates();
+
+      // then
+      expect(wrapper.state('elementTemplates').map(({ name }) => name)).to.eql([
+        'Template 1',
+        'Template 2'
+      ]);
+    });
+
+
     it('should list element templates', async function() {
 
       // given
@@ -266,24 +285,6 @@ const DEFAULT_ELEMENT_TEMPLATES = [
     appliesTo: [
       'bpmn:ServiceTask'
     ],
-    id: 'some-rpa-template',
-    description: 'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-    metadata: {
-      catalogOrganizationId: '00000000-0000-0000-0000-000000000000',
-      catalogTemplateId: '00000000-0000-0000-0000-000000000000',
-      created: 1000000000000,
-      tags: [
-        'Walt\'s Catalog'
-      ],
-      updated: 1000000000000
-    },
-    name: 'Template 1',
-    properties: []
-  },
-  {
-    appliesTo: [
-      'bpmn:ServiceTask'
-    ],
     id: 'another-rpa-template',
     metadata: {
       catalogOrganizationId: '00000000-0000-0000-0000-000000000000',
@@ -312,6 +313,24 @@ const DEFAULT_ELEMENT_TEMPLATES = [
       updated: 1000000000000
     },
     name: 'Template 3',
+    properties: []
+  },
+  {
+    appliesTo: [
+      'bpmn:ServiceTask'
+    ],
+    id: 'some-rpa-template',
+    description: 'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    metadata: {
+      catalogOrganizationId: '00000000-0000-0000-0000-000000000000',
+      catalogTemplateId: '00000000-0000-0000-0000-000000000000',
+      created: 1000000000000,
+      tags: [
+        'Walt\'s Catalog'
+      ],
+      updated: 1000000000000
+    },
+    name: 'Template 1',
     properties: []
   }
 ];

--- a/client/src/plugins/element-templates-modal/components/__tests__/ElementTemplatesViewSpec.js
+++ b/client/src/plugins/element-templates-modal/components/__tests__/ElementTemplatesViewSpec.js
@@ -168,6 +168,7 @@ describe('<ElementTemplatesView>', function() {
 
       // then
       expect(wrapper.state('expanded')).to.equal('some-rpa-template');
+      expect(wrapper.state('selected')).to.be.null;
     });
 
 
@@ -189,6 +190,7 @@ describe('<ElementTemplatesView>', function() {
 
       // then
       expect(wrapper.state('expanded')).to.equal(null);
+      expect(wrapper.state('selected')).to.be.null;
     });
 
 

--- a/client/src/plugins/element-templates-modal/components/__tests__/ElementTemplatesViewSpec.js
+++ b/client/src/plugins/element-templates-modal/components/__tests__/ElementTemplatesViewSpec.js
@@ -314,6 +314,30 @@ describe('<ElementTemplatesView>', function() {
       expect(wrapper.find(Dropdown)).to.have.length(0);
     });
 
+
+    it('should disable apply button if selected element template does not match filter', async function() {
+
+      // given
+      const {
+        instance,
+        wrapper
+      } = await createElementTemplatesModalView();
+
+      wrapper.update();
+
+      const elementTemplatesListItem = wrapper.find(ElementTemplatesListItem).first();
+
+      elementTemplatesListItem.simulate('click');
+
+      // when
+      instance.onSearchChange('Template 4');
+
+      wrapper.update();
+
+      // then
+      expect(wrapper.find('.button--apply').first().prop('disabled')).to.be.true;
+    });
+
   });
 
 });

--- a/client/src/plugins/element-templates-modal/components/__tests__/ElementTemplatesViewSpec.js
+++ b/client/src/plugins/element-templates-modal/components/__tests__/ElementTemplatesViewSpec.js
@@ -191,6 +191,28 @@ describe('<ElementTemplatesView>', function() {
       expect(wrapper.state('expanded')).to.equal(null);
     });
 
+
+    it('should have sticky header', async function() {
+
+      // given
+      const {
+        instance,
+        wrapper
+      } = await createElementTemplatesModalView();
+
+      wrapper.update();
+
+      // when
+      instance.onScroll({
+        target: {
+          scrollTop: 100
+        }
+      });
+
+      // then
+      expect(wrapper.state('scroll')).to.be.true;
+    });
+
   });
 
 

--- a/client/src/plugins/element-templates-modal/components/__tests__/ElementTemplatesViewSpec.js
+++ b/client/src/plugins/element-templates-modal/components/__tests__/ElementTemplatesViewSpec.js
@@ -98,6 +98,24 @@ describe('<ElementTemplatesView>', function() {
     });
 
 
+    it('should display meta data', async function() {
+
+      // given
+      const elementTemplate = DEFAULT_ELEMENT_TEMPLATES.find(({ name }) => name === 'Template 1');
+
+      const { wrapper } = await createElementTemplatesModalView();
+
+      wrapper.update();
+
+      // then
+      const listItem = wrapper.findWhere(n => n.prop('elementTemplate') === elementTemplate).first();
+
+      const meta = listItem.find('.element-templates-list__item-meta').first();
+
+      expect(meta.text()).to.equal('Walt\'s Catalog | 2001-09-09');
+    });
+
+
     it('should not list element templates (no element templates for element type)', async function() {
 
       // given


### PR DESCRIPTION
Follow-up to https://github.com/camunda/camunda-modeler/pull/1910. Fixes remaining issues.

* fix input styles
* sort element templates alphabetically
* display date correctly
* make header sticky
* disable apply button if selected element template does not match filter
* filter once per filter change
* do not select on description expand

__Definition of Done__

* [x] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [x] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [x] passes Continuous Integration checks
* [x] available as feature branch on GitHub
  * [x] contains the cleaned up commit history
  * [x] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
