### PR TITLE
feat(form/linting): account for full semver specifiying version

### DIFF
--- a/client/src/app/tabs/Linting.js
+++ b/client/src/app/tabs/Linting.js
@@ -63,11 +63,17 @@ export function Linting(props) {
 
   return <Fill slot="status-bar__file" group="9_linting">
     <button
-      className={ classnames(css.Linting, 'btn', { 'btn--active': panel.open && panel.tab === 'linting' }) }
+      className={ classnames(
+        css.Linting,
+        'btn',
+        { 'btn--active': panel.open && panel.tab === 'linting',
+          'has-errors': errors > 0
+        }
+      ) }
       onClick={ onClick }
       title="Toggle Errors"
     >
-      <ErrorIcon className={ classnames({ 'has-errors': errors > 0 }) } />
+      <ErrorIcon />
       { errors } { errors === 1 ? 'error' : 'errors' }
     </button>
   </Fill>;

--- a/client/src/app/tabs/Linting.js
+++ b/client/src/app/tabs/Linting.js
@@ -61,7 +61,7 @@ export function Linting(props) {
     });
   };
 
-  return <Fill slot="status-bar__file" group="2_linting">
+  return <Fill slot="status-bar__file" group="9_linting">
     <button
       className={ classnames(css.Linting, 'btn', { 'btn--active': panel.open && panel.tab === 'linting' }) }
       onClick={ onClick }

--- a/client/src/app/tabs/Linting.less
+++ b/client/src/app/tabs/Linting.less
@@ -5,8 +5,12 @@
     margin-left: -5px;
     width: 24px;
     height: 24px;
+  }
 
