### PR TITLE
Handle deployment to older camunda versions that don't expose their version.

### DIFF
--- a/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
@@ -167,16 +167,17 @@ export default class DeploymentTool extends PureComponent {
       duration: 4000
     });
 
+    // If we retrieved the executionPlatformVersion, include it in event
+    const deployedTo = (version &&
+      { executionPlatformVersion: version, executionPlatform: ET_EXECUTION_PLATFORM_NAME }) || undefined;
+
     // notify interested parties
     triggerAction('emit-event', {
       type: 'deployment.done',
       payload: {
         deployment,
-        deployedTo: {
-          executionPlatformVersion: version,
-          executionPlatform: ET_EXECUTION_PLATFORM_NAME
-        },
-        context: 'deploymentTool'
+        context: 'deploymentTool',
+        ...(deployedTo && { deployedTo: deployedTo })
       }
     });
   }

--- a/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentToolSpec.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentToolSpec.js
@@ -498,6 +498,24 @@ describe('<DeploymentTool>', () => {
     });
 
 
+    it('should fetch the executionPlatformVersion but no version is available', async () => {
+
+      // given
+      const deploySpy = sinon.spy();
+      const getVersionSpy = sinon.spy(() => { return { version: null }; });
+      const activeTab = createTab({ name: 'foo.bpmn' });
+      const {
+        instance
+      } = createDeploymentTool({ activeTab, deploySpy, getVersionSpy });
+
+      // when
+      await instance.deploy();
+
+      // then
+      expect(getVersionSpy).to.have.been.calledOnce;
+    });
+
+
     it('should use saved config to fetch executionPlatformVersion', async () => {
 
       // given

--- a/client/src/plugins/camunda-plugin/shared/CamundaAPI.js
+++ b/client/src/plugins/camunda-plugin/shared/CamundaAPI.js
@@ -121,15 +121,8 @@ export default class CamundaAPI {
 
     const response = await this.fetch('/version');
 
-    if (response.status !== 200) {
-      return {
-        version: null
-      };
-    }
-
-    const { version } = await response.json();
-
     if (response.ok) {
+      const { version } = await response.json();
       return {
         version: version
       };

--- a/client/src/plugins/camunda-plugin/shared/CamundaAPI.js
+++ b/client/src/plugins/camunda-plugin/shared/CamundaAPI.js
@@ -121,6 +121,12 @@ export default class CamundaAPI {
 
     const response = await this.fetch('/version');
 
+    if (response.status !== 200) {
+      return {
+        version: null
+      };
+    }
+
     const { version } = await response.json();
 
     if (response.ok) {

--- a/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
@@ -405,16 +405,17 @@ export default class StartInstanceTool extends PureComponent {
       triggerAction
     } = this.props;
 
+    // If we retrieved the executionPlatformVersion, include it in event
+    const deployedTo = (version &&
+      { executionPlatformVersion: version, executionPlatform: ET_EXECUTION_PLATFORM_NAME }) || undefined;
+
     // notify interested parties
     triggerAction('emit-event', {
       type: 'deployment.done',
       payload: {
         deployment,
         context: 'startInstanceTool',
-        deployedTo: {
-          executionPlatformVersion: version,
-          executionPlatform: ET_EXECUTION_PLATFORM_NAME
-        }
+        ...(deployedTo && { deployedTo: deployedTo })
       }
     });
 

--- a/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
@@ -12,7 +12,7 @@ import React, { PureComponent } from 'react';
 
 import PlayIcon from 'icons/Play.svg';
 
-import CamundaAPI from '../shared/CamundaAPI';
+import CamundaAPI, { ConnectionError } from '../shared/CamundaAPI';
 
 import StartInstanceConfigModal from './StartInstanceConfigModal';
 
@@ -222,7 +222,14 @@ export default class StartInstanceTool extends PureComponent {
     try {
 
       // (5.1) Retrieve version via API
-      version = (await this.getVersion(deploymentConfig)).version;
+      try {
+        version = (await this.getVersion(deploymentConfig)).version;
+      } catch (error) {
+        if (!(error instanceof ConnectionError)) {
+          throw error;
+        }
+        version = null;
+      }
 
       // (5.2) Deploy via API
       const deployment = await this.deploy(tab, deploymentConfig);
@@ -405,17 +412,16 @@ export default class StartInstanceTool extends PureComponent {
       triggerAction
     } = this.props;
 
-    // If we retrieved the executionPlatformVersion, include it in event
-    const deployedTo = (version &&
-      { executionPlatformVersion: version, executionPlatform: ET_EXECUTION_PLATFORM_NAME }) || undefined;
-
     // notify interested parties
     triggerAction('emit-event', {
       type: 'deployment.done',
       payload: {
         deployment,
         context: 'startInstanceTool',
-        ...(deployedTo && { deployedTo: deployedTo })
+        deployedTo: {
+          executionPlatformVersion: version,
+          executionPlatform: ET_EXECUTION_PLATFORM_NAME
+        }
       }
     });
 


### PR DESCRIPTION
This PR adds a try catch around version retrieval and only send it in the event when we have a version.

This fixes a regression in 4.8.0 that broke deployment to some older camunda versions (7.8, but newer might also be impacted).

See #2340 for more info.

@barmac 
