### PR TITLE
fix: keep tab open when save dialog is canceled

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -378,7 +378,11 @@ export class App extends PureComponent {
       const { button } = await this.showCloseFileDialog({ name });
 
       if (button === 'save') {
-        await this.saveTab(tab);
+        var saved = await this.saveTab(tab);
+
+        if (!saved) {
+          return false;
+        }
       } else if (button === 'cancel') {
         return false;
       }

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -645,6 +645,41 @@ describe('<App>', function() {
     });
 
 
+    it('should not close tab when saving dialog is canceled', async function() {
+
+      // given
+      const dialog = new Dialog();
+
+      const {
+        app
+      } = createApp({
+        globals: {
+          dialog
+        }
+      });
+
+      const tab = await app.createDiagram();
+
+      app.setState({
+        ...app.setDirty(tab)
+      });
+
+      dialog.setShowCloseFileDialogResponse({ button: 'save' });
+      dialog.setShowSaveFileDialogResponse(false);
+
+      // when
+      const closeTabResponse = await app.closeTab(tab);
+
+      // then
+      const {
+        tabs
+      } = app.state;
+
+      expect(tabs).to.contain(tab);
+      expect(closeTabResponse).to.eql(false);
+    });
+
+
     it('should resolve to false if saving was canceled', async function() {
 
       // given


### PR DESCRIPTION
closes #2359

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
![recording (16)](https://user-images.githubusercontent.com/21984219/129537365-5857e07c-151f-4b99-92aa-c296e788724e.gif)
