### PR TITLE
fix(element-templates-modal): get local and global element templates

### DIFF
--- a/client/src/app/plugins/PluginsRoot.js
+++ b/client/src/app/plugins/PluginsRoot.js
@@ -85,6 +85,8 @@ export default class PluginsRoot extends PureComponent {
           <PluginComponent
             triggerAction={ app.triggerAction }
             config={ config }
+            getConfig={ app.getConfig }
+            setConfig={ app.setConfig }
             subscribe={ subscribe }
             log={ this.log }
             displayNotification={ this.displayNotification }

--- a/client/src/app/plugins/__tests__/PluginsRootSpec.js
+++ b/client/src/app/plugins/__tests__/PluginsRootSpec.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+
+import TestRenderer from 'react-test-renderer';
+
+import PluginsRoot from '../PluginsRoot';
+
+
+describe('<PluginParent>', function() {
+
+  it('should render', function() {
+    createPluginsRoot();
+  });
+
+
+  it('should pass props to plugin', function() {
+    createPluginsRoot({
+      plugins: [
+        props => {
+          expect(props.triggerAction).to.exist;
+          expect(props.config).to.exist;
+          expect(props.getConfig).to.exist;
+          expect(props.setConfig).to.exist;
+          expect(props.subscribe).to.exist;
+          expect(props.log).to.exist;
+          expect(props.displayNotification).to.exist;
+          expect(props._getGlobal).to.exist;
+
+          return null;
+        }
+      ]
+    });
+  });
+
+});
+
+// helpers //////////
+
+function createPluginsRoot(props = {}) {
+  const defaultProps = {
+    app: new App(),
+    plugins: []
+  };
+
+  return TestRenderer.create(<PluginsRoot { ...{ ...defaultProps, ...props } } />);
+}
+
+class App {
+  getConfig = () => {}
+
+  setConfig = () => {}
+
+  getGlobal = name => {
+    if (name === 'config') {
+      return new Config();
+    }
+  }
+
+  triggerAction = () => {}
+}
+
+class Config {
+  get = () => {}
+}

--- a/client/src/plugins/element-templates-modal/components/ElementTemplatesModalView.js
+++ b/client/src/plugins/element-templates-modal/components/ElementTemplatesModalView.js
@@ -52,11 +52,11 @@ class ElementTemplatesView extends PureComponent {
 
   getElementTemplates = async () => {
     const {
-      config,
+      getConfig,
       triggerAction
     } = this.props;
 
-    let elementTemplates = await config.get('bpmn.elementTemplates');
+    let elementTemplates = await getConfig('bpmn.elementTemplates');
 
     const selectedElement = await triggerAction('getSelectedElement');
 

--- a/client/src/plugins/element-templates-modal/components/__tests__/ElementTemplatesModalViewSpec.js
+++ b/client/src/plugins/element-templates-modal/components/__tests__/ElementTemplatesModalViewSpec.js
@@ -313,15 +313,13 @@ describe('<ElementTemplatesView>', function() {
 
       // when
       const { wrapper } = await createElementTemplatesModalView({
-        config: new Config({
-          get(key, ...args) {
-            if (key === 'bpmn.elementTemplates') {
-              return Promise.resolve([]);
-            }
-
-            throw Error('Unknown key');
+        getConfig: (key, ...args) => {
+          if (key === 'bpmn.elementTemplates') {
+            return Promise.resolve([]);
           }
-        })
+
+          throw Error('Unknown key');
+        }
       });
 
       // then
@@ -431,8 +429,8 @@ async function createElementTemplatesModalView(props = {}) {
   }
 
   const defaultProps = {
-    config: new Config(),
     displayNotification() {},
+    getConfig: defaultGetConfig,
     onApply() {},
     onClose() {},
     subscribe() {},
@@ -451,18 +449,10 @@ async function createElementTemplatesModalView(props = {}) {
   };
 }
 
-class Config {
-  constructor(overrides = {}) {
-    this.elementTemplates = DEFAULT_ELEMENT_TEMPLATES;
-
-    Object.assign(this, overrides);
+function defaultGetConfig(key, ...args) {
+  if (key === 'bpmn.elementTemplates') {
+    return Promise.resolve(DEFAULT_ELEMENT_TEMPLATES);
   }
 
-  get(key, ...args) {
-    if (key === 'bpmn.elementTemplates') {
-      return Promise.resolve(this.elementTemplates);
-    }
-
-    throw Error('Unknown key');
-  }
+  throw Error('Unknown key');
 }


### PR DESCRIPTION

<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

Closes https://github.com/camunda/camunda-modeler/issues/2012

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
