### PR TITLE
feat(overlay): add styles for overlay forms

### DIFF
--- a/client/src/shared/ui/overlay/Overlay.less
+++ b/client/src/shared/ui/overlay/Overlay.less
@@ -60,4 +60,18 @@
     border-top: 1px solid var(--overlay-border-color);
   }
   
+  .fieldset {
+    border: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .fields {
+    display: grid;
+    grid-gap: 12px;
+  }
+
+  button[type="submit"] {
+    width: 100%;
+  }
 }

--- a/client/src/styles/_forms.less
+++ b/client/src/styles/_forms.less
@@ -1,6 +1,4 @@
 .form-group {
-
-  --input-width: calc(100% - 40px);
   --input-background-color: var(--color-ffffff);
 
   input[type=password].form-control,
@@ -9,7 +7,7 @@
     border-radius: 3px;
     border: solid 1px var(--silver-darken-80);
     background-color: var(--input-background-color);
-    width: var(--input-width);
+    width: 100%;
     height: 30px;
     font-size: 13px;
     padding-left: 8px;
@@ -309,7 +307,7 @@
   .file-list-item {
     display: grid;
     align-items: center;
-    grid-template-columns: var(--input-width) auto;
+    grid-template-columns: 100% auto;
   }
 
   .file-list-item-content {

--- a/client/src/styles/_modal.less
+++ b/client/src/styles/_modal.less
@@ -1,4 +1,6 @@
 .modal {
+  --input-width: calc(100% - 40px);
+
   position: absolute;
   top: 0;
   left: 0;
@@ -98,6 +100,16 @@
   .fields {
     display: grid;
     grid-row-gap: 15px;
+  }
+
+  input[type=password].form-control,
+  input[type=text].form-control,
+  select.form-control {
+    width: var(--input-width);
+  }
+
+  .file-list-item {
+    grid-template-columns: var(--input-width) auto;
   }
 }
 


### PR DESCRIPTION
Related to #2489 

- Add missing styles for forms to overlay component (already in use for modals in `_modal.less`)
- Make submit button width 100% (will be used in all overlays)
- Change default input width used for forms to 100% and move current input width to modals

Preparation for migrating modals to overlays: make styles available to update Cloud Connect.

Will allow screenshot bellow (taken from Cloud Connect overlay [feature branch](https://github.com/camunda/cloud-connect-modeler-plugin/tree/48-replace-modal-with-overlay) - in progress):

<img width="299" alt="Screenshot 2021-10-18 at 17 48 18" src="https://user-images.githubusercontent.com/25825387/137771181-ae017c8a-fc6c-4b25-9577-5977ddbbb1d9.png">


