### PR TITLE
fix(app): ignore Chromium switches when parsing CLI arguments

### DIFF
--- a/app/lib/__tests__/cli-spec.js
+++ b/app/lib/__tests__/cli-spec.js
@@ -172,6 +172,23 @@ describe('cli', function() {
 
   });
 
+
+  describe('#filterArgs', function() {
+
+    it('should filter chromium switches', function() {
+
+      // given
+      var args = [ '--allow-file-access-from-files', '--bar', '-xyz', '--hello=1231', '123' ];
+
+      // when
+      var actualArgs = Cli.filterArgs(args);
+
+      // then
+      expect(actualArgs).to.eql([ '--bar', '-xyz', '--hello=1231', '123' ]);
+    });
+
+  });
+
 });
 
 

--- a/app/lib/cli.js
+++ b/app/lib/cli.js
@@ -17,6 +17,12 @@ const mri = require('mri');
 
 const log = require('./log')('app:cli');
 
+const chromiumSwitches = [ '--allow-file-access-from-files' ];
+
+function isChromiumSwitch(argument) {
+  return chromiumSwitches.includes(argument);
+}
+
 /**
  * Parse file arguments from the command line
  * and return them as a list of paths.
@@ -33,7 +39,7 @@ function parse(args, cwd) {
   const {
     _,
     ...flags
-  } = mri(args.slice(1));
+  } = mri(filterArgs(args).slice(1));
 
   const files = _.filter(isPath).map(f => path.resolve(cwd, f)).filter(isFile);
 
@@ -70,6 +76,14 @@ function appendArgs(args, additionalArgs) {
 }
 
 module.exports.appendArgs = appendArgs;
+
+
+function filterArgs(args) {
+  return args.filter((argument) => !isChromiumSwitch(argument));
+}
+
+module.exports.filterArgs = filterArgs;
+
 
 /**
  * Check a possible filePath represents an existing file.


### PR DESCRIPTION
I've decided to simply ignore any known Chromium switches since reordering the list of arguments is error-prone. For now, the only known Chromium switch is `--allow-file-access-from-files`. My assumption is that it's unlikely that the list of arguments will change that often and if it does we will find out if the flags feature is broken during our integration tests.

Closes #2268

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
