### PR TITLE
Backspace element removal

### DIFF
--- a/client/src/app/AppParent.js
+++ b/client/src/app/AppParent.js
@@ -103,9 +103,12 @@ export default class AppParent extends PureComponent {
 
     const { editMenu } = state;
 
-    keyboardBindings.update(editMenu);
+    const updatedMenu = keyboardBindings.update(editMenu);
 
-    this.getBackend().sendMenuUpdate(state);
+    this.getBackend().sendMenuUpdate({
+      editMenu: updatedMenu,
+      ...state
+    });
   }
 
   handleContextMenu = (type, options) => {

--- a/client/src/app/KeyboardBindings.js
+++ b/client/src/app/KeyboardBindings.js
@@ -15,17 +15,24 @@ import {
 } from 'diagram-js/lib/features/keyboard/KeyboardUtil';
 
 import {
+  findIndex,
+  forEach,
   isArray,
   omit
 } from 'min-dash';
 
 
 /**
- * Fixes issue with Electron applications on Linux and Windows. Checks for
- * menu item accelarators that can't be overridden (CommandOrControl+A/C/V) and
+ * Fixes issues with Electron applications on Linux, Windows and Mac. Checks for
+ * menu item accelerators that can't be overridden (CommandOrControl+A/C/V) and
  * manually triggers corresponding editor actions.
  *
  * See https://github.com/electron/electron/issues/7165.
+ *
+ * Also, adds actions to accelerators which are already registered to other ones, since
+ * multiple accelerators are currently not supported.
+ *
+ * See https://github.com/camunda/camunda-modeler/issues/1989.
  */
 export default class KeyboardBindings {
 
@@ -35,19 +42,24 @@ export default class KeyboardBindings {
    * @param {Object} options - Options.
    * @param {Object} [options.menu] - Menu.
    * @param {Function} [options.onAction] - Function to be called on action.
+   * @param {boolean} [options.isMac] - Whether platform is Mac or not.
    */
   constructor(options = {}) {
     const {
       menu,
-      onAction
+      onAction,
+      isMac
     } = options;
 
     this.onAction = onAction;
+
+    this.isMac = isMac,
 
     this.copy = null;
     this.cut = null;
     this.paste = null;
     this.selectAll = null;
+    this.removeSelection = null;
     this.undo = null;
     this.redo = null;
 
@@ -75,7 +87,10 @@ export default class KeyboardBindings {
   _keyDownHandler = (event) => {
     let action = null;
 
-    const { onAction } = this;
+    const {
+      isMac,
+      onAction
+    } = this;
 
     const commandOrCtrl = isCommandOrControl(event);
 
@@ -101,6 +116,14 @@ export default class KeyboardBindings {
       !hasRole(this.selectAll, 'selectAll')
     ) {
       action = getAction(this.selectAll);
+    }
+
+    // remove selection
+    if (isSecondaryRemoveSelection(event, isMac) &&
+      isEnabled(this.removeSelection) &&
+      !hasRole(this.removeSelection, 'delete')
+    ) {
+      action = getAction(this.removeSelection);
     }
 
     // undo
@@ -175,7 +198,29 @@ export default class KeyboardBindings {
     this.undo = findUndo(menu);
     this.redo = findRedo(menu);
 
+    menu = this.updateRemoveSelectionEntry(menu);
+
     this.updateCustomEntries(menu);
+
+    return menu;
+  }
+
+  updateRemoveSelectionEntry(menu) {
+
+    // (1) set primary shortcut depending on platform
+    const primaryAccelerator = this.isMac ? 'Backspace' : 'Delete';
+
+    menu = findAndReplaceAll(
+      menu,
+      ({ accelerator }) => isAccelerator(accelerator, 'Delete'),
+      { accelerator: primaryAccelerator }
+    );
+
+    // (2) register it
+    this.removeSelection =
+      find(menu, ({ accelerator }) => isAccelerator(accelerator, primaryAccelerator));
+
+    return menu;
   }
 
   updateCustomEntries(menu) {
@@ -247,6 +292,14 @@ function isRedo(event) {
     (isKey([ 'y', 'Y' ], event) || (isKey(['z', 'Z'], event) && isShift(event)));
 }
 
+// Secondary delete shortcut
+// Delete (Mac), Backspace (Linux, Windows)
+function isSecondaryRemoveSelection(event, isMac) {
+  const key = isMac ? 'Delete' : 'Backspace';
+
+  return isKey(key, event);
+}
+
 /**
  * Compare accelerators ignoring whitespace and upper/lowercase.
  *
@@ -304,6 +357,48 @@ export function findAll(menu = [], matcher) {
 
     return found;
   }, []);
+}
+
+/**
+ * Find all matching entries and replace properties.
+ *
+ * @param {Array} [menu] - Menu.
+ * @param {Function} matcher - Matcher function.
+ * @param {Object} overrides - Overriding properties.
+ *
+ *
+ * @returns {Array<Object>}
+ */
+export function findAndReplaceAll(menu = [], matcher, overrides = {}) {
+
+  let updatedMenu = menu;
+
+  forEach(menu, entry => {
+    if (isArray(entry)) {
+      const idx = findIndex(menu, entry);
+
+      updatedMenu[idx] = findAndReplaceAll(entry, matcher, overrides);
+    }
+
+    if (matcher(entry)) {
+      const idx = findIndex(menu, entry);
+
+      updatedMenu[idx] = {
+        ...entry,
+        ...overrides
+      };
+    }
+
+    if (entry.submenu) {
+      entry = {
+        ...entry,
+        submenu: findAndReplaceAll(entry.submenu, matcher, overrides)
+      };
+    }
+
+  });
+
+  return updatedMenu;
 }
 
 function findCopy(menu) {

--- a/client/src/app/__tests__/KeyboardBindingsSpec.js
+++ b/client/src/app/__tests__/KeyboardBindingsSpec.js
@@ -12,7 +12,8 @@
 
 import KeyboardBindings, {
   find,
-  findAll
+  findAll,
+  findAndReplaceAll
 } from '../KeyboardBindings';
 
 import {
@@ -248,6 +249,100 @@ describe('KeyboardBindings', function() {
   });
 
 
+  describe('removeSelection', function() {
+
+    it('should NOT update primary <removeSelection>', function() {
+
+      // given
+      keyboardBindings = new KeyboardBindings({
+        onAction: actionSpy,
+        isMac: false
+      });
+
+      const entry = {
+        accelerator: 'Delete',
+        action: 'removeSelection'
+      };
+
+      // when
+      const updated = keyboardBindings.update([ entry ]);
+
+      // then
+      expect(updated).to.deep.include(entry);
+      expect(keyboardBindings.removeSelection).to.eql(entry);
+    });
+
+
+    it('should update primary <removeSelection>', function() {
+
+      // given
+      keyboardBindings = new KeyboardBindings({
+        onAction: actionSpy,
+        isMac: true
+      });
+
+      const entry = {
+        accelerator: 'Delete',
+        action: 'removeSelection'
+      };
+
+      // when
+      const updated = keyboardBindings.update([ entry ]);
+
+      const expectedEntry = {
+        accelerator: 'Backspace',
+        action: 'removeSelection'
+      };
+
+      // then
+      expect(updated).not.to.deep.include(entry);
+      expect(updated).to.deep.include(expectedEntry);
+      expect(keyboardBindings.removeSelection).to.eql(expectedEntry);
+    });
+
+
+    it('secondary <removeSelection>', function() {
+
+      // given
+      event = createKeyEvent('Backspace');
+
+      keyboardBindings.update([{
+        accelerator: 'Delete',
+        action: 'removeSelection'
+      }]);
+
+      // when
+      keyboardBindings._keyDownHandler(event);
+
+      // then
+      expect(actionSpy).to.have.been.calledWith(null, 'removeSelection');
+    });
+
+
+    it('secondary <removeSelection> - mac', function() {
+
+      // given
+      keyboardBindings = new KeyboardBindings({
+        onAction: actionSpy,
+        isMac: true
+      });
+
+      event = createKeyEvent('Delete');
+
+      keyboardBindings.update([{
+        accelerator: 'Delete',
+        action: 'removeSelection'
+      }]);
+
+      // when
+      keyboardBindings._keyDownHandler(event);
+
+      // then
+      expect(actionSpy).to.have.been.calledWith(null, 'removeSelection');
+    });
+  });
+
+
   it('#setOnAction', function() {
 
     // given
@@ -320,6 +415,43 @@ describe('KeyboardBindings', function() {
       expect(entries).to.eql([
         menu[0][0],
         menu[1][0]
+      ]);
+    });
+
+  });
+
+
+  describe('#findAndReplaceAll', function() {
+
+    it('should find all and replace entries', function() {
+
+      // given
+      const menu = [
+        [
+          { accelerator: 'A', custom: true },
+          { accelerator: 'B' }
+        ],
+        [
+          { accelerator: 'C', custom: true }
+        ]
+      ];
+
+      // when
+      const updated = findAndReplaceAll(
+        menu,
+        entry => entry.accelerator === 'A',
+        { custom: false }
+      );
+
+      // then
+      expect(updated).to.deep.eql([
+        [
+          { accelerator: 'A', custom: false },
+          { accelerator: 'B' }
+        ],
+        [
+          { accelerator: 'C', custom: true }
+        ]
       ]);
     });
 


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

> * Make the most standard shortcut (i.e. Backspace on MacOS and DELETE on other systems) the menu shortcut
> * Make the other shortcut available via the browser view (listen to it and react accordingly)

Closes #1989 

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
