### PR TITLE
feat(toggle): allow toggle switch to be `disabled`

### DIFF
--- a/client/src/shared/ui/form/ToggleSwitch.js
+++ b/client/src/shared/ui/form/ToggleSwitch.js
@@ -19,6 +19,7 @@ export default function ToggleSwitch(props) {
     description,
     field,
     form,
+    disabled,
     ...restProps
   } = props;
 
@@ -37,6 +38,7 @@ export default function ToggleSwitch(props) {
                 { ...field }
                 { ...restProps }
                 defaultChecked={ field.value }
+                disabled={ disabled }
               />
               <span className="toggle-switch__slider" />
             </label>

--- a/client/src/styles/_forms.less
+++ b/client/src/styles/_forms.less
@@ -1,7 +1,8 @@
 .form-group {
   --input-background-color: var(--color-white);
   --toggle-switch-on-background-color: var(--color-blue-205-100-50);
-  --toggle-switch-off-background-color: var(--color-grey-225-10-75);
+  --toggle-switch-off-background-color: var(--color-grey-225-10-55);
+  --toggle-switch-disabled-background-color: var(--color-grey-225-10-85);
   --toggle-switch-switcher-background-color: var(--color-white);
 
   input[type=password].form-control,
@@ -431,6 +432,11 @@
   .toggle-switch .toggle-switch__switcher input[type='checkbox']:checked + .toggle-switch__slider {
     background-color: var(--toggle-switch-on-background-color);
     box-shadow: 0 0 1px ;
+  }
+
+  .toggle-switch .toggle-switch__switcher input[type='checkbox']:disabled + .toggle-switch__slider {
+    background-color: var(--toggle-switch-disabled-background-color);
+    box-shadow: none ;
   }
   
   .toggle-switch .toggle-switch__switcher input[type='checkbox']:checked + .toggle-switch__slider:before {


### PR DESCRIPTION
Related to camunda/cloud-connect-modeler-plugin/issues/49

- add `disabled` prop
- change slider color based on `disabled` prop - temporary until new form items are aligned (talked over with @andreasgeier)

__Screenshot__
Switched off vs disabled:
<img width="298" alt="Screenshot 2021-11-09 at 16 05 40" src="https://user-images.githubusercontent.com/25825387/140950370-d55cee33-a54d-411e-b0b4-7637211b5eb3.png">


