### PR TITLE
fix(telemetry): use 'generated' keyword for formkey usertask tracking

### DIFF
--- a/client/src/plugins/usage-statistics/event-handlers/__tests__/DeploymentEventHandlerSpec.js
+++ b/client/src/plugins/usage-statistics/event-handlers/__tests__/DeploymentEventHandlerSpec.js
@@ -266,7 +266,7 @@ describe('<DeploymentEventHandler>', () => {
             count: 6,
             embedded: 3,
             external: 1,
-            generic: 1,
+            generated: 1,
             other: 1
           }
         });
@@ -297,7 +297,7 @@ describe('<DeploymentEventHandler>', () => {
             count: 6,
             embedded: 3,
             external: 1,
-            generic: 1,
+            generated: 1,
             other: 1
           }
         });
@@ -328,7 +328,7 @@ describe('<DeploymentEventHandler>', () => {
             count: 4,
             embedded: 1,
             external: 2,
-            generic: 0,
+            generated: 0,
             other: 1
           }
         });
@@ -359,7 +359,7 @@ describe('<DeploymentEventHandler>', () => {
             count: 0,
             embedded: 0,
             external: 0,
-            generic: 0,
+            generated: 0,
             other: 0
           }
         });

--- a/client/src/plugins/usage-statistics/event-handlers/__tests__/DiagramOpenEventHandlerSpec.js
+++ b/client/src/plugins/usage-statistics/event-handlers/__tests__/DiagramOpenEventHandlerSpec.js
@@ -319,7 +319,7 @@ describe('<DiagramOpenEventHandler>', () => {
             count: 6,
             embedded: 3,
             external: 1,
-            generic: 1,
+            generated: 1,
             other: 1
           }
         });
@@ -358,7 +358,7 @@ describe('<DiagramOpenEventHandler>', () => {
             count: 6,
             embedded: 3,
             external: 1,
-            generic: 1,
+            generated: 1,
             other: 1
           }
         });
@@ -397,7 +397,7 @@ describe('<DiagramOpenEventHandler>', () => {
             count: 4,
             embedded: 1,
             external: 2,
-            generic: 0,
+            generated: 0,
             other: 1
           }
         });
@@ -436,7 +436,7 @@ describe('<DiagramOpenEventHandler>', () => {
             count: 0,
             embedded: 0,
             external: 0,
-            generic: 0,
+            generated: 0,
             other: 0
           }
         });

--- a/client/src/util/metrics/userTasks.js
+++ b/client/src/util/metrics/userTasks.js
@@ -41,7 +41,7 @@ function parseUserTaskForms(userTasks) {
     count: userTasks.filter((userTask) => hasFormKey(userTask) || hasFormField(userTask)).length,
     embedded: userTasks.filter((userTask) => hasFormKey(userTask) && isEmbedded(userTask.formKey)).length,
     external: userTasks.filter((userTask) => hasFormKey(userTask) && isExternal(userTask.formKey)).length,
-    generic: userTasks.filter((userTask) => !hasFormKey(userTask) && hasFormField(userTask)).length,
+    generated: userTasks.filter((userTask) => !hasFormKey(userTask) && hasFormField(userTask)).length,
     other: userTasks.filter((userTask) => hasFormKey(userTask) && isOther(userTask.formKey)).length,
   };
 }


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

Bug was directly reported by @volkergersabeck based on data from the nightly modeler build
Closes #2062 

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
