### PR TITLE
feat(flags): add `DISABLE-PLATFORM` flag

### DIFF
--- a/client/src/app/EmptyTab.js
+++ b/client/src/app/EmptyTab.js
@@ -22,7 +22,7 @@ import {
   Tab
 } from './primitives';
 
-import Flags, { DISABLE_DMN, DISABLE_FORM, DISABLE_ZEEBE } from '../util/Flags';
+import Flags, { DISABLE_DMN, DISABLE_FORM, DISABLE_ZEEBE, DISABLE_PLATFORM } from '../util/Flags';
 
 
 export default class EmptyTab extends PureComponent {
@@ -96,7 +96,11 @@ export default class EmptyTab extends PureComponent {
 
     return (
       <Tab className={ css.EmptyTab }>
-        {this.renderPlatformColumn()}
+        {
+          !Flags.get(DISABLE_PLATFORM) && (
+            this.renderPlatformColumn()
+          )
+        }
 
         {
           !Flags.get(DISABLE_ZEEBE) && (

--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -37,11 +37,12 @@ import {
 } from './tabs/util/namespace';
 
 import {
-  Flags,
   generateId
 } from '../util';
 
 import FormLinter from './tabs/form/linting/FormLinter';
+
+import Flags, { DISABLE_DMN, DISABLE_FORM, DISABLE_ZEEBE, DISABLE_PLATFORM, DISABLE_CMMN } from '../util/Flags';
 
 const createdByType = {};
 
@@ -382,22 +383,35 @@ export default class TabsProvider {
       form: [ this.providers['cloud-form'], this.providers.form ]
     };
 
-    if (Flags.get('disable-zeebe')) {
+    if (Flags.get(DISABLE_ZEEBE)) {
       this.providersByFileType.bpmn = this.providersByFileType.bpmn.filter(p => p !== this.providers['cloud-bpmn']);
       delete this.providers['cloud-bpmn'];
     }
 
-    if (Flags.get('disable-cmmn', true)) {
+    if (Flags.get(DISABLE_PLATFORM)) {
+      this.providersByFileType.bpmn = this.providersByFileType.bpmn.filter(p => p !== this.providers.bpmn);
+      delete this.providers.bpmn;
+
+      delete this.providers.cmmn;
+      delete this.providersByFileType.cmmn;
+
+      delete this.providers.dmn;
+      delete this.providersByFileType.dmn;
+
+      delete this.providers.form;
+    }
+
+    if (Flags.get(DISABLE_CMMN, true)) {
       delete this.providers.cmmn;
       delete this.providersByFileType.cmmn;
     }
 
-    if (Flags.get('disable-dmn')) {
+    if (Flags.get(DISABLE_DMN)) {
       delete this.providers.dmn;
       delete this.providersByFileType.dmn;
     }
 
-    if (Flags.get('disable-form')) {
+    if (Flags.get(DISABLE_FORM)) {
       delete this.providers.form;
       delete this.providers['cloud-form'];
       delete this.providersByFileType.form;

--- a/client/src/app/__tests__/EmptyTabSpec.js
+++ b/client/src/app/__tests__/EmptyTabSpec.js
@@ -16,7 +16,7 @@ import {
 
 import EmptyTab from '../EmptyTab';
 
-import Flags, { DISABLE_DMN, DISABLE_FORM, DISABLE_ZEEBE } from '../../util/Flags';
+import Flags, { DISABLE_DMN, DISABLE_FORM, DISABLE_ZEEBE, DISABLE_PLATFORM } from '../../util/Flags';
 
 /* global sinon */
 
@@ -122,6 +122,49 @@ describe('<EmptyTab>', function() {
           wrapper => wrapper.text().startsWith('Form')
         ).first().exists()
       ).to.be.true;
+    });
+
+  });
+
+
+  describe('enable platform', function() {
+
+    afterEach(sinon.restore);
+
+    it('should display platform without flag', function() {
+
+      // when
+      const {
+        tree
+      } = createEmptyTab();
+
+      // then
+      expect(tree.find('.create-buttons')).to.have.length(2);
+      expect(
+        tree.findWhere(
+          wrapper => wrapper.text().startsWith('Camunda Platform')
+        ).exists()
+      ).to.be.true;
+    });
+
+
+    it('should NOT display platform with flag', function() {
+
+      // given
+      sinon.stub(Flags, 'get').withArgs(DISABLE_PLATFORM).returns(true);
+
+      // given
+      const {
+        tree
+      } = createEmptyTab();
+
+      // then
+      expect(tree.find('.create-buttons')).to.have.length(1);
+      expect(
+        tree.findWhere(
+          wrapper => wrapper.text().startsWith('Camunda Platform')
+        ).exists()
+      ).to.be.false;
     });
 
   });

--- a/client/src/util/Flags.js
+++ b/client/src/util/Flags.js
@@ -34,6 +34,7 @@ export default new Flags();
 export const DISABLE_CMMN = 'disable-cmmn';
 export const DISABLE_DMN = 'disable-dmn';
 export const DISABLE_FORM = 'disable-form';
+export const DISABLE_PLATFORM = 'disable-platform';
 export const DISABLE_ZEEBE = 'disable-zeebe';
 export const DISABLE_ADJUST_ORIGIN = 'disable-adjust-origin';
 export const DISABLE_PLUGINS = 'disable-plugins';

--- a/docs/flags/README.md
+++ b/docs/flags/README.md
@@ -33,6 +33,7 @@ Flags passed as command line arguments take precedence over those configured via
 | "disable-adjust-origin"  | false |
 | "disable-cmmn" | true |
 | "disable-dmn" | false |
+| "disable-platform" | false |
 | "disable-zeebe" | false |
 | "disable-remote-interaction" | false |
 | "single-instance" | false |


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/58601/138710797-f953bbab-e929-4b0d-b7a1-0b9c8a8f6b10.png)

---

Closes #2506

---

Note:

- currently, the forms engine select doesn't check for enabled engines (even in the case of zeebe) (see [here]( https://github.com/camunda/camunda-modeler/blob/bd6d1bbbfc5610243843790f41ddc9d694fd5eb4/client/src/app/tabs/EngineProfile.js#L24))