### PR TITLE
deps: update @sentry/browser and @sentry/node dependencies

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -76,47 +76,47 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@sentry/core": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
-      "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.6.tgz",
+      "integrity": "sha512-w6BRizAqh7BaiM9oeKzO6aACXwRijUPacYaVLX/OfhqCSueF9uDxpMRT7+4D/eCeDVqgJYhBJ4Vsu2NSstkk4A==",
       "requires": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/minimal": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
+        "@sentry/hub": "6.3.6",
+        "@sentry/minimal": "6.3.6",
+        "@sentry/types": "6.3.6",
+        "@sentry/utils": "6.3.6",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
-      "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.6.tgz",
+      "integrity": "sha512-foBZ3ilMnm9Gf9OolrAxYHK8jrA6IF72faDdJ3Al+1H27qcpnBaMdrdEp2/jzwu/dgmwuLmbBaMjEPXaGH/0JQ==",
       "requires": {
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
+        "@sentry/types": "6.3.6",
+        "@sentry/utils": "6.3.6",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
-      "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.6.tgz",
+      "integrity": "sha512-uM2/dH0a6zfvI5f+vg+/mST+uTBdN6Jgpm585ipH84ckCYQwIIDRg6daqsen4S1sy/xgg1P1YyC3zdEC4G6b1Q==",
       "requires": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/types": "5.30.0",
+        "@sentry/hub": "6.3.6",
+        "@sentry/types": "6.3.6",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.30.0.tgz",
-      "integrity": "sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.3.6.tgz",
+      "integrity": "sha512-QVWakREgVUV/rocm4uMq+RkC0/g9d/z2BYic+2b0ZZMZD2aXF5RulrUQlAO2MzoXcO+bqpkXQsqdhMccqB4Zeg==",
       "requires": {
-        "@sentry/core": "5.30.0",
-        "@sentry/hub": "5.30.0",
-        "@sentry/tracing": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
+        "@sentry/core": "6.3.6",
+        "@sentry/hub": "6.3.6",
+        "@sentry/tracing": "6.3.6",
+        "@sentry/types": "6.3.6",
+        "@sentry/utils": "6.3.6",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -124,28 +124,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.30.0.tgz",
-      "integrity": "sha512-dUFowCr0AIMwiLD7Fs314Mdzcug+gBVo/+NCMyDw8tFxJkwWAKl7Qa2OZxLQ0ZHjakcj1hNKfCQJ9rhyfOl4Aw==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.3.6.tgz",
+      "integrity": "sha512-dfyYY2eESJGt5Qbigmfmb2U9ntqbwPhLNAOcjKaVg9WQRV5q2RkHCVctPoYk7TEAvfNeNRXCD8SnuFOZhttt8g==",
       "requires": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/minimal": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
+        "@sentry/hub": "6.3.6",
+        "@sentry/minimal": "6.3.6",
+        "@sentry/types": "6.3.6",
+        "@sentry/utils": "6.3.6",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
-      "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw=="
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.6.tgz",
+      "integrity": "sha512-93cFJdJkWyCfyZeWFARSU11qnoHVOS/R2h5WIsEf+jbQmkqG2C+TXVz/19s6nHVsfDrwpvYpwALPv4/nrxfU7g=="
     },
     "@sentry/utils": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
-      "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.6.tgz",
+      "integrity": "sha512-HnYlDBf8Dq8MEv7AulH7B6R1D/2LAooVclGdjg48tSrr9g+31kmtj+SAj2WWVHP9+bp29BWaC7i5nkfKrOibWw==",
       "requires": {
-        "@sentry/types": "5.30.0",
+        "@sentry/types": "6.3.6",
         "tslib": "^1.9.3"
       }
     },

--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@sentry/node": "^5.30.0",
+    "@sentry/node": "^6.3.6",
     "form-data": "^2.5.1",
     "glob": "^7.1.6",
     "ids": "^1.0.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1138,13 +1138,13 @@
 			"integrity": "sha512-tU1DGIInadVbO1YLd+k4S35lLQTu7fgSVyjwEGUt9wdmPk9xca4Pup1zVd9S0gLdXAddnox37jsL6dJhKlNUVQ=="
 		},
 		"@sentry/browser": {
-			"version": "5.15.5",
-			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.15.5.tgz",
-			"integrity": "sha512-rqDvjk/EvogfdbZ4TiEpxM/lwpPKmq23z9YKEO4q81+1SwJNua53H60dOk9HpRU8nOJ1g84TMKT2Ov8H7sqDWA==",
+			"version": "6.3.6",
+			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.3.6.tgz",
+			"integrity": "sha512-l4323jxuBOArki6Wf+EHes39IEyJ2Zj/CIUaTY7GWh7CntpfHQAfFmZWQw3Ozq+ka1u8lVp25RPhb4Wng3azNA==",
 			"requires": {
-				"@sentry/core": "5.15.5",
-				"@sentry/types": "5.15.5",
-				"@sentry/utils": "5.15.5",
+				"@sentry/core": "6.3.6",
+				"@sentry/types": "6.3.6",
+				"@sentry/utils": "6.3.6",
 				"tslib": "^1.9.3"
 			}
 		},
