### PR TITLE
2375 support cluster url

### DIFF
--- a/app/lib/zeebe-api.js
+++ b/app/lib/zeebe-api.js
@@ -67,6 +67,7 @@ const BPMN_SUFFIX = '.bpmn';
  * @property {string} clusterId
  * @property {string} clientId
  * @property {string} clientSecret
+ * @property {string} [clusterRegion] if not provided, zeebe-node will assume 'bru-2'
  */
 
 /**
@@ -290,7 +291,8 @@ class ZeebeAPI {
           clientId: endpoint.clientId,
           clientSecret: endpoint.clientSecret,
           clusterId: endpoint.clusterId,
-          cacheOnDisk: false
+          cacheOnDisk: false,
+          ...(endpoint.clusterRegion ? { clusterRegion: endpoint.clusterRegion } : {})
         },
         useTLS: true
       };

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
@@ -301,7 +301,7 @@ export default class DeploymentPlugin extends PureComponent {
       clientSecret: '',
       camundaCloudClientId: '',
       camundaCloudClientSecret: '',
-      camundaCloudClusterId: '',
+      camundaCloudClusterUrl: '',
       rememberCredentials: false
     };
 

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
@@ -310,6 +310,11 @@ export default class DeploymentPlugin extends PureComponent {
       endpoint = previousEndpoints[0];
     }
 
+    // #2375 => if we only have a clusterId, transform it to clusterURL for backwards-compatability
+    if (!endpoint.camundaCloudClusterUrl && endpoint.camundaCloudClusterId) {
+      endpoint.camundaCloudClusterUrl = createCamundaCloudClusterUrl(endpoint.camundaCloudClusterId);
+    }
+
     return endpoint;
   }
 
@@ -531,4 +536,8 @@ function getGRPCErrorCode(error) {
   } = error;
 
   return code ? GRPC_ERROR_CODES[code] : 'UNKNOWN';
+}
+
+function createCamundaCloudClusterUrl(camundaCloudClusterId) {
+  return camundaCloudClusterId + '.bru-2.zeebe.camunda.io:443';
 }

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginConstants.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginConstants.js
@@ -26,7 +26,7 @@ export const OAUTH_URL = 'OAuth URL';
 export const AUDIENCE = 'Audience';
 export const CLIENT_ID = 'Client ID';
 export const CLIENT_SECRET = 'Client Secret';
-export const CLUSTER_ID = 'Cluster ID';
+export const CLUSTER_ID = 'Cluster URL';
 export const REMEMBER_CREDENTIALS = 'Remember credentials';
 
 export const MUST_PROVIDE_A_VALUE = 'Must provide a value.';
@@ -35,8 +35,8 @@ export const OAUTH_URL_MUST_NOT_BE_EMPTY = 'OAuth URL must not be empty.';
 export const AUDIENCE_MUST_NOT_BE_EMPTY = 'Audience must not be empty.';
 export const CLIENT_ID_MUST_NOT_BE_EMPTY = 'Client ID must not be empty.';
 export const CLIENT_SECRET_MUST_NOT_BE_EMPTY = 'Client Secret must not be empty.';
-export const CLUSTER_ID_MUST_NOT_BE_EMPTY = 'Cluster ID must not be empty.';
 export const FILL_IN_ALL_THE_FIELDS = 'You must fill in all the fields';
+export const CLUSTER_URL_MUST_BE_VALID_CLOUD_URL = 'Must be a valid Camunda Cloud URL.';
 
 export const ERROR_REASONS = {
   UNKNOWN: 'UNKNOWN',

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginConstants.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginConstants.js
@@ -26,7 +26,7 @@ export const OAUTH_URL = 'OAuth URL';
 export const AUDIENCE = 'Audience';
 export const CLIENT_ID = 'Client ID';
 export const CLIENT_SECRET = 'Client Secret';
-export const CLUSTER_ID = 'Cluster URL';
+export const CLUSTER_URL = 'Cluster URL';
 export const REMEMBER_CREDENTIALS = 'Remember credentials';
 
 export const MUST_PROVIDE_A_VALUE = 'Must provide a value.';

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginModal.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginModal.js
@@ -385,9 +385,9 @@ function extractClusterId(camundaCloudClusterUrl) {
 
 
 /**
- * extractClusterRegion - description
+ * extractClusterRegion
  *
- * @param  {type} camundaCloudClusterUrl description
+ * @param  {type} camundaCloudClusterUrl
  * @return {type} camundaCloudClusterRegion
  */
 function extractClusterRegion(camundaCloudClusterUrl) {

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginModal.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginModal.js
@@ -28,7 +28,7 @@ import {
   AUDIENCE,
   CLIENT_ID,
   CLIENT_SECRET,
-  CLUSTER_ID,
+  CLUSTER_URL,
   REMEMBER_CREDENTIALS,
   ERROR_REASONS,
   CONNECTION_ERROR_MESSAGES
@@ -308,7 +308,7 @@ export default class DeploymentPluginModal extends React.PureComponent {
                             <Field
                               name="endpoint.camundaCloudClusterUrl"
                               component={ TextInput }
-                              label={ CLUSTER_ID }
+                              label={ CLUSTER_URL }
                               fieldError={ this.endpointConfigurationFieldError }
                               validate={ validatorFunctionsByFieldNames.camundaCloudClusterUrl }
                               autoFocus

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginModal.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginModal.js
@@ -168,9 +168,16 @@ export default class DeploymentPluginModal extends React.PureComponent {
   }
 
   handleFormSubmit = async (values, { setSubmitting }) => {
+    const { endpoint } = values;
+
+    // Extract clusterId and clusterRegion as required by zeebeAPI for camundaCloud
+    if (endpoint.targetType === CAMUNDA_CLOUD && endpoint.camundaCloudClusterUrl) {
+      endpoint.camundaCloudClusterId = extractClusterId(endpoint.camundaCloudClusterUrl);
+      endpoint.camundaCloudClusterRegion = extractClusterRegion(endpoint.camundaCloudClusterUrl);
+    }
 
     // check connection
-    const { connectionResult } = await this.connectionChecker.check(values.endpoint);
+    const { connectionResult } = await this.connectionChecker.check(endpoint);
 
     if (!connectionResult.success) {
       return setSubmitting(false);
@@ -361,4 +368,28 @@ export default class DeploymentPluginModal extends React.PureComponent {
       </Modal>
     );
   }
+}
+
+
+// helper ////////
+
+/**
+  * extractClusterId
+  *
+  * @param  {string} camundaCloudClusterUrl
+  * @return {string} camundaCloudClusterId
+  */
+function extractClusterId(camundaCloudClusterUrl) {
+  return camundaCloudClusterUrl.match(/([a-z\d]+-){2,}[a-z\d]+/g)[0];
+}
+
+
+/**
+ * extractClusterRegion - description
+ *
+ * @param  {type} camundaCloudClusterUrl description
+ * @return {type} camundaCloudClusterRegion
+ */
+function extractClusterRegion(camundaCloudClusterUrl) {
+  return camundaCloudClusterUrl.match(/(?<=\.)[a-z]+-[\d]+/g)[0];
 }

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginModal.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginModal.js
@@ -82,7 +82,7 @@ export default class DeploymentPluginModal extends React.PureComponent {
       clientSecret: validator.validateClientSecret,
       camundaCloudClientId: validator.validateClientId,
       camundaCloudClientSecret: validator.validateClientSecret,
-      camundaCloudClusterId: validator.validateClusterId
+      camundaCloudClusterUrl: validator.validateClusterUrl
     };
 
     this.connectionChecker = validator.createConnectionChecker();
@@ -118,11 +118,11 @@ export default class DeploymentPluginModal extends React.PureComponent {
       return fieldName === 'contactPoint' &&
         CONNECTION_ERROR_MESSAGES[failureReason];
     case ERROR_REASONS.CLUSTER_UNAVAILABLE:
-      return fieldName === 'camundaCloudClusterId' && CONNECTION_ERROR_MESSAGES[failureReason];
+      return fieldName === 'camundaCloudClusterUrl' && CONNECTION_ERROR_MESSAGES[failureReason];
     case ERROR_REASONS.UNSUPPORTED_ENGINE:
       return [
         'contactPoint',
-        'camundaCloudClusterId'
+        'camundaCloudClusterUrl'
       ].includes(fieldName) && CONNECTION_ERROR_MESSAGES[failureReason];
     case ERROR_REASONS.UNAUTHORIZED:
     case ERROR_REASONS.FORBIDDEN:
@@ -137,7 +137,7 @@ export default class DeploymentPluginModal extends React.PureComponent {
     case ERROR_REASONS.UNKNOWN:
       return [
         'contactPoint',
-        'camundaCloudClusterId'
+        'camundaCloudClusterUrl'
       ].includes(fieldName) && CONNECTION_ERROR_MESSAGES[failureReason];
     }
   }
@@ -299,11 +299,11 @@ export default class DeploymentPluginModal extends React.PureComponent {
                         form.values.endpoint.targetType === CAMUNDA_CLOUD && (
                           <React.Fragment>
                             <Field
-                              name="endpoint.camundaCloudClusterId"
+                              name="endpoint.camundaCloudClusterUrl"
                               component={ TextInput }
                               label={ CLUSTER_ID }
                               fieldError={ this.endpointConfigurationFieldError }
-                              validate={ validatorFunctionsByFieldNames.camundaCloudClusterId }
+                              validate={ validatorFunctionsByFieldNames.camundaCloudClusterUrl }
                               autoFocus
                             />
                             <Field

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginValidator.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginValidator.js
@@ -15,7 +15,7 @@ import {
   AUDIENCE_MUST_NOT_BE_EMPTY,
   CLIENT_ID_MUST_NOT_BE_EMPTY,
   CLIENT_SECRET_MUST_NOT_BE_EMPTY,
-  CLUSTER_ID_MUST_NOT_BE_EMPTY,
+  CLUSTER_URL_MUST_BE_VALID_CLOUD_URL
 } from './DeploymentPluginConstants';
 
 import { AUTH_TYPES } from '../shared/ZeebeAuthTypes';
@@ -39,6 +39,10 @@ export default class DeploymentPluginValidator {
     return value ? null : message;
   }
 
+  validateUrl = (value, message = CLUSTER_URL_MUST_BE_VALID_CLOUD_URL) => {
+    return validCloudUrl(value) ? null : message;
+  }
+
   validateZeebeContactPoint = (value) => {
     return this.validateNonEmpty(value, CONTACT_POINT_MUST_NOT_BE_EMPTY);
   }
@@ -59,8 +63,8 @@ export default class DeploymentPluginValidator {
     return this.validateNonEmpty(value, CLIENT_SECRET_MUST_NOT_BE_EMPTY);
   }
 
-  validateClusterId = (value) => {
-    return this.validateNonEmpty(value, CLUSTER_ID_MUST_NOT_BE_EMPTY);
+  validateClusterUrl = (value) => {
+    return this.validateUrl(value, CLUSTER_URL_MUST_BE_VALID_CLOUD_URL);
   }
 
   validateConnection = (endpoint) => {
@@ -87,7 +91,7 @@ export default class DeploymentPluginValidator {
       validators = {
         camundaCloudClientId: this.validateClientId,
         camundaCloudClientSecret: this.validateClientSecret,
-        camundaCloudClusterId: this.validateClusterId
+        camundaCloudClusterUrl: this.validateClusterUrl
       };
     } else if (targetType === SELF_HOSTED) {
       if (endpoint.authType === AUTH_TYPES.NONE) {
@@ -302,4 +306,8 @@ function hash(el) {
 
 function shallowEquals(a, b) {
   return hash(a) === hash(b);
+}
+
+function validCloudUrl(url) {
+  return /^(https:\/\/|)[a-z\d-]+\.[a-z]+-\d+\.zeebe\.camunda\.io:443/.test(url);
 }

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginValidator.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginValidator.js
@@ -309,5 +309,5 @@ function shallowEquals(a, b) {
 }
 
 function validCloudUrl(url) {
-  return /^(https:\/\/|)[a-z\d-]+\.[a-z]+-\d+\.zeebe\.camunda\.io:443/.test(url);
+  return /^(https:\/\/|)[a-z\d-]+\.[a-z]+-\d+\.zeebe\.camunda\.io(:443|)\/?/.test(url);
 }

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginModalSpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginModalSpec.js
@@ -56,6 +56,59 @@ describe('<DeploymentPluginModal> (Zeebe)', () => {
   });
 
 
+  it('should extract clusterId and clusterRegion', done => {
+
+    // given
+    const { wrapper } = createDeploymentPluginModal({
+      onDeploy,
+      config: {
+        endpoint: {
+          targetType: 'camundaCloud',
+          camundaCloudClusterUrl: '7edda473-891c-4978-aa27-2e727d8560ff.ber-5.zeebe.camunda.io:443'
+        }
+      } });
+
+    // when
+    const form = wrapper.find('form');
+    form.simulate('submit');
+
+    // then
+    function onDeploy(values) {
+      const { endpoint } = values;
+
+      expect(endpoint.camundaCloudClusterId).to.equal('7edda473-891c-4978-aa27-2e727d8560ff');
+      expect(endpoint.camundaCloudClusterRegion).to.equal('ber-5');
+      done();
+    }
+  });
+
+
+  it('should extract clusterId with https', done => {
+
+    // given
+    const { wrapper } = createDeploymentPluginModal({
+      onDeploy,
+      config: {
+        endpoint: {
+          targetType: 'camundaCloud',
+          camundaCloudClusterUrl: 'https://7edda473-891c-4978-aa27-2e727d8560ff.ber-5.zeebe.camunda.io:443'
+        }
+      } });
+
+    // when
+    const form = wrapper.find('form');
+    form.simulate('submit');
+
+    // then
+    function onDeploy(values) {
+      const { endpoint } = values;
+
+      expect(endpoint.camundaCloudClusterId).to.equal('7edda473-891c-4978-aa27-2e727d8560ff');
+      done();
+    }
+  });
+
+
   it('should close when pressed on secondary button', async () => {
 
     // given

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginValidatorSpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginValidatorSpec.js
@@ -93,12 +93,20 @@ describe('<DeploymentPluginValidator> (Zeebe)', () => {
       // given
       const nonValidClusterUrl = '';
       const validClusterUrlHttps = 'https://asdf2-a1213-123a.ber-05.zeebe.camunda.io:443';
+      const validClusterUrlHttpsSlash = 'https://asdf2-a1213-123a.ber-05.zeebe.camunda.io:443/';
+      const validClusterUrlHttpsNoPort = 'https://asdf2-a1213-123a.ber-05.zeebe.camunda.io';
+      const validClusterUrlHttpsNoPortSlash = 'https://asdf2-a1213-123a.ber-05.zeebe.camunda.io/';
       const validClusterUrl = 'asdf2-a1213-123a.ber-05.zeebe.camunda.io:443';
+      const validClusterUrlSlash = 'asdf2-a1213-123a.ber-05.zeebe.camunda.io:443/';
 
       // then
       expect(validator.validateClusterUrl(nonValidClusterUrl)).to.eql(CLUSTER_URL_MUST_BE_VALID_CLOUD_URL);
       expect(validator.validateClusterUrl(validClusterUrlHttps)).to.not.exist;
+      expect(validator.validateClusterUrl(validClusterUrlHttpsSlash)).to.not.exist;
+      expect(validator.validateClusterUrl(validClusterUrlHttpsNoPort)).to.not.exist;
+      expect(validator.validateClusterUrl(validClusterUrlHttpsNoPortSlash)).to.not.exist;
       expect(validator.validateClusterUrl(validClusterUrl)).to.not.exist;
+      expect(validator.validateClusterUrl(validClusterUrlSlash)).to.not.exist;
     });
 
 

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginValidatorSpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginValidatorSpec.js
@@ -18,7 +18,7 @@ import {
   AUDIENCE_MUST_NOT_BE_EMPTY,
   CLIENT_ID_MUST_NOT_BE_EMPTY,
   CLIENT_SECRET_MUST_NOT_BE_EMPTY,
-  CLUSTER_ID_MUST_NOT_BE_EMPTY,
+  CLUSTER_URL_MUST_BE_VALID_CLOUD_URL,
 } from '../DeploymentPluginConstants';
 
 
@@ -88,15 +88,17 @@ describe('<DeploymentPluginValidator> (Zeebe)', () => {
     });
 
 
-    it('should validate cluster id', () => {
+    it('should validate cluster url', () => {
 
       // given
-      const nonValidClusterId = '';
-      const validClusterId = 'validClusterId';
+      const nonValidClusterUrl = '';
+      const validClusterUrlHttps = 'https://asdf2-a1213-123a.ber-05.zeebe.camunda.io:443';
+      const validClusterUrl = 'asdf2-a1213-123a.ber-05.zeebe.camunda.io:443';
 
       // then
-      expect(validator.validateClusterId(nonValidClusterId)).to.eql(CLUSTER_ID_MUST_NOT_BE_EMPTY);
-      expect(validator.validateClusterId(validClusterId)).to.not.exist;
+      expect(validator.validateClusterUrl(nonValidClusterUrl)).to.eql(CLUSTER_URL_MUST_BE_VALID_CLOUD_URL);
+      expect(validator.validateClusterUrl(validClusterUrlHttps)).to.not.exist;
+      expect(validator.validateClusterUrl(validClusterUrl)).to.not.exist;
     });
 
 
@@ -111,7 +113,7 @@ describe('<DeploymentPluginValidator> (Zeebe)', () => {
           targetType: 'camundaCloud',
           camundaCloudClientId: 'test',
           camundaCloudClientSecret: 'test',
-          camundaCloudClusterId: 'test'
+          camundaCloudClusterUrl: 'a213-asdf1-312as.bru-02.zeebe.camunda.io:443'
         }
       };
       const wrongConfig = {

--- a/client/src/remote/ZeebeAPI.js
+++ b/client/src/remote/ZeebeAPI.js
@@ -83,7 +83,8 @@ function getEndpointConfiguration(endpoint) {
     contactPoint,
     camundaCloudClientId,
     camundaCloudClientSecret,
-    camundaCloudClusterId
+    camundaCloudClusterId,
+    camundaCloudClusterRegion
   } = endpoint;
 
   if (targetType === targetTypes.SELF_HOSTED) {
@@ -112,7 +113,8 @@ function getEndpointConfiguration(endpoint) {
       type: targetTypes.CAMUNDA_CLOUD,
       clientId: camundaCloudClientId,
       clientSecret: camundaCloudClientSecret,
-      clusterId: camundaCloudClusterId
+      clusterId: camundaCloudClusterId,
+      ...(camundaCloudClusterRegion ? { clusterRegion: camundaCloudClusterRegion } : {})
     };
   }
 


### PR DESCRIPTION
closes #2375 

Note that:
* In the Modal, we want to have the clusterURL as input (since it is
  inline with the Camunda Cloud Config modal and it only requires the
user to copy/paste one value)
* However, with version 1.4.0 zeebe-node does not take an entire URL
  anymore. It requires to be passed clusterId and clusterRegion
seperately. (see
https://github.com/camunda-community-hub/zeebe-client-node-js/blob/master/CHANGELOG.md)
* Therefore, we extract that info from the URL before
  passing it to zeebe-node.

I manually tested that this works with `bru-2` and `chs-1` clusters.

![Screenshot_20210816_090615](https://user-images.githubusercontent.com/42800119/129524455-84885167-d74c-4fa1-9cbd-9d91f6e4b4ef.png)
