### PR TITLE
Fix typo in electron-builder.json

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -64,6 +64,6 @@
       "description": "FORM file",
       "role": "Editor",
       "mimeType": "application/camunda-form"
-    },
+    }
   ]
 }


### PR DESCRIPTION
Dangling comma is not allowed in JSON.