### PR TITLE
fix: update tab with new attributes

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -275,10 +275,14 @@ export class App extends PureComponent {
       throw new Error('must not change tab.id');
     }
 
-    const updatedTab = {
-      ...tab,
-      ...newAttrs
-    };
+    const {
+      tabsProvider
+    } = this.props;
+
+    let updatedTab = tabsProvider.createTabForFile(tab.file);
+    updatedTab.id = tab.id;
+
+    assign(updatedTab, newAttrs);
 
     this.setState((state) => {
 

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -2139,6 +2139,21 @@ describe('<App>', function() {
     });
 
 
+    it('should update with attributes getters', async function() {
+
+      // given
+      const tab = await app.createDiagram('form');
+
+      // when
+      const updatedTab = await app.triggerAction('lint-tab', { tab });
+
+      updatedTab.file.name = 'newname.form';
+
+      // then
+      expect(updatedTab.name).to.eql(updatedTab.file.name);
+    });
+
+
     it('should update navigation history', async function() {
 
       // given
@@ -2177,7 +2192,7 @@ describe('<App>', function() {
       } = app.state;
 
       // then
-      expect(updatedTab).to.not.eql(tab);
+      expect(updatedTab).to.include(newAttrs);
       expect(updatedTab).to.eql(activeTab);
       expect(tabs).to.not.include(tab);
       expect(tabs).to.include(updatedTab);


### PR DESCRIPTION
Closes #2581

Explanation: the spread operator only keeps the enumerable properties of the object itself. Therefore, functions like `getTitle()` were getting lost.