### PR TITLE
style(tabbed): increase tab max-width

### DIFF
--- a/client/src/app/primitives/Tabbed.less
+++ b/client/src/app/primitives/Tabbed.less
@@ -1,3 +1,7 @@
+:root {
+  --tab-max-width: 220px;
+}
+
 .tab-base() {
   position: relative;
   flex: 1;
@@ -40,7 +44,7 @@
     flex-grow: 1;
     flex-shrink: 1;
     flex-basis: 20px;
-    max-width: 160px;
+    max-width: var(--tab-max-width);
     color: var(--tab-font-color);
     border-right: 1px solid var(--tab-border-right-color);
     user-select: none;


### PR DESCRIPTION
Related to #2440

This is a follow-up to the discussions in [this issue](https://github.com/camunda/camunda-modeler/issues/2440). Note that I didn't touch the font size. Rationale: we use 14px in the status bar as well, and personally I think it's better to keep that consistent.

![image](https://user-images.githubusercontent.com/9433996/144860061-5130e11e-f721-4c8a-99b0-ef2295ec55b5.png)

