### PR TITLE
Tab context action

### DIFF
--- a/client/resources/icons/TabContext.svg
+++ b/client/resources/icons/TabContext.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>tab-context</title>
+    <g id="tab-context" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path d="M2.5,6.5 C1.675,6.5 1,7.175 1,8 C1,8.825 1.675,9.5 2.5,9.5 C3.325,9.5 4,8.825 4,8 C4,7.175 3.325,6.5 2.5,6.5 Z M13.5,6.5 C12.675,6.5 12,7.175 12,8 C12,8.825 12.675,9.5 13.5,9.5 C14.325,9.5 15,8.825 15,8 C15,7.175 14.325,6.5 13.5,6.5 Z M8,6.5 C7.175,6.5 6.5,7.175 6.5,8 C6.5,8.825 7.175,9.5 8,9.5 C8.825,9.5 9.5,8.825 9.5,8 C9.5,7.175 8.825,6.5 8,6.5 Z" id="Shape" fill="#505562" fill-rule="nonzero"></path>
+    </g>
+</svg>

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1015,6 +1015,12 @@ export class App extends PureComponent {
       }
     }
 
+    if (tabs !== prevState.tabs) {
+      this.emit('app.tabsChanged', {
+        tabs
+      });
+    }
+
     if (
       activeTab !== prevState.activeTab ||
       tabs !== prevState.tabs ||

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -735,6 +735,27 @@ describe('<App>', function() {
       expect(closeTabResponse).to.eql(false);
     });
 
+
+    it('should emit <app.tabsChanged> event on tab closed', async function() {
+
+      // given
+      const eventSpy = sinon.spy();
+
+      const {
+        app
+      } = createApp();
+
+      const tab = await app.createDiagram('bpmn');
+
+      app.on('app.tabsChanged', eventSpy);
+
+      // when
+      await app.closeTab(tab);
+
+      // then
+      expect(eventSpy).to.have.been.calledOnce;
+    });
+
   });
 
 
@@ -1199,6 +1220,25 @@ describe('<App>', function() {
         [ 'tab-changed', tab ],
         [ 'tab-shown', tab ]
       ]);
+    });
+
+
+    it('should emit <app.tabsChanged> event on tab created', async function() {
+
+      // given
+      const eventSpy = sinon.spy();
+
+      const {
+        app
+      } = createApp();
+
+      app.on('app.tabsChanged', eventSpy);
+
+      // when
+      await app.createDiagram('bpmn');
+
+      // then
+      expect(eventSpy).to.have.been.calledOnce;
     });
 
   });

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -2243,6 +2243,26 @@ describe('<App>', function() {
         expect(e.message).to.eql('must not change tab.id');
       }
     });
+
+
+    it('should emit <app.tabsChanged> event on tab updated', async function() {
+
+      // given
+      const eventSpy = sinon.spy();
+
+      const newAttrs = {
+        name: 'foo.bpmn'
+      };
+
+      app.on('app.tabsChanged', eventSpy);
+
+      // when
+      await app.updateTab(tab, newAttrs);
+
+      // then
+      expect(eventSpy).to.have.been.calledOnce;
+    });
+
   });
 
 

