### PR TITLE
chore: mark root package as private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "camunda-modeler-builder",
   "version": "0.0.0",
+  "private": true,
   "description": "Camunda Modeler for BPMN, DMN and CMMN, based on bpmn.io",
   "scripts": {
     "app:auto-test": "npm run app:test -- --watch",


### PR DESCRIPTION
This way we can avoid publishing `camunda-modeler-builder` by accident. This has happened at least once.