### PR TITLE
feat(client): add toggle form field

### DIFF
--- a/client/src/remote/Plugins.js
+++ b/client/src/remote/Plugins.js
@@ -12,7 +12,8 @@ import { filter } from 'min-dash';
 
 import {
   Modal,
-  Overlay
+  Overlay,
+  ToggleSwitch
 } from '../shared/ui';
 
 import { Fill } from '../app/slot-fill';
@@ -55,7 +56,8 @@ export default class Plugins {
     global.components = {
       Fill,
       Modal,
-      Overlay
+      Overlay,
+      ToggleSwitch
     };
 
     global.getModelerDirectory = () => {

--- a/client/src/shared/ui/form/ToggleSwitch.js
+++ b/client/src/shared/ui/form/ToggleSwitch.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+
+
+export default function ToggleSwitch(props) {
+  const {
+    id,
+    label,
+    switcherLabel,
+    description,
+    field,
+    form,
+    ...restProps
+  } = props;
+
+  return (
+    <div className="custom-control-toggle" data-entry-id={ id }>
+      <div className="toggle-switch">
+        <label className="label"
+          htmlFor={ id }>
+          { label }
+        </label>
+        <div className="field-wrapper custom-control custom-checkbox">
+          <label className="toggle-switch__switcher">
+            <input
+              type="checkbox"
+              { ...field }
+              { ...restProps }
+              checked={ field.value }
+            />
+            <span className="toggle-switch__slider" />
+          </label>
+          <p className="toggle-switch__label">{ switcherLabel }</p>
+        </div>
+      </div>
+      { description && <div className="description">{ description }</div> }
+    </div>
+  );
+}

--- a/client/src/shared/ui/form/__tests__/ToggleSwitchSpec.js
+++ b/client/src/shared/ui/form/__tests__/ToggleSwitchSpec.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { ToggleSwitch } from '..';
+
+
+describe('<ToggleSwitch>', function() {
+
+  it('should render', function() {
+    createToggleSwitch();
+  });
+
+
+  it('should enable option', function() {
+
+    // given
+    const wrapper = createToggleSwitch({
+      field:
+        {
+          value: true
+        }
+    });
+
+    const input = wrapper.find('input');
+
+    // then
+    expect(input.prop('checked')).to.be.true;
+
+  });
+
+});
+
+
+// helpers ///////////////////
+
+function createToggleSwitch(options = {}) {
+
+  return shallow(<ToggleSwitch
+    field={ options.field || {} }
+  />);
+
+}

--- a/client/src/shared/ui/form/index.js
+++ b/client/src/shared/ui/form/index.js
@@ -12,3 +12,4 @@ export { default as CheckBox } from './CheckBox';
 export { default as TextInput } from './TextInput';
 export { default as Radio } from './Radio';
 export { default as FileInput } from './FileInput';
+export { default as ToggleSwitch } from './ToggleSwitch';

--- a/client/src/styles/_forms.less
+++ b/client/src/styles/_forms.less
@@ -1,5 +1,8 @@
 .form-group {
   --input-background-color: var(--color-ffffff);
+  --toggle-switch-on-background-color: var(--blue-darken-55);
+  --toggle-switch-off-background-color: var(--color-cccccc);
+  --toggle-switch-switcher-background-color: var(--color-ffffff);
 
   input[type=password].form-control,
   input[type=text].form-control,
@@ -355,5 +358,82 @@
     .error {
       margin-left: 3px;
     }
+  } 
+}
+
+.custom-control-toggle {
+
+  margin-top: -8px;
+  
+  > .description {
+    margin:6px 0 6px 38px;
+    font-size: 13px;
+    color: var(--grey-lighten-56);
+
+  }
+  
+  .toggle-switch .field-wrapper {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+  
+  .toggle-switch > .label {
+    font-size: var(--text-size-base);
+  }
+  
+  .toggle-switch .toggle-switch__label {
+    margin: 0;
+    margin-left: 6px;
+    font-size: var(--text-size-base);
+  }
+  
+  .toggle-switch .toggle-switch__switcher {
+    position: relative;
+    width: 32px;
+    height: 16px;
+  }
+  
+  .toggle-switch .toggle-switch__switcher input[type='checkbox'] {
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+  
+  .toggle-switch .toggle-switch__switcher .toggle-switch__slider {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: var(--toggle-switch-off-background-color);
+    -webkit-transition: 0.4s;
+    transition: 0.4s;
+    border-radius: 34px;
+  }
+  
+  .toggle-switch .toggle-switch__switcher .toggle-switch__slider:before {
+    position: absolute;
+    content: "";
+    height: 12px;
+    width: 12px;
+    left: 2px;
+    bottom: 2px;
+    background-color: var(--toggle-switch-switcher-background-color);
+    -webkit-transition: 0.4s;
+    transition: 0.4s;
+    border-radius: 50%;
+  }
+  
+  .toggle-switch .toggle-switch__switcher input[type='checkbox']:checked + .toggle-switch__slider {
+    background-color: var(--toggle-switch-on-background-color);
+    box-shadow: 0 0 1px ;
+  }
+  
+  .toggle-switch .toggle-switch__switcher input[type='checkbox']:checked + .toggle-switch__slider:before {
+    -webkit-transform: translateX(16px);
+    -ms-transform: translateX(16px);
+    transform: translateX(16px);
   }
 }
+


### PR DESCRIPTION
Related to camunda/cloud-connect-modeler-plugin/issues/48

- This PR implements the toggle-switch button (with the same style and behaviour as the one used for in the properties panel) and exposes it to plugins
- Can be tested with this [feature-branch](https://github.com/camunda/cloud-connect-modeler-plugin/tree/48-replace-modal-with-overlay) that is implementing the UI changes in `cloud-connect-plugin`.

https://user-images.githubusercontent.com/25825387/138126550-00909858-acf9-4479-91f7-60b683160dd6.mov


