### PR TITLE
feat(app): allow contextIsolation to be disabled via feature toggle

### DIFF
--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -410,7 +410,7 @@ app.createEditorWindow = function() {
 
   const contextIsolation = !flags.get('dangerously-disable-context-isolation', false);
 
-  if (contextIsolation) {
+  if (!contextIsolation) {
     log.warn('contextIsolation is disabled via --dangerously-disable-context-isolation');
   }
 

--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -402,10 +402,16 @@ app.openFiles = function(filePaths) {
  */
 app.createEditorWindow = function() {
 
-  const nodeIntegration = !!flags.get('dangerously-enable-node-integration');
+  const nodeIntegration = flags.get('dangerously-enable-node-integration', false);
 
   if (nodeIntegration) {
     log.warn('nodeIntegration is enabled via --dangerously-enable-node-integration');
+  }
+
+  const contextIsolation = !flags.get('dangerously-disable-context-isolation', false);
+
+  if (contextIsolation) {
+    log.warn('contextIsolation is disabled via --dangerously-disable-context-isolation');
   }
 
   const windowOptions = {
@@ -416,7 +422,7 @@ app.createEditorWindow = function() {
     minHeight: MINIMUM_SIZE.height,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
-      contextIsolation: true,
+      contextIsolation,
       nodeIntegration
     }
   };


### PR DESCRIPTION
The latest version of the Camunda Modeler is based on Electron 12, which disables the use of `require` (and other node integrations) by default when `contextIsolation` is enabled. See this electron issue comment and linked documentation: https://github.com/electron/electron-quick-start/issues/463#issuecomment-790716070.

Consequently, to allow plugins to continue to have access to the file system (understandably _dangerous!!_) with the latest version of the Camunda Modeler, an additional flag is required to dangerously disable context isolation.
