### PR TITLE
fix(element-template-modal): properly match element types

### DIFF
--- a/client/src/plugins/element-templates-modal/components/ElementTemplatesModalView.js
+++ b/client/src/plugins/element-templates-modal/components/ElementTemplatesModalView.js
@@ -24,6 +24,8 @@ import {
   isNil
 } from 'min-dash';
 
+import { isAny } from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
+
 const MAX_DESCRIPTION_LENGTH = 200;
 
 class ElementTemplatesView extends PureComponent {
@@ -56,19 +58,23 @@ class ElementTemplatesView extends PureComponent {
 
     let elementTemplates = await config.get('bpmn.elementTemplates');
 
-    const selectedElementType = await triggerAction('getSelectedElementType');
+    const selectedElement = await triggerAction('getSelectedElement');
 
-    elementTemplates = elementTemplates
-      .filter(({ appliesTo }) => {
-        return appliesTo.includes(selectedElementType);
-      })
-      .sort((a, b) => {
-        if (a.name.toLowerCase() < b.name.toLowerCase()) {
-          return -1;
-        } else {
-          return 1;
-        }
-      });
+    if (selectedElement) {
+      elementTemplates = elementTemplates
+        .filter(({ appliesTo }) => {
+          return isAny(selectedElement, appliesTo);
+        })
+        .sort((a, b) => {
+          if (a.name.toLowerCase() < b.name.toLowerCase()) {
+            return -1;
+          } else {
+            return 1;
+          }
+        });
+    } else {
+      elementTemplates = [];
+    }
 
     const selectedElementAppliedElementTemplate = await triggerAction('getSelectedElementAppliedElementTemplate');
 

--- a/client/src/plugins/element-templates-modal/components/__tests__/ElementTemplatesViewSpec.js
+++ b/client/src/plugins/element-templates-modal/components/__tests__/ElementTemplatesViewSpec.js
@@ -17,6 +17,11 @@ import { mount } from 'enzyme';
 import ElementTemplatesView, { ElementTemplatesListItem, ElementTemplatesListItemEmpty } from '../ElementTemplatesModalView';
 import Dropdown from '../Dropdown';
 
+import BpmnModdle from 'bpmn-moddle';
+import camundaModdlePackage from 'camunda-bpmn-moddle/resources/camunda';
+
+const moddle = new BpmnModdle({ camunda: camundaModdlePackage });
+
 
 describe('<ElementTemplatesView>', function() {
 
@@ -63,7 +68,7 @@ describe('<ElementTemplatesView>', function() {
       await instance.getElementTemplates();
 
       // then
-      expect(wrapper.state('elementTemplates')).to.have.length(2);
+      expect(wrapper.state('elementTemplates')).to.have.length(3);
     });
 
 
@@ -81,7 +86,8 @@ describe('<ElementTemplatesView>', function() {
       // then
       expect(wrapper.state('elementTemplates').map(({ name }) => name)).to.eql([
         'Template 1',
-        'Template 2'
+        'Template 2',
+        'Template 4'
       ]);
     });
 
@@ -94,7 +100,7 @@ describe('<ElementTemplatesView>', function() {
       wrapper.update();
 
       // then
-      expect(wrapper.find(ElementTemplatesListItem)).to.have.length(2);
+      expect(wrapper.find(ElementTemplatesListItem)).to.have.length(3);
     });
 
 
@@ -398,13 +404,23 @@ const DEFAULT_ELEMENT_TEMPLATES = [
     },
     name: 'Template 1',
     properties: []
+  },
+  {
+    appliesTo: [
+      'bpmn:Activity'
+    ],
+    id: 'some-local-template',
+    name: 'Template 4',
+    properties: []
   }
 ];
 
 async function createElementTemplatesModalView(props = {}) {
   function triggerAction(action) {
-    if (action === 'getSelectedElementType') {
-      return 'bpmn:ServiceTask';
+    if (action === 'getSelectedElement') {
+      return {
+        businessObject: moddle.create('bpmn:ServiceTask')
+      };
     }
   }
 

--- a/client/src/plugins/element-templates-modal/modeler/EditorActions.js
+++ b/client/src/plugins/element-templates-modal/modeler/EditorActions.js
@@ -27,16 +27,14 @@ export default class EditorActions {
       return true;
     });
 
-    editorActions.register('getSelectedElementType', () => {
+    editorActions.register('getSelectedElement', () => {
       const selectedElements = selection.get();
 
       if (selectedElements.length !== 1) {
         return null;
       }
 
-      const { type } = selectedElements[ 0 ];
-
-      return type;
+      return selectedElements[ 0 ];
     });
 
     editorActions.register('getSelectedElementAppliedElementTemplate', () => {

--- a/client/src/plugins/element-templates-modal/modeler/__tests__/bpmn-io-modelers/EditorActionsSpec.js
+++ b/client/src/plugins/element-templates-modal/modeler/__tests__/bpmn-io-modelers/EditorActionsSpec.js
@@ -93,9 +93,9 @@ describe('EditorActions', function() {
   });
 
 
-  describe('getSelectedElementType', function() {
+  describe('getSelectedElement', function() {
 
-    it('should get selected element type', function() {
+    it('should get selected element', function() {
 
       // given
       const editorActions = modeler.get('editorActions'),
@@ -107,10 +107,11 @@ describe('EditorActions', function() {
       selection.select(serviceTask);
 
       // when
-      const selectedElementType = editorActions.trigger('getSelectedElementType');
+      const selectedElement = editorActions.trigger('getSelectedElement');
 
       // then
-      expect(selectedElementType).to.equal('bpmn:ServiceTask');
+      expect(selectedElement).to.exist;
+      expect(selectedElement.businessObject.$type).to.equal('bpmn:ServiceTask');
     });
 
 
@@ -120,10 +121,10 @@ describe('EditorActions', function() {
       const editorActions = modeler.get('editorActions');
 
       // when
-      const selectedElementType = editorActions.trigger('getSelectedElementType');
+      const selectedElement = editorActions.trigger('getSelectedElement');
 
       // then
-      expect(selectedElementType).to.be.null;
+      expect(selectedElement).not.to.exist;
     });
 
   });


### PR DESCRIPTION
Match element types using `isAny` utility.

<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

Closes #1947

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
