### PR TITLE
docs(element-templates): update supported types for <property> binding

### DIFF
--- a/docs/element-templates/README.md
+++ b/docs/element-templates/README.md
@@ -249,7 +249,7 @@ Notice that adherence to the following configuration options is not enforced. No
 
 | **Binding `type`**  | `property`  |
 |---|---|
-| **Valid property `type`'s** | `String`<br />`Hidden`<br />`Dropdown`<br />`Boolean` |
+| **Valid property `type`'s** | all property types are supported |
 | **Binding parameters**  | `name`: the name of the property  |
 | **Mapping result** | `<... [name]=[userInput] ... />`  |
 


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

We should not permit the `Text` type for `property` bindings since
* it's reasonable for properties like `name` or `documentation`
* we have exactly this case [inside our samples](https://github.com/camunda/camunda-modeler/blob/develop/resources/element-templates/samples.json#L190)

When we start validating these combinations (https://github.com/bpmn-io/element-templates-json-schema/issues/9), we should ensure valid combinations are not permitted. 

I double-checked all other cases and this one seems to be the only missing one.
__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
