### PR TITLE
fix(releaseInfo): add space before links

### DIFF
--- a/client/src/plugins/version-info/ReleaseInfo.js
+++ b/client/src/plugins/version-info/ReleaseInfo.js
@@ -51,10 +51,10 @@ export function ReleaseInfo(props) {
         <li>
           <b>Form reference bindings for User Tasks and Start Events</b><br />
           With the Camunda Platform 7.16.0 release you now have an additional way to bind Camunda Forms to
-          User Tasks or Start Events. Besides the existing way of binding using a
-          <a href="https://docs.camunda.org/manual/latest/user-guide/task-forms/#form-key">form key</a>,
-          you can now alternatively use a
-          <a href="https://docs.camunda.org/manual/latest/user-guide/task-forms/#form-reference">form reference</a>.
+          User Tasks or Start Events. Besides the existing way of binding using
+          a <a href="https://docs.camunda.org/manual/latest/user-guide/task-forms/#form-key">form key</a>,
+          you can now alternatively use
+          a <a href="https://docs.camunda.org/manual/latest/user-guide/task-forms/#form-reference">form reference</a>.
           This allows you to bind a specific version, or the latest version from the deployment.
         </li>
         <li>


### PR DESCRIPTION
In the 4.11.0-rc.0 release, the release info looks is lacking white-space:

Root cause: line starts with JSX
Fix: don't have the link on a new line

Old:
![image](https://user-images.githubusercontent.com/21984219/136389870-bd026933-a973-40ac-b340-63e8f60193b4.png)

New:
![image](https://user-images.githubusercontent.com/21984219/136390383-5ab1652d-0aa8-4506-84aa-ca32885a8641.png)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
