### PR TITLE
fix: set minimum window size

### DIFF
--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -55,6 +55,10 @@ bootstrapLogging();
 
 const name = app.name = 'Camunda Modeler';
 const version = app.version = require('../package').version;
+const MINIMUM_SIZE = {
+  width: 640,
+  height: 480
+};
 
 bootstrapLog.info(`starting ${ name } v${ version }`);
 
@@ -378,6 +382,8 @@ app.createEditorWindow = function() {
     resizable: true,
     show: false,
     title: 'Camunda Modeler' + getTitleSuffix(app.metadata.version),
+    minWidth: MINIMUM_SIZE.width,
+    minHeight: MINIMUM_SIZE.height,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,


### PR DESCRIPTION
Sets minimum window size to 640x480.

Can be tested with artifacts:

- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/minimum-size/camunda-modeler-minimum-size-linux-x64.tar.gz
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/minimum-size/camunda-modeler-minimum-size-mac.dmg
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/minimum-size/camunda-modeler-minimum-size-mac.zip
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/minimum-size/camunda-modeler-minimum-size-win-ia32.zip
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/minimum-size/camunda-modeler-minimum-size-win-x64.zip
---


Related to SUPPORT-10593