### PR TITLE
chore(cloud-bpmn): add flag to enable zeebe user tasks

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2691,9 +2691,9 @@
       }
     },
     "camunda-bpmn-js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-0.3.0.tgz",
-      "integrity": "sha512-acFuJUbXtZPB4iXbZkKr8WArpKAX7GF60V8mSC4nKzTR9GQ3LmJgQuGX8JMML5WsGJy5AQbnJwnEcjDWgWfsGQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-0.4.0.tgz",
+      "integrity": "sha512-3zBK5obt58pH3Hp1Z7cML1cU/PtVCxtu7HjKmwJXSfNX8wpwBjfd8hDRGsyRz7vVGQeQCWFpxKKXElOAXjw8Lw==",
       "requires": {
         "@bpmn-io/align-to-origin": "^0.6.0",
         "bpmn-js": "^8.2.1",

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
     "@sentry/browser": "^5.15.5",
     "bpmn-js": "^8.2.1",
     "bpmn-js-properties-panel": "^0.41.0",
-    "camunda-bpmn-js": "^0.3.0",
+    "camunda-bpmn-js": "^0.4.0",
     "camunda-bpmn-moddle": "^5.0.0",
     "camunda-cmmn-moddle": "^1.0.0",
     "camunda-dmn-moddle": "^1.1.0",

--- a/client/src/app/tabs/cloud-bpmn/modeler/BpmnModeler.js
+++ b/client/src/app/tabs/cloud-bpmn/modeler/BpmnModeler.js
@@ -17,7 +17,10 @@ import globalClipboardModule from './features/global-clipboard';
 import handToolOnSpaceModule from '../../bpmn/modeler/features/hand-tool-on-space';
 import propertiesPanelKeyboardBindingsModule from '../../bpmn/modeler/features/properties-panel-keyboard-bindings';
 
-import Flags, { DISABLE_ADJUST_ORIGIN } from '../../../../util/Flags';
+import Flags, {
+  DISABLE_ADJUST_ORIGIN,
+  ENABLE_ZEEBE_USER_TASKS
+} from '../../../../util/Flags';
 
 import 'camunda-bpmn-js/dist/assets/camunda-cloud-modeler.css';
 
@@ -34,7 +37,8 @@ export default class CloudBpmnModeler extends BpmnModeler {
     super({
       ...otherOptions,
       moddleExtensions: moddleExtensions || {},
-      disableAdjustOrigin: Flags.get(DISABLE_ADJUST_ORIGIN)
+      disableAdjustOrigin: Flags.get(DISABLE_ADJUST_ORIGIN),
+      enableZeebeUserTasks: Flags.get(ENABLE_ZEEBE_USER_TASKS),
     });
   }
 }

--- a/client/src/util/Flags.js
+++ b/client/src/util/Flags.js
@@ -41,3 +41,4 @@ export const UPDATE_SERVER_URL = 'update-server-url';
 export const FORCE_UPDATE_CHECKS = 'force-update-checks';
 export const SENTRY_DSN = 'sentry-dsn';
 export const ET_ENDPOINT = 'et-endpoint';
+export const ENABLE_ZEEBE_USER_TASKS = 'enable-zeebe-user-tasks';

--- a/docs/flags/README.md
+++ b/docs/flags/README.md
@@ -35,6 +35,7 @@ Flags passed as command line arguments take precedence over those configured via
 | "disable-dmn" | false |
 | "single-instance" | false |
 | "user-data-dir" | [Electron default](../search-paths) |
+| "enable-zeebe-user-tasks" | false |
 
 
 ## Examples


### PR DESCRIPTION
* Disables Zeebe User Tasks support per default
* Adds a flag `enable-zeebe-user-tasks` so that we can enable it until it got properly released in May.


```json
// flags.json
{
  "enable-zeebe-user-tasks": true
}
```


Closes #2140
