### PR TITLE
Define engine profiles globally

### DIFF
--- a/client/src/app/tabs/EngineProfile.js
+++ b/client/src/app/tabs/EngineProfile.js
@@ -316,8 +316,8 @@ function filterEngineOptions() {
 
   return ENGINE_PROFILES.filter(
     option => (
-      Flags.get(DISABLE_PLATFORM) && option.executionPlatform != ENGINES.PLATFORM ||
-      Flags.get(DISABLE_ZEEBE) && option.executionPlatform != ENGINES.CLOUD
+      Flags.get(DISABLE_PLATFORM) && option.executionPlatform !== ENGINES.PLATFORM ||
+      Flags.get(DISABLE_ZEEBE) && option.executionPlatform !== ENGINES.CLOUD
     ));
 }
 

--- a/client/src/app/tabs/EngineProfile.js
+++ b/client/src/app/tabs/EngineProfile.js
@@ -20,19 +20,9 @@ import Arrow from '../../../resources/icons/Arrow.svg';
 import LinkArrow from '../../../resources/icons/LinkArrow.svg';
 
 import Flags, { DISABLE_ZEEBE, DISABLE_PLATFORM } from '../../util/Flags';
+import { ENGINES, ENGINE_PROFILES } from '../../util/Engines';
 
 import css from './EngineProfile.less';
