### PR TITLE
fix(ci): specify target-branch for electron* updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 0
   - package-ecosystem: "npm"
+    target-branch: "develop"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This should make it possible to keep two configurations for the root package.

Cf. https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#target-branch

Closes #2529

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
