### PR TITLE
Start Process Instance Modal does not have correct label

### DIFF
--- a/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
@@ -182,7 +182,7 @@ export default class StartInstanceTool extends PureComponent {
     if (showStartConfig) {
 
       const uiOptions = {
-        title: !configure ? 'Start Process Instance - Step 2 of 2' : null
+        title: configure ? 'Start Process Instance - Step 2 of 2' : null
       };
 
       // (3.3) Open Modal to enter start configuration


### PR DESCRIPTION
#1777: changed condition for displaying message config should be true

Closes #1777

__Which issue does this PR address?__

The modal message on the dialog should be "Start Process Instance Step 2 of 2"

__Acceptance Criteria__

Modal should show this heading on the second step "Start Process Instance Step 2 of 2".
