### PR TITLE
Validate `bpmnlint:recommended` rules

### DIFF
--- a/client/resources/icons/Warning.svg
+++ b/client/resources/icons/Warning.svg
@@ -1,6 +1,51 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="14" viewBox="0 0 20 17">
-  <g fill="none" fill-rule="evenodd">
-    <path fill="#FF3D3D" fill-rule="nonzero" d="M10.8682431,1.5194255 L19.1450635,16.0038611 C19.4190734,16.4833785 19.2524767,17.0942332 18.7729593,17.3682431 C18.6218616,17.4545847 18.4508473,17.5 18.2768203,17.5 L1.72317968,17.5 C1.17089493,17.5 0.723179678,17.0522847 0.723179678,16.5 C0.723179678,16.3259731 0.768594996,16.1549588 0.854936536,16.0038611 L9.13175686,1.5194255 C9.40576683,1.03990805 10.0166215,0.873311325 10.4961389,1.14732129 C10.6511702,1.2359106 10.7796538,1.36439422 10.8682431,1.5194255 Z"/>
-    <path fill="#FFF" d="M8.75,12.5 L11.25,12.5 L11.25,15 L8.75,15 L8.75,12.5 Z M9.07631812,11.25 L8.125,5 L11.875,5 L10.9437836,11.25 L9.07631812,11.25 Z"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 30 29.142857"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="Warning.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     id="namedview10"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="41.133328"
+     inkscape:cx="10.076987"
+     inkscape:cy="8.8857385"
+     inkscape:window-width="2552"
+     inkscape:window-height="1375"
+     inkscape:window-x="0"
+     inkscape:window-y="61"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g6" />
+  <g
+     fill="none"
+     fill-rule="evenodd"
+     id="g6"
+     transform="translate(4.9999146,5.3137318)">
+    <path
+       fill="#FF3D3D"
+       fill-rule="nonzero"
+       d="m 10.868243,1.5194255 8.27682,14.4844355 c 0.27401,0.479517 0.107414,1.090372 -0.372104,1.364382 C 18.621862,17.454585 18.450847,17.5 18.27682,17.5 H 1.7231797 c -0.5522848,0 -1.00000002,-0.447715 -1.00000002,-1 0,-0.174027 0.0454153,-0.345041 0.13175686,-0.496139 L 9.1317569,1.5194255 C 9.4057668,1.039908 10.016621,0.87331132 10.496139,1.1473213 c 0.155031,0.088589 0.283515,0.2170729 0.372104,0.3721042 z"
+       id="path2"
+       style="fill:#ff7f2a" />
+    <path
+       fill="#ffffff"
+       d="m 8.75,12.864668 h 2.5 v 2.5 h -2.5 z m 0.3263181,-1.25 L 8.125,6.9448951 h 3.75 l -0.931216,4.6697729 z"
+       id="path4"
+       sodipodi:nodetypes="cccccccccc" />
   </g>
 </svg>

--- a/client/src/app/tabs/cloud-bpmn/linting/BpmnLinter.js
+++ b/client/src/app/tabs/cloud-bpmn/linting/BpmnLinter.js
@@ -19,15 +19,29 @@ import { isString } from 'min-dash';
 
 import linterConfig from '../../.bpmnlintrc';
 
+import fullLinterConfig from '../../full.bpmnlintrc';
+
+import {
+  default as Flags,
+  ENABLE_BPMNLINT_RECOMMENDED
+} from '../../../../util/Flags';
+
 const moddle = new BpmnModdle({
   modeler: modelerModdleSchema,
   zeebe: zeebeModdleSchema
 });
 
