### PR TITLE
chore(TabsProvider): remove ambigious CTRL+T hotkey

### DIFF
--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -137,7 +137,6 @@ export default class TabsProvider {
         getNewFileMenu() {
           return [{
             label: 'BPMN Diagram (Camunda Platform)',
-            accelerator: 'CommandOrControl+T',
             action: 'create-bpmn-diagram'
           }];
         },


### PR DESCRIPTION
Closes #2312

* Ambiguity results from the fact that we now support CamundaCloud and
  CamundaPlatform
* However, the feature to have a shortcut creation of a new tab, shall
  be re-added soon. Also see #2309

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
