### PR TITLE
feat(cloud-bpmn): integrate `@bpmn-io/bpmn-properties-panel`

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1059,6 +1059,24 @@
 			"resolved": "https://registry.npmjs.org/@bpmn-io/align-to-origin/-/align-to-origin-0.7.0.tgz",
 			"integrity": "sha512-a8Ri5q2uhCrHJ415BR9ZulajvOw0SX2Eh0jxwoMZ/ynxcZPBbOKm6kW6HAQFJp0EFHwftMiJstcvIcSjyz0hZA=="
 		},
+		"@bpmn-io/bpmn-properties-panel": {
+			"version": "github:bpmn-io/bpmn-properties-panel#e8ab736aad0f61eed136d29deb69bb10a5e17abf",
+			"from": "github:bpmn-io/bpmn-properties-panel#v0.1.0",
+			"requires": {
+				"@bpmn-io/properties-panel": "^0.1.1",
+				"classnames": "^2.3.1",
+				"ids": "^1.0.0",
+				"min-dom": "^3.1.3",
+				"preact": "^10.5.13"
+			},
+			"dependencies": {
+				"classnames": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+					"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+				}
+			}
+		},
 		"@bpmn-io/dmn-migrate": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/@bpmn-io/dmn-migrate/-/dmn-migrate-0.4.3.tgz",
@@ -1125,6 +1143,23 @@
 			"integrity": "sha512-luBGfBUZ7NPsVgXmEuEqx82mXUD6dwcrsCHyBDXagpJ0wlnj55Tsz1euxi2XziHqo/KOTYKDvm93LBbAs5aF4w==",
 			"requires": {
 				"preact": "^10.5.12"
+			}
+		},
+		"@bpmn-io/properties-panel": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.1.1.tgz",
+			"integrity": "sha512-7efnyYrMNKwcUo7VPHBRUJq4GZ6EeT9gi5R1hwiykBcdnPdeXZI+CQtRyJvfXTsHfUy/PzDQq0UDZDxSPURfAA==",
+			"requires": {
+				"classnames": "^2.3.1",
+				"min-dash": "^3.7.0",
+				"min-dom": "^3.1.3"
+			},
+			"dependencies": {
+				"classnames": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+					"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+				}
 			}
 		},
 		"@bpmn-io/replace-ids": {

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@bpmn-io/add-exporter": "^0.2.0",
     "@bpmn-io/align-to-origin": "^0.7.0",
+    "@bpmn-io/bpmn-properties-panel": "github:bpmn-io/bpmn-properties-panel#v0.1.0",
     "@bpmn-io/dmn-migrate": "^0.4.3",
     "@bpmn-io/extract-process-variables": "^0.4.3",
     "@bpmn-io/form-js": "0.0.12",

--- a/client/src/app/tabs/PropertiesContainer.less
+++ b/client/src/app/tabs/PropertiesContainer.less
@@ -49,4 +49,8 @@
     overflow-y: auto;
   }
 
+  .bio-properties-panel {
+    background: var(--color-ffffff);
+  }
+
 }

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/PropertiesPanelKeyoardBindings.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/PropertiesPanelKeyoardBindings.js
@@ -67,7 +67,7 @@ export default class PropertiesPanelKeyboardBindings {
   }
 
   _getContainer() {
-    return this._propertiesPanel._container;
+    return this._propertiesPanel._parentNode || this._propertiesPanel._container;
   }
 }
 

--- a/client/src/app/tabs/cloud-bpmn/modeler/BpmnModeler.js
+++ b/client/src/app/tabs/cloud-bpmn/modeler/BpmnModeler.js
@@ -8,9 +8,19 @@
  * except in compliance with the MIT License.
  */
 
+import {
+  has
+} from 'min-dash';
+
 import BpmnModeler from 'camunda-bpmn-js/lib/camunda-cloud/Modeler';
 
 import addExporterModule from '@bpmn-io/add-exporter';
+
+import {
+  BpmnPropertiesPanelModule,
+  BpmnPropertiesProviderModule,
+  ZeebePropertiesProviderModule
+} from '@bpmn-io/bpmn-properties-panel';
 
 import completeDirectEditingModule from '../../bpmn/modeler/features/complete-direct-editing';
 import globalClipboardModule from './features/global-clipboard';
@@ -22,6 +32,8 @@ import Flags, {
 } from '../../../../util/Flags';
 
 import 'camunda-bpmn-js/dist/assets/camunda-cloud-modeler.css';
+
+import '@bpmn-io/bpmn-properties-panel/dist/assets/properties-panel.css';
 
 
 export default class CloudBpmnModeler extends BpmnModeler {
@@ -49,9 +61,22 @@ const extensionModules = [
   globalClipboardModule,
   handToolOnSpaceModule,
   propertiesPanelKeyboardBindingsModule,
+  BpmnPropertiesPanelModule,
+  BpmnPropertiesProviderModule,
+  ZeebePropertiesProviderModule
 ];
 
 CloudBpmnModeler.prototype._modules = [
-  ...defaultModules,
+  ...excludeOldModules(defaultModules),
   ...extensionModules
 ];
+
+
+// helper /////////////////////
+
+/**
+ * Excludes old properties panel + provider coming from camunda-bpmn-js.
+ */
+function excludeOldModules(modules) {
+  return modules.filter(m => !has(m, 'propertiesPanel') && !has(m, 'propertiesProvider'));
+}


### PR DESCRIPTION
Replaces old with new properties panel in Cloud Bpmn Editor

Related to bpmn-io/properties-panel#5
Closes #2347
Depends on https://github.com/bpmn-io/bpmn-properties-panel/pull/14

<img width="1200" alt="Bildschirmfoto 2021-07-12 um 10 14 32" src="https://user-images.githubusercontent.com/9433996/125253710-fcbe5c00-e2f9-11eb-91d7-017bfd5a77e7.png">