### PR TITLE
Updates Check Menu Action

### DIFF
--- a/app/lib/menu/mac-os/mac-menu-builder.js
+++ b/app/lib/menu/mac-os/mac-menu-builder.js
@@ -29,6 +29,9 @@ class MacMenuBuilder extends MenuBuilder {
         label: 'About ' + this.options.appName,
         role: 'about'
       }, {
+        label: 'Check for Updates',
+        click: () => app.emit('menu:action', 'emit-event', { type: 'updateChecks.execute' })
+      },{
         type: 'separator'
       }, {
         label: 'Services',
@@ -77,6 +80,15 @@ class MacMenuBuilder extends MenuBuilder {
     const fullScreenEntry = submenuTemplate.find(({ label }) => label === 'Fullscreen');
 
     fullScreenEntry.accelerator = 'Ctrl+Cmd+F';
+
+    return submenuTemplate;
+  }
+
+  getHelpSubmenuTemplate() {
+    let submenuTemplate = super.getHelpSubmenuTemplate();
+
+    // remove check updates entry to avoid duplication with app menu
+    submenuTemplate = submenuTemplate.filter(({ label }) => label !== 'Check for Updates');
 
     return submenuTemplate;
   }

--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -546,6 +546,10 @@ class MenuBuilder {
           label: 'Privacy Preferences',
           click: () => app.emit('menu:action', 'emit-event', { type: 'show-privacy-preferences' })
         },
+        {
+          label: 'Check for Updates',
+          click: () => app.emit('menu:action', 'emit-event', { type: 'updateChecks.execute' })
+        },
       ] : [],
       getSeparatorTemplate()
     ];

--- a/client/src/plugins/privacy-preferences/PrivacyPreferences.js
+++ b/client/src/plugins/privacy-preferences/PrivacyPreferences.js
@@ -50,9 +50,14 @@ export default class PrivacyPreferences extends PureComponent {
       });
     }
 
