### PR TITLE
ci: run against node@14, not LTS

### DIFF
--- a/.github/workflows/BUILD_ON_DEMAND.yml
+++ b/.github/workflows/BUILD_ON_DEMAND.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 'lts/*'
+        node-version: 14
     - name: Cache Node.js modules
       uses: actions/cache@v2
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 'lts/*'
+        node-version: 14
     - name: Cache Node.js modules
       uses: actions/cache@v2
       with:

--- a/.github/workflows/NIGHTLY.yml
+++ b/.github/workflows/NIGHTLY.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 'lts/*'
+        node-version: 14
     - name: Cache Node.js modules
       uses: actions/cache@v2
       with:

--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 'lts/*'
+        node-version: 14
     - name: Cache Node.js modules
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
LTS now changed to 16 and we're not compatible with it yet.