### PR TITLE
pass flags correctly

### DIFF
--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -125,7 +125,7 @@ renderer.onSync('app:get-plugins', () => {
 });
 
 renderer.onSync('app:get-flags', () => {
-  return flags;
+  return flags.getAll();
 });
 
 renderer.onSync('app:get-metadata', () => {


### PR DESCRIPTION
Before this PR, the Flags object was passed to the preload script. Then, it was serialized to `{ flags: ... }` but we expect the flag names to be the keys of the object.

So instead of:

```json
{
  "disable-remote-interaction": true
}
```

we got:

```json
{
  "flags": {
    "disable-remote-interaction": true
  }
}
```