### PR TITLE
style(client): make white app background explicit

### DIFF
--- a/client/src/styles/_base.less
+++ b/client/src/styles/_base.less
@@ -5,6 +5,7 @@
 body {
   font-family: Arial, sans-serif;
   font-size: 12px;
+  background-color: var(--color-ffffff);
 }
 
 :root {


### PR DESCRIPTION
When setting the OS color scheme to dark and opening the developer tools the app background is the color of the dark color scheme:

<img width="960" alt="electron_m86RbxqYls" src="https://user-images.githubusercontent.com/7633572/124630402-ae850500-de82-11eb-8679-aa647cab7b65.png">

Making the white app background explicit fixes the issue:

<img width="960" alt="electron_O5mIwkwJlj" src="https://user-images.githubusercontent.com/7633572/124630515-c9f01000-de82-11eb-89ad-ba8acc2e9ae3.png">

