### PR TITLE
Await styles

### DIFF
--- a/client/src/remote/Plugins.js
+++ b/client/src/remote/Plugins.js
@@ -37,11 +37,9 @@ export default class Plugins {
     const stylePlugins = filter(appPlugins, appPlugin => appPlugin.style),
           scriptPlugins = filter(appPlugins, appPlugin => appPlugin.script);
 
-    // load style plugins
-    stylePlugins.forEach(this._loadStylePlugin);
-
-    // load script plugins
-    return Promise.all(scriptPlugins.map(this._loadScriptPlugin));
+    return Promise.resolve()
+      .then(() => Promise.all(stylePlugins.map(this._loadStylePlugin)))
+      .then(() => Promise.all(scriptPlugins.map(this._loadScriptPlugin)));
   }
 
   /**
@@ -97,12 +95,15 @@ export default class Plugins {
   _loadStylePlugin(stylePlugin) {
     const { style } = stylePlugin;
 
-    const styleTag = document.createElement('link');
+    return new Promise(resolve => {
+      const styleTag = document.createElement('link');
 
-    styleTag.href = style;
-    styleTag.rel = 'stylesheet';
+      styleTag.href = style;
+      styleTag.rel = 'stylesheet';
+      styleTag.onload = resolve;
 
-    document.head.appendChild(styleTag);
+      document.head.appendChild(styleTag);
+    });
   }
 
   /**

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -138,7 +138,7 @@ function sentryIntegration() {
   const { version } = pkg;
 
   // necessary SENTRY_AUTH_TOKEN, SENTRY_ORG and SENTRY_PROJECT environment
-  // variables are injected via Travis when building.
+  // variables are injected via CI when building.
   return [
     new SentryWebpackPlugin({
       release: NODE_ENV === 'production' ? version : 'dev',


### PR DESCRIPTION
This ensures plug-ins can rely on their styles being loaded before they are executed.

For context, cf. https://github.com/bpmn-io/bpmn-js-token-simulation-plugin/pull/32#issuecomment-845075888.