### PR TITLE
feat: disable zeebe without feature toggle

### DIFF
--- a/client/src/app/EmptyTab.js
+++ b/client/src/app/EmptyTab.js
@@ -16,7 +16,7 @@ import {
   Tab
 } from './primitives';
 
-import Flags, { DISABLE_DMN, DISABLE_FORM } from '../util/Flags';
+import Flags, { DISABLE_DMN, DISABLE_FORM, DISABLE_ZEEBE } from '../util/Flags';
 
 
 export default class EmptyTab extends PureComponent {
@@ -38,7 +38,13 @@ export default class EmptyTab extends PureComponent {
         <div className="create-buttons">
           <p>Create a new file:</p>
           <button className="btn btn-secondary" onClick={ () => onAction('create-bpmn-diagram') }>BPMN diagram (Camunda Engine)</button>
-          <button className="btn btn-secondary" onClick={ () => onAction('create-cloud-bpmn-diagram') }>BPMN diagram (Zeebe Engine)</button>
+
+          {
+            !Flags.get(DISABLE_ZEEBE, true) && (
+              <button className="btn btn-secondary" onClick={ () => onAction('create-cloud-bpmn-diagram') }>BPMN diagram (Zeebe Engine)</button>
+            )
+          }
+
           {
             !Flags.get(DISABLE_DMN) && (
               <button className="btn btn-secondary" onClick={ () => onAction('create-dmn-diagram') }>DMN diagram (Camunda DMN Engine)</button>

--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -329,6 +329,12 @@ export default class TabsProvider {
       form: [ this.providers.form ]
     };
 
+    if (Flags.get('disable-zeebe', true)) {
+      this.providersByFileType.bpmn.filter(p => p !== this.providers['cloud-bpmn']);
+
+      delete this.providers['cloud-bpmn'];
+    }
+
     if (Flags.get('disable-cmmn', true)) {
       delete this.providers.cmmn;
       delete this.providersByFileType.cmmn;

--- a/client/src/app/__tests__/EmptyTabSpec.js
+++ b/client/src/app/__tests__/EmptyTabSpec.js
@@ -16,7 +16,7 @@ import {
 
 import EmptyTab from '../EmptyTab';
 
-import Flags, { DISABLE_DMN, DISABLE_FORM } from '../../util/Flags';
+import Flags, { DISABLE_DMN, DISABLE_FORM, DISABLE_ZEEBE } from '../../util/Flags';
 
 /* global sinon */
 
@@ -38,10 +38,9 @@ describe('<EmptyTab>', function() {
       buttons.forEach(wrapper => wrapper.simulate('click'));
 
       // then
-      expect(onAction).to.have.callCount(4);
+      expect(onAction).to.have.callCount(3);
       expect(onAction.args).to.eql([
         [ 'create-bpmn-diagram' ],
-        [ 'create-cloud-bpmn-diagram' ],
         [ 'create-dmn-diagram' ],
         [ 'create-form' ]
       ]);
@@ -85,7 +84,6 @@ describe('<EmptyTab>', function() {
   });
 
 
-
   describe('disabling form', function() {
 
     afterEach(sinon.restore);
@@ -120,6 +118,47 @@ describe('<EmptyTab>', function() {
       expect(
         tree.findWhere(
           wrapper => wrapper.text().startsWith('Form')
+        ).first().exists()
+      ).to.be.true;
+    });
+
+  });
+
+
+  describe('enable zeebe', function() {
+
+    afterEach(sinon.restore);
+
+    it('should NOT display zeebe without flag', function() {
+
+      // when
+      const {
+        tree
+      } = createEmptyTab();
+
+      // then
+      expect(
+        tree.findWhere(
+          wrapper => wrapper.text().startsWith('BPMN diagram (Zeebe')
+        ).first().exists()
+      ).to.be.false;
+    });
+
+
+    it('should display zeebe with inverted flag', function() {
+
+      // given
+      sinon.stub(Flags, 'get').withArgs(DISABLE_ZEEBE).returns(false);
+
+      // given
+      const {
+        tree
+      } = createEmptyTab();
+
+      // then
+      expect(
+        tree.findWhere(
+          wrapper => wrapper.text().startsWith('BPMN diagram (Zeebe')
         ).first().exists()
       ).to.be.true;
     });

--- a/client/src/app/__tests__/TabsProviderSpec.js
+++ b/client/src/app/__tests__/TabsProviderSpec.js
@@ -10,7 +10,7 @@
 
 import TabsProvider from '../TabsProvider';
 
-import Flags, { DISABLE_DMN, DISABLE_CMMN } from '../../util/Flags';
+import Flags, { DISABLE_DMN, DISABLE_CMMN, DISABLE_ZEEBE } from '../../util/Flags';
 
 
 describe('TabsProvider', function() {
@@ -96,7 +96,8 @@ describe('TabsProvider', function() {
 
         // given
         Flags.init({
-          [DISABLE_CMMN]: false
+          [DISABLE_CMMN]: false,
+          [DISABLE_ZEEBE]: false
         });
 
         const tabsProvider = new TabsProvider();
@@ -244,6 +245,10 @@ describe('TabsProvider', function() {
     it('should take cloud-bpmn first for known bpmn file', function() {
 
       // given
+      Flags.init({
+        [DISABLE_ZEEBE]: false
+      });
+
       const tabsProvider = new TabsProvider();
 
       const file = {
@@ -332,6 +337,7 @@ describe('TabsProvider', function() {
       // then
       expect(hasProvider).to.be.true;
     });
+
 
     it('should NOT have provider', function() {
 

--- a/client/src/util/Flags.js
+++ b/client/src/util/Flags.js
@@ -34,6 +34,7 @@ export default new Flags();
 export const DISABLE_CMMN = 'disable-cmmn';
 export const DISABLE_DMN = 'disable-dmn';
 export const DISABLE_FORM = 'disable-form';
+export const DISABLE_ZEEBE = 'disable-zeebe';
 export const DISABLE_ADJUST_ORIGIN = 'disable-adjust-origin';
 export const DISABLE_PLUGINS = 'disable-plugins';
 export const RELAUNCH = 'relaunch';


### PR DESCRIPTION
This PR demonstrates how to disable our new Zeebe features temporarily using a feature toggle.

If merged, only once given `--no-disable-zeebe` Zeebe features are actually activated.