### PR TITLE
feat(camunda-plugin): display Deployment Tool on Camunda tabs only

### DIFF
--- a/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
@@ -431,7 +431,7 @@ export default class DeploymentTool extends PureComponent {
     } = this.state;
 
     return <React.Fragment>
-      { activeTab && activeTab.type !== 'empty' && <Fill slot="toolbar" group="8_deploy">
+      { isCamundaTab(activeTab) && <Fill slot="toolbar" group="8_deploy">
         <Button
           onClick={ this.deploy }
           title="Deploy current diagram"
@@ -484,4 +484,12 @@ function addOrUpdateById(collection, element) {
     ...collection,
     element
   ];
+}
+
+function isCamundaTab(tab) {
+  return tab && [
+    'bpmn',
+    'cmmn',
+    'dmn'
+  ].includes(tab.type);
 }

--- a/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentToolSpec.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentToolSpec.js
@@ -39,13 +39,42 @@ describe('<DeploymentTool>', () => {
   });
 
 
-  it('should not display the button if there is no active tab', () => {
+  it('should display the button if there is an active tab', () => {
 
     // given
-    const { wrapper } = createDeploymentTool({ activeTab: { type: 'empty', id: '__empty' } });
+    const activeTab = createTab({ type: 'bpmn' });
+
+    // when
+    const { wrapper } = createDeploymentTool({ activeTab });
 
     // then
-    expect(wrapper).to.be.empty;
+    expect(wrapper.find('Button')).to.have.lengthOf(1);
+  });
+
+
+  it('should NOT display the button if there is no active tab', () => {
+
+    // given
+    const activeTab = createTab({ type: 'empty', id: '__empty' });
+
+    // when
+    const { wrapper } = createDeploymentTool({ activeTab });
+
+    // then
+    expect(wrapper.find('Button')).to.have.lengthOf(0);
+  });
+
+
+  it('should NOT display the button if there is no camunda tab', () => {
+
+    // given
+    const activeTab = createTab();
+
+    // when
+    const { wrapper } = createDeploymentTool({ activeTab });
+
+    // then
+    expect(wrapper.find('Button')).to.have.lengthOf(0);
   });
 
 
@@ -605,7 +634,7 @@ function createDeploymentTool({
   ...props
 } = {}, render = shallow) {
   const subscribe = (event, callback) => {
-    event === 'app.activeTabChanged' && callback(activeTab);
+    event === 'app.activeTabChanged' && callback({ activeTab });
   };
 
   const triggerAction = (event, context) => {


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

As preparation for the Unified Modeler, we should display the Deployment Tool only on Camunda tabs.

Related to #2029 

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
