### PR TITLE
fix(dmn): enable backspace in literalExpressions editor

### DIFF
--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -394,6 +394,11 @@ export class DmnEditor extends CachedComponent {
         selectAll: true
       });
 
+      // The literalExpressions editor does not fire events when
+      // elements are selected, so we always set inputActive to true.
+      // cf. https://github.com/camunda/camunda-modeler/pull/2394
+      newState.inputActive = true;
+
       editMenu = getDmnLiteralExpressionEditMenu(newState);
     }
 

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -687,6 +687,37 @@ describe('<DmnEditor>', function() {
 
       });
 
+
+      describe('literal expression', function() {
+
+        it('Remove shortcut should always have role: delete', async function() {
+
+          // given
+          const changedSpy = sinon.spy();
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          changedSpy.resetHistory();
+
+          // when
+          const modeler = instance.getModeler();
+
+          modeler.open({ type: 'literalExpression' });
+          instance.handleChanged();
+
+          // then
+          expect(changedSpy).to.be.calledOnce;
+
+          const state = changedSpy.firstCall.args[0];
+
+          expect(hasMenuEntry(state.editMenu, 'Remove Selected')).to.be.true;
+          expect(getMenuEntry(state.editMenu, 'Remove Selected').role).to.equal('delete');
+        });
+
+      });
+
     });
 
 
@@ -1877,6 +1908,25 @@ function renderEditor(xml, options = {}) {
 
 function getEvent(events, eventName) {
   return find(events, e => e.type === eventName);
+}
+
+function getMenuEntry(editMenu, label) {
+  for (let i = 0; i < editMenu.length; i++) {
+    const entry = editMenu[i];
+
+    if (isArray(entry)) {
+      const res = getMenuEntry(entry, label);
+      if (res) {
+        return res;
+      }
+    } else {
+      if (entry.label === label) {
+        return entry;
+      }
+    }
+  }
+
+  return false;
 }
 
 function hasMenuEntry(editMenu, label) {


### PR DESCRIPTION
Root cause: The literalExpressions editor does not fire events when elements are selected, so `inputActive` is not set correctly.

As introducing these events would be a bigger refactoring and the action should never be performed without `role: delete`, I decided to fix it in the modeler by setting `inputActive` to true. 

closes #2095

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
