### PR TITLE
fix(tabs): show close on non active tabs until threshold width

### DIFF
--- a/client/src/app/primitives/TabLinks.js
+++ b/client/src/app/primitives/TabLinks.js
@@ -33,7 +33,8 @@ const TABS_OPTS = {
   }
 };
 
-const SMALL_TAB_WIDTH = 45;
+const SMALL_TAB_WIDTH = 90;
+const SMALLER_TAB_WIDTH = 45;
 
 
 export default class TabLinks extends PureComponent {
@@ -158,6 +159,7 @@ function Tab(props) {
 
   const tabRef = React.useRef(0);
   const [ small, setSmall ] = React.useState(false);
+  const [ smaller, setSmaller ] = React.useState(false);
 
   const tabNode = tabRef.current;
 
@@ -169,6 +171,7 @@ function Tab(props) {
     const resizeObserver = new ResizeObserver(() => {
       const width = tabNode.getBoundingClientRect().width;
       setSmall(width < SMALL_TAB_WIDTH);
+      setSmaller(width < SMALLER_TAB_WIDTH);
     });
 
     resizeObserver.observe(tabNode);
@@ -183,7 +186,8 @@ function Tab(props) {
       className={ classNames('tab', {
         'tab--active': active,
         'tab--dirty': dirty,
-        'tab--small': small
+        'tab--small': small,
+        'tab--smaller': smaller
       }) }
       onClick={ (event) => onSelect(tab, event) }
       onContextMenu={ (event) => (onContextMenu || noop)(tab, event) }
@@ -196,7 +200,7 @@ function Tab(props) {
         }
         <p className="tab__name">{tab.name}</p>
         {
-          active && (
+          (active || !small) && (
             <TabClose
               tab={ tab }
               dirty={ dirty }

--- a/client/src/app/primitives/TabLinks.js
+++ b/client/src/app/primitives/TabLinks.js
@@ -33,6 +33,13 @@ const TABS_OPTS = {
   }
 };
 
+/**
+ * markers to indicate a tab has less width than
+ * a defined threshold
+ *
+ * a) 90px => small
+ * b) 45px => even smaller
+ */
 const SMALL_TAB_WIDTH = 90;
 const SMALLER_TAB_WIDTH = 45;
 

--- a/client/src/app/primitives/Tabbed.less
+++ b/client/src/app/primitives/Tabbed.less
@@ -100,7 +100,7 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: clip;
-      margin: 0 6px 0 0;
+      margin: 0 28px 0 0;
     }
 
     .tab__dirty-marker {
@@ -142,6 +142,14 @@
     }
 
     &.tab--small {
+      &:not(.tab--active) {
+        .tab__name {
+          margin-right: 6px;
+        }
+      }
+    }
+
+    &.tab--smaller {
       .tab__type {
         margin: auto;
       }
@@ -176,12 +184,6 @@
       
       .tab__content {
         padding-left: 12px;
-      }
-    }
-
-    &.tab--active {
-      .tab__name {
-        margin-right: 28px;
       }
     }
 

--- a/client/src/app/primitives/__tests__/TabLinksSpec.js
+++ b/client/src/app/primitives/__tests__/TabLinksSpec.js
@@ -116,7 +116,7 @@ describe('<TabLinks>', function() {
     });
 
 
-    it('should NOT display close on non active', function() {
+    it('should display close on non active', function() {
 
       // given
       const {
@@ -127,7 +127,7 @@ describe('<TabLinks>', function() {
       const close = tree.find('.tab[data-tab-id="tab2"] .tab__close');
 
       // then
-      expect(close.exists()).to.be.false;
+      expect(close.exists()).to.be.true;
     });
 
 
@@ -395,6 +395,53 @@ describe('<TabLinks>', function() {
     // TODO(pinussilvestrus): the resize observer is hard to test
     // in the current test environment
     it.skip('should set <small> selector on resize', function() {
+
+      // given
+      const tabs = Array(10).fill().map((_, i) => {
+        return {
+          id: `tab${i}`,
+          name: `tab${i}.tab`
+        };
+      });
+
+      const {
+        tree
+      } = renderTabLinks({
+        tabs
+      });
+
+      // when
+      const tabNode = tree.find('.tab[data-tab-id="tab1"]').getDOMNode();
+
+      tabNode.dispatchEvent(new Event('resize'));
+
+      // then
+      expect(tabNode.classList.contains('tab--small')).to.be.true;
+    });
+
+  });
+
+
+  describe('smaller state', function() {
+
+    it('should NOT set <smaller> selector initially', function() {
+
+      // given
+      const {
+        tree
+      } = renderTabLinks();
+
+      // when
+      const tabNode = tree.find('.tab[data-tab-id="tab1"]').getDOMNode();
+
+      // then
+      expect(tabNode.classList.contains('tab--smaller')).to.be.false;
+    });
+
+
+    // TODO(pinussilvestrus): the resize observer is hard to test
+    // in the current test environment
+    it.skip('should set <smaller> selector on resize', function() {
 
       // given
       const tabs = Array(20).fill().map((_, i) => {


### PR DESCRIPTION
Closes #2639 

_Artifacts build [is running](https://github.com/camunda/camunda-modeler/runs/4701274691)_

- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2639-tab-close-non-active/camunda-modeler-2639-tab-close-non-active-linux-x64.tar.gz
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2639-tab-close-non-active/camunda-modeler-2639-tab-close-non-active-mac.dmg
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2639-tab-close-non-active/camunda-modeler-2639-tab-close-non-active-mac.zip
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2639-tab-close-non-active/camunda-modeler-2639-tab-close-non-active-win-ia32.zip
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2639-tab-close-non-active/camunda-modeler-2639-tab-close-non-active-win-x64.zip

![Kapture 2022-01-03 at 14 54 26](https://user-images.githubusercontent.com/9433996/147938791-cd2170c1-e1eb-4c00-8eef-4339849e7fb2.gif)