-    this.props.subscribe('show-privacy-preferences', async () => {
+    this.props.subscribe('show-privacy-preferences', async (context) => {
+      const {
+        autoFocusKey
+      } = context;
+
       let preferences = await config.get(CONFIG_KEY);
       this.setState({
+        autoFocusKey,
         showModal: true,
         isInitialPreferences: false,
         preferences: preferences
@@ -79,6 +84,7 @@ export default class PrivacyPreferences extends PureComponent {
 
   render() {
     const {
+      autoFocusKey,
       showModal,
       isInitialPreferences,
       preferences
@@ -87,6 +93,7 @@ export default class PrivacyPreferences extends PureComponent {
     return <React.Fragment>
       { showModal &&
         <PrivacyPreferencesView
+          autoFocusKey={ autoFocusKey }
           onClose={ this.onClose }
           preferences={ preferences }
           onSaveAndClose={ this.onSaveAndClose }

--- a/client/src/plugins/privacy-preferences/PrivacyPreferencesView.js
+++ b/client/src/plugins/privacy-preferences/PrivacyPreferencesView.js
@@ -49,7 +49,16 @@ class PrivacyPreferencesView extends PureComponent {
     return preferences[key];
   }
 
+  hasAutoFocus(key) {
+    const {
+      autoFocusKey
+    } = this.props;
+
+    return key === autoFocusKey;
+  }
+
   renderPreferences() {
+
     return PREFERENCES_LIST.map((item) => (
       <Fragment key={ item.key }>
         <div className="privacyPreferencesCheckbox">
@@ -62,6 +71,7 @@ class PrivacyPreferencesView extends PureComponent {
                 type="checkbox"
                 className="custom-control-input"
                 defaultChecked={ this.isEnabled(item.key) }
+                autoFocus={ this.hasAutoFocus(item.key) }
                 onChange={ (event) => {
                   this.setState({ [item.key]: event.target.checked });
                 } } />

--- a/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesSpec.js
+++ b/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesSpec.js
@@ -33,13 +33,15 @@ describe('<PrivacyPreferences>', () => {
   it('should show modal on start if config non existent', async () => {
 
     // when
-    const wrapper = await shallow(<PrivacyPreferences config={ {
-      get() {
-        return new Promise((resolve, reject) => {
-          resolve(null);
-        });
+    const wrapper = await createPrivacyPreferences({
+      config: {
+        get() {
+          return new Promise((resolve, reject) => {
+            resolve(null);
+          });
+        }
       }
-    } } />);
+    });
 
     // then
     expect(wrapper.state('showModal')).to.be.true;
@@ -49,13 +51,15 @@ describe('<PrivacyPreferences>', () => {
   it('should not show modal on start if config existent', async () => {
 
     // when
-    const wrapper = await shallow(<PrivacyPreferences config={ {
-      get() {
-        return new Promise((resolve, reject) => {
-          resolve({});
-        });
+    const wrapper = await createPrivacyPreferences({
+      config: {
+        get() {
+          return new Promise((resolve, reject) => {
+            resolve({});
+          });
+        }
       }
-    } } />);
+    });
 
     // then
     expect(wrapper.state('showModal')).to.be.false;
@@ -65,13 +69,15 @@ describe('<PrivacyPreferences>', () => {
   it('should set isInitialPreferences on start if config non existent', async () => {
 
     // when
-    const wrapper = await shallow(<PrivacyPreferences config={ {
-      get() {
-        return new Promise((resolve, reject) => {
-          resolve(null);
-        });
+    const wrapper = await createPrivacyPreferences({
+      config: {
+        get() {
+          return new Promise((resolve, reject) => {
+            resolve(null);
+          });
+        }
       }
-    } } />);
+    });
 
     // then
     expect(wrapper.state('isInitialPreferences')).to.be.true;
@@ -103,6 +109,7 @@ describe('<PrivacyPreferences>', () => {
 
     // given
     const setSpy = spy();
+
     const wrapper = await createPrivacyPreferences({
       config: {
         get() {
@@ -121,6 +128,7 @@ describe('<PrivacyPreferences>', () => {
 
     // when
     await wrapper.update();
+
     wrapper.find('.btn-primary').first().simulate('click');
 
     // then
@@ -132,7 +140,9 @@ describe('<PrivacyPreferences>', () => {
 
     // given
     let subscribeFunc;
+
     const setSpy = spy();
+
     const config = {
       get() {
         return new Promise((resolve, reject) => {
@@ -143,17 +153,20 @@ describe('<PrivacyPreferences>', () => {
         setSpy();
       }
     };
+
     const subscribe = (type, func) => {
       if (type === 'show-privacy-preferences') {
         subscribeFunc = func;
       }
     };
+
     const wrapper = await createPrivacyPreferences({
       config, subscribe
     }, mount);
 
     // when
-    await subscribeFunc();
+    await subscribeFunc({});
+
     await wrapper.update();
 
     // then
@@ -165,7 +178,9 @@ describe('<PrivacyPreferences>', () => {
 
     // given
     let subscribeFunc;
+
     const setSpy = spy();
+
     const wrapper = await createPrivacyPreferences({
       config: {
         get() {
@@ -181,24 +196,35 @@ describe('<PrivacyPreferences>', () => {
     }, mount);
 
     // when
-    await subscribeFunc();
+    await subscribeFunc({});
     await wrapper.update();
     wrapper.find('.btn-secondary').simulate('click');
 
     // then
     expect(setSpy).to.not.have.been.called;
   });
+
 });
 
 
+// helper ///////////////////
 
-// helper
-function createPrivacyPreferences({
-  config = {}, triggerAction = noop, subscribe = noop
-} = {}, mount = shallow) {
-  return mount(<PrivacyPreferences
-    config={ config } triggerAction={ triggerAction } subscribe={ subscribe }
-  />);
+function createPrivacyPreferences(props = {}, mount = shallow) {
+  const {
+    autoFocusKey,
+    config,
+    triggerAction,
+    subscribe
+  } = props;
+
+  return mount(
+    <PrivacyPreferences
+      autoFocusKey={ autoFocusKey }
+      config={ config }
+      triggerAction={ triggerAction || noop }
+      subscribe={ subscribe || noop }
+    />
+  );
 }
 
 function noop() {}

--- a/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesViewSpec.js
+++ b/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesViewSpec.js
@@ -135,10 +135,12 @@ describe('<PrivacyPreferencesView>', function() {
 
     it('should use default values if preferences empty', function() {
 
+      // when
       const wrapper = mount(<PrivacyPreferencesView />);
 
       const checkboxes = wrapper.find(PRIVACY_PREFERENCES_SELECTOR).find('input');
 
+      // then
       checkboxes.forEach(function(checkbox, index) {
         expect(checkbox.props().defaultChecked).to.be.eql(false);
       });
@@ -147,6 +149,7 @@ describe('<PrivacyPreferencesView>', function() {
 
     it('should load privacy preferences', function() {
 
+      // given
       const values = [false, true, false];
 
       const privacyPreferences = {
@@ -155,15 +158,45 @@ describe('<PrivacyPreferencesView>', function() {
         ENABLE_UPDATE_CHECKS: values[2]
       };
 
+      // when
       const wrapper = mount(
         <PrivacyPreferencesView preferences={ privacyPreferences } />
       );
 
       const checkboxes = wrapper.find(PRIVACY_PREFERENCES_SELECTOR).find('input');
 
+      // then
       checkboxes.forEach(function(checkbox, index) {
         expect(checkbox.props().defaultChecked).to.be.eql(values[index]);
       });
+    });
+
+    it('should not set autofocus', async () => {
+
+      // given
+      const preferenceKey = PREFERENCES_LIST[2].key;
+
+      // when
+      const wrapper = mount(<PrivacyPreferencesView />);
+
+      // then
+      expect(wrapper.find(`#${preferenceKey}`).is(':focus')).to.be.false;
+    });
+
+
+
+    it('should set autofocus if specified', async () => {
+
+      // given
+      const preferenceKey = PREFERENCES_LIST[2].key;
+
+      // when
+      const wrapper = mount(
+        <PrivacyPreferencesView autoFocusKey={ preferenceKey } />
+      );
+
+      // then
+      expect(wrapper.find(`#${preferenceKey}`).is(':focus')).to.be.true;
     });
 
 

--- a/client/src/plugins/update-checks/NewVersionInfoView.js
+++ b/client/src/plugins/update-checks/NewVersionInfoView.js
@@ -14,6 +14,8 @@ import {
   Modal
 } from '../../app/primitives';
 
+import PrivacyPreferencesLink from './PrivacyPreferencesLink';
+
 import {
   MODAL_TITLE,
   BUTTON_NEGATIVE,
@@ -49,7 +51,9 @@ class NewVersionInfoView extends PureComponent {
       latestVersionInfo,
       currentVersion,
       onClose,
-      onGoToDownloadPage
+      onGoToDownloadPage,
+      onOpenPrivacyPreferences,
+      updateChecksEnabled
     } = this.props;
 
     const {
@@ -76,6 +80,10 @@ class NewVersionInfoView extends PureComponent {
               { this.renderHtmlSnippets(releases) }
             </div>
           </div>
+          <PrivacyPreferencesLink
+            onOpenPrivacyPreferences={ onOpenPrivacyPreferences }
+            updateChecksEnabled={ updateChecksEnabled }
+          />
         </Modal.Body>
 
         <Modal.Footer>

--- a/client/src/plugins/update-checks/PrivacyPreferencesLink.js
+++ b/client/src/plugins/update-checks/PrivacyPreferencesLink.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React, { PureComponent } from 'react';
+
+export default class PrivacyPreferencesLink extends PureComponent {
+
+  render() {
+    const {
+      updateChecksEnabled,
+      onOpenPrivacyPreferences
+    } = this.props;
+
+    return (
+      !updateChecksEnabled && (
+        <div>
+          <p>
+            Periodic checks for new updates are currently <b>disabled</b>.
+          </p>
+          <p>
+            <a href="#" onClick={ onOpenPrivacyPreferences }>
+              Open the Privacy Preferences
+            </a>
+            {' '} to enable them.
+          </p>
+        </div>
+      )
+    );
+  }
+}

--- a/client/src/plugins/update-checks/UpdateChecks.js
+++ b/client/src/plugins/update-checks/UpdateChecks.js
@@ -152,6 +152,9 @@ export default class UpdateChecks extends PureComponent {
 
     triggerAction('emit-event', {
       type: 'show-privacy-preferences',
+      payload: {
+        autoFocusKey: 'ENABLE_UPDATE_CHECKS'
+      }
     });
   }
 

--- a/client/src/plugins/update-checks/__tests__/PrivacyPreferencesLinkSpec.js
+++ b/client/src/plugins/update-checks/__tests__/PrivacyPreferencesLinkSpec.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/* global sinon */
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import PrivacyPreferencesLink from '../PrivacyPreferencesLink';
+
+
+describe('<PrivacyPreferencesLink>', function() {
+
+  it('should render', function() {
+    shallow(<PrivacyPreferencesLink />);
+  });
+
+
+  it('should display if updates check are disabled', function() {
+
+    // when
+    const wrapper = createPrivacyPreferencesLink({
+      updateChecksEnabled: false
+    });
+
+    // then
+    expect(wrapper.exists('a')).to.be.true;
+  });
+
+
+  it('should NOT display if updates check are enabled', function() {
+
+    // when
+    const wrapper = createPrivacyPreferencesLink({
+      updateChecksEnabled: true
+    });
+
+    // then
+    expect(wrapper.exists('a')).to.be.false;
+  });
+
+
+  it('should open privacy preferences', function() {
+
+    // given
+    const openSpy = sinon.spy();
+
+    const wrapper = createPrivacyPreferencesLink({
+      updateChecksEnabled: false,
+      onOpenPrivacyPreferences: openSpy
+    });
+
+    // when
+    wrapper.find('a').simulate('click');
+
+    // then
+    expect(openSpy).to.have.been.calledOnce;
+  });
+
+});
+
+
+// helper
+
+function createPrivacyPreferencesLink(props = {}) {
+  const {
+    onOpenPrivacyPreferences,
+    updateChecksEnabled
+  } = props;
+
+  const wrapper = shallow(
+    <PrivacyPreferencesLink
+      updateChecksEnabled={ updateChecksEnabled }
+      onOpenPrivacyPreferences={ onOpenPrivacyPreferences || noop }
+    />
+  );
+
+  return wrapper;
+}
+
+function noop() {}


### PR DESCRIPTION
Accessible via

```sh
npx @bpmn-io/sr camunda/camunda-modeler#2010-updates-check-menu-item
```

_______

__Which issue does this PR address?__

* Add "Check for Updates" menu item under
  * "Help" (Linux/ Windows)
  * App Menu (macOS)
* Make it possible to trigger update checks manually (unscheduled)
* Make it possible to display a notification when no updates available
* Reference Privacy Preferences Modal if update checks are disabled

Closes #2010 

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
