### PR TITLE
feat(formEditor): track `diagramOpen`

### DIFF
--- a/client/src/app/tabs/form/FormEditor.js
+++ b/client/src/app/tabs/form/FormEditor.js
@@ -402,12 +402,22 @@ export class FormEditor extends CachedComponent {
     );
   }
 
-  static createCachedState() {
+  static createCachedState(props) {
+
+    const {
+      onAction,
+    } = props;
+
     const form = new Form({});
 
     const commandStack = form.get('commandStack');
 
     const stackIdx = commandStack._stackIdx;
+
+    onAction('emit-event', {
+      type: 'form.modeler.created',
+      payload: form
+    });
 
     return {
       __destroy: () => {

--- a/client/src/app/tabs/form/__tests__/FormEditorSpec.js
+++ b/client/src/app/tabs/form/__tests__/FormEditorSpec.js
@@ -728,6 +728,46 @@ describe('<FormEditor>', function() {
 
   });
 
+
+  describe('extensions event emitting', function() {
+
+    let recordActions, emittedEvents;
+
+    beforeEach(function() {
+      emittedEvents = [];
+
+      recordActions = (action, options) => {
+        emittedEvents.push(options);
+      };
+    });
+
+
+    it('should notify when form was created', async function() {
+
+      // when
+      const {
+        instance
+      } = await renderEditor(engineProfileSchema, {
+        onAction: recordActions
+      });
+
+      const {
+        form
+      } = instance.getCached();
+
+      // then
+      const modelerCreatedEvent = getEvent(emittedEvents, 'form.modeler.created');
+
+      const {
+        payload,
+      } = modelerCreatedEvent;
+
+      expect(modelerCreatedEvent).to.exist;
+      expect(payload).to.eql(form);
+    });
+
+  });
+
 });
 
 
@@ -794,4 +834,9 @@ async function renderEditor(schema, options = {}) {
       });
     }
   });
+}
+
+
+function getEvent(events, eventName) {
+  return events.find(e => e.type === eventName);
 }

--- a/client/src/plugins/usage-statistics/event-handlers/DiagramOpenEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/DiagramOpenEventHandler.js
@@ -24,7 +24,8 @@ const ELEMENT_TEMPLATES_CONFIG_KEY = 'bpmn.elementTemplates';
 const types = {
   BPMN: 'bpmn',
   DMN: 'dmn',
-  CMMN: 'cmmn'
+  CMMN: 'cmmn',
+  FORM: 'form'
 };
 
 // Sends a diagramOpened event to ET when an user opens any diagram
@@ -67,6 +68,18 @@ export default class DiagramOpenEventHandler extends BaseEventHandler {
 
     subscribe('cmmn.modeler.created', () => {
       this.onDiagramOpened(types.CMMN);
+    });
+
+    subscribe('form.modeler.created', async (context) => {
+      const {
+        tab
+      } = context;
+
+      const {
+        schema
+      } = tab;
+
+      return await this.onFormOpened(schema);
     });
   }
 
@@ -134,6 +147,19 @@ export default class DiagramOpenEventHandler extends BaseEventHandler {
       // Payload too large, send again with smaller payload
       this.sendToET(omit(payload, ['elementTemplates']));
     }
