### PR TITLE
feat(overlay): add more dimen options

### DIFF
--- a/client/src/shared/ui/__tests__/OverlaySpec.js
+++ b/client/src/shared/ui/__tests__/OverlaySpec.js
@@ -98,34 +98,59 @@ describe('<Overlay>', function() {
   });
 
 
-  describe('props#maxHeight', function() {
+  [
+    'maxHeight',
+    'maxWidth',
+    'minHeight',
+    'minWidth'
+  ].forEach(function(property) {
 
-    function expectStyle(wrapper, expectedStyle) {
-      expect(wrapper.find('.test[style]').prop('style')).to.include(expectedStyle);
+    const cssProperty = `--overlay-${camelCaseToDash(property)}`;
+
+    function createOverlay(props={}) {
+      const {
+        maxHeight,
+        maxWidth,
+        minHeight,
+        minWidth
+      } = props;
+
+      return mount(
+        <Overlay
+          className="test"
+          anchor={ anchor }
+          maxHeight={ maxHeight }
+          maxWidth={ maxWidth }
+          minHeight={ minHeight }
+          minWidth={ minWidth }
+        />);
     }
 
+    describe(`props#${property}`, function() {
 
-    it('should specify string (maxHeight="100vh")', function() {
+      it(`should specify string (${property}="100vh")`, function() {
 
-      // when
-      wrapper = mount(<Overlay className="test" anchor={ anchor } maxHeight="100vh" />);
+        // when
+        wrapper = createOverlay({ [property]: '100vh' });
 
-      // then
-      expectStyle(wrapper, {
-        '--overlay-max-height': '100vh'
+        // then
+        expectStyle(wrapper, {
+          [cssProperty]: '100vh'
+        });
+
       });
 
-    });
 
+      it(`should specify (pixel) number (${property}=100)`, function() {
 
-    it('should specify (pixel) number (maxHeight=100)', function() {
+        // when
+        wrapper = createOverlay({ [property]: 100 });
 
-      // when
-      wrapper = mount(<Overlay className="test" anchor={ anchor } maxHeight={ 100 } />);
+        // then
+        expectStyle(wrapper, {
+          [cssProperty]: '100px'
+        });
 
-      // then
-      expectStyle(wrapper, {
-        '--overlay-max-height': '100px'
       });
 
     });
@@ -173,6 +198,7 @@ describe('<Overlay>', function() {
 
       expect(overlayRect.right).to.be.closeTo(anchorRect.right + offset.right, 5);
     });
+
   });
 
 
@@ -340,6 +366,17 @@ describe('<Overlay>', function() {
 
 });
 
+
+// helper ///////////////////
+
 function boundingRect(domNode) {
   return domNode.getBoundingClientRect();
+}
+
+function expectStyle(wrapper, expectedStyle) {
+  expect(wrapper.find('.test[style]').prop('style')).to.include(expectedStyle);
+}
+
+function camelCaseToDash(str) {
+  return str.replace(/([a-zA-Z])(?=[A-Z])/g, '$1-').toLowerCase();
 }

--- a/client/src/shared/ui/overlay/Overlay.js
+++ b/client/src/shared/ui/overlay/Overlay.js
@@ -75,6 +75,9 @@ export class Overlay extends PureComponent {
 
     const {
       maxHeight,
+      maxWidth,
+      minHeight,
+      minWidth,
       anchor,
       offset = {}
     } = this.props;
@@ -83,14 +86,46 @@ export class Overlay extends PureComponent {
     const anchorRect = anchor.getBoundingClientRect();
 
     let style = {
-      position: 'absolute',
-      bottom: Math.round(bodyRect.height - anchorRect.top + (offset.bottom || DEFAULT_OFFSET.bottom))
+      position: 'absolute'
     };
 
     if (maxHeight) {
       style = {
         ...style,
         '--overlay-max-height': isString(maxHeight) ? maxHeight : `${maxHeight}px`
+      };
+    }
+
+    if (maxWidth) {
+      style = {
+        ...style,
+        '--overlay-max-width': isString(maxWidth) ? maxWidth : `${maxWidth}px`
+      };
+    }
+
+    if (minHeight) {
+      style = {
+        ...style,
+        '--overlay-min-height': isString(minHeight) ? minHeight : `${minHeight}px`
+      };
+    }
+
+    if (minWidth) {
+      style = {
+        ...style,
+        '--overlay-min-width': isString(minWidth) ? minWidth : `${minWidth}px`
+      };
+    }
+
+    if ('top' in offset) {
+      style = {
+        ...style,
+        top: Math.round(anchorRect.top + anchorRect.height + offset.top)
+      };
+    } else {
+      style = {
+        ...style,
+        bottom: Math.round(bodyRect.height - anchorRect.top + (offset.bottom || DEFAULT_OFFSET.bottom))
       };
     }
 

--- a/client/src/shared/ui/overlay/Overlay.js
+++ b/client/src/shared/ui/overlay/Overlay.js
@@ -30,7 +30,11 @@ const DEFAULT_OFFSET = {
 /**
  * @typedef {object} OverlayProps
  * @prop {Node} anchor
- * @prop {{ bottom?: number, left?: number, right?: number }} [offset={}]
+ * @prop {{ top?: number, bottom?: number, left?: number, right?: number }} [offset={}]
+ * @prop {Number} [maxHeight]
+ * @prop {Number} [maxWidth]
+ * @prop {Number} [minHeight]
+ * @prop {Number} [minWidth]
  * @prop {function} [onClose]
  *
  * @extends {PureComponent<OverlayProps>}

--- a/client/src/shared/ui/overlay/Overlay.less
+++ b/client/src/shared/ui/overlay/Overlay.less
@@ -1,5 +1,8 @@
 :local(.Overlay) {
   --overlay-max-height: auto;
+  --overlay-max-width: auto;
+  --overlay-min-height: auto;
+  --overlay-min-width: auto;
 
   display: flex;
   flex: auto;
@@ -16,6 +19,9 @@
   color: var(--overlay-font-color);
 
   max-height: var(--overlay-max-height);
+  max-width: var(--overlay-max-width);
+  min-height: var(--overlay-min-height);
+  min-width: var(--overlay-min-width);
   overflow-y: auto;
 
   font-size: 14px;


### PR DESCRIPTION
This allows specifying more dimension properties as the existing `maxHeight`, `bottom`, `right`, `left`:

* `maxWidth`
* `minHeight`
* `minWidth`
* `top`

Rationale: it should be possible to place an overlay anywhere on the screen, not only above the status bar. This makes things as the coming tab actions possible, also in setting a specific minimal width.

![image](https://user-images.githubusercontent.com/9433996/144584005-7fa0d405-328e-450f-9e31-7f4de3a6590f.png)

