### PR TITLE
feat(form): allow to create form with engine profile set

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1658,6 +1658,10 @@ export class App extends PureComponent {
       return this.createDiagram('form');
     }
 
+    if (action === 'create-cloud-form') {
+      return this.createDiagram('cloud-form');
+    }
+
     if (action === 'create-cloud-bpmn-diagram') {
       return this.createDiagram('cloud-bpmn');
     }

--- a/client/src/app/EmptyTab.js
+++ b/client/src/app/EmptyTab.js
@@ -60,7 +60,7 @@ export default class EmptyTab extends PureComponent {
         {this.renderDiagramButton('create-cloud-bpmn-diagram', 'BPMN diagram', <BPMNIcon />)}
         {
           !Flags.get(DISABLE_FORM) && (
-            this.renderDiagramButton('create-form', 'Form', <FormIcon />)
+            this.renderDiagramButton('create-cloud-form', 'Form', <FormIcon />)
           )
         }
       </div>

--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -13,6 +13,7 @@ import cloudBpmnDiagram from './tabs/cloud-bpmn/diagram.bpmn';
 import cmmnDiagram from './tabs/cmmn/diagram.cmmn';
 import dmnDiagram from './tabs/dmn/diagram.dmn';
 import form from './tabs/form/initial.form';
+import cloudForm from './tabs/form/initial-cloud.form';
 
 import replaceIds from '@bpmn-io/replace-ids';
 
@@ -322,14 +323,50 @@ export default class TabsProvider {
         },
         getNewFileMenu() {
           return [{
-            label: 'Form (Camunda Platform or Cloud)',
+            label: 'Form (Camunda Platform)',
             action: 'create-form'
           }];
         },
         getNewFileButton() {
           return {
-            label: 'Create new Form (Camunda Platform or Cloud)',
+            label: 'Create new Form (Camunda Platform)',
             action: 'create-form'
+          };
+        },
+        getLinter() {
+          return FormLinter;
+        }
+      },
+      'cloud-form': {
+        name: null,
+        encoding: ENCODING_UTF8,
+        exports: {},
+        extensions: [ 'form' ],
+        canOpen(file) {
+          return file.name.endsWith('.form');
+        },
+        getComponent(options) {
+          return import('./tabs/form');
+        },
+        getInitialContents() {
+          return cloudForm;
+        },
+        getInitialFilename(suffix) {
+          return `form_${suffix}.form`;
+        },
+        getHelpMenu() {
+          return [];
+        },
+        getNewFileMenu() {
+          return [{
+            label: 'Form (Camunda Cloud)',
+            action: 'create-cloud-form'
+          }];
+        },
+        getNewFileButton() {
+          return {
+            label: 'Create new Form (Camunda Cloud)',
+            action: 'create-cloud-form'
           };
         },
         getLinter() {
@@ -342,7 +379,7 @@ export default class TabsProvider {
       bpmn: [ this.providers['cloud-bpmn'], this.providers.bpmn ],
       dmn: [ this.providers.dmn ],
       cmmn: [ this.providers.cmmn ],
-      form: [ this.providers.form ]
+      form: [ this.providers['cloud-form'], this.providers.form ]
     };
 
     if (Flags.get('disable-zeebe')) {
@@ -362,6 +399,7 @@ export default class TabsProvider {
 
     if (Flags.get('disable-form')) {
       delete this.providers.form;
+      delete this.providers['cloud-form'];
       delete this.providersByFileType.form;
     }
   }

--- a/client/src/app/__tests__/EmptyTabSpec.js
+++ b/client/src/app/__tests__/EmptyTabSpec.js
@@ -44,7 +44,7 @@ describe('<EmptyTab>', function() {
         [ 'create-dmn-diagram' ],
         [ 'create-form' ],
         [ 'create-cloud-bpmn-diagram' ],
-        [ 'create-form' ] // TODO(smbea): replace with 'create-cloud-form'
+        [ 'create-cloud-form' ]
       ]);
     });
 

--- a/client/src/app/__tests__/TabsProviderSpec.js
+++ b/client/src/app/__tests__/TabsProviderSpec.js
@@ -122,6 +122,7 @@ describe('TabsProvider', function() {
 
     verifyExists('form');
 
+    verifyExists('cloud-form');
 
     it('for an empty file of known type', function() {
 

--- a/client/src/app/tabs/form/initial-cloud.form
+++ b/client/src/app/tabs/form/initial-cloud.form
@@ -1,0 +1,6 @@
+{
+  "type": "default",
+  "components": [],
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "1.2"
+}

--- a/client/src/app/tabs/form/initial.form
+++ b/client/src/app/tabs/form/initial.form
@@ -1,4 +1,6 @@
 {
   "type": "default",
-  "components": []
+  "components": [],
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.16"
 }


### PR DESCRIPTION
Closes #2480

- allows to create form with engine profile set from welcome tab buttons and file menu


__Screenshot:__

<img width="449" alt="Screenshot 2021-10-13 at 11 57 25" src="https://user-images.githubusercontent.com/25825387/137135673-ecd51af5-5bd5-4b46-8127-01225b740d01.png">

__Note:__ There are a few possibilities as to how to address the UI of the engine profile select, such as:
* keep as is -> user can still change after choosing in the welcome tab or file menu
* can only change version -> user is stuck with the chosen engine
  * what happens when user opens form file without the execution platform? keep "No platform selected" or define a default engine?
  
 Since this wasn't discussed with @andreasgeier, I propose keeping the select as is and decide on changes later on, if needed (this topic is mentioned in the tasks of #2470 so it doesn't get lost).
