### PR TITLE
Add IBM Plex Font

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1198,6 +1198,11 @@
 			"resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.4.0.tgz",
 			"integrity": "sha512-M5xW61ba7z2maBxfoT4c1bjuLD8OIL7863et/hULiNG6+R/B9CZ4Qze1juuIfXv4zpF2fYSuUsTPkTtiZrcspQ=="
 		},
+		"@ibm/plex": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@ibm/plex/-/plex-6.0.0.tgz",
+			"integrity": "sha512-KJv808kiPfyolO1fd2xHwhltHy2MlvpwRcGca+tOul+hbLf8r/Xx+8Xz5/KyKl/vvDJR8YXQCq09vGBAmrNDZw=="
+		},
 		"@sentry/browser": {
 			"version": "6.3.6",
 			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.3.6.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "@bpmn-io/extract-process-variables": "^0.4.3",
     "@bpmn-io/form-js": "^0.5.0",
     "@bpmn-io/replace-ids": "^0.2.0",
+    "@ibm/plex": "^6.0.0",
     "@sentry/browser": "^6.3.6",
     "bpmn-js": "^8.7.3",
     "bpmn-js-properties-panel": "^0.46.0",

--- a/client/src/app/Log.less
+++ b/client/src/app/Log.less
@@ -17,7 +17,7 @@
     border: none;
 
     font-size: 13px;
-    font-family: monospace;
+    font-family: var(--font-family-monospace);
     color: var(--grey-base-40);
 
     white-space: pre-wrap;

--- a/client/src/app/modals/keyboard-shortcuts/View.less
+++ b/client/src/app/modals/keyboard-shortcuts/View.less
@@ -5,7 +5,11 @@
 
   .binding {
     padding: 5px 10px;
-    font-family: monospace;
+    font-family: var(--font-family-monospace);
+
+    code {
+      font-family: inherit;
+    }
   }
 
   .buttonDiv {

--- a/client/src/app/tabs/PropertiesContainer.less
+++ b/client/src/app/tabs/PropertiesContainer.less
@@ -50,6 +50,8 @@
   }
 
   .bio-properties-panel {
+    --font-family: inherit;
+    --font-family-monospace: inherit;
     background: var(--color-ffffff);
   }
 

--- a/client/src/app/tabs/bpmn/BpmnEditor.less
+++ b/client/src/app/tabs/bpmn/BpmnEditor.less
@@ -18,6 +18,10 @@
     }
   }
 
+  .bjs-container {
+    --bjs-font-family: var(--font-family);
+  }
+
   /**
    * Fix properties tabbing
    */

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.less
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.less
@@ -13,6 +13,10 @@
     flex: none;
   }
 
+  .bjs-container {
+    --bjs-font-family: var(--font-family);
+  }
+
   /**
    * Fix properties tabbing
    */

--- a/client/src/app/tabs/dmn/DmnEditor.less
+++ b/client/src/app/tabs/dmn/DmnEditor.less
@@ -23,6 +23,7 @@
       font-size: 14px;
       color: var(--color-444444);
       font-weight: bold;
+      font-family: inherit;
       outline: none;
       margin-right: 10px;
 

--- a/client/src/app/tabs/dmn/DmnEditor.less
+++ b/client/src/app/tabs/dmn/DmnEditor.less
@@ -5,6 +5,19 @@
 
   flex-direction: column;
 
