### PR TITLE
Add re-usable section component

### DIFF
--- a/client/src/plugins/report-feedback/ReportFeedbackOverlay.js
+++ b/client/src/plugins/report-feedback/ReportFeedbackOverlay.js
@@ -12,7 +12,7 @@ import React from 'react';
 
 import { Overlay, Section } from '../../shared/ui';
 
-import { ReportFeedbackSystemInfo } from './ReportFeedbackSystemInfo';
+import { ReportFeedbackSystemInfoSection } from './ReportFeedbackSystemInfoSection';
 
 import css from './ReportFeedbackOverlay.less';
 
@@ -31,18 +31,18 @@ export function ReportFeedbackOverlay(props) {
       offset={ OFFSET }
       className={ css.ReportFeedbackOverlay }
     >
-      <ReportFeedbackChannels
+      <ReportFeedbackChannelsSection
         onClose={ props.onClose }
       />
 
-      <ReportFeedbackSystemInfo
+      <ReportFeedbackSystemInfoSection
         onSubmit={ props.onSubmit }
       />
     </Overlay>
   );
 }
 
-function ReportFeedbackChannels(props) {
+function ReportFeedbackChannelsSection(props) {
 
   const {
     onClose

--- a/client/src/plugins/report-feedback/ReportFeedbackOverlay.js
+++ b/client/src/plugins/report-feedback/ReportFeedbackOverlay.js
@@ -8,9 +8,9 @@
  * except in compliance with the MIT License.
  */
 
-import React, { Fragment } from 'react';
+import React from 'react';
 
-import { Overlay } from '../../shared/ui';
+import { Overlay, Section } from '../../shared/ui';
 
 import { ReportFeedbackSystemInfo } from './ReportFeedbackSystemInfo';
 
@@ -27,12 +27,14 @@ export function ReportFeedbackOverlay(props) {
     <Overlay
       anchor={ props.anchor }
       onClose={ props.onClose }
+      maxHeight="calc(100vh - 250px)"
       offset={ OFFSET }
       className={ css.ReportFeedbackOverlay }
     >
       <ReportFeedbackChannels
         onClose={ props.onClose }
       />
+
       <ReportFeedbackSystemInfo
         onSubmit={ props.onSubmit }
       />
@@ -41,31 +43,26 @@ export function ReportFeedbackOverlay(props) {
 }
 
 function ReportFeedbackChannels(props) {
-  return (
-    <Fragment>
-      <Overlay.Title>
-        Your feedback is welcome
-      </Overlay.Title>
-      <Overlay.Body>
-        <ReportFeedbackChannelsContent
-          onClose={ props.onClose }
-        />
-      </Overlay.Body>
-    </Fragment>
-  );
-}
 
-function ReportFeedbackChannelsContent(props) {
+  const {
+    onClose
+  } = props;
+
   return (
-    <Fragment>
-      <p>
-        Have you found an issue or would like to send a feature request?<br />
-        <a onClick={ props.onClose } href={ REPORT_ISSUE_LINK }>Report an issue on GitHub</a>
-      </p>
-      <p>
-        Would you like to discuss with other users?<br />
-        <a onClick={ props.onClose } href={ USER_FORUM_LINK }>Visit the User Forum</a>
-      </p>
-    </Fragment>
+    <Section>
+      <Section.Header>
+        Your feedback is welcome
+      </Section.Header>
+      <Section.Body>
+        <p>
+          Have you found an issue or would like to send a feature request?<br />
+          <a onClick={ onClose } href={ REPORT_ISSUE_LINK }>Report an issue on GitHub</a>
+        </p>
+        <p>
+          Would you like to discuss with other users?<br />
+          <a onClick={ onClose } href={ USER_FORUM_LINK }>Visit the User Forum</a>
+        </p>
+      </Section.Body>
+    </Section>
   );
 }

--- a/client/src/plugins/report-feedback/ReportFeedbackOverlay.less
+++ b/client/src/plugins/report-feedback/ReportFeedbackOverlay.less
@@ -1,32 +1,5 @@
 :local(.ReportFeedbackOverlay) {
-  max-height: calc(100vh - 250px);
-
-  overflow: auto;
-
-  h1, h2, h3, h4 {
-    font-size: inherit;
-  }
-
-  h1, h2, h3, h4, p {
-    margin: 12px 0;
-
-    &:first-child {
-      margin-top: 0;
-    }
-
-  }
-
-  form {
-    margin: 12px 0 0;
-
-    button {
-      margin-top: 8px;
-
-      width: 100%;
-    }
-  }
-
-  .feedback__message{
+  .feedback__message {
     color: var(--color-red-360-100-45);
   }
 }

--- a/client/src/plugins/report-feedback/ReportFeedbackSystemInfo.js
+++ b/client/src/plugins/report-feedback/ReportFeedbackSystemInfo.js
@@ -10,7 +10,7 @@
 
 import React, { useState, useEffect } from 'react';
 
-import { Overlay } from '../../shared/ui';
+import { Section } from '../../shared/ui';
 
 import {
   Formik,
@@ -34,7 +34,9 @@ const BUTTON_DISABLED_TIME = 3000;
 
 
 export function ReportFeedbackSystemInfo(props) {
-  const { onSubmit } = props;
+  const {
+    onSubmit
+  } = props;
 
   const [hasSubmitCompleted, setHasSubmitCompleted] = useState(false);
   let timer;
@@ -69,54 +71,59 @@ export function ReportFeedbackSystemInfo(props) {
   };
 
   return (
-    <Overlay.Footer>
-      <h2 className="overlay__title">
+    <Section>
+      <Section.Header>
         Don't forget to add system information
-      </h2>
-      <Formik
-        initialValues={ INITIAL_VALUES }
-        onSubmit={ submitForm }
-        validate={ validateFormData }
-      >
-        {formik => {
-          return (
-            <Form>
-              <Field
-                name="version"
-                component={ CheckBox }
-                type="checkbox"
-                label="Version"
-              />
-              <Field
-                name="operatingSystem"
-                component={ CheckBox }
-                type="checkbox"
-                label="Operating System"
-              />
-              <Field
-                name="installedPlugins"
-                component={ CheckBox }
-                type="checkbox"
-                label="Installed Plugins"
-              />
-              <Field
-                name="executionPlatform"
-                component={ CheckBox }
-                type="checkbox"
-                label="Execution Platform"
-              />
-              {formik.errors._form && allFieldsTruthy(formik.touched) && <div className="feedback__message">{formik.errors._form}</div>}
-              <button
-                type="submit"
-                className="btn btn-primary"
-                disabled={ hasSubmitCompleted }
-              >
-                {!hasSubmitCompleted ? 'Copy to clipboard': 'Copied!' }
-              </button>
-            </Form>
-          );
-        }}
-      </Formik>
-    </Overlay.Footer>
+      </Section.Header>
+      <Section.Body>
+        <Formik
+          initialValues={ INITIAL_VALUES }
+          onSubmit={ submitForm }
+          validate={ validateFormData }
+        >
+          {formik => {
+            return (
+              <Form>
+                <Field
+                  name="version"
+                  component={ CheckBox }
+                  type="checkbox"
+                  label="Version"
+                />
+                <Field
+                  name="operatingSystem"
+                  component={ CheckBox }
+                  type="checkbox"
+                  label="Operating System"
+                />
+                <Field
+                  name="installedPlugins"
+                  component={ CheckBox }
+                  type="checkbox"
+                  label="Installed Plugins"
+                />
+                <Field
+                  name="executionPlatform"
+                  component={ CheckBox }
+                  type="checkbox"
+                  label="Execution Platform"
+                />
+                {formik.errors._form && allFieldsTruthy(formik.touched) && <div className="feedback__message">{formik.errors._form}</div>}
+
+                <Section.Actions>
+                  <button
+                    type="submit"
+                    className="btn btn-primary"
+                    disabled={ hasSubmitCompleted }
+                  >
+                    {!hasSubmitCompleted ? 'Copy to clipboard': 'Copied!' }
+                  </button>
+                </Section.Actions>
+              </Form>
+            );
+          }}
+        </Formik>
+      </Section.Body>
+    </Section>
   );
 }

--- a/client/src/plugins/report-feedback/ReportFeedbackSystemInfoSection.js
+++ b/client/src/plugins/report-feedback/ReportFeedbackSystemInfoSection.js
@@ -33,7 +33,7 @@ const INITIAL_VALUES = {
 const BUTTON_DISABLED_TIME = 3000;
 
 
-export function ReportFeedbackSystemInfo(props) {
+export function ReportFeedbackSystemInfoSection(props) {
   const {
     onSubmit
   } = props;

--- a/client/src/plugins/report-feedback/ReportFeedbackSystemInfoSection.js
+++ b/client/src/plugins/report-feedback/ReportFeedbackSystemInfoSection.js
@@ -64,7 +64,7 @@ export function ReportFeedbackSystemInfoSection(props) {
   }
   const validateFormData = values => {
     const errors = {};
-    if (!values.installedPlugins && !values.version && !values.operatingSystem && !values.executionPlatform) {
+    if (!Object.values(values).some(v => v)) {
       errors._form = 'Select at least one checkbox.';
     }
     return errors;

--- a/client/src/plugins/report-feedback/__tests__/ReportFeedbackSystemInfoSpec.js
+++ b/client/src/plugins/report-feedback/__tests__/ReportFeedbackSystemInfoSpec.js
@@ -12,10 +12,10 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { ReportFeedbackSystemInfo } from '../ReportFeedbackSystemInfo';
+import { ReportFeedbackSystemInfoSection } from '../ReportFeedbackSystemInfoSection';
 
 
-describe('<ReportFeedbackSystemInfo>', () => {
+describe('<ReportFeedbackSystemInfoSection>', () => {
 
   it('should render', function() {
 
@@ -30,7 +30,7 @@ describe('<ReportFeedbackSystemInfo>', () => {
 
 function createReportFeedbackSystemInfo(props = {}, mount = shallow) {
   return mount(
-    <ReportFeedbackSystemInfo
+    <ReportFeedbackSystemInfoSection
       onSubmit={ props.onSubmit || noop }
     />
   );

--- a/client/src/plugins/version-info/ReleaseInfo.less
+++ b/client/src/plugins/version-info/ReleaseInfo.less
@@ -1,6 +1,4 @@
 :local(.ReleaseInfo) {
-  max-height: calc(100vh - 250px);
-
   overflow: auto;
 
   h1, h2, h3, h4 {

--- a/client/src/plugins/version-info/VersionInfoOverlay.js
+++ b/client/src/plugins/version-info/VersionInfoOverlay.js
@@ -10,7 +10,7 @@
 
 import React from 'react';
 
-import { Overlay } from '../../shared/ui';
+import { Overlay, Section } from '../../shared/ui';
 
 import { ReleaseInfo } from './ReleaseInfo';
 
@@ -28,28 +28,40 @@ export function VersionInfoOverlay(props) {
       id="version-info-overlay" anchor={ props.anchor } onClose={ props.onClose } offset={ OFFSET }
       className={ css.VersionInfoOverlay }
     >
-      <Overlay.Title>
-        What's new in Modeler { props.version }
-      </Overlay.Title>
-      <Overlay.Body>
-        <ReleaseInfo />
-      </Overlay.Body>
-      <LearnMore />
+      <WhatsNewSection version={ props.version } />
+
+      <LearnMoreSection />
     </Overlay>
   );
 }
 
-function LearnMore(props) {
+function WhatsNewSection(props) {
+
   return (
-    <Overlay.Footer>
-      <h2 className="overlay__title">
+    <Section maxHeight="calc(100vh - 250px)">
+      <Section.Header>
+        What's new in Modeler { props.version }
+      </Section.Header>
+      <Section.Body>
+        <ReleaseInfo />
+      </Section.Body>
+    </Section>
+  );
+}
+
+function LearnMoreSection(props) {
+  return (
+    <Section>
+      <Section.Header>
         Learn More
-      </h2>
-      <ul>
-        <li><a href={ RELEASE_NOTES_LINK }>Release Notes on Camunda blog</a></li>
-        <li><a href={ DOCS_LINK }>Camunda Modeler docs</a></li>
-        <li><a href={ CHANGELOG_LINK }>Changelog on GitHub</a></li>
-      </ul>
-    </Overlay.Footer>
+      </Section.Header>
+      <Section.Body>
+        <ul>
+          <li><a href={ RELEASE_NOTES_LINK }>Release Notes on Camunda blog</a></li>
+          <li><a href={ DOCS_LINK }>Camunda Modeler docs</a></li>
+          <li><a href={ CHANGELOG_LINK }>Changelog on GitHub</a></li>
+        </ul>
+      </Section.Body>
+    </Section>
   );
 }

--- a/client/src/plugins/version-info/VersionInfoOverlay.less
+++ b/client/src/plugins/version-info/VersionInfoOverlay.less
@@ -1,8 +1,6 @@
 :local(.VersionInfoOverlay) {
   ul, ol {
     padding-inline-start: 16px;
-
-    margin: 12px 0 0;
   }
 
   li + li {

--- a/client/src/shared/ui/Section.js
+++ b/client/src/shared/ui/Section.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { isString } from 'min-dash';
+
+import React from 'react';
+
+import css from './Section.less';
+
+
+export function Section(props) {
+
+  const {
+    children,
+    maxHeight
+  } = props;
+
+  let style = {};
+
+  if (maxHeight) {
+
+    if (maxHeight === true) {
+      style = {
+        'overflow-y': 'hidden'
+      };
+    } else {
+      style = {
+        '--section-max-height': isString(maxHeight) ? maxHeight : `${maxHeight}px`
+      };
+    }
+  }
+
+  return (
+    <section
+      className={ css.Section }
+      style={ style }
+    >
+      { children }
+    </section>
+  );
+}
+
+
+Section.Header = function(props) {
+  return (
+    <h3 className="section__header">
+      { props.children }
+    </h3>
+  );
+};
+
+Section.Actions = function(props) {
+  return (
+    <span className="section__actions">{ props.children }</span>
+  );
+};
+
+Section.Body = function(props) {
+  return (
+    <div className="section__body">
+      { props.children }
+    </div>
+  );
+};

--- a/client/src/shared/ui/Section.less
+++ b/client/src/shared/ui/Section.less
@@ -27,12 +27,14 @@
     font-size: inherit;
     overflow-y: auto;
 
-    p {
-      margin: 0;
+    p, ul, ol {
+      margin: 0 0 15px 0;
     }
 
-    p + p {
-      margin-top: 15px;
+    p:last-child,
+    ul:last-child,
+    ol:last-child {
+      margin-bottom: 0;
     }
   }
 

--- a/client/src/shared/ui/Section.less
+++ b/client/src/shared/ui/Section.less
@@ -1,0 +1,46 @@
+:local(.Section) {
+  --section-max-height: initial;
+
+  display: flex;
+  flex-direction: column;
+  max-height: var(--section-max-height);
+  flex: inherit;
+
+  .section__header,
+  .section__body {
+    padding: 12px;
+  }
+
+  .section__body:not(:first-child) {
+    padding-top: 0;
+  }
+
+  .section__header {
+    margin: 0;
+
+    font-size: inherit;
+    font-weight: normal;
+    color: var(--overlay-title-color);
+  }
+
+  .section__body {
+    font-size: inherit;
+    overflow-y: auto;
+
+    p {
+      margin: 0;
+    }
+
+    p + p {
+      margin-top: 15px;
+    }
+  }
+
+  .section__actions .btn {
+    margin-top: 8px;
+  }
+
+  & + :local(.Section) {
+    border-top: 1px solid var(--overlay-border-color);
+  }
+}

--- a/client/src/shared/ui/__tests__/OverlaySpec.js
+++ b/client/src/shared/ui/__tests__/OverlaySpec.js
@@ -98,6 +98,41 @@ describe('<Overlay>', function() {
   });
 
 
+  describe('props#maxHeight', function() {
+
+    function expectStyle(wrapper, expectedStyle) {
+      expect(wrapper.find('.test[style]').prop('style')).to.include(expectedStyle);
+    }
+
+
+    it('should specify string (maxHeight="100vh")', function() {
+
+      // when
+      wrapper = mount(<Overlay className="test" anchor={ anchor } maxHeight="100vh" />);
+
+      // then
+      expectStyle(wrapper, {
+        '--overlay-max-height': '100vh'
+      });
+
+    });
+
+
+    it('should specify (pixel) number (maxHeight=100)', function() {
+
+      // when
+      wrapper = mount(<Overlay className="test" anchor={ anchor } maxHeight={ 100 } />);
+
+      // then
+      expectStyle(wrapper, {
+        '--overlay-max-height': '100px'
+      });
+
+    });
+
+  });
+
+
   describe('props#offset', function() {
 
     it('should use provided offset { left }', function() {

--- a/client/src/shared/ui/__tests__/SectionSpec.js
+++ b/client/src/shared/ui/__tests__/SectionSpec.js
@@ -1,0 +1,132 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+
+import {
+  shallow
+} from 'enzyme';
+
+import { Section } from '..';
+
+
+describe('<Section>', function() {
+
+  let wrapper;
+
+  afterEach(function() {
+    if (wrapper && wrapper.exists()) {
+      wrapper.unmount();
+    }
+  });
+
+
+  it('should render', function() {
+    const wrapper = shallow(
+      <Section>
+        <Section.Header>
+          <span>{ 'HEADER' }</span>
+          <Section.Actions>
+            <button>{ 'BUTTON' }</button>
+          </Section.Actions>
+        </Section.Header>
+        <Section.Body>
+          <p>{ 'BODY' }</p>
+        </Section.Body>
+      </Section>
+    );
+
+    expectHTML(wrapper, `
+      <section>
+        <h3 class="section__header">
+          <span>HEADER</span>
+          <span class="section__actions">
+            <button>BUTTON</button>
+          </span>
+        </h3>
+        <div class="section__body">
+          <p>BODY</p>
+        </div>
+      </section>
+    `);
+  });
+
+
+  describe('props#maxHeight', function() {
+
+    function expectStyle(wrapper, expectedStyle) {
+      expect(wrapper.prop('style')).to.eql(expectedStyle);
+    }
+
+
+    it('should scroll (maxHeight=true)', function() {
+
+      // when
+      wrapper = shallow(<Section maxHeight={ true } />);
+
+      // then
+      expectStyle(wrapper, {
+        'overflow-y': 'hidden'
+      });
+
+    });
+
+
+    it('should specify string (maxHeight="100vh")', function() {
+
+      // when
+      wrapper = shallow(<Section maxHeight="100vh" />);
+
+      // then
+      expectStyle(wrapper, {
+        '--section-max-height': '100vh'
+      });
+
+    });
+
+
+    it('should specify (pixel) number (maxHeight=100)', function() {
+
+      // when
+      wrapper = shallow(<Section maxHeight={ 100 } />);
+
+      // then
+      expectStyle(wrapper, {
+        '--section-max-height': '100px'
+      });
+
+    });
+
+  });
+
+
+  describe('<Section.Header>', function() {
+
+    it('should render', function() {
+      wrapper = shallow(<Section.Header />);
+    });
+
+  });
+
+
+  describe('<Section.Body>', function() {
+
+    it('should render', function() {
+      wrapper = shallow(<Section.Body />);
+    });
+
+  });
+
+});
+
+
+function expectHTML(wrapper, expectedHTML) {
+  expect(wrapper.html()).to.eql(expectedHTML.replace(/\s*\n\s*/g, ''));
+}

--- a/client/src/shared/ui/index.js
+++ b/client/src/shared/ui/index.js
@@ -13,4 +13,6 @@ export { default as DropdownButton } from './DropdownButton';
 export { Icon } from './icon';
 export { Modal } from './modal';
 export { Overlay, OverlayDropdown } from './overlay';
+export { Section } from './Section';
+
 export * from './form';

--- a/client/src/shared/ui/overlay/Overlay.js
+++ b/client/src/shared/ui/overlay/Overlay.js
@@ -11,6 +11,8 @@
 import React, { PureComponent } from 'react';
 import ReactDOM from 'react-dom';
 
+import { isString } from 'min-dash';
+
 import classNames from 'classnames';
 
 import FocusTrap from '../modal/FocusTrap';
@@ -70,14 +72,27 @@ export class Overlay extends PureComponent {
   }
 
   getStyle() {
-    const { anchor, offset = {} } = this.props;
+
+    const {
+      maxHeight,
+      anchor,
+      offset = {}
+    } = this.props;
+
     const bodyRect = document.body.getBoundingClientRect();
     const anchorRect = anchor.getBoundingClientRect();
 
-    const style = {
+    let style = {
       position: 'absolute',
       bottom: Math.round(bodyRect.height - anchorRect.top + (offset.bottom || DEFAULT_OFFSET.bottom))
     };
+
+    if (maxHeight) {
+      style = {
+        ...style,
+        '--overlay-max-height': isString(maxHeight) ? maxHeight : `${maxHeight}px`
+      };
+    }
 
     if ('right' in offset) {
       return {

--- a/client/src/shared/ui/overlay/Overlay.less
+++ b/client/src/shared/ui/overlay/Overlay.less
@@ -1,4 +1,6 @@
 :local(.Overlay) {
+  --overlay-max-height: auto;
+
   display: flex;
   flex: auto;
   flex-direction: column;
@@ -13,6 +15,9 @@
 
   background-color: var(--overlay-background-color);
   color: var(--overlay-font-color);
+
+  max-height: var(--overlay-max-height);
+  overflow-y: auto;
 
   font-size: 14px;
 


### PR DESCRIPTION
This contribution adds a re-usable section component.

Sections are fully pluggeable into existing UI components (i.e. overlays) and shall be used when the existing abstractions (overlay with single header, body and footer) do not work.

Sections and overlays are now properly max-sizeable without the need for a custom CSS:

![capture 5gkWq7_optimized](https://user-images.githubusercontent.com/58601/142627746-2f9be72a-ab47-46c2-afbb-7528d26e0764.gif)


---

General spirit of this PR:

* We shall not ever require custom CSS for basic UI (https://github.com/camunda/camunda-modeler/commit/21cd1f9fdd0f5202b59dfac778fe965b92615522) but rely on pre-built components entirely.
* We shall centralize the UI components we need and break out of the existing usage patter _explicitly_, where needed.

---

#### TODO

* [x] Get basic buy-in
* [x] Test cover
* [x] Port what's new component to Section structure

---

This PR is work in progress, as we need to discuss this as a team. Needs to be adjusted to https://github.com/camunda/camunda-modeler/pull/2576.