### PR TITLE
Add usage tracking for Version Info

### DIFF
--- a/client/src/plugins/usage-statistics/event-handlers/BaseEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/BaseEventHandler.js
@@ -21,27 +21,27 @@ export default class BaseEventHandler {
     this._onSend = onSend;
   }
 
-  onAfterEnable = () => {}
+  onAfterEnable() {}
 
-  onAfterDisable = () => {}
+  onAfterDisable() {}
 
-  isEnabled = () => {
+  isEnabled() {
     return this._isEnabled;
   }
 
-  enable = () => {
+  enable() {
     this._isEnabled = true;
 
     this.onAfterEnable();
   }
 
-  disable = () => {
+  disable() {
     this._isEnabled = false;
 
     this.onAfterDisable();
   }
 
-  sendToET = (data) => {
+  sendToET(data) {
 
     if (!this.isEnabled()) {
       return;

--- a/client/src/plugins/usage-statistics/event-handlers/PingEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/PingEventHandler.js
@@ -35,16 +35,14 @@ export default class PingEventHandler extends BaseEventHandler {
   }
 
   onAfterEnable = () => {
-    const { sendToET } = this;
-
     if (!this.sentInitially) {
-      sendToET();
+      this.sendToET();
 
       this.sentInitially = true;
     }
 
     if (this._intervalID === null) {
-      this._intervalID = this.setInterval(sendToET.bind(this));
+      this._intervalID = this.setInterval(() => this.sendToET());
     }
   }
 

--- a/client/src/plugins/usage-statistics/event-handlers/VersionInfoLinkOpenedEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/VersionInfoLinkOpenedEventHandler.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import BaseEventHandler from './BaseEventHandler';
+
+const VERSION_INFO_OVERLAY_ID = 'version-info-overlay';
+const LINK_SELECTOR = `#${VERSION_INFO_OVERLAY_ID} a[href]`;
+
+/**
+  * Sends event when user opens a link from the version info overlay.
+ */
+export default class VersionInfoLinkOpenedEventHandler extends BaseEventHandler {
+
+  constructor(props) {
+    const {
+      onSend
+    } = props;
+
+    super('versionInfoLinkOpened', onSend);
+  }
+
+  // In Chromium, a click event is dispatched also when user activates a link with the keyboard.
+  onAfterEnable() {
+    document.addEventListener('click', this.handleLinkOpened);
+  }
+
+  onAfterDisable() {
+    document.removeEventListener('click', this.handleLinkOpened);
+  }
+
+  /**
+   *
+   * @param {MouseEvent} event
+   */
+  handleLinkOpened = event => {
+    const { target } = event;
+
+    if (!target.matches(LINK_SELECTOR)) {
+      return;
+    }
+
+    const label = target.textContent;
+
+    this.sendToET({ label });
+  }
+}

--- a/client/src/plugins/usage-statistics/event-handlers/VersionInfoOpenedEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/VersionInfoOpenedEventHandler.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import BaseEventHandler from './BaseEventHandler';
+
+/**
+ * Sends event when user opens version info overlay.
+ */
+export default class VersionInfoOpenedEventHandler extends BaseEventHandler {
+
+  constructor(props) {
+    const {
+      onSend,
+      subscribe
+    } = props;
+
+    super('versionInfoOpened', onSend);
+
+    this._subscribe = subscribe;
+  }
+
+  onAfterEnable() {
+    this._subscription = this._subscribe('versionInfo.opened', this.handleEvent);
+  }
+
+  onAfterDisable() {
+    this._subscription && this._subscription.cancel();
+  }
+
+  handleEvent = payload => {
+    return this.sendToET({ source: payload.source });
+  }
+}

--- a/client/src/plugins/usage-statistics/event-handlers/__tests__/BaseEventHandlerSpec.js
+++ b/client/src/plugins/usage-statistics/event-handlers/__tests__/BaseEventHandlerSpec.js
@@ -111,4 +111,45 @@ describe('<BaseEventHandler>', () => {
     // then
     expect(sendSpy).to.not.have.been.called;
   });
+
+
+  describe('hooks', () => {
+
+    it('should call <onAfterEnable>', () => {
+
+      // given
+      const spy = sinon.spy();
+      class TestHandler extends BaseEventHandler {
+        onAfterEnable() {
+          spy();
+        }
+      }
+      const testHandler = new TestHandler('test', noop);
+
+      // when
+      testHandler.enable();
+
+      // then
+      expect(spy).to.have.been.calledOnce;
+    });
+
+
+    it('should call <onAfterDisable>', () => {
+
+      // given
+      const spy = sinon.spy();
+      class TestHandler extends BaseEventHandler {
+        onAfterDisable() {
+          spy();
+        }
+      }
+      const testHandler = new TestHandler('test', noop);
+
+      // when
+      testHandler.disable();
+
+      // then
+      expect(spy).to.have.been.calledOnce;
+    });
+  });
 });

--- a/client/src/plugins/usage-statistics/event-handlers/__tests__/VersionInfoLinkOpenedEventHandlerSpec.js
+++ b/client/src/plugins/usage-statistics/event-handlers/__tests__/VersionInfoLinkOpenedEventHandlerSpec.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/* global sinon */
+
+import MochaTestContainer from 'mocha-test-container-support';
+
+import VersionInfoLinkOpenedEventHandler from '../VersionInfoLinkOpenedEventHandler';
+
+
+describe('<VersionInfoLinkOpenedEventHandler>', () => {
+
+  let container, linkInside, linkOutside;
+
+  beforeEach(function() {
+    container = MochaTestContainer.get(this);
+
+    const versionInfoOverlay = document.createElement('div');
+    versionInfoOverlay.id = 'version-info-overlay';
+
+    linkInside = createAnchor('inside');
+    linkOutside = createAnchor('outside');
+
+    versionInfoOverlay.appendChild(linkInside);
+
+    container.appendChild(linkOutside);
+    container.appendChild(versionInfoOverlay);
+  });
+
+
+  afterEach(function() {
+    container.innerHTML = '';
+  });
+
+
+  it('should send event on link clicked', () => {
+
+    // given
+    const onSend = sinon.spy();
+    const handler = new VersionInfoLinkOpenedEventHandler({ onSend });
+    handler.enable();
+
+    // when
+    linkInside.click();
+
+    // then
+    expect(onSend).to.have.been.calledOnceWith({
+      event: 'versionInfoLinkOpened', label: 'inside'
+    });
+  });
+
+
+  it('should NOT send event when link outside of scope is clicked', () => {
+
+    // given
+    const onSend = sinon.spy();
+    const handler = new VersionInfoLinkOpenedEventHandler({ onSend });
+    handler.enable();
+
+    // when
+    linkOutside.click();
+
+    // then
+    expect(onSend).not.to.have.been.called;
+  });
+
+
+  it('should send only one event when re-enabled', () => {
+
+    // given
+    const onSend = sinon.spy();
+    const handler = new VersionInfoLinkOpenedEventHandler({ onSend });
+    handler.enable();
+
+    // when
+    handler.disable();
+    handler.enable();
+    linkInside.click();
+
+    // then
+    expect(onSend).to.have.been.calledOnceWith({
+      event: 'versionInfoLinkOpened', label: 'inside'
+    });
+  });
+});
+
+
+function createAnchor(label, href = 'test') {
+  const anchor = document.createElement('a');
+  anchor.textContent = label;
+  anchor.href = href;
+
+  // prevent redirect
+  anchor.addEventListener('click', event => event.preventDefault());
+
+  return anchor;
+}

--- a/client/src/plugins/usage-statistics/event-handlers/__tests__/VersionInfoOpenedEventHandlerSpec.js
+++ b/client/src/plugins/usage-statistics/event-handlers/__tests__/VersionInfoOpenedEventHandlerSpec.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/* global sinon */
+
+import VersionInfoOpenedEventHandler from '../VersionInfoOpenedEventHandler';
+
+const noop = () => {};
+
+describe('<VersionInfoOpenedEventHandler>', () => {
+
+  it('should subscribe to versionInfo.opened', () => {
+
+    // given
+    const onSend = sinon.spy();
+    const subscribe = createSubscribe();
+    const handler = new VersionInfoOpenedEventHandler({ onSend, subscribe });
+    handler.enable();
+
+    // when
+    subscribe.emit({ source: 'statusBar' });
+
+    // then
+    expect(onSend).to.have.been.calledOnceWith({ event: 'versionInfoOpened', source: 'statusBar' });
+  });
+
+
+  it('should pass the source name', () => {
+
+    // given
+    const onSend = sinon.spy();
+    const subscribe = createSubscribe();
+    const handler = new VersionInfoOpenedEventHandler({ onSend, subscribe });
+    handler.enable();
+
+    // when
+    subscribe.emit({ source: 'menu' });
+
+    // then
+    expect(onSend).to.have.been.calledOnceWith({ event: 'versionInfoOpened', source: 'menu' });
+  });
+
+
+  it('should unsubscribe when handler is disabled', () => {
+
+    // given
+    const onSend = sinon.spy();
+    const subscribe = createSubscribe();
+    const handler = new VersionInfoOpenedEventHandler({ onSend, subscribe });
+    handler.enable();
+
+    // when
+    handler.disable();
+    subscribe.emit({ source: 'menu' });
+
+    // then
+    expect(onSend).not.to.have.been.called;
+    expect(subscribe.getListener()).to.eql(noop);
+  });
+});
+
+function createSubscribe() {
+
+  let cb = noop;
+
+  function subscribe(_, callback) {
+    cb = callback;
+
+    return {
+      cancel() {
+        cb = noop;
+      }
+    };
+  }
+
+  subscribe.emit = (payload) => cb(payload);
+  subscribe.getListener = () => cb;
+
+  return subscribe;
+}

--- a/client/src/plugins/usage-statistics/event-handlers/index.js
+++ b/client/src/plugins/usage-statistics/event-handlers/index.js
@@ -11,9 +11,13 @@
 import PingEventHandler from './PingEventHandler';
 import DiagramOpenEventHandler from './DiagramOpenEventHandler';
 import DeploymentEventHandler from './DeploymentEventHandler';
+import VersionInfoOpenedEventHandler from './VersionInfoOpenedEventHandler';
+import VersionInfoLinkOpenedEventHandler from './VersionInfoLinkOpenedEventHandler';
 
 export default [
   PingEventHandler,
   DiagramOpenEventHandler,
-  DeploymentEventHandler
+  DeploymentEventHandler,
+  VersionInfoOpenedEventHandler,
+  VersionInfoLinkOpenedEventHandler
 ];

--- a/client/src/plugins/version-info/VersionInfo.js
+++ b/client/src/plugins/version-info/VersionInfo.js
@@ -36,25 +36,39 @@ export class VersionInfo extends PureComponent {
   }
 
   componentDidMount() {
-    this.props.subscribe('versionInfo.open', () => {
-      this.setOpen(true);
+    this._subscription = this.props.subscribe('versionInfo.open', () => {
+      if (this.state.open) {
+        return;
+      }
+
+      this.open('menu');
     });
 
     this._checkIfUnread();
   }
 
-  componentDidUpdate() {
+  toggle = () => {
     if (this.state.open) {
-      this._onOpen();
+      this.close();
+    } else {
+      this.open();
     }
   }
 
-  toggle = () => {
-    this.setState(state => ({ ...state, open: !state.open }));
+  open(source = 'statusBar') {
+    this.setState({ open: true });
+
+    this._onOpen(source);
   }
 
-  setOpen = value => {
-    this.setState({ open: value });
+  close() {
+    this.setState({ open: false });
+  }
+
+  _triggerEvent(event) {
+    if (event.type === 'open') {
+      this.props.triggerAction('emit-event', { type: 'versionInfo.opened', payload: event });
+    }
   }
 
   async _checkIfUnread() {
@@ -67,7 +81,9 @@ export class VersionInfo extends PureComponent {
     this.setState({ unread: false });
   }
 
-  async _onOpen() {
+  async _onOpen(source) {
+    this._triggerEvent({ type: 'open', source });
+
     if (!this.state.unread) {
       return;
     }
@@ -89,10 +105,9 @@ export class VersionInfo extends PureComponent {
     const {
       _buttonRef: buttonRef,
       _version: version,
-      setOpen,
       toggle
     } = this;
-    const close = () => setOpen(false);
+    const close = () => this.close();
 
     return (
       <Fragment>

--- a/client/src/plugins/version-info/VersionInfoOverlay.js
+++ b/client/src/plugins/version-info/VersionInfoOverlay.js
@@ -25,7 +25,7 @@ const OFFSET = { right: 0 };
 export function VersionInfoOverlay(props) {
   return (
     <Overlay
-      anchor={ props.anchor } onClose={ props.onClose } offset={ OFFSET }
+      id="version-info-overlay" anchor={ props.anchor } onClose={ props.onClose } offset={ OFFSET }
       className={ css.VersionInfoOverlay }
     >
       <Overlay.Title>

--- a/client/src/shared/ui/__tests__/OverlaySpec.js
+++ b/client/src/shared/ui/__tests__/OverlaySpec.js
@@ -64,6 +64,40 @@ describe('<Overlay>', function() {
     expect(wrapper.contains(<div>{ 'Test' }</div>)).to.be.true;
   });
 
+
+  describe('DOM props', function() {
+
+    it('should allow to pass custom class', function() {
+
+      // when
+      wrapper = mount(<Overlay anchor={ anchor } className="custom" />);
+
+      // then
+      expect(wrapper.exists('.custom'), 'Class is not set').to.be.true;
+    });
+
+
+    it('should allow to pass custom id', function() {
+
+      // when
+      wrapper = mount(<Overlay anchor={ anchor } id="custom" />);
+
+      // then
+      expect(wrapper.exists('#custom'), 'Id is not set').to.be.true;
+    });
+
+
+    it('should NOT set id if not provided', function() {
+
+      // when
+      wrapper = mount(<Overlay anchor={ anchor } />);
+
+      // then
+      expect(wrapper.getDOMNode().id).to.eql('');
+    });
+  });
+
+
   describe('props#offset', function() {
 
     it('should use provided offset { left }', function() {

--- a/client/src/shared/ui/overlay/Overlay.js
+++ b/client/src/shared/ui/overlay/Overlay.js
@@ -95,15 +95,19 @@ export class Overlay extends PureComponent {
   render() {
     const {
       className,
-      children
+      children,
+      id
     } = this.props;
+
+    // set id only if passed via props
+    const optionalId = id ? { id } : {};
 
     const style = this.getStyle();
 
     return ReactDOM.createPortal(
       <KeyboardInteractionTrap>
         <div
-          className={ classNames(css.Overlay, className) } style={ style }
+          className={ classNames(css.Overlay, className) } style={ style } { ...optionalId }
           ref={ this.overlayRef } role="dialog"
         >
           { children }

--- a/docs/telemetry/README.md
+++ b/docs/telemetry/README.md
@@ -203,3 +203,30 @@ If it is set in the diagram, we also add target engine profile information:
   }
 }
 ```
+
+
+### Version Info Events
+
+The version info events are sent in following situations:
+
+ - User opens version info overlay via the button on the status bar
+ - User opens version info overlay via the menu
+ - User opens a link in the version info overlay
+
+In the two first cases, a `versionInfoOpened` event is sent:
+
+```json
+{
+  "event": "versionInfoOpened",
+  "source": "[menu or statusBar]"
+}
+```
+
+When a link is clicked, a `versionInfoLinkOpened` event is sent:
+
+```json
+{
+  "event": "versionInfoLinkOpened",
+  "label": "[anchor content, e.g. Camunda Modeler docs]"
+}
+```


### PR DESCRIPTION
This allows us to track whether users open the version info and which links they are interested in.

Closes #2303

---

To test this in action, I used the following setup:

In a terminal tab run:

```sh
npx http-echo-server 3000
```

In parallel, in Camunda Modeler repo root directory you can run then:

```sh
ET_ENDPOINT=http://localhost:3000 npm start
```