### PR TITLE
chore(DeploymentPlugin): relax cloud URL validation

### DIFF
--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginValidator.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginValidator.js
@@ -309,5 +309,6 @@ function shallowEquals(a, b) {
 }
 
 function validCloudUrl(url) {
-  return /^(https:\/\/|)[a-z\d-]+\.[a-z]+-\d+\.zeebe\.camunda\.io(:443|)\/?/.test(url);
+  return /^(https:\/\/|)[a-z\d-]+\.[a-z]+-\d+\.zeebe\.[\w.]+\.[\w]+(:443|)\/?$/
+    .test(url);
 }

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginValidatorSpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginValidatorSpec.js
@@ -92,21 +92,27 @@ describe('<DeploymentPluginValidator> (Zeebe)', () => {
 
       // given
       const nonValidClusterUrl = '';
+      const nonValidClusterUrlUsername = 'asdf222.usa-22.zeebe.ultraw@somethingombat.com:443';
       const validClusterUrlHttps = 'https://asdf2-a1213-123a.ber-05.zeebe.camunda.io:443';
       const validClusterUrlHttpsSlash = 'https://asdf2-a1213-123a.ber-05.zeebe.camunda.io:443/';
       const validClusterUrlHttpsNoPort = 'https://asdf2-a1213-123a.ber-05.zeebe.camunda.io';
       const validClusterUrlHttpsNoPortSlash = 'https://asdf2-a1213-123a.ber-05.zeebe.camunda.io/';
       const validClusterUrl = 'asdf2-a1213-123a.ber-05.zeebe.camunda.io:443';
       const validClusterUrlSlash = 'asdf2-a1213-123a.ber-05.zeebe.camunda.io:443/';
+      const validClusterUrlDev = 'asdf222.usa-22.zeebe.dev.ultrawombat.com:443';
+      const validClusterUrlInt = 'asdf222.usa-22.zeebe.ultrawombat.com:443';
 
       // then
       expect(validator.validateClusterUrl(nonValidClusterUrl)).to.eql(CLUSTER_URL_MUST_BE_VALID_CLOUD_URL);
+      expect(validator.validateClusterUrl(nonValidClusterUrlUsername)).to.eql(CLUSTER_URL_MUST_BE_VALID_CLOUD_URL);
       expect(validator.validateClusterUrl(validClusterUrlHttps)).to.not.exist;
       expect(validator.validateClusterUrl(validClusterUrlHttpsSlash)).to.not.exist;
       expect(validator.validateClusterUrl(validClusterUrlHttpsNoPort)).to.not.exist;
       expect(validator.validateClusterUrl(validClusterUrlHttpsNoPortSlash)).to.not.exist;
       expect(validator.validateClusterUrl(validClusterUrl)).to.not.exist;
       expect(validator.validateClusterUrl(validClusterUrlSlash)).to.not.exist;
+      expect(validator.validateClusterUrl(validClusterUrlDev)).to.not.exist;
+      expect(validator.validateClusterUrl(validClusterUrlInt)).to.not.exist;
     });
 
 


### PR DESCRIPTION
* according to: `<uuid>.<region>.zeebe.<someHost>.<someTopLevelDomain>:443`

closes #2636

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
