### PR TITLE
chore: update preset-env target to Chrome@78

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -8,7 +8,7 @@
       "@babel/preset-env", {
         "modules": false,
         "targets": {
-          "chrome": "66"
+          "chrome": "78"
         }
       }
     ],


### PR DESCRIPTION
This is the Chrome version shipped with Electron@7.
