### PR TITLE
fix(remote): remove `getAppPreload` once loaded

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -10,15 +10,6 @@
 
 import './styles/style.less';
 
-import React from 'react';
-import ReactDOM from 'react-dom';
-
-import {
-  AppParent,
-  KeyboardBindings,
-  TabsProvider
-} from './app';
-
 import {
   backend,
   config,
@@ -30,6 +21,15 @@ import {
   metadata,
   workspace
 } from './remote';
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import {
+  AppParent,
+  KeyboardBindings,
+  TabsProvider
+} from './app';
 
 import Metadata from './util/Metadata';
 import Flags from './util/Flags';

--- a/client/src/remote/__tests__/RemoteSpec.js
+++ b/client/src/remote/__tests__/RemoteSpec.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+describe('remote', function() {
+
+  it('should remove `window.getAppPreload` once loaded', async () => {
+
+    // given
+    window.getAppPreload = () => ({});
+
+    // when
+    await import('..');
+
+    // then
+    expect(window.getAppPreload).not.to.exist;
+  });
+});

--- a/client/src/remote/index.js
+++ b/client/src/remote/index.js
@@ -24,6 +24,10 @@ const {
   ipcRenderer
 } = window.getAppPreload();
 
+// remove the preloaded handles from the global scope
+// related to https://github.com/camunda/camunda-modeler/issues/2143
+delete window.getAppPreload;
+
 export const backend = new Backend(ipcRenderer, platform);
 
 export const fileSystem = new FileSystem(backend);


### PR DESCRIPTION
This prevents using `window.getAppPreload` by other code than
the application. Thus, only the application has access to
the IPCRenderer and can decide which APIs it provides.

Closes #2143.

Related to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28154

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
