### PR TITLE
Expose properties panel to plugins

### DIFF
--- a/client/src/remote/Plugins.js
+++ b/client/src/remote/Plugins.js
@@ -20,6 +20,13 @@ import { Fill } from '../app/slot-fill';
 
 import React, * as ReactExports from 'react';
 
+import * as PropertiesPanel from '@bpmn-io/properties-panel';
+import * as Preact from '@bpmn-io/properties-panel/preact';
+import PreactCompat, * as PreactCompatExports from '@bpmn-io/properties-panel/preact/compat';
+import * as PreactHooks from '@bpmn-io/properties-panel/preact/hooks';
+import * as PreactJsxRuntime from '@bpmn-io/properties-panel/preact/jsx-runtime';
+import * as BpmnJsPropertiesPanel from 'bpmn-js-properties-panel';
+
 
 const PLUGINS_PROTOCOL = 'app-plugins://';
 
@@ -49,10 +56,12 @@ export default class Plugins {
    */
   bindHelpers(global) {
 
+    // React exports for the client plugins
     global.react = ReactExports;
 
     global.react.React = React;
 
+    // Camunda Modeler UI components
     global.components = {
       Fill,
       Modal,
@@ -60,6 +69,7 @@ export default class Plugins {
       ToggleSwitch
     };
 
+    // deprecated helpers
     global.getModelerDirectory = () => {
       throw new Error('not implemented in Camunda Modeler >= 3.0.0');
     };
@@ -75,6 +85,20 @@ export default class Plugins {
       return PLUGINS_PROTOCOL;
     };
 
+    // properties panel
+    global.propertiesPanel = {
+      common: PropertiesPanel,
+      preact: {
+        root: Preact,
+        compat: {
+          ...PreactCompatExports,
+          default: PreactCompat
+        },
+        hooks: PreactHooks,
+        jsxRuntime: PreactJsxRuntime
+      },
+      bpmn: BpmnJsPropertiesPanel
+    };
   }
 
   /**

--- a/client/src/remote/__tests__/PluginsSpec.js
+++ b/client/src/remote/__tests__/PluginsSpec.js
@@ -166,15 +166,74 @@ describe('plugins', function() {
 
       const plugins = new Plugins();
 
+      // when
       plugins.bindHelpers(global);
 
-      // when
+      // then
       expect(() => {
         global.getModelerDirectory();
       }).to.throw('not implemented in Camunda Modeler >= 3');
 
     });
 
+
+    it('should expose properties panel building blocks via window#propertiesPanel.common',
+      function() {
+
+        // given
+        const global = {};
+
+        const plugins = new Plugins();
+
+        // when
+        plugins.bindHelpers(global);
+
+        // then
+        expect(global.propertiesPanel.common).to.exist;
+        expect(global.propertiesPanel.common).to.have.property('PropertiesPanel');
+        expect(global.propertiesPanel.common).to.have.property('Group');
+        expect(global.propertiesPanel.common).to.have.property('ListGroup');
+        expect(global.propertiesPanel.common).to.have.property('TextFieldEntry');
+      }
+    );
+
+    it('should expose properties panel preact with subpackages via window#propertiesPanel.preact[...]',
+      function() {
+
+        // given
+        const global = {};
+
+        const plugins = new Plugins();
+
+        // when
+        plugins.bindHelpers(global);
+
+        // then
+        expect(global.propertiesPanel.preact).to.exist;
+        expect(global.propertiesPanel.preact.root).to.exist;
+        expect(global.propertiesPanel.preact.compat).to.exist;
+        expect(global.propertiesPanel.preact.compat.default).to.exist;
+        expect(global.propertiesPanel.preact.hooks).to.exist;
+        expect(global.propertiesPanel.preact.jsxRuntime).to.exist;
+      }
+    );
+
+    it('should expose BPMN properties panel building blocks via window#propertiesPanel.bpmn',
+      function() {
+
+        // given
+        const global = {};
+
+        const plugins = new Plugins();
+
+        // when
+        plugins.bindHelpers(global);
+
+        // then
+        expect(global.propertiesPanel.bpmn).to.exist;
+        expect(global.propertiesPanel.bpmn).to.have.property('useService');
+      }
+    );
   });
 
 });


### PR DESCRIPTION
This requires the `bpmn-js-properties-panel@1.0.0-alpha.0` to be released and integrated.
