### PR TITLE
fix(tabs-provider): change order of bpmn providers

### DIFF
--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -89,51 +89,6 @@ export default class TabsProvider {
           return null;
         }
       },
-      bpmn: {
-        name: 'BPMN',
-        encoding: ENCODING_UTF8,
-        exports: {
-          png: EXPORT_PNG,
-          jpeg: EXPORT_JPEG,
-          svg: EXPORT_SVG
-        },
-        extensions: [ 'bpmn', 'xml' ],
-        canOpen(file) {
-          return parseDiagramType(file.contents) === 'bpmn';
-        },
-        getComponent(options) {
-          return import('./tabs/bpmn');
-        },
-        getInitialContents(options) {
-          return bpmnDiagram;
-        },
-        getInitialFilename(suffix) {
-          return `diagram_${suffix}.bpmn`;
-        },
-        getHelpMenu() {
-          return [{
-            label: 'BPMN 2.0 Tutorial',
-            action: 'https://camunda.org/bpmn/tutorial/'
-          },
-          {
-            label: 'BPMN Modeling Reference',
-            action: 'https://camunda.org/bpmn/reference/'
-          }];
-        },
-        getNewFileMenu() {
-          return [{
-            label: 'BPMN Diagram (Camunda Engine)',
-            accelerator: 'CommandOrControl+T',
-            action: 'create-bpmn-diagram'
-          }];
-        },
-        getNewFileButton() {
-          return {
-            label: 'Create new BPMN Diagram (Camunda Engine)',
-            action: 'create-bpmn-diagram'
-          };
-        }
-      },
       'cloud-bpmn': {
         name: null,
         encoding: ENCODING_UTF8,
@@ -190,6 +145,51 @@ export default class TabsProvider {
           return {
             label: 'Create new BPMN Diagram (Zeebe Engine)',
             action: 'create-cloud-bpmn-diagram'
+          };
+        }
+      },
+      bpmn: {
+        name: 'BPMN',
+        encoding: ENCODING_UTF8,
+        exports: {
+          png: EXPORT_PNG,
+          jpeg: EXPORT_JPEG,
+          svg: EXPORT_SVG
+        },
+        extensions: [ 'bpmn', 'xml' ],
+        canOpen(file) {
+          return parseDiagramType(file.contents) === 'bpmn';
+        },
+        getComponent(options) {
+          return import('./tabs/bpmn');
+        },
+        getInitialContents(options) {
+          return bpmnDiagram;
+        },
+        getInitialFilename(suffix) {
+          return `diagram_${suffix}.bpmn`;
+        },
+        getHelpMenu() {
+          return [{
+            label: 'BPMN 2.0 Tutorial',
+            action: 'https://camunda.org/bpmn/tutorial/'
+          },
+          {
+            label: 'BPMN Modeling Reference',
+            action: 'https://camunda.org/bpmn/reference/'
+          }];
+        },
+        getNewFileMenu() {
+          return [{
+            label: 'BPMN Diagram (Camunda Engine)',
+            accelerator: 'CommandOrControl+T',
+            action: 'create-bpmn-diagram'
+          }];
+        },
+        getNewFileButton() {
+          return {
+            label: 'Create new BPMN Diagram (Camunda Engine)',
+            action: 'create-bpmn-diagram'
           };
         }
       },

--- a/client/src/app/__tests__/TabsProviderSpec.cloud.bpmn
+++ b/client/src/app/__tests__/TabsProviderSpec.cloud.bpmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_08w3e1r" targetNamespace="http://bpmn.io/schema/bpmn" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+  <bpmn:process id="Process_190qxut" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_190qxut">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/client/src/app/__tests__/TabsProviderSpec.js
+++ b/client/src/app/__tests__/TabsProviderSpec.js
@@ -235,6 +235,27 @@ describe('TabsProvider', function() {
     });
 
 
+    it('should take cloud-bpmn first for known bpmn file', function() {
+
+      // given
+      const tabsProvider = new TabsProvider();
+
+      const file = {
+        name: 'foo.xml',
+        path: '/a/foo.xml',
+        contents: require('./TabsProviderSpec.cloud.bpmn')
+      };
+
+      // when
+      const tab = tabsProvider.createTabForFile(file);
+
+      // then
+      expect(tab.name).to.eql(file.name);
+      expect(tab.title).to.eql(file.path);
+      expect(tab.type).to.eql('cloud-bpmn');
+    });
+
+
     it('should not create for unknown file', function() {
 
       // given


### PR DESCRIPTION
Take `cloud-bpmn` first, `bpmn` as fallback

Closes #2130

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