-
-export const engineProfiles = [
-  {
-    executionPlatform: 'Camunda Platform',
-    executionPlatformVersions: [ '7.16', '7.15' ]
-  },
-  {
-    executionPlatform: 'Camunda Cloud',
-    executionPlatformVersions: [ '1.2', '1.1', '1.0' ]
-  }
-];
 
 
 export function EngineProfile(props) {
@@ -262,7 +252,7 @@ function EngineProfileDescription(props) {
 
   const { executionPlatform } = engineProfile;
 
-  if (executionPlatform === 'Camunda Platform') {
+  if (executionPlatform === ENGINES.PLATFORM) {
     return (
       <Fragment>
         <Overlay.Body>
@@ -275,7 +265,7 @@ function EngineProfileDescription(props) {
         </Overlay.Footer>
       </Fragment>
     );
-  } else if (executionPlatform === 'Camunda Cloud') {
+  } else if (executionPlatform === ENGINES.CLOUD) {
     return (
       <Fragment>
         <Overlay.Body>
@@ -322,12 +312,12 @@ function Link(props) {
 function filterEngineOptions() {
 
   if (!Flags.get(DISABLE_PLATFORM) && ! Flags.get(DISABLE_ZEEBE))
-    return engineProfiles;
+    return ENGINE_PROFILES;
 
-  return engineProfiles.filter(
+  return ENGINE_PROFILES.filter(
     option => (
-      Flags.get(DISABLE_PLATFORM) && option.executionPlatform != 'Camunda Platform' ||
-      Flags.get(DISABLE_ZEEBE) && option.executionPlatform != 'Camunda Cloud'
+      Flags.get(DISABLE_PLATFORM) && option.executionPlatform != ENGINES.PLATFORM ||
+      Flags.get(DISABLE_ZEEBE) && option.executionPlatform != ENGINES.CLOUD
     ));
 }
 
@@ -347,7 +337,7 @@ export function isKnownEngineProfile(engineProfile = {}) {
     return false;
   }
 
-  const knownEngineProfile = engineProfiles.find(({ executionPlatform }) => executionPlatform === engineProfile.executionPlatform);
+  const knownEngineProfile = ENGINE_PROFILES.find(({ executionPlatform }) => executionPlatform === engineProfile.executionPlatform);
 
   if (!knownEngineProfile || !knownEngineProfile.executionPlatformVersions.includes(engineProfile.executionPlatformVersion)) {
     return false;

--- a/client/src/app/tabs/__tests__/EngineProfileSpec.js
+++ b/client/src/app/tabs/__tests__/EngineProfileSpec.js
@@ -21,9 +21,10 @@ import {
 
 import {
   EngineProfile,
-  engineProfiles,
   toKebapCase
 } from '../EngineProfile';
+
+import { ENGINE_PROFILES } from '../../../util/Engines';
 
 import { engineProfile as bpmnEngineProfile } from '../bpmn/BpmnEditor';
 import { engineProfile as cloudBpmnEngineProfile } from '../cloud-bpmn/BpmnEditor';
@@ -33,7 +34,7 @@ import Flags, { DISABLE_ZEEBE, DISABLE_PLATFORM } from '../../../util/Flags';
 
 const spy = sinon.spy;
 
-const allEngineProfiles = engineProfiles.reduce((allEngineProfiles, engineProfile) => {
+const allEngineProfiles = ENGINE_PROFILES.reduce((allEngineProfiles, engineProfile) => {
   const {
     executionPlatform,
     executionPlatformVersions

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -65,6 +65,8 @@ import { DEFAULT_LAYOUT as propertiesPanelDefaultLayout } from '../PropertiesCon
 
 import { EngineProfile } from '../EngineProfile';
 
+import { ENGINES } from '../../../util/Engines';
+
 const NAMESPACE_URL_ACTIVITI = 'http://activiti.org/bpmn';
 
 const NAMESPACE_CAMUNDA = {
@@ -101,7 +103,7 @@ const COLORS = [{
 }];
 
 export const engineProfile = {
-  executionPlatform: 'Camunda Platform'
+  executionPlatform: ENGINES.PLATFORM
 };
 
 

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -72,6 +72,8 @@ import { DEFAULT_LAYOUT as overviewDefaultLayout } from './OverviewContainer';
 
 import { EngineProfile } from '../EngineProfile';
 
+import { ENGINES } from '../../../util/Engines';
+
 const EXPORT_AS = [ 'png', 'jpeg', 'svg' ];
 
 const NAMESPACE_URL_DMN11 = 'http://www.omg.org/spec/DMN/20151101/dmn.xsd',
@@ -80,7 +82,7 @@ const NAMESPACE_URL_DMN11 = 'http://www.omg.org/spec/DMN/20151101/dmn.xsd',
 const CONFIG_KEY = 'editor.askDmnMigration';
 
 export const engineProfile = {
-  executionPlatform: 'Camunda Platform'
+  executionPlatform: ENGINES.PLATFORM
 };
 
 

--- a/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
@@ -29,6 +29,8 @@ import {
   Icon
 } from '../../../shared/ui';
 
+import { ENGINES } from '../../../util/Engines';
+
 const DEPLOYMENT_DETAILS_CONFIG_KEY = 'deployment-tool';
 const ENGINE_ENDPOINTS_CONFIG_KEY = 'camundaEngineEndpoints';
 const PROCESS_DEFINITION_CONFIG_KEY = 'process-definition';
@@ -40,8 +42,6 @@ const DEFAULT_ENDPOINT = {
 };
 
 const TOMCAT_DEFAULT_URL = 'http://localhost:8080/engine-rest';
-
-const ET_EXECUTION_PLATFORM_NAME = 'Camunda Platform';
 
 export default class DeploymentTool extends PureComponent {
 
@@ -181,7 +181,7 @@ export default class DeploymentTool extends PureComponent {
         deployment,
         deployedTo: {
           executionPlatformVersion: version,
-          executionPlatform: ET_EXECUTION_PLATFORM_NAME
+          executionPlatform: ENGINES.PLATFORM
         },
         context: 'deploymentTool'
       }
@@ -226,7 +226,7 @@ export default class DeploymentTool extends PureComponent {
 
     // If we retrieved the executionPlatformVersion, include it in event
     const deployedTo = (version &&
-      { executionPlatformVersion: version, executionPlatform: ET_EXECUTION_PLATFORM_NAME }) || undefined;
+      { executionPlatformVersion: version, executionPlatform: ENGINES.PLATFORM }) || undefined;
 
     // notify interested parties
     triggerAction('emit-event', {

--- a/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
@@ -29,13 +29,13 @@ import {
 
 import isExecutable from './util/isExecutable';
 
+import { ENGINES } from '../../../util/Engines';
+
 const START_DETAILS_CONFIG_KEY = 'start-instance-tool';
 
 const START_INSTANCE_FAILED = 'Starting process instance failed';
 
 const PROCESS_DEFINITION_CONFIG_KEY = 'process-definition';
-
-const ET_EXECUTION_PLATFORM_NAME = 'Camunda Platform';
 
 export default class StartInstanceTool extends PureComponent {
 
@@ -420,7 +420,7 @@ export default class StartInstanceTool extends PureComponent {
         context: 'startInstanceTool',
         deployedTo: {
           executionPlatformVersion: version,
-          executionPlatform: ET_EXECUTION_PLATFORM_NAME
+          executionPlatform: ENGINES.PLATFORM
         }
       }
     });
@@ -449,7 +449,7 @@ export default class StartInstanceTool extends PureComponent {
 
     // If we retrieved the executionPlatformVersion, include it in event
     const deployedTo = (version &&
-      { executionPlatformVersion: version, executionPlatform: ET_EXECUTION_PLATFORM_NAME }) || undefined;
+      { executionPlatformVersion: version, executionPlatform: ENGINES.PLATFORM }) || undefined;
 
     // notify interested parties
     triggerAction('emit-event', {

--- a/client/src/plugins/usage-statistics/event-handlers/DeploymentEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/DeploymentEventHandler.js
@@ -23,6 +23,8 @@ import {
   getEngineProfile as parseEngineProfile
 } from '../../../util/parse';
 
+import { ENGINES } from '../../../util/Engines';
+
 const BPMN_TAB_TYPE = 'bpmn';
 const CLOUD_BPMN_TAB_TYPE = 'cloud-bpmn';
 const DMN_TAB_TYPE = 'dmn';
@@ -165,8 +167,8 @@ function getDiagramType(tabType) {
 
 function getDefaultExecutionPlatform(type) {
   if (type === 'cloud-bpmn') {
-    return 'Camunda Cloud';
+    return ENGINES.CLOUD;
   }
 
-  return 'Camunda Platform';
+  return ENGINES.PLATFORM;
 }

--- a/client/src/plugins/usage-statistics/event-handlers/DiagramOpenEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/DiagramOpenEventHandler.js
@@ -16,6 +16,8 @@ import { getMetrics } from '../../../util';
 
 import { getEngineProfile as parseEngineProfile } from '../../../util/parse';
 
+import { ENGINES } from '../../../util/Engines';
+
 const HTTP_STATUS_PAYLOAD_TOO_BIG = 413;
 
 const BINDING_TYPE_PROPERTY = 'property';
@@ -257,8 +259,8 @@ export default class DiagramOpenEventHandler extends BaseEventHandler {
 
 function getDefaultExecutionPlatform(type) {
   if (type === 'cloud-bpmn') {
-    return 'Camunda Cloud';
+    return ENGINES.CLOUD;
   }
 
-  return 'Camunda Platform';
+  return ENGINES.PLATFORM;
 }

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
@@ -34,9 +34,9 @@ import DeploymentPluginModal from './DeploymentPluginModal';
 
 import DeploymentPluginValidator from './DeploymentPluginValidator';
 
-const DEPLOYMENT_CONFIG_KEY = 'zeebe-deployment-tool';
+import { ENGINES } from '../../../util/Engines';
 
-const ET_EXECUTION_PLATFORM_NAME = 'Camunda Cloud';
+const DEPLOYMENT_CONFIG_KEY = 'zeebe-deployment-tool';
 
 const ZEEBE_ENDPOINTS_CONFIG_KEY = 'zeebeEndpoints';
 
@@ -395,7 +395,7 @@ export default class DeploymentPlugin extends PureComponent {
         targetType: endpoint && endpoint.targetType,
         deployedTo: {
           executionPlatformVersion: gatewayVersion,
-          executionPlatform: ET_EXECUTION_PLATFORM_NAME
+          executionPlatform: ENGINES.CLOUD
         }
       }
     });
@@ -422,7 +422,7 @@ export default class DeploymentPlugin extends PureComponent {
 
     // If we retrieved the gatewayVersion, include it in event
     const deployedTo = (gatewayVersion &&
-      { executionPlatformVersion: gatewayVersion, executionPlatform: ET_EXECUTION_PLATFORM_NAME }) || undefined;
+      { executionPlatformVersion: gatewayVersion, executionPlatform: ENGINES.CLOUD }) || undefined;
 
     displayNotification({
       type: 'error',

--- a/client/src/util/Engines.js
+++ b/client/src/util/Engines.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+export const ENGINES = {
+  PLATFORM: 'Camunda Platform',
+  CLOUD: 'Camunda Cloud'
+};
+
+export const ENGINE_PROFILES = [
+  {
+    executionPlatform: ENGINES.PLATFORM,
+    executionPlatformVersions: [ '7.16', '7.15' ]
+  },
+  {
+    executionPlatform: ENGINES.CLOUD,
+    executionPlatformVersions: [ '1.2', '1.1', '1.0' ]
+  }
+];


### PR DESCRIPTION
Closes #2544

- define engine strings and supported engine profiles globally
- replace `engineProfiles` for global const in `EngineProfile.js`
- replace 'Camunda Platform' and 'Camunda Cloud' strings with global consts