### PR TITLE
Do not use default undo/redo for decision tables

### DIFF
--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -364,7 +364,7 @@ export class DmnEditor extends CachedComponent {
     } else if (activeView.type === 'decisionTable') {
       assign(newState, {
         defaultCopyCutPaste: true,
-        defaultUndoRedo: true,
+        defaultUndoRedo: false,
         hasSelection: activeViewer.get('selection').hasSelection(),
         removeSelected: inputActive,
         selectAll: inputActive

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -660,6 +660,27 @@ describe('<DmnEditor>', function() {
           expect(hasMenuEntry(state.editMenu, 'Select Cell Below')).to.be.true;
         });
 
+
+        it('should provide und/redo entries', async function() {
+
+          // given
+          const changedSpy = (state) => {
+
+            const editMenuEntries = getUndoRedoEntries(state);
+
+            // then
+            expect(state.editMenu).to.deep.include(editMenuEntries);
+
+          };
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          // when
+          instance.handleChanged();
+        });
+
       });
 
     });


### PR DESCRIPTION
Closes #1923

Default undo/redo breaks the decision table undo/redo functionalities. This PR fixes it. See the GIF:

![Kapture 2020-09-21 at 14 16 31](https://user-images.githubusercontent.com/15003836/93765591-71ae9100-fc15-11ea-8390-3ddf239051da.gif)

__Definition of Done__

* [x] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [x] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [x] passes Continuous Integration checks
* [x] available as feature branch on GitHub
  * [x] contains the cleaned up commit history
  * [x] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [x] a single commit closes the issue via Closes #issuenr