+  .dmn-drd-container {
+    --drd-font-family-monospace: var(--font-family-monospace);
+  }
+
+  .dmn-decision-table-container {
+    --decision-table-font-family: var(--font-family);
+  }
+
+  .dmn-literal-expression-container {
+    --literal-expression-font-family: var(--font-family);
+    --literal-expression-font-family-monospace: var(--font-family-monospace);
+  }
+
   :not(.top) + .bottom {
     .dmn-decision-table-container,
     .dmn-literal-expression-container {

--- a/client/src/app/tabs/form/FormEditor.less
+++ b/client/src/app/tabs/form/FormEditor.less
@@ -9,6 +9,7 @@
     flex-direction: row;
   
     .fjs-container {
+      --font-family: inherit;
       display: flex;
       flex: 1;
       flex-direction: row;

--- a/client/src/app/tabs/json/JSONEditor.less
+++ b/client/src/app/tabs/json/JSONEditor.less
@@ -13,6 +13,7 @@
   .CodeMirror {
     height: 100%;
     font-size: 13px;
+    font-family: var(--font-family-monospace);
 
     position: absolute;
     top: 0;

--- a/client/src/app/tabs/xml/XMLEditor.less
+++ b/client/src/app/tabs/xml/XMLEditor.less
@@ -13,6 +13,7 @@
   .CodeMirror {
     height: 100%;
     font-size: 13px;
+    font-family: var(--font-family-monospace);
 
     position: absolute;
     top: 0;

--- a/client/src/styles/_base.less
+++ b/client/src/styles/_base.less
@@ -3,7 +3,7 @@
 }
 
 body {
-  font-family: Arial, sans-serif;
+  font-family: var(--font-family);
   font-size: 12px;
   background-color: var(--color-ffffff);
 }

--- a/client/src/styles/_buttons.less
+++ b/client/src/styles/_buttons.less
@@ -6,6 +6,7 @@
   font-weight: bold;
   font-stretch: normal;
   font-style: normal;
+  font-family: inherit;
   line-height: normal;
   letter-spacing: normal;
   text-align: center;

--- a/client/src/styles/_font.less
+++ b/client/src/styles/_font.less
@@ -38,6 +38,15 @@
   src: local("IBM Plex Sans Bold"), local("IBMPlexSans-Bold"), url("~@ibm/plex/IBM-Plex-Sans/fonts/complete/woff2/IBMPlexSans-Bold.woff2") format("woff2"), url("~@ibm/plex/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Bold.woff") format("woff"); 
 }
 
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local("IBM Plex Mono"), local("IBMPlexMono"), url("~@ibm/plex/IBM-Plex-Mono/fonts/complete/woff2/IBMPlexMono-Regular.woff2") format("woff2"), url("~@ibm/plex/IBM-Plex-Mono/fonts/complete/woff/IBMPlexMono-Regular.woff") format("woff"); 
+}
+
 :root {
   --font-family: 'IBM Plex Sans', system-ui, Arial, sans-serif;
+  --font-family-monospace: 'IBM Plex Mono', monospace;
 }

--- a/client/src/styles/_font.less
+++ b/client/src/styles/_font.less
@@ -1,0 +1,43 @@
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 300;
+  font-display: swap;
+  src: local("IBM Plex Sans Light"), local("IBMPlexSans-Light"), url("~@ibm/plex/IBM-Plex-Sans/fonts/complete/woff2/IBMPlexSans-Light.woff2") format("woff2"), url("~@ibm/plex/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Light.woff") format("woff"); 
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local("IBM Plex Sans"), local("IBMPlexSans"), url("~@ibm/plex/IBM-Plex-Sans/fonts/complete/woff2/IBMPlexSans-Regular.woff2") format("woff2"), url("~@ibm/plex/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff") format("woff"); 
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: local("IBM Plex Sans Medm"), local("IBMPlexSans-Medm"), url("~@ibm/plex/IBM-Plex-Sans/fonts/complete/woff2/IBMPlexSans-Medium.woff2") format("woff2"), url("~@ibm/plex/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Medium.woff") format("woff"); 
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: local("IBM Plex Sans SmBld"), local("IBMPlexSans-SmBld"), url("~@ibm/plex/IBM-Plex-Sans/fonts/complete/woff2/IBMPlexSans-SemiBold.woff2") format("woff2"), url("~@ibm/plex/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff") format("woff"); 
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: local("IBM Plex Sans Bold"), local("IBMPlexSans-Bold"), url("~@ibm/plex/IBM-Plex-Sans/fonts/complete/woff2/IBMPlexSans-Bold.woff2") format("woff2"), url("~@ibm/plex/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Bold.woff") format("woff"); 
+}
+
+:root {
+  --font-family: 'IBM Plex Sans', system-ui, Arial, sans-serif;
+}

--- a/client/src/styles/_forms.less
+++ b/client/src/styles/_forms.less
@@ -15,6 +15,7 @@
     font-size: 13px;
     padding-left: 8px;
     color: var(--grey-darken-30);
+    font-family: inherit;
     font-weight: normal;
     font-stretch: normal;
     font-style: normal;

--- a/client/src/styles/_modal.less
+++ b/client/src/styles/_modal.less
@@ -80,6 +80,7 @@
     font-weight: bold;
     font-stretch: normal;
     font-style: normal;
+    font-family: inherit;
     line-height: normal;
     letter-spacing: normal;
     color: var(--grey-darken-33);

--- a/client/src/styles/style.less
+++ b/client/src/styles/style.less
@@ -1,4 +1,5 @@
 @import "_colors";
+@import "_font";
 
 @import "_base";
 


### PR DESCRIPTION
Closes #2458 

Artifacts
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2458-ibm-plex-font/camunda-modeler-2458-ibm-plex-font-linux-x64.tar.gz
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2458-ibm-plex-font/camunda-modeler-2458-ibm-plex-font-mac.dmg
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2458-ibm-plex-font/camunda-modeler-2458-ibm-plex-font-mac.zip
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2458-ibm-plex-font/camunda-modeler-2458-ibm-plex-font-win-ia32.zip
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2458-ibm-plex-font/camunda-modeler-2458-ibm-plex-font-win-x64.zip

Using IBM Plex Sans as default font family
![Bildschirmfoto 2021-10-22 um 11 27 22](https://user-images.githubusercontent.com/9433996/138430411-52610af7-8f4d-4cf5-976f-3d6d1815f4d3.png)

![Bildschirmfoto 2021-10-22 um 14 10 54](https://user-images.githubusercontent.com/9433996/138451505-729b93d9-2fdc-44ca-9cad-5020564b1326.png)


Using IBM Plex Mono as monospace font family (e.g. code editors)
![Bildschirmfoto 2021-10-22 um 11 53 49](https://user-images.githubusercontent.com/9433996/138434301-bf71a197-bb6e-425c-875f-391ad6705ce6.png)

------

This also implied changes in the upstream libraries:
* https://github.com/bpmn-io/form-js/pull/189
* https://github.com/bpmn-io/dmn-js/pull/662
* https://github.com/bpmn-io/properties-panel/pull/110
* https://github.com/bpmn-io/dmn-js-properties-panel/pull/25