-const linter = new Linter(linterConfig);
 
 export default class BpmnLinter {
   static async lint(contents) {
+
+    const linter = new Linter(
+      Flags.get(ENABLE_BPMNLINT_RECOMMENDED)
+        ? fullLinterConfig
+        : linterConfig
+    );
+
+
     let rootElement;
 
     if (isString(contents)) {
@@ -37,6 +51,8 @@ export default class BpmnLinter {
     }
 
     const results = await linter.lint(rootElement);
+
+    console.log(results);
 
     return Object.values(results).reduce((results, result) => {
       return [ ...results, ...result ];

--- a/client/src/app/tabs/form/linting/FormLinter.js
+++ b/client/src/app/tabs/form/linting/FormLinter.js
@@ -13,7 +13,12 @@ import {
   isString
 } from 'min-dash';
 
+import {
+  toSemverMinor
+} from '../../EngineProfile';
+
 import cmp from 'semver-compare';
+
 
 const formJSVersions = {
   'Camunda Cloud': {
@@ -41,12 +46,16 @@ export default class FormLinter {
 
     const {
       executionPlatform,
-      executionPlatformVersion
+      executionPlatformVersion: _executionPlatformVersion
     } = schema;
 
     if (!executionPlatform) {
       return [];
     }
+
+    // normalize execution platform version
+    // (account for <major>.<minor> vs <major>.<minor>.<patch> parsed from form)
+    const executionPlatformVersion = toSemverMinor(_executionPlatformVersion);
 
     const types = [
       'button',
@@ -103,5 +112,5 @@ function getFormJSVersion(executionPlatform, executionPlatformVersion) {
     return null;
   }
 
-  return formJSVersions[ executionPlatform ][ executionPlatformVersion ] || null;
+  return formJSVersions[ executionPlatform ][ executionPlatformVersion ];
 }

--- a/client/src/app/tabs/form/linting/__tests__/FormLinterSpec.js
+++ b/client/src/app/tabs/form/linting/__tests__/FormLinterSpec.js
@@ -14,10 +14,12 @@ import camundaCloud10 from './camunda-cloud-1-0.json';
 import camundaCloud10Errors from './camunda-cloud-1-0-errors.json';
 import camundaCloud11 from './camunda-cloud-1-1.json';
 import camundaCloud12 from './camunda-cloud-1-2.json';
+import camundaCloud120 from './camunda-cloud-1-2-0.json';
 import camundaCloud13 from './camunda-cloud-1-3.json';
 import camundaPlatform715 from './camunda-platform-7-15.json';
 import camundaPlatform715Errors from './camunda-platform-7-15-errors.json';
 import camundaPlatform716 from './camunda-platform-7-16.json';
+import camundaPlatform7160 from './camunda-platform-7-16-0.json';
 import noEngineProfile from './no-engine-profile.json';
 
 
@@ -59,9 +61,11 @@ describe('FormLinter', function() {
   [
     [ 'Camunda Platform 7.15', camundaPlatform715, camundaPlatform715Errors ],
     [ 'Camunda Platform 7.16', camundaPlatform716 ],
+    [ 'Camunda Platform 7.16.0', camundaPlatform7160 ],
     [ 'Camunda Cloud 1.0', camundaCloud10, camundaCloud10Errors ],
     [ 'Camunda Cloud 1.1', camundaCloud11 ],
     [ 'Camunda Cloud 1.2', camundaCloud12 ],
+    [ 'Camunda Cloud 1.2', camundaCloud120 ],
     [ 'Camunda Cloud 1.3', camundaCloud13 ]
   ].forEach(([ engineProfile, noErrorsSchema, errorsSchema ]) => {
 

--- a/client/src/app/tabs/form/linting/__tests__/camunda-cloud-1-2-0.json
+++ b/client/src/app/tabs/form/linting/__tests__/camunda-cloud-1-2-0.json
@@ -1,0 +1,52 @@
+{
+  "components": [
+    {
+      "id": "Field_1",
+      "key": "creditor",
+      "label": "Creditor",
+      "type": "textfield",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "description": "An invoice number in the format: C-123.",
+      "id": "Field_2",
+      "key": "invoiceNumber",
+      "label": "Invoice Number",
+      "type": "textfield",
+      "validate": {
+        "pattern": "^C-[0-9]+$"
+      }
+    },
+    {
+      "id": "Field_3",
+      "key": "approved",
+      "label": "Approved",
+      "type": "checkbox"
+    },
+    {
+      "id": "Field_4",
+      "key": "approvedBy",
+      "label": "Approved By",
+      "type": "textfield"
+    },
+    {
+      "id": "Field_5",
+      "key": "submit",
+      "label": "Submit",
+      "type": "button"
+    },
+    {
+      "id": "Field_6",
+      "action": "reset",
+      "key": "reset",
+      "label": "Reset",
+      "type": "button"
+    }
+  ],
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "1.2.0",
+  "id": "Form_1",
+  "type": "default"
+}

--- a/client/src/app/tabs/form/linting/__tests__/camunda-platform-7-16-0.json
+++ b/client/src/app/tabs/form/linting/__tests__/camunda-platform-7-16-0.json
@@ -1,0 +1,52 @@
+{
+  "components": [
+    {
+      "id": "Field_1",
+      "key": "creditor",
+      "label": "Creditor",
+      "type": "textfield",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "description": "An invoice number in the format: C-123.",
+      "id": "Field_2",
+      "key": "invoiceNumber",
+      "label": "Invoice Number",
+      "type": "textfield",
+      "validate": {
+        "pattern": "^C-[0-9]+$"
+      }
+    },
+    {
+      "id": "Field_3",
+      "key": "approved",
+      "label": "Approved",
+      "type": "checkbox"
+    },
+    {
+      "id": "Field_4",
+      "key": "approvedBy",
+      "label": "Approved By",
+      "type": "textfield"
+    },
+    {
+      "id": "Field_5",
+      "key": "submit",
+      "label": "Submit",
+      "type": "button"
+    },
+    {
+      "id": "Field_6",
+      "action": "reset",
+      "key": "reset",
+      "label": "Reset",
+      "type": "button"
+    }
+  ],
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.16.0",
+  "id": "Form_1",
+  "type": "default"
+}

--- a/client/src/app/tabs/full.bpmnlintrc
+++ b/client/src/app/tabs/full.bpmnlintrc
@@ -1,0 +1,24 @@
+{
+  "extends": [
+    "plugin:camunda-compat/recommended"
+  ],
+  "rules": {
+    "bpmnlint/conditional-flows": "warn",
+    "bpmnlint/end-event-required": "warn",
+    "bpmnlint/event-sub-process-typed-start-event": "warn",
+    "bpmnlint/fake-join": "warn",
+    "bpmnlint/label-required": "warn",
+    "bpmnlint/no-bpmndi": "warn",
+    "bpmnlint/no-complex-gateway": "warn",
+    "bpmnlint/no-disconnected": "warn",
+    "bpmnlint/no-duplicate-sequence-flows": "warn",
+    "bpmnlint/no-gateway-join-fork": "warn",
+    "bpmnlint/no-implicit-split": "warn",
+    "bpmnlint/no-inclusive-gateway": "warn",
+    "bpmnlint/single-blank-start-event": "warn",
+    "bpmnlint/single-event-definition": "warn",
+    "bpmnlint/start-event-required": "warn",
+    "bpmnlint/sub-process-blank-start-event": "warn",
+    "bpmnlint/superfluous-gateway": "warn"
+  }
+}

--- a/client/src/app/tabs/panel/tabs/LintingTab.js
+++ b/client/src/app/tabs/panel/tabs/LintingTab.js
@@ -17,6 +17,7 @@ import Panel from '../Panel';
 import css from './LintingTab.less';
 
 import ErrorIcon from '../../../../../resources/icons/Error.svg';
+import WarningIcon from '../../../../../resources/icons/Warning.svg';
 
 
 export default function LintingTab(props) {
@@ -67,13 +68,16 @@ function LintingIssue(props) {
   const {
     id,
     label,
-    message
+    message,
+    category
   } = issue;
 
+  console.log(issue);
+
   return <div className={ classnames(css.LintingIssue, 'linting-issue') }>
-    <ErrorIcon />
+    { category === 'error' ? <ErrorIcon /> : <WarningIcon /> }
     <div className="linting-issue__text">
-      Error : <span className="linting-issue__link" onClick={ onClick }>{ label || id }</span> - { message }
+      { category === 'error' ? 'Error' : 'Warning' } : <span className="linting-issue__link" onClick={ onClick }>{ label || id }</span> - { message }
     </div>
   </div>;
 }

--- a/client/src/util/Flags.js
+++ b/client/src/util/Flags.js
@@ -44,3 +44,4 @@ export const UPDATE_SERVER_URL = 'update-server-url';
 export const FORCE_UPDATE_CHECKS = 'force-update-checks';
 export const SENTRY_DSN = 'sentry-dsn';
 export const ET_ENDPOINT = 'et-endpoint';
+export const ENABLE_BPMNLINT_RECOMMENDED = 'enable-bpmnlint-recommended';


### PR DESCRIPTION
This PR showcases validation of `bpmnlint:recommended` rules.

There is clearly a couple of things that we'd need to account for beyond this PR to make this possible. However the PR (screen capture attached) already showcases a few things:

* We shall include the recommended modeling guidelines (`bpmnlint:recommended` rules) as _warnings_, not errors. From the automation perspective, these are rather un-critical, good to have things.
* We shall re-work our iconography for warnings (the PR does a poor attempt to fix the existing (unused?) warning icon.
* We shall aim for warnings not being prominently displayed on the diagram (while errors shall be prominently featured. However, warnings are not at all featured at the moment
* We can easily roll this out via a feature toggle. This PR hides the feature behind `--enable-bpmnlint-recommended`.

---

![capture 19r1Vy_optimized](https://user-images.githubusercontent.com/58601/145456378-1e6b599c-0365-470b-898b-49392ae60eab.gif)
