### PR TITLE
Handle template errors as warnings

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1091,7 +1091,7 @@ export class App extends PureComponent {
 
   /**
    * Propagates warnings to parent.
-   * @param {Error} error
+   * @param {Error|{ message: string }} warning
    * @param {Tab|string} [categoryOrTab]
    */
   handleWarning(warning, categoryOrTab) {

--- a/client/src/app/tabs/MultiSheetTab.js
+++ b/client/src/app/tabs/MultiSheetTab.js
@@ -399,6 +399,7 @@ export class MultiSheetTab extends CachedComponent {
             getConfig={ this.props.getConfig }
             setConfig={ this.props.setConfig }
             getPlugins={ this.props.getPlugins }
+            onWarning={ this.handleWarning }
           />
         </TabContainer>
 

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -244,11 +244,15 @@ export class BpmnEditor extends CachedComponent {
 
   handleElementTemplateErrors = (event) => {
     const {
+      onWarning
+    } = this.props;
+
+    const {
       errors
     } = event;
 
     errors.forEach(error => {
-      this.handleError({ error });
+      onWarning({ message: error.message });
     });
   }
 

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -1211,6 +1211,30 @@ describe('<BpmnEditor>', function() {
       });
     });
 
+
+    it('should handle template errors as warning', async function() {
+
+      // given
+      const warningSpy = spy();
+
+      const error1 = new Error('template error 1');
+      const error2 = new Error('template error 2');
+      const error3 = new Error('template error 3');
+
+      const { instance } = await renderEditor(diagramXML, {
+        onWarning: warningSpy
+      });
+
+      // when
+      await instance.handleElementTemplateErrors({ errors: [ error1, error2, error3 ] });
+
+      // then
+      expect(warningSpy).to.have.been.calledThrice;
+      expect(warningSpy).to.have.been.calledWith({ message: error1.message });
+      expect(warningSpy).to.have.been.calledWith({ message: error2.message });
+      expect(warningSpy).to.have.been.calledWith({ message: error3.message });
+    });
+
   });
 
 
@@ -1491,6 +1515,7 @@ async function renderEditor(xml, options = {}) {
     onChanged,
     onContentUpdated,
     onError,
+    onWarning,
     onImport,
     onLayoutChanged,
     onModal,
@@ -1508,6 +1533,7 @@ async function renderEditor(xml, options = {}) {
       onAction={ onAction || noop }
       onChanged={ onChanged || noop }
       onError={ onError || noop }
+      onWarning={ onWarning || noop }
       onImport={ onImport || noop }
       onLayoutChanged={ onLayoutChanged || noop }
       onContentUpdated={ onContentUpdated || noop }


### PR DESCRIPTION
Closes #2287

This PR handles element [template validation errors](https://github.com/bpmn-io/bpmn-js-properties-panel/blob/master/lib/provider/camunda/element-templates/ElementTemplatesLoader.js#L82) as warnings - and avoids showing the stacktrace for these since it will be the same for each validation warning (no real benefit). I also think it's okay to assume these errors are only validation errors since we handle [template loading errors](https://github.com/camunda/camunda-modeler/blob/develop/client/src/app/tabs/bpmn/BpmnEditor.js#L142) separately. 

This also prevents sending the validation errors to Sentry.

**before**
<img width="1338" alt="Bildschirmfoto 2021-06-10 um 09 40 15" src="https://user-images.githubusercontent.com/9433996/121490515-64207d80-c9d5-11eb-81c9-2ab997713261.png">

**after**
<img width="1338" alt="Bildschirmfoto 2021-06-10 um 09 49 33" src="https://user-images.githubusercontent.com/9433996/121490529-67b40480-c9d5-11eb-83b0-a98f7c54174f.png">