@@ -1204,48 +1204,48 @@
 			}
 		},
 		"@sentry/core": {
-			"version": "5.15.5",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.15.5.tgz",
-			"integrity": "sha512-enxBLv5eibBMqcWyr+vApqeix8uqkfn0iGsD3piKvoMXCgKsrfMwlb/qo9Ox0lKr71qIlZVt+9/A2vZohdgnlg==",
+			"version": "6.3.6",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.6.tgz",
+			"integrity": "sha512-w6BRizAqh7BaiM9oeKzO6aACXwRijUPacYaVLX/OfhqCSueF9uDxpMRT7+4D/eCeDVqgJYhBJ4Vsu2NSstkk4A==",
 			"requires": {
-				"@sentry/hub": "5.15.5",
-				"@sentry/minimal": "5.15.5",
-				"@sentry/types": "5.15.5",
-				"@sentry/utils": "5.15.5",
+				"@sentry/hub": "6.3.6",
+				"@sentry/minimal": "6.3.6",
+				"@sentry/types": "6.3.6",
+				"@sentry/utils": "6.3.6",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@sentry/hub": {
-			"version": "5.15.5",
-			"resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.15.5.tgz",
-			"integrity": "sha512-zX9o49PcNIVMA4BZHe//GkbQ4Jx+nVofqU/Il32/IbwKhcpPlhGX3c1sOVQo4uag3cqd/JuQsk+DML9TKkN0Lw==",
+			"version": "6.3.6",
+			"resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.6.tgz",
+			"integrity": "sha512-foBZ3ilMnm9Gf9OolrAxYHK8jrA6IF72faDdJ3Al+1H27qcpnBaMdrdEp2/jzwu/dgmwuLmbBaMjEPXaGH/0JQ==",
 			"requires": {
-				"@sentry/types": "5.15.5",
-				"@sentry/utils": "5.15.5",
+				"@sentry/types": "6.3.6",
+				"@sentry/utils": "6.3.6",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@sentry/minimal": {
-			"version": "5.15.5",
-			"resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.15.5.tgz",
-			"integrity": "sha512-zQkkJ1l9AjmU/Us5IrOTzu7bic4sTPKCatptXvLSTfyKW7N6K9MPIIFeSpZf9o1yM2sRYdK7GV08wS2eCT3JYw==",
+			"version": "6.3.6",
+			"resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.6.tgz",
+			"integrity": "sha512-uM2/dH0a6zfvI5f+vg+/mST+uTBdN6Jgpm585ipH84ckCYQwIIDRg6daqsen4S1sy/xgg1P1YyC3zdEC4G6b1Q==",
 			"requires": {
-				"@sentry/hub": "5.15.5",
-				"@sentry/types": "5.15.5",
+				"@sentry/hub": "6.3.6",
+				"@sentry/types": "6.3.6",
 				"tslib": "^1.9.3"
 			}
 		},
 		"@sentry/types": {
-			"version": "5.15.5",
-			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.15.5.tgz",
-			"integrity": "sha512-F9A5W7ucgQLJUG4LXw1ZIy4iLevrYZzbeZ7GJ09aMlmXH9PqGThm1t5LSZlVpZvUfQ2rYA8NU6BdKJSt7B5LPw=="
+			"version": "6.3.6",
+			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.6.tgz",
+			"integrity": "sha512-93cFJdJkWyCfyZeWFARSU11qnoHVOS/R2h5WIsEf+jbQmkqG2C+TXVz/19s6nHVsfDrwpvYpwALPv4/nrxfU7g=="
 		},
 		"@sentry/utils": {
-			"version": "5.15.5",
-			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.15.5.tgz",
-			"integrity": "sha512-Nl9gl/MGnzSkuKeo3QaefoD/OJrFLB8HmwQ7HUbTXb6E7yyEzNKAQMHXGkwNAjbdYyYbd42iABP6Y5F/h39NtA==",
+			"version": "6.3.6",
+			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.6.tgz",
+			"integrity": "sha512-HnYlDBf8Dq8MEv7AulH7B6R1D/2LAooVclGdjg48tSrr9g+31kmtj+SAj2WWVHP9+bp29BWaC7i5nkfKrOibWw==",
 			"requires": {
-				"@sentry/types": "5.15.5",
+				"@sentry/types": "6.3.6",
 				"tslib": "^1.9.3"
 			}
 		},

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,7 @@
     "@bpmn-io/extract-process-variables": "^0.4.3",
     "@bpmn-io/form-js": "0.0.12",
     "@bpmn-io/replace-ids": "^0.2.0",
-    "@sentry/browser": "^5.15.5",
+    "@sentry/browser": "^6.3.6",
     "bpmn-js": "^8.5.0",
     "bpmn-js-properties-panel": "^0.43.0",
     "camunda-bpmn-js": "^0.7.0",


### PR DESCRIPTION
Updates `@sentry` dependencies from v5 to v6. According to the release notes, there are no breaking changes: https://github.com/getsentry/sentry-javascript/releases/tag/6.0.0