### PR TITLE
Use correct @bpmn-io/bpmn-properties-panel in the build

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1060,13 +1060,14 @@
 			"integrity": "sha512-a8Ri5q2uhCrHJ415BR9ZulajvOw0SX2Eh0jxwoMZ/ynxcZPBbOKm6kW6HAQFJp0EFHwftMiJstcvIcSjyz0hZA=="
 		},
 		"@bpmn-io/bpmn-properties-panel": {
-			"version": "github:bpmn-io/bpmn-properties-panel#597900e194e8bc940fa91e0876aa1e98c81faa28",
-			"from": "github:bpmn-io/bpmn-properties-panel#v0.2.0",
+			"version": "github:bpmn-io/bpmn-properties-panel#5d8fccf3f8c3854040ce88f5e61014d8545ed322",
+			"from": "github:bpmn-io/bpmn-properties-panel#v0.3.0",
 			"requires": {
 				"@bpmn-io/extract-process-variables": "^0.4.3",
-				"@bpmn-io/properties-panel": "^0.3.0",
+				"@bpmn-io/properties-panel": "^0.4.2",
 				"classnames": "^2.3.1",
 				"ids": "^1.0.0",
+				"min-dash": "^3.8.0",
 				"min-dom": "^3.1.3",
 				"preact": "^10.5.13"
 			},
@@ -1075,6 +1076,11 @@
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
 					"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+				},
+				"min-dash": {
+					"version": "3.8.0",
+					"resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.0.tgz",
+					"integrity": "sha512-a0TLbmL6p4RlNGblZcLd2yjPORp+bCYRlNGvwK5OMwWaMROWh1DlRgN9W8jJm2x9gVuscvD38BEosV7cnikKnw=="
 				}
 			}
 		},
@@ -1161,9 +1167,9 @@
 			}
 		},
 		"@bpmn-io/properties-panel": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.3.0.tgz",
-			"integrity": "sha512-kNHGSSfnfJcwYPEiF7JolKeUJA3q4M2E/lVXC0SQv3RezomZ058Pu5gv0QF1JK8aInBJH5xkvucxV/pPqAm+Fw==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.4.2.tgz",
+			"integrity": "sha512-uoPweDHsacTmq6my9LJiR0NHWZ/J1r8P6L1XwEFx3zPVy8VhMqfgTk2fBvQq5MYz0TD1AemElmnmX20DEmqQjQ==",
 			"requires": {
 				"classnames": "^2.3.1",
 				"min-dash": "^3.7.0",


### PR DESCRIPTION
In the `4.11.0-rc.0` release, we did not use the new cloud properties panel version.

Root Cause: bumping the tag in the `package.json` and running `npm i` does not update the `package-lock` if the dependency is a github link.

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
