### PR TITLE
fix(start-instance-tool): re-throw errors when unknown

### DIFF
--- a/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
@@ -16,6 +16,8 @@ import CamundaAPI from '../shared/CamundaAPI';
 
 import StartInstanceConfigModal from './StartInstanceConfigModal';
 
+import { DeploymentError, StartInstanceError } from '../shared/CamundaAPI';
+
 import css from './StartInstanceTool.less';
 
 import { Fill } from '../../../app/slot-fill';
@@ -208,6 +210,10 @@ export default class StartInstanceTool extends PureComponent {
 
       await this.handleDeploymentSuccess(tab, deployment);
     } catch (error) {
+      if (!(error instanceof DeploymentError)) {
+        throw error;
+      }
+
       return await this.handleDeploymentError(tab, error);
     }
 
@@ -227,6 +233,10 @@ export default class StartInstanceTool extends PureComponent {
 
       await this.handleStartSuccess(processInstance, endpoint);
     } catch (error) {
+      if (!(error instanceof StartInstanceError)) {
+        throw error;
+      }
+
       await this.handleStartError(tab, error);
     }
   }


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

Closes #

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
