### PR TITLE
fix(client): fix file error message

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -2055,7 +2055,7 @@ export default WithCache(App);
 
 // helpers //////////
 
-function getOpenFileErrorDialog(options) {
+export function getOpenFileErrorDialog(options) {
   const {
     name,
     providerNames
@@ -2068,7 +2068,7 @@ function getOpenFileErrorDialog(options) {
 
     let seperator = '';
 
-    if (isLast) {
+    if (isLast && !isFirst) {
       seperator = ' or ';
     } else if (!isFirst) {
       seperator = ', ';

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -17,7 +17,8 @@ import {
 
 import {
   App,
-  EMPTY_TAB
+  EMPTY_TAB,
+  getOpenFileErrorDialog
 } from '../App';
 
 import Log from '../Log';
@@ -2621,6 +2622,62 @@ describe('<App>', function() {
 
       // then
       expect(eventSpy).to.have.been.called;
+    });
+
+  });
+
+
+  describe('dialogs', function() {
+
+    describe('#getOpenFileErrorDialog', function() {
+
+      it('should list all supported file endings', function() {
+
+        // given
+        const options = {
+          name: 'file.ext',
+          providerNames: ['CMMN', 'BPMN', 'DMN', 'FORM']
+        };
+
+        // when
+        const { message, detail } = getOpenFileErrorDialog(options);
+
+        // then
+        expect(message).to.equal('Unable to open file.');
+        expect(detail).to.equal('"file.ext" is not a CMMN, BPMN, DMN or FORM file.');
+      });
+
+
+      it('should use correct separator for 2 providers', function() {
+
+        // given
+        const options = {
+          name: 'file.ext',
+          providerNames: ['BPMN', 'DMN']
+        };
+
+        // when
+        const { detail } = getOpenFileErrorDialog(options);
+
+        // then
+        expect(detail).to.equal('"file.ext" is not a BPMN or DMN file.');
+      });
+
+
+      it('should not use any separators for single providers', function() {
+
+        // given
+        const options = {
+          name: 'file.ext',
+          providerNames: ['BPMN']
+        };
+
+        // when
+        const { detail } = getOpenFileErrorDialog(options);
+
+        // then
+        expect(detail).to.equal('"file.ext" is not a BPMN file.');
+      });
     });
 
   });


### PR DESCRIPTION
This fixes the grammar of the Unsupported file message if only one file type is enabled.
![image](https://user-images.githubusercontent.com/21984219/115249380-d63cba80-a128-11eb-9093-de0ba71a253b.png)

closes #2028

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