--- a/client/src/plugins/create-new-action/CreateNewAction.js
+++ b/client/src/plugins/create-new-action/CreateNewAction.js
@@ -88,7 +88,7 @@ export function CreateNewActionPlugin(props) {
   const newFileItems = _getFromApp('_getNewFileItems')();
 
   return (
-    <Fill slot="tab-actions">
+    <Fill slot="tab-actions" priority={ 2 }>
       <CreateNewAction newFileItems={ newFileItems } { ...props } />
     </Fill>
   );

--- a/client/src/plugins/index.js
+++ b/client/src/plugins/index.js
@@ -9,6 +9,7 @@
  */
 
 import CamundaPlugin from './camunda-plugin';
+import ContextAction from './tab-context-action';
 import CreateNewAction from './create-new-action';
 import ElementTemplatesModal from './element-templates-modal';
 import ErrorTracking from './error-tracking';
@@ -21,6 +22,7 @@ import ZeebePlugin from './zeebe-plugin';
 
 export default [
   CamundaPlugin,
+  ContextAction,
   CreateNewAction,
   ElementTemplatesModal,
   ErrorTracking,

--- a/client/src/plugins/tab-context-action/TabContextAction.js
+++ b/client/src/plugins/tab-context-action/TabContextAction.js
@@ -1,0 +1,181 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+
+import { Fill } from '../../app/slot-fill';
+
+import {
+  OverlayDropdown
+} from '../../shared/ui';
+
+import TabContext from '../../../resources/icons/TabContext.svg';
+
+const OVERLAY_OFFSET = { top: 0, right: 0 };
+const OVERLAY_MIN_WIDTH = '160px';
+const OVERLAY_MAX_WIDTH = '300px';
+const SECTION_MAX_HEIGHT = 'calc(80vh - 150px)';
+
+const overlayConfig = {
+  offset: OVERLAY_OFFSET,
+  minWidth: OVERLAY_MIN_WIDTH,
+  maxWidth: OVERLAY_MAX_WIDTH
+};
+
+
+export class TabContextAction extends React.PureComponent {
+
+  constructor(props) {
+    super(props);
+
+    this.state = { tabs: [] };
+
+    this._buttonRef = React.createRef();
+  }
+
+  updateTabs = (context) => {
+    const {
+      tabs
+    } = context;
+
+    this.setState({
+      tabs
+    });
+  }
+
+  getActionOptions = () => {
+    const {
+      triggerAction
+    } = this.props;
+
+    const {
+      tabs
+    } = this.state;
+
+    const options = {
+      key: 'actions',
+      items: [
+        {
+          text: 'Save all files',
+          onClick: () => triggerAction('save-all')
+        },
+        {
+          text: 'Close active tab',
+          onClick: () => triggerAction('close-active-tab')
+        }
+      ]
+    };
+
+    if (tabs.length > 1) {
+      options.items.push({
+        text: 'Close all tabs',
+        onClick: () => triggerAction('close-all-tabs')
+      },
+      {
+        text: 'Close other tabs',
+        onClick: () => triggerAction('close-other-tabs')
+      });
+    }
+
+    return options;
+  }
+
+  getOpenedEditorsOptions = () => {
+    const {
+      getTabIcon,
+      onSelect,
+    } = this.props;
+
+    const {
+      tabs
+    } = this.state;
+
+    return {
+      key: 'openedEditors',
+      label: 'Opened editors',
+      maxHeight: SECTION_MAX_HEIGHT,
+      items: getOpenTabsList(tabs, onSelect, getTabIcon)
+    };
+  }
+
+  componentDidMount() {
+    const {
+      subscribe
+    } = this.props;
+
+    subscribe('app.tabsChanged', this.updateTabs);
+  }
+
+  render() {
+    const {
+      tabs
+    } = this.state;
+
+    const options = [
+      this.getActionOptions(),
+      this.getOpenedEditorsOptions()
+    ];
+
+    return (
+      <React.Fragment>
+        {
+          tabs.length ? (
+            <OverlayDropdown
+              className="btn--tab-action"
+              items={ options }
+              title="More actions ..."
+              buttonRef={ this._buttonRef }
+              overlayConfig={ overlayConfig }
+            >
+              <TabContext />
+            </OverlayDropdown>
+          ) : null
+        }
+      </React.Fragment>
+    );
+  }
+
+}
+
+export function TabContextActionPlugin(props) {
+  const {
+    subscribe,
+    _getFromApp,
+    ...restProps
+  } = props;
+
+  const getTabIcon = _getFromApp('_getTabIcon');
+  const onSelect = _getFromApp('selectTab');
+
+  return (
+    <Fill slot="tab-actions" priority={ 1 }>
+      <TabContextAction
+        { ...restProps }
+        getTabIcon={ getTabIcon }
+        onSelect={ onSelect }
+        subscribe={ subscribe } />
+    </Fill>
+  );
+}
+
+
+// helper ///////////////
+
+function getOpenTabsList(tabs, onSelect, getTabIcon) {
+  return tabs.map(tab => {
+    const IconComponent = getTabIcon(tab);
+
+    return {
+      text: tab.name,
+      icon: IconComponent,
+      onClick: () => onSelect(tab)
+    };
+  });
+}

--- a/client/src/plugins/tab-context-action/__tests__/TabContextActionSpec.js
+++ b/client/src/plugins/tab-context-action/__tests__/TabContextActionSpec.js
@@ -1,0 +1,320 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/* global sinon */
+
+import React from 'react';
+
+import {
+  mount
+} from 'enzyme';
+
+import { TabContextAction } from '../TabContextAction';
+
+const DEFAULT_TABS = [
+  {
+    id: 'tab1',
+    name: 'tab1.name'
+  },
+  {
+    id: 'tab2',
+    name: 'tab2.name'
+  },
+  {
+    id: 'tab3',
+    name: 'tab3.name'
+  }
+];
+
+
+describe('<TabContextAction>', function() {
+
+  it('should render', function() {
+    expect(createTabAction).not.to.throw();
+  });
+
+
+  it('should display', async function() {
+
+    // when
+    const {
+      tree
+    } = createTabAction();
+
+    // then
+    expect(tree.isEmptyRender()).to.be.false;
+  });
+
+
+  it('should NOT display on no tabs', function() {
+
+    // given
+    const tabs = [];
+
+    // when
+    const {
+      tree
+    } = createTabAction({ tabs });
+
+    // then
+    expect(tree.isEmptyRender()).to.be.true;
+  });
+
+
+  it('should open', function() {
+
+    // given
+    const {
+      tree
+    } = createTabAction();
+
+    // assume
+    expect(tree.exists('Overlay')).to.be.false;
+
+    // when
+    tree.find('button').simulate('click');
+
+    // then
+    expect(tree.exists('Overlay')).to.be.true;
+  });
+
+
+  it('should render items', function() {
+
+    // given
+    const {
+      tree
+    } = createTabAction();
+
+    tree.find('button').simulate('click');
+
+    // when
+    const items = tree.find('Overlay li');
+
+    // then
+    expect(nodesAsTextList(items)).to.eql([
+      'Save all files',
+      'Close active tab',
+      'Close all tabs',
+      'Close other tabs',
+      'tab1.name',
+      'tab2.name',
+      'tab3.name'
+    ]);
+  });
+
+
+  it('should set items via event', function() {
+
+    // given
+    const subscribe = createSubscribe();
+
+    const {
+      tree
+    } = createTabAction({ subscribe });
+
+    // when
+    subscribe.emit({
+      tabs: [
+        ...DEFAULT_TABS,
+        {
+          id: 'foo',
+          name: 'bar'
+        }
+      ]
+    });
+    tree.find('button').simulate('click');
+
+    const items = tree.find('Overlay li');
+
+    // then
+    expect(nodesAsTextList(items)).to.eql([
+      'Save all files',
+      'Close active tab',
+      'Close all tabs',
+      'Close other tabs',
+      'tab1.name',
+      'tab2.name',
+      'tab3.name',
+      'bar'
+    ]);
+  });
+
+
+  describe('#getActionOptions', function() {
+
+    it('should retrieve all actions', function() {
+
+      // given
+      const {
+        instance
+      } = createTabAction();
+
+      // when
+      const options = instance.getActionOptions();
+
+      // then
+      expect(asTextList(options.items)).to.eql([
+        'Save all files',
+        'Close active tab',
+        'Close all tabs',
+        'Close other tabs'
+      ]);
+    });
+
+
+    it('should NOT retrieve all options on one tab only', function() {
+
+      // given
+      const tabs = [
+        {
+          id: 'foo',
+          name: 'bar'
+        }
+      ];
+
+      const {
+        instance
+      } = createTabAction({
+        tabs
+      });
+
+      // when
+      const options = instance.getActionOptions();
+
+      // then
+      expect(asTextList(options.items)).to.eql([
+        'Save all files',
+        'Close active tab'
+      ]);
+    });
+
+  });
+
+
+  describe('trigger actions', function() {
+
+    [
+      'save-all',
+      'close-active-tab',
+      'close-all-tabs',
+      'close-other-tabs'
+    ].forEach((action, index) => {
+
+      it(`should trigger <${action}>`, function() {
+
+        // given
+        const actionSpy = sinon.spy();
+
+        const {
+          tree
+        } = createTabAction({ triggerAction: actionSpy });
+
+        tree.find('button').simulate('click');
+
+        // when
+        const item = tree.find('Overlay li').at(index);
+        item.simulate('click');
+
+        // then
+        expect(actionSpy).to.have.been.calledWith(action);
+      });
+    });
+
+
+    it('should select tab', function() {
+
+      // given
+      const selectSpy = sinon.spy();
+
+      const {
+        tree
+      } = createTabAction({ onSelect: selectSpy });
+
+      tree.find('button').simulate('click');
+
+      // when
+      const item = tree.find('Overlay li').at(4);
+      item.simulate('click');
+
+      // then
+      expect(selectSpy).to.have.been.calledWith(DEFAULT_TABS[0]);
+    });
+
+  });
+
+
+});
+
+
+// helpers /////////////////////////////////////
+
+function createTabAction(options = {}) {
+  const {
+    getTabIcon,
+    onSelect,
+    subscribe,
+    tabs = DEFAULT_TABS,
+    triggerAction
+  } = options;
+
+  const tree = mount(
+    <TabContextAction
+      getTabIcon={ getTabIcon || noop }
+      onSelect={ onSelect || noop }
+      subscribe={ subscribe || createSubscribe() }
+      triggerAction={ triggerAction || noop } />
+  );
+
+  const instance = tree.instance();
+
+  setTabs(tabs, tree, instance);
+
+  return {
+    tree,
+    instance
+  };
+}
+
+function setTabs(tabs, wrapper, instance) {
+  instance.setState({
+    tabs
+  });
+  return wrapper.update();
+}
+
+function noop() {}
+
+function createSubscribe() {
+
+  let cb = noop;
+
+  function subscribe(_, callback) {
+    cb = callback;
+
+    return {
+      cancel() {
+        cb = noop;
+      }
+    };
+  }
+
+  subscribe.emit = (payload) => cb(payload);
+
+  return subscribe;
+}
+
+function nodesAsTextList(items) {
+  return items.map(i => i.text());
+}
+
+function asTextList(items) {
+  return items.map(i => i.text);
+}

--- a/client/src/plugins/tab-context-action/index.js
+++ b/client/src/plugins/tab-context-action/index.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+export { TabContextActionPlugin as default } from './TabContextAction';

--- a/client/src/shared/ui/__tests__/OverlayDropdownSpec.js
+++ b/client/src/shared/ui/__tests__/OverlayDropdownSpec.js
@@ -139,4 +139,29 @@ describe('<OverlayDropdown>', function() {
     expect(wrapper.find('Overlay section')).to.have.length(3);
   });
 
+
+  it('should set max height for option group', () => {
+
+    // given
+    const items = [
+      { key: 'section', items: [], maxHeight: 300 }
+    ];
+
+    const wrapper = mount((
+      <OverlayDropdown items={ items } buttonRef={ mockButtonRef }>
+        TestButton
+      </OverlayDropdown>
+    ));
+
+    // when
+    wrapper.find('button').simulate('click');
+
+    const section = wrapper.find('Overlay section').at(0);
+
+    // then
+    expect(section.prop('style')).to.eql({
+      '--section-max-height': '300px'
+    });
+  });
+
 });

