### PR TITLE
Fix toggle switch alignment

### DIFF
--- a/client/src/styles/_forms.less
+++ b/client/src/styles/_forms.less
@@ -392,6 +392,7 @@
     position: relative;
     width: 32px;
     height: 16px;
+    margin: 0;
   }
   
   .toggle-switch .toggle-switch__switcher input[type='checkbox'] {


### PR DESCRIPTION
Related to camunda/cloud-connect-modeler-plugin/pull/65

Toggle was inheriting the margin from standard form labels.

__Screenshot:__

Before:
<img width="277" alt="Screenshot 2021-10-26 at 10 40 25" src="https://user-images.githubusercontent.com/25825387/138843056-4d3ace33-539a-4f68-bb16-ac017c7e1a7b.png">

After:
<img width="296" alt="Screenshot 2021-10-26 at 10 39 13" src="https://user-images.githubusercontent.com/25825387/138843069-c62354b6-73da-4817-a642-011d9c78df43.png">