-    &.has-errors {
+  &.has-errors {
+    color: var(--color-red-360-100-45) !important;
+
+    svg {
       fill: var(--color-red-360-100-45);
     }
   }

--- a/client/src/app/tabs/form/linting/FormLinter.js
+++ b/client/src/app/tabs/form/linting/FormLinter.js
@@ -13,7 +13,12 @@ import {
   isString
 } from 'min-dash';
 
+import {
+  toSemverMinor
+} from '../../EngineProfile';
+
 import cmp from 'semver-compare';
+
 
 const formJSVersions = {
   'Camunda Cloud': {
@@ -41,12 +46,16 @@ export default class FormLinter {
 
     const {
       executionPlatform,
-      executionPlatformVersion
+      executionPlatformVersion: _executionPlatformVersion
     } = schema;
 
     if (!executionPlatform) {
       return [];
     }
+
+    // normalize execution platform version
+    // (account for <major>.<minor> vs <major>.<minor>.<patch> parsed from form)
+    const executionPlatformVersion = toSemverMinor(_executionPlatformVersion);
 
     const types = [
       'button',
@@ -103,5 +112,5 @@ function getFormJSVersion(executionPlatform, executionPlatformVersion) {
     return null;
   }
 
-  return formJSVersions[ executionPlatform ][ executionPlatformVersion ] || null;
+  return formJSVersions[ executionPlatform ][ executionPlatformVersion ];
 }

--- a/client/src/app/tabs/form/linting/__tests__/FormLinterSpec.js
+++ b/client/src/app/tabs/form/linting/__tests__/FormLinterSpec.js
@@ -14,10 +14,12 @@ import camundaCloud10 from './camunda-cloud-1-0.json';
 import camundaCloud10Errors from './camunda-cloud-1-0-errors.json';
 import camundaCloud11 from './camunda-cloud-1-1.json';
 import camundaCloud12 from './camunda-cloud-1-2.json';
+import camundaCloud120 from './camunda-cloud-1-2-0.json';
 import camundaCloud13 from './camunda-cloud-1-3.json';
 import camundaPlatform715 from './camunda-platform-7-15.json';
 import camundaPlatform715Errors from './camunda-platform-7-15-errors.json';
 import camundaPlatform716 from './camunda-platform-7-16.json';
+import camundaPlatform7160 from './camunda-platform-7-16-0.json';
 import noEngineProfile from './no-engine-profile.json';
 
 
@@ -59,9 +61,11 @@ describe('FormLinter', function() {
   [
     [ 'Camunda Platform 7.15', camundaPlatform715, camundaPlatform715Errors ],
     [ 'Camunda Platform 7.16', camundaPlatform716 ],
+    [ 'Camunda Platform 7.16.0', camundaPlatform7160 ],
     [ 'Camunda Cloud 1.0', camundaCloud10, camundaCloud10Errors ],
     [ 'Camunda Cloud 1.1', camundaCloud11 ],
     [ 'Camunda Cloud 1.2', camundaCloud12 ],
+    [ 'Camunda Cloud 1.2', camundaCloud120 ],
     [ 'Camunda Cloud 1.3', camundaCloud13 ]
   ].forEach(([ engineProfile, noErrorsSchema, errorsSchema ]) => {
 

--- a/client/src/app/tabs/form/linting/__tests__/camunda-cloud-1-2-0.json
+++ b/client/src/app/tabs/form/linting/__tests__/camunda-cloud-1-2-0.json
@@ -1,0 +1,52 @@
+{
+  "components": [
+    {
+      "id": "Field_1",
+      "key": "creditor",
+      "label": "Creditor",
+      "type": "textfield",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "description": "An invoice number in the format: C-123.",
+      "id": "Field_2",
+      "key": "invoiceNumber",
+      "label": "Invoice Number",
+      "type": "textfield",
+      "validate": {
+        "pattern": "^C-[0-9]+$"
+      }
+    },
+    {
+      "id": "Field_3",
+      "key": "approved",
+      "label": "Approved",
+      "type": "checkbox"
+    },
+    {
+      "id": "Field_4",
+      "key": "approvedBy",
+      "label": "Approved By",
+      "type": "textfield"
+    },
+    {
+      "id": "Field_5",
+      "key": "submit",
+      "label": "Submit",
+      "type": "button"
+    },
+    {
+      "id": "Field_6",
+      "action": "reset",
+      "key": "reset",
+      "label": "Reset",
+      "type": "button"
+    }
+  ],
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "1.2.0",
+  "id": "Form_1",
+  "type": "default"
+}

--- a/client/src/app/tabs/form/linting/__tests__/camunda-platform-7-16-0.json
+++ b/client/src/app/tabs/form/linting/__tests__/camunda-platform-7-16-0.json
@@ -1,0 +1,52 @@
+{
+  "components": [
+    {
+      "id": "Field_1",
+      "key": "creditor",
+      "label": "Creditor",
+      "type": "textfield",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "description": "An invoice number in the format: C-123.",
+      "id": "Field_2",
+      "key": "invoiceNumber",
+      "label": "Invoice Number",
+      "type": "textfield",
+      "validate": {
+        "pattern": "^C-[0-9]+$"
+      }
+    },
+    {
+      "id": "Field_3",
+      "key": "approved",
+      "label": "Approved",
+      "type": "checkbox"
+    },
+    {
+      "id": "Field_4",
+      "key": "approvedBy",
+      "label": "Approved By",
+      "type": "textfield"
+    },
+    {
+      "id": "Field_5",
+      "key": "submit",
+      "label": "Submit",
+      "type": "button"
+    },
+    {
+      "id": "Field_6",
+      "action": "reset",
+      "key": "reset",
+      "label": "Reset",
+      "type": "button"
+    }
+  ],
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.16.0",
+  "id": "Form_1",
+  "type": "default"
+}


### PR DESCRIPTION
* Account for full `major.minor.patch` being serialized in diagrams.
* Show `major.minor` in error messages only

---

#### Built Artifacts

* https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/form-semver-maj-mi-pa/camunda-modeler-form-semver-maj-mi-pa-linux-x64.tar.gz
* https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/form-semver-maj-mi-pa/camunda-modeler-form-semver-maj-mi-pa-mac.dmg
* https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/form-semver-maj-mi-pa/camunda-modeler-form-semver-maj-mi-pa-mac.zip
* https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/form-semver-maj-mi-pa/camunda-modeler-form-semver-maj-mi-pa-win-ia32.zip
* https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/form-semver-maj-mi-pa/camunda-modeler-form-semver-maj-mi-pa-win-x64.zip