+  }
+
+  onFormOpened = async (schema, context = {}) => {
+
+    var engineProfile = { } ;
+
+    if (schema) {
+      engineProfile = { executionPlatform: schema.executionPlatform } ;
+    }
+
+    return await this.onDiagramOpened(types.FORM, {
+      engineProfile,
+      ...context });
   }
 
   onBpmnDiagramOpened = async (file, type, context = {}) => {

--- a/client/src/plugins/usage-statistics/event-handlers/__tests__/DiagramOpenEventHandlerSpec.js
+++ b/client/src/plugins/usage-statistics/event-handlers/__tests__/DiagramOpenEventHandlerSpec.js
@@ -16,6 +16,10 @@ import emptyXML from './fixtures/empty.bpmn';
 
 import engineProfileXML from './fixtures/engine-profile.bpmn';
 
+import engineProfilePlatform from './fixtures/engine-platform.json';
+
+import engineProfileCloud from './fixtures/engine-cloud.json';
+
 import processVariablesXML from './fixtures/process-variables.bpmn';
 
 import serviceTasksXML from './fixtures/service-tasks.bpmn';
@@ -81,6 +85,19 @@ describe('<DiagramOpenEventHandler>', () => {
 
     // then
     expect(subscribe.getCall(2).args[0]).to.eql('cmmn.modeler.created');
+  });
+
+
+  it('should subscribe to form.modeler.created', () => {
+
+    // given
+    const subscribe = sinon.spy();
+
+    // when
+    new DiagramOpenEventHandler({ subscribe });
+
+    // then
+    expect(subscribe.getCall(3).args[0]).to.eql('form.modeler.created');
   });
 
 
@@ -163,6 +180,36 @@ describe('<DiagramOpenEventHandler>', () => {
     expect(onSend).to.have.been.calledWith({
       event: 'diagramOpened',
       diagramType: 'cmmn'
+    });
+  });
+
+
+  it('should send with diagram type: form', async () => {
+
+    // given
+    const subscribe = sinon.spy();
+
+    const onSend = sinon.spy();
+
+    const tab = createTab({
+      file: {},
+      type: 'form'
+    });
+
+    // when
+    const diagramOpenEventHandler = new DiagramOpenEventHandler({ onSend, subscribe });
+
+    diagramOpenEventHandler.enable();
+
+    const bpmnCallback = subscribe.getCall(3).args[1];
+
+    await bpmnCallback({ tab });
+
+    // then
+    expect(onSend).to.have.been.calledWith({
+      event: 'diagramOpened',
+      diagramType: 'form',
+      engineProfile: {}
     });
   });
 
@@ -1148,6 +1195,68 @@ describe('<DiagramOpenEventHandler>', () => {
       diagramOpenEventHandler.enable();
 
       const bpmnCallback = subscribe.getCall(0).args[1];
+
+      await bpmnCallback({ tab });
+
+      const { engineProfile } = onSend.getCall(0).args[0];
+
+      // then
+      expect(engineProfile).to.eql({
+        executionPlatform: 'Camunda Cloud'
+      });
+    });
+
+    it('should send Platform engine profile (forms)', async () => {
+
+      // given
+      const subscribe = sinon.spy();
+
+      const onSend = sinon.spy();
+
+      const tab = createTab({
+        type: 'form',
+        schema: engineProfilePlatform
+      });
+
+      const config = { get: () => null };
+
+      // when
+      const diagramOpenEventHandler = new DiagramOpenEventHandler({ onSend, subscribe, config });
+
+      diagramOpenEventHandler.enable();
+
+      const bpmnCallback = subscribe.getCall(3).args[1];
+
+      await bpmnCallback({ tab });
+
+      const { engineProfile } = onSend.getCall(0).args[0];
+
+      // then
+      expect(engineProfile).to.eql({
+        executionPlatform: 'Camunda Platform'
+      });
+    });
+
+    it('should send Cloud engine profile (forms)', async () => {
+
+      // given
+      const subscribe = sinon.spy();
+
+      const onSend = sinon.spy();
+
+      const tab = createTab({
+        type: 'form',
+        schema: engineProfileCloud
+      });
+
+      const config = { get: () => null };
+
+      // when
+      const diagramOpenEventHandler = new DiagramOpenEventHandler({ onSend, subscribe, config });
+
+      diagramOpenEventHandler.enable();
+
+      const bpmnCallback = subscribe.getCall(3).args[1];
 
       await bpmnCallback({ tab });
 

--- a/client/src/plugins/usage-statistics/event-handlers/__tests__/fixtures/engine-cloud.json
+++ b/client/src/plugins/usage-statistics/event-handlers/__tests__/fixtures/engine-cloud.json
@@ -1,0 +1,8 @@
+{
+    "schemaVersion": 2,
+    "components": [],
+    "type": "default",
+    "id": "Form_1xx04pn",
+    "executionPlatform": "Camunda Cloud",
+    "executionPlatformVersion": "1.1"
+  }

--- a/client/src/plugins/usage-statistics/event-handlers/__tests__/fixtures/engine-platform.json
+++ b/client/src/plugins/usage-statistics/event-handlers/__tests__/fixtures/engine-platform.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 2,
+  "components": [],
+  "type": "default",
+  "id": "Form_0sczxmf",
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.15"
+}

--- a/docs/telemetry/README.md
+++ b/docs/telemetry/README.md
@@ -43,15 +43,27 @@ The `Diagram Opened Event` is sent in following situations:
  - User created a new BPMN diagram
  - User created a new DMN diagram
  - User created a new CMMN diagram
+ - User created a new Form
  - User opened an existing BPMN diagram
  - User opened an existing DMN diagram
  - User opened an existing CMMN diagram
+ - User opened an existing Form
 
 The Diagram Opened Event has the following core structure:
 ```json
 {
   "event": "diagramOpened",
-  "diagramType": "[bpmn, dmn or cmmn]"
+  "diagramType": "[bpmn, dmn, cmmn or form]"
+}
+```
+
+In the case of bpmn and form, we add the engine profile:
+
+```json
+{
+  "engineProfile": {
+    "executionPlatform": "Camunda Cloud"
+  }
 }
 ```
 
@@ -109,15 +121,6 @@ Also in the case of BPMN diagrams, we add selected diagram metrics:
 }
 ```
 
-In terms it is set in the diagram, we add the engine profile:
-
-```json
-{
-  "engineProfile": {
-    "executionPlatform": "Camunda Cloud"
-  }
-}
-```
 
 ### Deployment Event
 The `Deployment Event` is sent in following situations:


### PR DESCRIPTION
Closes #2405 

- [x]  Diagram open is tracked for forms similar to our other editors, including the engine profile, if set
- [x]  Telemetry documentation is updated accordingly