### PR TITLE
ci: fetch full git history in release job

### DIFF
--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # required to compare versions in the license book summary
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
This should fix the problem revealed in https://github.com/camunda/camunda-modeler/runs/2999852513?check_suite_focus=true#step:9:32