### PR TITLE
fix(element-templates): fix example

### DIFF
--- a/resources/element-templates/samples.json
+++ b/resources/element-templates/samples.json
@@ -343,7 +343,7 @@
           "type": "camunda:in",
           "target": "var_called_expr",
           "variables": "local",
-          "expression": "true"
+          "expression": true
         },
         "constraints": {
           "notEmpty": true


### PR DESCRIPTION
`expression` was set to `"true"` instead of `true` resulting in an error logged everytime you'd open a BPMN tab in development mode.

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
