### PR TITLE
Bump camunda-bpmn-js from 0.9.3 to 0.10.0

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2780,23 +2780,23 @@
 			}
 		},
 		"camunda-bpmn-js": {
-			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-0.9.3.tgz",
-			"integrity": "sha512-yM7mGEB8GobQGsVBu7B6LqJXT6J1AS+4raZtw/DCpNCZi1xdYCeiFM4Q93QX2rXNJXdLr/72s2h8q4ih7DQ+Pw==",
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-0.10.0.tgz",
+			"integrity": "sha512-YC0RJNRVMatuo25Dex1nZQa3cnkPYA55kLmKRURhuCTNA3Jz9AhVUL8eNZJIQp8eVijaoS7fwWFaE0/x9KEUlw==",
 			"requires": {
 				"@bpmn-io/align-to-origin": "^0.7.0",
-				"bpmn-js": "^8.7.1",
+				"bpmn-js": "^8.7.3",
 				"bpmn-js-disable-collapsed-subprocess": "^0.1.3",
 				"bpmn-js-executable-fix": "^0.1.3",
 				"bpmn-js-properties-panel": "^0.44.0",
 				"bpmn-js-signavio-compat": "^1.2.3",
-				"camunda-bpmn-moddle": "^5.1.2",
+				"camunda-bpmn-moddle": "^6.0.0",
 				"diagram-js": "^7.3.0",
 				"diagram-js-minimap": "^2.0.4",
 				"diagram-js-origin": "^1.3.2",
 				"inherits": "^2.0.4",
 				"min-dash": "^3.7.0",
-				"zeebe-bpmn-moddle": "^0.7.1"
+				"zeebe-bpmn-moddle": "^0.8.0"
 			},
 			"dependencies": {
 				"inherits": {
@@ -2804,10 +2804,10 @@
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 				},
-				"zeebe-bpmn-moddle": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.7.1.tgz",
-					"integrity": "sha512-XUUaGKY/w6QcxgtHPMgy8wt9yhu2BJ17ahjEz6pTr1wosdKra4pq/akF1XXPpUYSEfEswtyK4j0lWT1cu51lKw=="
+			  	"zeebe-bpmn-moddle": {
+					"version": "0.8.0",
+					"resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.8.0.tgz",
+					"integrity": "sha512-1wly1tG5KB3rbF2OeCuubqsosmR9nPkhvwfi1Wq/qqfChCHLvbfZNny4a/fbxKefTCSlRvxJxxAwjPf1KBrUBg=="
 				}
 			}
 		},

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,7 @@
     "@sentry/browser": "^6.3.6",
     "bpmn-js": "^8.7.3",
     "bpmn-js-properties-panel": "^0.44.0",
-    "camunda-bpmn-js": "^0.9.3",
+    "camunda-bpmn-js": "^0.10.0",
     "camunda-bpmn-moddle": "^5.1.2",
     "camunda-cmmn-moddle": "^1.0.0",
     "camunda-dmn-moddle": "^1.1.0",


### PR DESCRIPTION
Closes #2423 and related to #2420 