### PR TITLE
chore(dmn): adjust the initial position of default dmn diagram

### DIFF
--- a/client/src/app/tabs/dmn/diagram.dmn
+++ b/client/src/app/tabs/dmn/diagram.dmn
@@ -13,7 +13,7 @@
   <dmndi:DMNDI>
     <dmndi:DMNDiagram>
       <dmndi:DMNShape dmnElementRef="Decision_{{ ID:decision }}">
-        <dc:Bounds height="80" width="180" x="100" y="100" />
+        <dc:Bounds height="80" width="180" x="160" y="100" />
       </dmndi:DMNShape>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>


### PR DESCRIPTION
Closes #1912

**Solution explained:**

When we create the Input Expression in the correct position inside the default diagram considering the grid snapping, [align-to-origin module won't adjust its position for the first time](https://github.com/bpmn-io/align-to-origin/blob/34931362346878ea9eec9b248b646c6ba714adf2/lib/align-to-origin.js#L68) therefore polluting the command stack and causing this undo&redo bug. So this is the easiest fix.

* [x] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [x] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [x] passes Continuous Integration checks
* [x] available as feature branch on GitHub
  * [x] contains the cleaned up commit history
  * [x] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [x] a single commit closes the issue via Closes #