### PR TITLE
fix(usage-statistics): ensure editor id

### DIFF
--- a/client/src/plugins/usage-statistics/UsageStatistics.js
+++ b/client/src/plugins/usage-statistics/UsageStatistics.js
@@ -85,7 +85,18 @@ export default class UsageStatistics extends PureComponent {
     this._eventHandlers.forEach((eventHandler) => eventHandler.disable());
   }
 
+  async setEditorId() {
+    this._editorID = await this.props.config.get(EDITOR_ID_CONFIG_KEY);
+
+    if (!this._editorID) {
+      throw new Error('missing editor id');
+    }
+  }
+
   async componentDidMount() {
+
+    // make sure we also set the editor although the plugin is not enabled
+    await this.setEditorId();
 
     if (!this.ET_ENDPOINT) {
       return log('Not enabled: ET Endpoint not configured.');
@@ -105,8 +116,6 @@ export default class UsageStatistics extends PureComponent {
     if (!isUsageStatisticsEnabled) {
       return log('Not enabled: Usage statistics are turned off via Privacy Preferences.');
     }
-
-    this._editorID = await this.props.config.get(EDITOR_ID_CONFIG_KEY);
 
     this.enable();
   }


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure you provide the relevant context.

-->

__Which issue does this PR address?__

This makes sure we do not send events with missing installation to E.T., to not rubbish our usage statistics data.

It also fixes the root cause of the missing installation id:
* start plugin with disabled configuration
* enable on runtime
* editor id is missing due to missing early configuration

Closes #1965
Closes #2076

__Acceptance Criteria__

<!--

Link the acceptance criteria here if they are defined.

-->

* [ ] Corresponds to the concept <!-- link document here -->
* [ ] Corresponds to the design <!-- link document here -->

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