--- a/client/src/shared/ui/overlay/OverlayDropdown.js
+++ b/client/src/shared/ui/overlay/OverlayDropdown.js
@@ -22,7 +22,7 @@ import css from './OverlayDropdown.less';
  */
 
 /**
- * @typedef {{ key: String, label: String, items: Array<Item> }} ItemGroup
+ * @typedef {{ key: String, label: String, items: Array<Item>, maxHeight: Number | String }} ItemGroup
  */
 
 
@@ -98,6 +98,7 @@ export function OverlayDropdown(props) {
                   key={ group.key }
                   label={ group.label }
                   items={ group.items }
+                  maxHeight={ group.maxHeight }
                   onSelect={ onSelect } />
               )
             ) : (
@@ -116,14 +117,19 @@ function OptionGroup(props) {
   const {
     items,
     label,
+    maxHeight,
     onSelect
   } = props;
 
   return (
-    <Section>
-      <Section.Header>
-        { label }
-      </Section.Header>
+    <Section maxHeight={ maxHeight }>
+      { label ?
+        (
+          <Section.Header>
+            { label }
+          </Section.Header>
+        ) : null
+      }
       <Options items={ items } onSelect={ onSelect }></Options>
     </Section>
   );

--- a/client/src/shared/ui/overlay/OverlayDropdown.less
+++ b/client/src/shared/ui/overlay/OverlayDropdown.less
@@ -72,7 +72,7 @@
     margin: 0;
     border: none;
     border-radius: 0;
-    overflow-y: hidden;
+    overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
 


### PR DESCRIPTION
Closes #2630 

This includes
* firing an `app.tabsChanged` event whenever the tabs change
* adding a `maxHeight` prop for overlay dropdown option groups
* adding the tab context action (requirements cf. #2630)

![image](https://user-images.githubusercontent.com/9433996/145832678-fc0ff323-f6f8-4e85-b0a2-4ce800757757.png)

![image](https://user-images.githubusercontent.com/9433996/145832863-bb72301a-161f-4cd7-8c88-30e8dadb830d.png)


------

Artifacts are ready to use 
* https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2630-tab-context-menu/camunda-modeler-2630-tab-context-menu-linux-x64.tar.gz
* https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2630-tab-context-menu/camunda-modeler-2630-tab-context-menu-mac.dmg
* https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2630-tab-context-menu/camunda-modeler-2630-tab-context-menu-mac.zip
* https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2630-tab-context-menu/camunda-modeler-2630-tab-context-menu-win-ia32.zip
* https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2630-tab-context-menu/camunda-modeler-2630-tab-context-menu-win-x64.zip 
