### PR TITLE
fix(mac-os): quit app when requested

### DIFF
--- a/app/lib/platform/mac-os/index.js
+++ b/app/lib/platform/mac-os/index.js
@@ -70,7 +70,7 @@ function MacOSPlatform(app) {
    * called or the window was closed.
    */
   app.on('window-all-closed', function(e) {
-    if (app.terminating) {
+    if (app.terminating || app.quitRequested) {
       return app.quit();
     }
 
@@ -79,6 +79,16 @@ function MacOSPlatform(app) {
     log.info('Keeping app in the dock');
 
     app.terminating = false;
+  });
+
+  /**
+   * Make sure app quits and does not hang after last
+   * window was closed.
+   *
+   * Cf. https://github.com/camunda/camunda-modeler/issues/1803
+   */
+  app.on('before-quit', function() {
+    app.quitRequested = true;
   });
 
   /**


### PR DESCRIPTION
Closes #1803

---

This ensures the application got terminated after the window got closed, once requested (`CMD+Q`, system shutdown, ...). 

The `before-quit` does not get fired if the macOS browser window is closed manually via "X" - that ensures the keep-in-dock behavior (cf. https://github.com/camunda/camunda-modeler/issues/1803#issuecomment-939861288).

https://user-images.githubusercontent.com/9433996/136804277-94452834-dc34-43a2-8b66-b603ccd4e6a5.mov
