### PR TITLE
chore(zeebe-plugin): update deployment target labels

### DIFF
--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginConstants.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginConstants.js
@@ -15,10 +15,10 @@ export const DEPLOY = 'Deploy';
 export const START = 'Start';
 
 export const DEPLOYMENT_NAME = 'Deployment Name';
-export const SELF_HOSTED_TEXT = 'Self-hosted';
+export const SELF_HOSTED_TEXT = 'Camunda Cloud Self-Managed';
 export const OAUTH_TEXT = 'OAuth';
 export const NONE = 'None';
-export const CAMUNDA_CLOUD_TEXT = 'Camunda Cloud';
+export const CAMUNDA_CLOUD_TEXT = 'Camunda Cloud SaaS';
 export const CONTACT_POINT = 'Contact Point';
 export const DEPLOYMENT_NAME_HINT = 'Default value is the file name.';
 export const CONTACT_POINT_HINT = 'Default value is 0.0.0.0:26500';

--- a/client/src/styles/_forms.less
+++ b/client/src/styles/_forms.less
@@ -62,7 +62,7 @@
 
   .form-check-inline {
     display: grid;
-    grid-auto-columns: 0.3fr;
+    grid-auto-columns: 0.4fr;
     grid-auto-flow: column;
   }
 


### PR DESCRIPTION
Closes #2141

![image](https://user-images.githubusercontent.com/9433996/110799969-049ebe80-827c-11eb-8cee-683a02d3a5c3.png)

Note: I had to adjust the column space to properly align the longer labels. This also touches the other part where we use those radio buttons (Camunda Platform Auth Configuration)

![image](https://user-images.githubusercontent.com/9433996/110799722-c1dce680-827b-11eb-8116-6d450d6faad0.png)

I think that's okayish, I wouldn't add extra effort to make this dynamic.
