### PR TITLE
fix: linting tests on Form Editor

### DIFF
--- a/client/src/app/tabs/form/__tests__/FormEditorSpec.js
+++ b/client/src/app/tabs/form/__tests__/FormEditorSpec.js
@@ -622,7 +622,11 @@ describe('<FormEditor>', function() {
       // then
       const { form } = instance.getCached();
 
-      expect(onActionSpy).to.have.been.calledOnce;
+      const calls = onActionSpy.getCalls()
+        .filter(call => call.args[0] === 'lint-tab');
+
+      // then
+      expect(calls).to.have.lengthOf(1);
       expect(onActionSpy).to.have.been.calledWith('lint-tab', { contents: form.getSchema() });
     });
 
@@ -641,9 +645,15 @@ describe('<FormEditor>', function() {
 
       form._emit('commandStack.changed');
 
+      const calls = onActionSpy.getCalls()
+        .filter(call => call.args[0] === 'lint-tab');
+
       // then
-      expect(onActionSpy).to.have.been.calledTwice;
-      expect(onActionSpy).to.have.been.always.calledWith('lint-tab', { contents: form.getSchema() });
+      expect(calls).to.have.lengthOf(2);
+
+      calls.forEach(function(call) {
+        expect(call[1] === form.getSchema());
+      });
     });
 
 
@@ -662,7 +672,7 @@ describe('<FormEditor>', function() {
       form._emit('commandStack.changed');
 
       // then
-      expect(onActionSpy).not.to.have.been.called;
+      expect(onActionSpy).not.to.have.been.calledWith('lint-tab');
     });
 
 
@@ -709,8 +719,11 @@ describe('<FormEditor>', function() {
 
       form._emit('commandStack.changed');
 
+      const calls = onActionSpy.getCalls()
+        .filter(call => call.args[0] === 'lint-tab');
+
       // then
-      expect(onActionSpy).to.have.been.calledOnce;
+      expect(calls).to.have.lengthOf(1);
     });
 
   });


### PR DESCRIPTION
#### Situation
* Tests for linting in the Form Editor check for any event being dispatched.

#### Problem
* If dispatches of other events that are not relevant to this test case are added, it will cause these tests to fail. 

#### Changes
* Tests assertions were modified to only consider events of type `lint-tab`