### PR TITLE
fix(file input): show file list scroll bar only on overlflow

### DIFF
--- a/client/src/styles/_forms.less
+++ b/client/src/styles/_forms.less
@@ -304,7 +304,7 @@
 
     list-style-type: none;
     max-height: 86px;
-    overflow: scroll;
+    overflow-y: auto;
   }
 
   .file-list-item {


### PR DESCRIPTION
The file list container for the file input was showing horizontal and vertical scroll bars even when there was no overflow:

<img width="350" src="https://user-images.githubusercontent.com/25825387/143879708-2cacccdc-8055-462b-b256-80692905fed3.png"/>

This PR makes it so that the only the vertical scroll bar is shown and when there actually is overflow:
<div>
<img width="350" src="https://user-images.githubusercontent.com/25825387/143879596-0ef157c9-b4c2-475e-82d5-49b7485afd59.png"/>
<img width="350" src="https://user-images.githubusercontent.com/25825387/143879832-155b3662-491a-49c3-b972-db5c695421a9.png"/>
</div>
