### PR TITLE
feat(app/menu): separate new file menus by group

### DIFF
--- a/app/test/spec/menu/menu-builder-spec.js
+++ b/app/test/spec/menu/menu-builder-spec.js
@@ -357,6 +357,42 @@ describe('MenuBuilder', () => {
     });
   });
 
+
+  describe('new file menu', () => {
+
+    it('should separate by group', () => {
+
+      // given
+      const providers = [
+        {
+          helpMenu: [],
+          newFileMenu: [ {
+            label: 'foo',
+            group: 'A',
+          } ]
+        },
+        {
+          helpMenu: [],
+          newFileMenu: [ {
+            label: 'bar',
+            group: 'B',
+          } ]
+        },
+      ];
+
+      const menuBuilder = new MenuBuilder({ providers });
+
+      // when
+      const { menu } = menuBuilder.build();
+
+      const editMenu = menu.find(item => item.label === 'File');
+      const newFileMenu = editMenu.submenu.find(item => item.label === 'New File');
+
+      expect(newFileMenu.submenu.length).to.equal(4);
+    });
+
+  });
+
 });
 
 


### PR DESCRIPTION
This allows separating new file menu entries by defining groups. An alternative could be to simply add the separators to the tabs provider. Since one can disable certain providers by flags, that would be hard to order properly. Touching the `menu-builder` instead gives enough flexibility.

Example: we want to separate creating new tabs by execution platform (Platform + Cloud). 

```js
[
  [
    { label: 'BPMN diagram', group: 'Camunda Platform', action: 'create-bpmn-diagram' }
  ],
  [
    { label: 'BPMN diagram', group: 'Camunda Cloud', action: 'create-cloud-bpmn-diagram' }
  ],
  [
    { label: 'DMN diagram', group: 'Camunda Platform', action: 'create-dmn-diagram' }
  ],
  [
    { label: 'Form', group: 'Camunda Platform', action: 'create-form' }
  ],
  [
    { label: 'Form', group: 'Camunda Cloud', action: 'create-cloud-form' }
  ]
]
```

This would result in the following menu. Note that there are no `titles` available in Electron, that's why I'd propose to show the group inside the label.

![image](https://user-images.githubusercontent.com/9433996/144586867-71b6f7b1-50cc-4106-b56a-62cc9c099d35.png)
