### PR TITLE
deps: bump to eslint-plugin-bpmn-io@0.13

### DIFF
--- a/app/lib/dialog.js
+++ b/app/lib/dialog.js
@@ -141,10 +141,10 @@ class Dialog {
         buttons: buttons.map(({ label }) => label)
       });
     } else {
-      buttons = [{
+      buttons = [ {
         id: 'close',
         label: 'Close'
-      }];
+      } ];
 
       assign(options, {
         buttons: [ 'Close' ]

--- a/app/lib/menu/mac-os/mac-menu-builder.js
+++ b/app/lib/menu/mac-os/mac-menu-builder.js
@@ -25,7 +25,7 @@ class MacMenuBuilder extends MenuBuilder {
 
   appendAppMenu() {
     const subMenu = new MacMenuBuilder({
-      template: [{
+      template: [ {
         label: 'About ' + this.options.appName,
         role: 'about'
       }, {
@@ -52,7 +52,7 @@ class MacMenuBuilder extends MenuBuilder {
         role: 'unhide'
       }, {
         type: 'separator'
-      }]
+      } ]
     }).appendQuit().get();
 
     this.menu.append(new MenuItem({

--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -149,10 +149,10 @@ class MenuBuilder {
       .filter(menu => Boolean(menu.length));
 
     if (!providedMenus.length) {
-      return [{
+      return [ {
         label: 'Empty',
         enabled: false
-      }];
+      } ];
     }
 
     const groups = groupBy(flatten(providedMenus), 'group');
@@ -300,7 +300,7 @@ class MenuBuilder {
   appendSwitchTab(submenu) {
     this.menu.append(new MenuItem({
       label: 'Switch Tab..',
-      submenu: submenu || Menu.buildFromTemplate([{
+      submenu: submenu || Menu.buildFromTemplate([ {
         label: 'Select Next Tab',
         enabled: canSwitchTab(this.options.state),
         accelerator: 'Control+TAB',
@@ -311,7 +311,7 @@ class MenuBuilder {
         enabled: canSwitchTab(this.options.state),
         accelerator: 'Control+SHIFT+TAB',
         click: () => app.emit('menu:action', 'select-tab', 'previous')
-      }])
+      } ])
     }));
 
     this.appendSeparator();

--- a/app/lib/util/filter-extensions.js
+++ b/app/lib/util/filter-extensions.js
@@ -18,7 +18,7 @@ var {
 var EXTENSIONS = {
   all: {
     name: 'All files',
-    extensions: ['*']
+    extensions: [ '*' ]
   },
   supported: {
     name: 'All supported',
@@ -50,7 +50,7 @@ var EXTENSIONS = {
   },
   svg: {
     name: 'SVG Image',
-    extensions: ['svg']
+    extensions: [ 'svg' ]
   }
 };
 

--- a/app/test/spec/dialog-spec.js
+++ b/app/test/spec/dialog-spec.js
@@ -50,13 +50,13 @@ describe('Dialog', function() {
       electronDialog.setResponse({ response: 0 });
 
       var options = {
-        buttons: [{
+        buttons: [ {
           id: 'foo',
           label: 'Foo'
         }, {
           id: 'bar',
           label: 'Bar'
-        }],
+        } ],
         title: 'error',
         type: 'error'
       };
@@ -82,13 +82,13 @@ describe('Dialog', function() {
       electronDialog.setResponse({ response: 0 });
 
       var options = {
-        buttons: [{
+        buttons: [ {
           id: 'foo',
           label: 'Foo'
         }, {
           id: 'bar',
           label: 'Bar'
-        }],
+        } ],
         title: 'warning',
         type: 'warning'
       };
@@ -114,13 +114,13 @@ describe('Dialog', function() {
       electronDialog.setResponse({ response: 0 });
 
       var options = {
-        buttons: [{
+        buttons: [ {
           id: 'foo',
           label: 'Foo'
         }, {
           id: 'bar',
           label: 'Bar'
-        }],
+        } ],
         title: 'info',
         type: 'info'
       };
@@ -146,13 +146,13 @@ describe('Dialog', function() {
       electronDialog.setResponse({ response: 0 });
 
       var options = {
-        buttons: [{
+        buttons: [ {
           id: 'foo',
           label: 'Foo'
         }, {
           id: 'bar',
           label: 'Bar'
-        }],
+        } ],
         title: 'question',
         type: 'question'
       };
@@ -181,10 +181,10 @@ describe('Dialog', function() {
       });
 
       var options = {
-        buttons: [{
+        buttons: [ {
           id: 'foo',
           label: 'Foo'
-        }],
+        } ],
         title: 'info',
         type: 'info',
         checkboxLabel: 'Bar'

--- a/app/test/spec/menu/menu-builder-spec.js
+++ b/app/test/spec/menu/menu-builder-spec.js
@@ -279,11 +279,11 @@ describe('MenuBuilder', () => {
       const action = sinon.spy(ElectronApp, 'emit');
       const menuBuilder = new MenuBuilder({
         state: {
-          editMenu: [{
+          editMenu: [ {
             label: 'label',
             enabled: true,
             action
-          }]
+          } ]
         }
       });
 
@@ -307,11 +307,11 @@ describe('MenuBuilder', () => {
       const action = sinon.spy(ElectronApp, 'emit');
       const menuBuilder = new MenuBuilder({
         state: {
-          editMenu: [{
+          editMenu: [ {
             label: 'label',
             enabled: true,
             action
-          }]
+          } ]
         }
       });
 
@@ -335,11 +335,11 @@ describe('MenuBuilder', () => {
       const action = sinon.spy(ElectronApp, 'emit');
       const menuBuilder = new MenuBuilder({
         state: {
-          editMenu: [{
+          editMenu: [ {
             label: 'label',
             enabled: true,
             action
-          }]
+          } ]
         }
       });
 

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -269,7 +269,7 @@ export class App extends PureComponent {
    * @param {Object} newAttrs
    * @param {Object} [newState={}]
    */
-  updateTab(tab, newAttrs, newState={}) {
+  updateTab(tab, newAttrs, newState = {}) {
 
     if (newAttrs.id && newAttrs.id !== tab.id) {
       throw new Error('must not change tab.id');
@@ -2239,10 +2239,10 @@ function getSaveFileDialogFilters(provider) {
     name
   } = provider;
 
-  return [{
+  return [ {
     name,
     extensions
-  }, FILTER_ALL_EXTENSIONS];
+  }, FILTER_ALL_EXTENSIONS ];
 }
 
 function getExportFileDialogFilters(provider) {

--- a/client/src/app/KeyboardBindings.js
+++ b/client/src/app/KeyboardBindings.js
@@ -263,33 +263,33 @@ export default class KeyboardBindings {
 
 // Ctrl + C
 function isCopy(event) {
-  return isKey(['c', 'C'], event) && isCommandOrControl(event);
+  return isKey([ 'c', 'C' ], event) && isCommandOrControl(event);
 }
 
 // Ctrl + X
 function isCut(event) {
-  return isKey(['x', 'X'], event) && isCommandOrControl(event);
+  return isKey([ 'x', 'X' ], event) && isCommandOrControl(event);
 }
 
 // Ctrl + V
 function isPaste(event) {
-  return isKey(['v', 'V'], event) && isCommandOrControl(event);
+  return isKey([ 'v', 'V' ], event) && isCommandOrControl(event);
 }
 
 // Ctrl + A
 function isSelectAll(event) {
-  return isKey(['a', 'A'], event) && isCommandOrControl(event);
+  return isKey([ 'a', 'A' ], event) && isCommandOrControl(event);
 }
 
 // Ctrl + Z
 function isUndo(event) {
-  return isKey(['z', 'Z'], event) && isCommandOrControl(event) && !isShift(event);
+  return isKey([ 'z', 'Z' ], event) && isCommandOrControl(event) && !isShift(event);
 }
 
 // Ctrl + Y or Ctrl + Shift + Z
 function isRedo(event) {
   return isCommandOrControl(event) &&
-    (isKey([ 'y', 'Y' ], event) || (isKey(['z', 'Z'], event) && isShift(event)));
+    (isKey([ 'y', 'Y' ], event) || (isKey([ 'z', 'Z' ], event) && isShift(event)));
 }
 
 // Secondary delete shortcut

--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -137,21 +137,21 @@ export default class TabsProvider {
           return `diagram_${suffix}.bpmn`;
         },
         getHelpMenu() {
-          return [{
+          return [ {
             label: 'BPMN 2.0 Tutorial',
             action: 'https://camunda.org/bpmn/tutorial/'
           },
           {
             label: 'BPMN Modeling Reference',
             action: 'https://camunda.org/bpmn/reference/'
-          }];
+          } ];
         },
         getNewFileMenu() {
-          return [{
+          return [ {
             label: 'BPMN diagram',
             group: 'Camunda Platform',
             action: 'create-bpmn-diagram'
-          }];
+          } ];
         },
         getLinter() {
           return null;
@@ -208,11 +208,11 @@ export default class TabsProvider {
           return [];
         },
         getNewFileMenu() {
-          return [{
+          return [ {
             label: 'BPMN diagram',
             group: 'Camunda Cloud',
             action: 'create-cloud-bpmn-diagram'
-          }];
+          } ];
         },
         getLinter() {
           return BpmnLinter;
@@ -243,21 +243,21 @@ export default class TabsProvider {
           return `diagram_${suffix}.cmmn`;
         },
         getHelpMenu() {
-          return [{
+          return [ {
             label: 'CMMN 1.1 Tutorial',
             action: 'https://docs.camunda.org/get-started/cmmn11/'
           },
           {
             label: 'CMMN Modeling Reference',
             action: 'https://docs.camunda.org/manual/latest/reference/cmmn11/'
-          }];
+          } ];
         },
         getNewFileMenu() {
-          return [{
+          return [ {
             label: 'CMMN diagram',
             group: 'Camunda Platform',
             action: 'create-cmmn-diagram'
-          }];
+          } ];
         },
         getLinter() {
           return null;
@@ -288,17 +288,17 @@ export default class TabsProvider {
           return `diagram_${suffix}.dmn`;
         },
         getHelpMenu() {
-          return [{
+          return [ {
             label: 'DMN Tutorial',
             action: 'https://camunda.org/dmn/tutorial/'
-          }];
+          } ];
         },
         getNewFileMenu() {
-          return [{
+          return [ {
             label: 'DMN diagram',
             group: 'Camunda Platform',
             action: 'create-dmn-diagram'
-          }];
+          } ];
         },
         getLinter() {
           return null;
@@ -328,11 +328,11 @@ export default class TabsProvider {
           return [];
         },
         getNewFileMenu() {
-          return [{
+          return [ {
             label: 'Form',
             group: 'Camunda Platform',
             action: 'create-form'
-          }];
+          } ];
         },
         getLinter() {
           return FormLinter;
@@ -373,11 +373,11 @@ export default class TabsProvider {
           return [];
         },
         getNewFileMenu() {
-          return [{
+          return [ {
             label: 'Form',
             group: 'Camunda Cloud',
             action: 'create-cloud-form'
-          }];
+          } ];
         },
         getLinter() {
           return FormLinter;

--- a/client/src/app/__tests__/AppParentSpec.js
+++ b/client/src/app/__tests__/AppParentSpec.js
@@ -884,7 +884,7 @@ describe('<AppParent>', function() {
       });
 
       const plugins = new Plugins({
-        getAppPlugins: () => [{}]
+        getAppPlugins: () => [ {} ]
       });
 
       const { appParent } = createAppParent({
@@ -942,7 +942,7 @@ describe('<AppParent>', function() {
 });
 
 
-function createAppParent(options = {}, mountFn=shallow) {
+function createAppParent(options = {}, mountFn = shallow) {
 
   if (typeof options === 'function') {
     mountFn = options;

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -1720,10 +1720,10 @@ describe('<App>', function() {
       // then
       const log = tree.find(Log).first();
 
-      expect(app.state.logEntries).to.eql([{
+      expect(app.state.logEntries).to.eql([ {
         message: 'foo',
         category: 'bar'
-      }]);
+      } ]);
 
       expect(log.props().layout.log.open).to.be.true;
     });
@@ -2525,10 +2525,10 @@ describe('<App>', function() {
         globals: {
           plugins: {
             get(type) {
-              return [{
+              return [ {
                 __init__: [ type ],
                 [ type ]: [ 'type', noop ]
-              }];
+              } ];
             }
           }
         }
@@ -2538,10 +2538,10 @@ describe('<App>', function() {
       const plugins = app.getPlugins('foo');
 
       // then
-      expect(plugins).to.eql([{
+      expect(plugins).to.eql([ {
         __init__: [ 'foo' ],
         foo: [ 'type', noop ]
-      }]);
+      } ]);
     });
   });
 
@@ -2724,7 +2724,7 @@ describe('<App>', function() {
         // given
         const options = {
           name: 'file.ext',
-          providerNames: ['CMMN', 'BPMN', 'DMN', 'FORM']
+          providerNames: [ 'CMMN', 'BPMN', 'DMN', 'FORM' ]
         };
 
         // when
@@ -2741,7 +2741,7 @@ describe('<App>', function() {
         // given
         const options = {
           name: 'file.ext',
-          providerNames: ['BPMN', 'DMN']
+          providerNames: [ 'BPMN', 'DMN' ]
         };
 
         // when
@@ -2757,7 +2757,7 @@ describe('<App>', function() {
         // given
         const options = {
           name: 'file.ext',
-          providerNames: ['BPMN']
+          providerNames: [ 'BPMN' ]
         };
 
         // when
@@ -2921,7 +2921,7 @@ class MockTab {
   triggerAction() {}
 }
 
-function createApp(options = {}, mountFn=shallow) {
+function createApp(options = {}, mountFn = shallow) {
 
   if (typeof options === 'function') {
     mountFn = options;

--- a/client/src/app/__tests__/EmptyTabSpec.js
+++ b/client/src/app/__tests__/EmptyTabSpec.js
@@ -219,7 +219,7 @@ describe('<EmptyTab>', function() {
 
 function noop() {}
 
-function createEmptyTab(options = {}, mountFn=shallow) {
+function createEmptyTab(options = {}, mountFn = shallow) {
 
   if (typeof options === 'function') {
     mountFn = options;

--- a/client/src/app/__tests__/KeyboardBindingsSpec.js
+++ b/client/src/app/__tests__/KeyboardBindingsSpec.js
@@ -46,12 +46,12 @@ describe('KeyboardBindings', function() {
       // given
       event = createKeyEvent('F');
 
-      keyboardBindings.update([{
+      keyboardBindings.update([ {
         custom: {
           key: 'F',
           keydown: 'foo'
         }
-      }]);
+      } ]);
 
       // when
       keyboardBindings._keyDownHandler(event);
@@ -70,12 +70,12 @@ describe('KeyboardBindings', function() {
       // given
       event = createKeyEvent('F');
 
-      keyboardBindings.update([{
+      keyboardBindings.update([ {
         custom: {
           key: 'F',
           keypress: 'foo'
         }
-      }]);
+      } ]);
 
       // when
       keyboardBindings._keyPressHandler(event);
@@ -98,12 +98,12 @@ describe('KeyboardBindings', function() {
       // given
       event = createKeyEvent('F');
 
-      keyboardBindings.update([{
+      keyboardBindings.update([ {
         custom: {
           key: 'F',
           keyup: 'foo'
         }
-      }]);
+      } ]);
 
       // when
       keyboardBindings._keyUpHandler(event);
@@ -124,10 +124,10 @@ describe('KeyboardBindings', function() {
     // given
     event = createKeyEvent('C', { ctrlKey: true });
 
-    keyboardBindings.update([{
+    keyboardBindings.update([ {
       accelerator: 'CommandOrControl + C',
       action: 'copy'
-    }]);
+    } ]);
 
     // when
     keyboardBindings._keyDownHandler(event);
@@ -142,10 +142,10 @@ describe('KeyboardBindings', function() {
     // given
     event = createKeyEvent('X', { ctrlKey: true });
 
-    keyboardBindings.update([{
+    keyboardBindings.update([ {
       accelerator: 'CommandOrControl + X',
       action: 'cut'
-    }]);
+    } ]);
 
     // when
     keyboardBindings._keyDownHandler(event);
@@ -160,10 +160,10 @@ describe('KeyboardBindings', function() {
     // given
     event = createKeyEvent('V', { ctrlKey: true });
 
-    keyboardBindings.update([{
+    keyboardBindings.update([ {
       accelerator: 'CommandOrControl + V',
       action: 'paste'
-    }]);
+    } ]);
 
     // when
     keyboardBindings._keyDownHandler(event);
@@ -178,10 +178,10 @@ describe('KeyboardBindings', function() {
     // given
     event = createKeyEvent('Z', { ctrlKey: true });
 
-    keyboardBindings.update([{
+    keyboardBindings.update([ {
       accelerator: 'CommandOrControl + Z',
       action: 'undo'
-    }]);
+    } ]);
 
     // when
     keyboardBindings._keyDownHandler(event);
@@ -198,10 +198,10 @@ describe('KeyboardBindings', function() {
       // given
       event = createKeyEvent('Y', { ctrlKey: true });
 
-      keyboardBindings.update([{
+      keyboardBindings.update([ {
         accelerator: 'CommandOrControl + Y',
         action: 'redo'
-      }]);
+      } ]);
 
       // when
       keyboardBindings._keyDownHandler(event);
@@ -216,10 +216,10 @@ describe('KeyboardBindings', function() {
       // given
       event = createKeyEvent('Z', { ctrlKey: true, shiftKey: true });
 
-      keyboardBindings.update([{
+      keyboardBindings.update([ {
         accelerator: 'CommandOrControl + Y',
         action: 'redo'
-      }]);
+      } ]);
 
       // when
       keyboardBindings._keyDownHandler(event);
@@ -236,10 +236,10 @@ describe('KeyboardBindings', function() {
     // given
     event = createKeyEvent('A', { ctrlKey: true });
 
-    keyboardBindings.update([{
+    keyboardBindings.update([ {
       accelerator: 'CommandOrControl + A',
       action: 'selectAll'
-    }]);
+    } ]);
 
     // when
     keyboardBindings._keyDownHandler(event);
@@ -306,10 +306,10 @@ describe('KeyboardBindings', function() {
       // given
       event = createKeyEvent('Backspace');
 
-      keyboardBindings.update([{
+      keyboardBindings.update([ {
         accelerator: 'Delete',
         action: 'removeSelection'
-      }]);
+      } ]);
 
       // when
       keyboardBindings._keyDownHandler(event);
@@ -329,10 +329,10 @@ describe('KeyboardBindings', function() {
 
       event = createKeyEvent('Delete');
 
-      keyboardBindings.update([{
+      keyboardBindings.update([ {
         accelerator: 'Delete',
         action: 'removeSelection'
-      }]);
+      } ]);
 
       // when
       keyboardBindings._keyDownHandler(event);
@@ -348,10 +348,10 @@ describe('KeyboardBindings', function() {
     // given
     event = createKeyEvent('A', { ctrlKey: true });
 
-    keyboardBindings.update([{
+    keyboardBindings.update([ {
       accelerator: 'CommandOrControl + A',
       action: 'selectAll'
-    }]);
+    } ]);
 
     const newActionSpy = spy();
 

--- a/client/src/app/modals/keyboard-shortcuts/__tests__/KeyboardShortcutsModalSpec.js
+++ b/client/src/app/modals/keyboard-shortcuts/__tests__/KeyboardShortcutsModalSpec.js
@@ -85,7 +85,7 @@ describe('<KeyboardShortcutsModal>', function() {
 });
 
 
-function renderOverlay(options={}) {
+function renderOverlay(options = {}) {
 
   const platform = options.platform || 'win32';
 

--- a/client/src/app/tabs/MultiSheetTab.js
+++ b/client/src/app/tabs/MultiSheetTab.js
@@ -466,13 +466,13 @@ function getErrorDialog({
     type: 'error',
     title: 'Import Error',
     message: 'Ooops!',
-    buttons: [{
+    buttons: [ {
       id: 'close',
       label: 'Close'
     }, {
       id: 'ask-in-forum',
       label: 'Ask in Forum'
-    }],
+    } ],
     detail: [
       error.message,
       '',

--- a/client/src/app/tabs/__tests__/EngineProfileSpec.js
+++ b/client/src/app/tabs/__tests__/EngineProfileSpec.js
@@ -299,7 +299,7 @@ function renderEngineProfile(options = {}) {
 
 function eachProfile(fn) {
   ENGINE_PROFILES.forEach(({ executionPlatform, executionPlatformVersions }) => {
-    [ undefined, ...executionPlatformVersions].forEach((executionPlatformVersion) => {
+    [ undefined, ...executionPlatformVersions ].forEach((executionPlatformVersion) => {
       fn(executionPlatform, executionPlatformVersion);
     });
   });

--- a/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
+++ b/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
@@ -293,7 +293,7 @@ describe('<MultiSheetTab>', function() {
         }
       }
 
-      const providers = [{
+      const providers = [ {
         type: 'default',
         editor: BrokenEditor,
         defaultName: 'Default'
@@ -302,7 +302,7 @@ describe('<MultiSheetTab>', function() {
         editor: DefaultEditor,
         defaultName: 'Fallback',
         isFallback: true
-      }];
+      } ];
 
       // when
       const { instance } = renderTab({ providers });
@@ -375,7 +375,7 @@ describe('<MultiSheetTab>', function() {
       const emitEventSpy = sinon.spy();
       const { instance } = renderTab({
         onAction: (...args) => args[0] === 'emit-event' && emitEventSpy(...args),
-        providers: [{
+        providers: [ {
           type: 'foo',
           editor: DefaultEditor,
           defaultName: 'Foo'
@@ -384,7 +384,7 @@ describe('<MultiSheetTab>', function() {
           editor: DefaultEditor,
           defaultName: 'Bar',
           isFallback: true
-        }]
+        } ]
       });
       const { sheets } = instance.getCached();
 
@@ -419,7 +419,7 @@ describe('<MultiSheetTab>', function() {
       ({ instance, wrapper } = renderTab({
         xml: INITIAL_XML,
         cache,
-        providers: [{
+        providers: [ {
           type: 'foo',
           editor: DefaultEditor,
           defaultName: 'Foo'
@@ -428,7 +428,7 @@ describe('<MultiSheetTab>', function() {
           editor: DefaultEditor,
           defaultName: 'Bar',
           isFallback: true
-        }]
+        } ]
       }));
     });
 

--- a/client/src/app/tabs/__tests__/mocks/index.js
+++ b/client/src/app/tabs/__tests__/mocks/index.js
@@ -32,7 +32,7 @@ export class Editor extends Component {
   }
 }
 
-export const providers = [{
+export const providers = [ {
   type: 'editor',
   editor: Editor,
   defaultName: 'Editor'
@@ -41,7 +41,7 @@ export const providers = [{
   editor: Editor,
   defaultName: 'Fallback',
   isFallback: true
-}];
+} ];
 
 export const tab = {
   id: 42,

--- a/client/src/app/tabs/bpmn/getBpmnContextMenu.js
+++ b/client/src/app/tabs/bpmn/getBpmnContextMenu.js
@@ -12,7 +12,7 @@ function getCopyPasteEntries({
   copy,
   paste
 }) {
-  return [{
+  return [ {
     label: 'Copy',
     accelerator: 'CommandOrControl+C',
     enabled: copy,
@@ -22,7 +22,7 @@ function getCopyPasteEntries({
     accelerator: 'CommandOrControl+V',
     enabled: paste,
     action: 'paste'
-  }];
+  } ];
 }
 
 export default function getBpmnContextMenu(state) {

--- a/client/src/app/tabs/bpmn/getBpmnWindowMenu.js
+++ b/client/src/app/tabs/bpmn/getBpmnWindowMenu.js
@@ -16,7 +16,7 @@ export default function getBpmnWindowMenu(state) {
 }
 
 function getZoomEntries({ zoom }) {
-  return zoom ? [{
+  return zoom ? [ {
     label: 'Zoom In',
 
     // We use Ctrl + = instead of Ctrl + + which works as expected but is shown incorrectly.
@@ -37,11 +37,11 @@ function getZoomEntries({ zoom }) {
     action: 'zoomFit'
   }, {
     type: 'separator'
-  }] : [];
+  } ] : [];
 }
 
 function getPropertiesPanelEntries({ propertiesPanel }) {
-  return propertiesPanel ? [{
+  return propertiesPanel ? [ {
     label: 'Toggle Properties Panel',
     accelerator: 'CommandOrControl+P',
     action: 'toggleProperties'
@@ -49,5 +49,5 @@ function getPropertiesPanelEntries({ propertiesPanel }) {
     label: 'Reset Properties Panel',
     accelerator: 'CommandOrControl+Shift+P',
     action: 'resetProperties'
-  }] : [];
+  } ] : [];
 }

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/PropertiesPanelKeyoardBindings.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/PropertiesPanelKeyoardBindings.js
@@ -76,9 +76,9 @@ PropertiesPanelKeyboardBindings.$inject = [ 'commandStack', 'eventBus', 'propert
 // helpers //////////
 
 function isUndo(event) {
-  return isCommandOrControl(event) && !isShift(event) && isKey(['z', 'Z'], event);
+  return isCommandOrControl(event) && !isShift(event) && isKey([ 'z', 'Z' ], event);
 }
 
 function isRedo(event) {
-  return isCommandOrControl(event) && (isKey(['y', 'Y'], event) || (isKey(['z', 'Z'], event) && isShift(event)));
+  return isCommandOrControl(event) && (isKey([ 'y', 'Y' ], event) || (isKey([ 'z', 'Z' ], event) && isShift(event)));
 }

--- a/client/src/app/tabs/cmmn/getCmmnWindowMenu.js
+++ b/client/src/app/tabs/cmmn/getCmmnWindowMenu.js
@@ -16,7 +16,7 @@ export default function getCmmnWindowMenu(state) {
 }
 
 function getZoomEntries({ zoom }) {
-  return zoom ? [{
+  return zoom ? [ {
     label: 'Zoom In',
 
     // We use Ctrl + = instead of Ctrl + + which works as expected but is shown incorrectly.
@@ -37,11 +37,11 @@ function getZoomEntries({ zoom }) {
     action: 'zoomFit'
   }, {
     type: 'separator'
-  }] : [];
+  } ] : [];
 }
 
 function getPropertiesPanelEntries({ propertiesPanel }) {
-  return propertiesPanel ? [{
+  return propertiesPanel ? [ {
     label: 'Toggle Properties Panel',
     accelerator: 'CommandOrControl+P',
     action: 'toggleProperties'
@@ -49,5 +49,5 @@ function getPropertiesPanelEntries({ propertiesPanel }) {
     label: 'Reset Properties Panel',
     accelerator: 'CommandOrControl+Shift+P',
     action: 'resetProperties'
-  }] : [];
+  } ] : [];
 }

--- a/client/src/app/tabs/dmn/getDmnWindowMenu.js
+++ b/client/src/app/tabs/dmn/getDmnWindowMenu.js
@@ -17,7 +17,7 @@ export default function getBpmnWindowMenu(state) {
 }
 
 function getZoomEntries({ zoom }) {
-  return zoom ? [{
+  return zoom ? [ {
     label: 'Zoom In',
 
     // We use Ctrl + = instead of Ctrl + + which works as expected but is shown incorrectly.
@@ -38,11 +38,11 @@ function getZoomEntries({ zoom }) {
     action: 'zoomFit'
   }, {
     type: 'separator'
-  }] : [];
+  } ] : [];
 }
 
 function getPropertiesPanelEntries({ propertiesPanel }) {
-  return propertiesPanel ? [{
+  return propertiesPanel ? [ {
     label: 'Toggle Properties Panel',
     accelerator: 'CommandOrControl+P',
     action: 'toggleProperties'
@@ -50,11 +50,11 @@ function getPropertiesPanelEntries({ propertiesPanel }) {
     label: 'Reset Properties Panel',
     accelerator: 'CommandOrControl+Shift+P',
     action: 'resetProperties'
-  }] : [];
+  } ] : [];
 }
 
 function getOverviewEntries({ overview }) {
-  return overview ? [{
+  return overview ? [ {
     label: 'Toggle Overview',
     accelerator: 'CommandOrControl+P',
     action: 'toggleOverview'
@@ -62,5 +62,5 @@ function getOverviewEntries({ overview }) {
     label: 'Reset Overview',
     accelerator: 'CommandOrControl+Shift+P',
     action: 'resetOverview'
-  }] : [];
+  } ] : [];
 }

--- a/client/src/app/tabs/dmn/modeler/features/overview/overview-renderer/OverviewRenderer.js
+++ b/client/src/app/tabs/dmn/modeler/features/overview/overview-renderer/OverviewRenderer.js
@@ -76,7 +76,7 @@ export default function DrdRenderer(eventBus, pathMap, styles, textRenderer) {
       // fix for safari / chrome / firefox bug not correctly
       // resetting stroke dash array
       if (attrs.strokeDasharray === 'none') {
-        attrs.strokeDasharray = [10000, 1];
+        attrs.strokeDasharray = [ 10000, 1 ];
       }
 
       var marker = svgCreate('marker');

--- a/client/src/app/tabs/getEditMenu.js
+++ b/client/src/app/tabs/getEditMenu.js
@@ -37,13 +37,13 @@ const COLORS = [
     title: 'Purple',
     fill: 'rgb(225, 190, 231)',
     stroke: 'rgb(142, 36, 170)'
-  }];
+  } ];
 
 export function getAlignDistributeEntries({
   align,
   distribute
 }) {
-  return [{
+  return [ {
     label: 'Align Elements',
     enabled: align,
     submenu: [ 'Left', 'Right', 'Center', 'Top', 'Bottom', 'Middle' ].map(direction => {
@@ -59,7 +59,7 @@ export function getAlignDistributeEntries({
   }, {
     label: 'Distribute Elements',
     enabled: distribute,
-    submenu: [{
+    submenu: [ {
       label: 'Distribute Horizontally',
       enabled: distribute,
       action: 'distributeElements',
@@ -73,15 +73,15 @@ export function getAlignDistributeEntries({
       options: {
         type: 'vertical'
       }
-    }]
-  }];
+    } ]
+  } ];
 }
 
 
 export function getColorEntries({
   setColor
 }) {
-  return [{
+  return [ {
     label: 'Set Color',
     enabled: setColor,
     submenu: COLORS.map(color => {
@@ -96,7 +96,7 @@ export function getColorEntries({
         icon: `resources/icons/${color.title.toLowerCase()}-circle.png`
       };
     })
-  }];
+  } ];
 }
 
 export function getCanvasEntries({
@@ -182,7 +182,7 @@ export function getCopyCutPasteEntries({
   cut,
   paste
 }) {
-  return [{
+  return [ {
     label: 'Copy',
     accelerator: 'CommandOrControl + C',
     enabled: copy,
@@ -197,11 +197,11 @@ export function getCopyCutPasteEntries({
     accelerator: 'CommandOrControl + V',
     enabled: paste,
     action: 'paste'
-  }];
+  } ];
 }
 
 export function getDefaultCopyCutPasteEntries(inputActive) {
-  return [{
+  return [ {
     label: 'Copy',
     role: 'copy',
     enabled: inputActive
@@ -213,18 +213,18 @@ export function getDefaultCopyCutPasteEntries(inputActive) {
     label: 'Paste',
     role: 'paste',
     enabled: inputActive
-  }];
+  } ];
 }
 
 export function getDiagramFindEntries({
   find
 }) {
-  return [{
+  return [ {
     label: 'Find',
     accelerator: 'CommandOrControl+F',
     enabled: find,
     action: 'find'
-  }];
+  } ];
 }
 
 export function getSelectionEntries({
@@ -331,7 +331,7 @@ export function getUndoRedoEntries({
   redo,
   undo
 }) {
-  return [{
+  return [ {
     label: 'Undo',
     accelerator: 'CommandOrControl+Z',
     enabled: undo,
@@ -341,11 +341,11 @@ export function getUndoRedoEntries({
     accelerator: 'CommandOrControl+Y',
     enabled: redo,
     action: 'redo'
-  }];
+  } ];
 }
 
 export function getDefaultUndoRedoEntries(inputActive) {
-  return [{
+  return [ {
     label: 'Undo',
     role: 'undo',
     enabled: inputActive
@@ -353,7 +353,7 @@ export function getDefaultUndoRedoEntries(inputActive) {
     label: 'Redo',
     role: 'redo',
     enabled: inputActive
-  }];
+  } ];
 }
 
 // helpers //////////

--- a/client/src/app/tabs/json/Menu.js
+++ b/client/src/app/tabs/json/Menu.js
@@ -13,7 +13,7 @@ import {
 } from '../getEditMenu';
 
 function getFindEntries() {
-  return [{
+  return [ {
     label: 'Find',
     accelerator: 'CommandOrControl+F',
     action: 'find'
@@ -29,7 +29,7 @@ function getFindEntries() {
     label: 'Replace',
     accelerator: 'Shift+CommandOrControl+F',
     action: 'replace'
-  }];
+  } ];
 }
 
 function getCopyCutPasteEntries() {

--- a/client/src/app/tabs/util/__tests__/namespaceSpec.js
+++ b/client/src/app/tabs/util/__tests__/namespaceSpec.js
@@ -44,7 +44,7 @@ describe('tabs/bpmn/util - namespace', function() {
       // then
       expect(used).to.eql({
         uri: NAMESPACE_URL_ACTIVITI,
-        prefixes: ['activiti']
+        prefixes: [ 'activiti' ]
       });
     });
 

--- a/client/src/app/tabs/xml/CodeMirror.js
+++ b/client/src/app/tabs/xml/CodeMirror.js
@@ -42,7 +42,7 @@ export default function create(options) {
   }, {
     autoCloseTags: true,
     dragDrop: true,
-    allowDropFileTypes: ['text/plain'],
+    allowDropFileTypes: [ 'text/plain' ],
     lineWrapping: true,
     lineNumbers: true,
     mode: {

--- a/client/src/app/tabs/xml/getXMLEditMenu.js
+++ b/client/src/app/tabs/xml/getXMLEditMenu.js
@@ -13,7 +13,7 @@ import {
 } from '../getEditMenu';
 
 function getXMLFindEntries() {
-  return [{
+  return [ {
     label: 'Find',
     accelerator: 'CommandOrControl+F',
     action: 'find'
@@ -29,7 +29,7 @@ function getXMLFindEntries() {
     label: 'Replace',
     accelerator: 'Shift+CommandOrControl+F',
     action: 'replace'
-  }];
+  } ];
 }
 
 function getXMLCopyCutPasteEntries() {

--- a/client/src/app/util/dragger.js
+++ b/client/src/app/util/dragger.js
@@ -12,7 +12,7 @@ import dragTabs from 'drag-tabs';
 
 const noop = () => {};
 
-export function addDragger(node, options, onDrag, onStart=noop) {
+export function addDragger(node, options, onDrag, onStart = noop) {
 
   const dragger = dragTabs(node, options);
 

--- a/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
@@ -95,7 +95,7 @@ export default class DeploymentTool extends PureComponent {
     return this.deployTab(activeTab, options, this._anchorRef);
   }
 
-  async deployTab(tab, options={}, anchor) {
+  async deployTab(tab, options = {}, anchor) {
 
     const {
       configure
@@ -537,7 +537,7 @@ export default class DeploymentTool extends PureComponent {
     // the primary button action: https://github.com/camunda/camunda-modeler/issues/1440
 
     const isDeployOpen = () => {
-      return overlayState ? overlayState.anchor===this._anchorRef : false;
+      return overlayState ? overlayState.anchor === this._anchorRef : false;
     };
 
     const onClick = () => {
@@ -620,7 +620,7 @@ function withoutExtension(name) {
 }
 
 function withoutCredentials(endpoint) {
-  return omit(endpoint, ['username', 'password', 'token']);
+  return omit(endpoint, [ 'username', 'password', 'token' ]);
 }
 
 function addOrUpdateById(collection, element) {

--- a/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentConfigOverlaySpec.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentConfigOverlaySpec.js
@@ -724,7 +724,7 @@ describe('<DeploymentConfigOverlay>', () => {
 
 // helpers //////////
 
-function createOverlay(props={}, renderFn = shallow) {
+function createOverlay(props = {}, renderFn = shallow) {
 
   const {
     configuration,

--- a/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentConfigValidatorSpec.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentConfigValidatorSpec.js
@@ -57,8 +57,8 @@ describe('<DeploymentConfigValidator>', () => {
 
     // then
     expect(validate([])).to.not.exist;
-    expect(validate([{ contents: 'content' }])).to.not.exist;
-    expect(validate([{ contents: null }])).to.eql([ FILE_NOT_FOUND_ERROR ]);
+    expect(validate([ { contents: 'content' } ])).to.not.exist;
+    expect(validate([ { contents: null } ])).to.eql([ FILE_NOT_FOUND_ERROR ]);
     expect(validate([
       { contents: null },
       { contents: 'content' }
@@ -366,9 +366,9 @@ describe('<DeploymentConfigValidator>', () => {
       const config = {
         deployment: {
           name: 'name',
-          attachments: [{
+          attachments: [ {
             contents: null
-          }]
+          } ]
         },
         endpoint: {
           authType: AuthTypes.bearer,

--- a/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentToolSpec.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentToolSpec.js
@@ -213,9 +213,9 @@ describe('<DeploymentTool>', () => {
         name: 'user.form',
         contents: []
       };
-      const attachments = [{
+      const attachments = [ {
         path: file.path
-      }];
+      } ];
       const configuration = createConfiguration({ attachments });
       const config = {
         get(key, defaultValue) {
@@ -261,9 +261,9 @@ describe('<DeploymentTool>', () => {
         name: 'user.form',
         contents: []
       };
-      const attachments = [{
+      const attachments = [ {
         path: file.path
-      }];
+      } ];
       const savedConfiguration = createConfiguration({ attachments });
       const config = {
         get(key, defaultValue) {
@@ -1404,5 +1404,5 @@ function createFileSystem(overrides = {}) {
 function noop() {}
 
 function withoutCredentials(endpoint) {
-  return omit(endpoint, ['username', 'password', 'token']);
+  return omit(endpoint, [ 'username', 'password', 'token' ]);
 }

--- a/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
@@ -134,7 +134,7 @@ export default class StartInstanceTool extends PureComponent {
      return null;
    }
 
-   async startInstance(options={}) {
+   async startInstance(options = {}) {
 
      const {
        configure
@@ -209,7 +209,7 @@ export default class StartInstanceTool extends PureComponent {
        const {
          action,
          configuration: userConfiguration
-       }= await this.getConfigurationFromUserInput(
+       } = await this.getConfigurationFromUserInput(
          tab,
          startConfiguration,
          uiOptions

--- a/client/src/plugins/camunda-plugin/start-instance-tool/__tests__/StartInstanceConfigOverlaySpec.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/__tests__/StartInstanceConfigOverlaySpec.js
@@ -48,7 +48,7 @@ describe('<StartInstanceConfigOverlay>', () => {
 
 // helpers //////////
 
-function createOverlay(props={}, renderFn = shallow) {
+function createOverlay(props = {}, renderFn = shallow) {
 
   const {
     configuration,

--- a/client/src/plugins/error-tracking/__tests__/ErrorTrackingSpec.js
+++ b/client/src/plugins/error-tracking/__tests__/ErrorTrackingSpec.js
@@ -471,7 +471,7 @@ function createMockSentryEvent(path) {
   };
 }
 
-function createErrorTracking(props={}) {
+function createErrorTracking(props = {}) {
 
   const configValues = props.configValues || {};
 

--- a/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesViewSpec.js
+++ b/client/src/plugins/privacy-preferences/__tests__/PrivacyPreferencesViewSpec.js
@@ -150,7 +150,7 @@ describe('<PrivacyPreferencesView>', function() {
     it('should load privacy preferences', function() {
 
       // given
-      const values = [false, true, false];
+      const values = [ false, true, false ];
 
       const privacyPreferences = {
         ENABLE_CRASH_REPORTS: values[0],

--- a/client/src/plugins/report-feedback/ReportFeedbackSystemInfoSection.js
+++ b/client/src/plugins/report-feedback/ReportFeedbackSystemInfoSection.js
@@ -38,7 +38,7 @@ export function ReportFeedbackSystemInfoSection(props) {
     onSubmit
   } = props;
 
-  const [hasSubmitCompleted, setHasSubmitCompleted] = useState(false);
+  const [ hasSubmitCompleted, setHasSubmitCompleted ] = useState(false);
   let timer;
 
   useEffect(() => {
@@ -116,7 +116,7 @@ export function ReportFeedbackSystemInfoSection(props) {
                     className="btn btn-primary"
                     disabled={ hasSubmitCompleted }
                   >
-                    {!hasSubmitCompleted ? 'Copy to clipboard': 'Copied!' }
+                    {!hasSubmitCompleted ? 'Copy to clipboard' : 'Copied!' }
                   </button>
                 </Section.Actions>
               </Form>

--- a/client/src/plugins/report-feedback/__tests__/ClipboardCopySystemInfoSpec.js
+++ b/client/src/plugins/report-feedback/__tests__/ClipboardCopySystemInfoSpec.js
@@ -110,7 +110,7 @@ describe('<ClipboardCopySystemInfo>', function() {
 
       // then
       const clipboardText = writeTextSpy.args[0][0].text;
-      expect(clipboardText).to.not.contain(' * Operating System: '+ currentOSInfo);
+      expect(clipboardText).to.not.contain(' * Operating System: ' + currentOSInfo);
     });
 
 

--- a/client/src/plugins/update-checks/__tests__/NewVersionInfoViewSpec.js
+++ b/client/src/plugins/update-checks/__tests__/NewVersionInfoViewSpec.js
@@ -36,13 +36,13 @@ describe('<NewVersionInfoView>', () => {
 
     wrapper = mount(<NewVersionInfoView latestVersionInfo={ {
       latestVersion: 'v3.7.0',
-      releases: [{
+      releases: [ {
         version: 'v3.5.0',
         releaseNoteHTML: 'HTML 1'
       }, {
         version: 'v3.6.0',
         releaseNoteHTML: 'HTML 2'
-      }]
+      } ]
     } } currentVersion={ 'v3.4.0' } />);
   });
 

--- a/client/src/plugins/update-checks/__tests__/UpdateChecksSpec.js
+++ b/client/src/plugins/update-checks/__tests__/UpdateChecksSpec.js
@@ -567,7 +567,7 @@ describe('<UpdateChecks>', function() {
 
 // helper /////////////////////
 
-async function tick(component, n=10) {
+async function tick(component, n = 10) {
   for (let i = 0; i < n; i ++) {
     await component.update();
   }
@@ -585,7 +585,7 @@ const mockServerResponse = (component, resp, callback) => {
 };
 
 
-function createComponent(props={}) {
+function createComponent(props = {}) {
 
   const onConfigSet = props.onConfigSet || function() {};
 

--- a/client/src/plugins/usage-statistics/__tests__/UsageStatisticsSpec.js
+++ b/client/src/plugins/usage-statistics/__tests__/UsageStatisticsSpec.js
@@ -426,7 +426,7 @@ describe('<UsageStatistics>', () => {
 
 // helpers //////////////////
 
-function createUsageStatistics(props={}) {
+function createUsageStatistics(props = {}) {
 
   const configValues = {
     'editor.id': 'test-editor-id',

--- a/client/src/plugins/usage-statistics/event-handlers/DeploymentEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/DeploymentEventHandler.js
@@ -43,7 +43,7 @@ const ENGINE_PROFILE_TAB_TYPES = [
 ];
 
 const DIAGRAM_BY_TAB_TYPE = {
-  'bpmn': [ BPMN_TAB_TYPE, CLOUD_BPMN_TAB_TYPE],
+  'bpmn': [ BPMN_TAB_TYPE, CLOUD_BPMN_TAB_TYPE ],
   'dmn': [ DMN_TAB_TYPE ]
 };
 

--- a/client/src/plugins/usage-statistics/event-handlers/DiagramOpenEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/DiagramOpenEventHandler.js
@@ -148,7 +148,7 @@ export default class DiagramOpenEventHandler extends BaseEventHandler {
     if (response && response.status === HTTP_STATUS_PAYLOAD_TOO_BIG) {
 
       // Payload too large, send again with smaller payload
-      this.sendToET(omit(payload, ['elementTemplates']));
+      this.sendToET(omit(payload, [ 'elementTemplates' ]));
     }
   }
 

--- a/client/src/plugins/usage-statistics/event-handlers/__tests__/DiagramOpenEventHandlerSpec.js
+++ b/client/src/plugins/usage-statistics/event-handlers/__tests__/DiagramOpenEventHandlerSpec.js
@@ -1315,7 +1315,7 @@ describe('<DiagramOpenEventHandler>', () => {
 function mockElementTemplates() {
   return [
     {
-      appliesTo: [ 'bpmn:ServiceTask'],
+      appliesTo: [ 'bpmn:ServiceTask' ],
       properties: [
         { binding: { name: 'camunda:class', type: 'property' } },
         { binding: { name: 'sender', type: 'camunda:inputParameter' } },

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
@@ -138,7 +138,7 @@ describe('<DeploymentPlugin> (Zeebe)', () => {
       endpointId: 'bar'
     };
 
-    const storedEndpoints = [{ id: storedTabConfiguration.endpointId }];
+    const storedEndpoints = [ { id: storedTabConfiguration.endpointId } ];
 
     const config = {
       get(key, defaultValue) {
@@ -274,7 +274,7 @@ describe('<DeploymentPlugin> (Zeebe)', () => {
       deployment: { name: 'foo' },
       endpointId: 'bar'
     };
-    const storedEndpoints = [{ id: storedTabConfiguration.endpointId }];
+    const storedEndpoints = [ { id: storedTabConfiguration.endpointId } ];
 
     const config = {
       get(key, defaultValue) {
@@ -309,9 +309,9 @@ describe('<DeploymentPlugin> (Zeebe)', () => {
       deployment: { name: 'foo' },
       camundaCloudClusterId: '1234-abcd'
     };
-    const storedEndpoints = [{
+    const storedEndpoints = [ {
       camundaCloudClusterId: storedTabConfiguration.camundaCloudClusterId
-    }];
+    } ];
 
     const config = {
       get(key, defaultValue) {
@@ -363,7 +363,7 @@ describe('<DeploymentPlugin> (Zeebe)', () => {
       deployment: { name: 'foo' },
       endpointId: 'bar'
     };
-    const storedEndpoints = [{ id: storedTabConfiguration.endpointId }];
+    const storedEndpoints = [ { id: storedTabConfiguration.endpointId } ];
 
     const config = {
       set: setEndpointsSpy,

--- a/client/src/shared/ui/__tests__/DropdownButtonSpec.js
+++ b/client/src/shared/ui/__tests__/DropdownButtonSpec.js
@@ -78,11 +78,11 @@ describe('<DropdownButton>', function() {
 
     function openDropdown(props) {
 
-      const items = [{
+      const items = [ {
         text: 'foo'
       }, {
         text: 'bar'
-      }];
+      } ];
 
       const wrapper = mount(<DropdownButton items={ items } { ...props } />);
 
@@ -147,10 +147,10 @@ describe('<DropdownButton>', function() {
     // given
     const spy = sinon.spy();
 
-    const items = [{
+    const items = [ {
       text: 'foo',
       onClick: spy
-    }];
+    } ];
 
     const wrapper = shallow(<DropdownButton items={ items } />);
 

--- a/client/src/shared/ui/__tests__/OverlayDropdownSpec.js
+++ b/client/src/shared/ui/__tests__/OverlayDropdownSpec.js
@@ -81,7 +81,7 @@ describe('<OverlayDropdown>', function() {
   it('should close when option is selected', () => {
 
     // given
-    const items = [{ text: 'TestOption', onClick: () => {} }];
+    const items = [ { text: 'TestOption', onClick: () => {} } ];
     const wrapper = mount((
       <OverlayDropdown items={ items } buttonRef={ mockButtonRef }>
         TestButton
@@ -101,7 +101,7 @@ describe('<OverlayDropdown>', function() {
 
     // given
     const spy = sinon.spy();
-    const items = [{ text: 'TestOption', onClick: spy }];
+    const items = [ { text: 'TestOption', onClick: spy } ];
     const wrapper = mount((
       <OverlayDropdown items={ items } buttonRef={ mockButtonRef }>
         TestButton

--- a/client/src/shared/ui/__tests__/OverlaySpec.js
+++ b/client/src/shared/ui/__tests__/OverlaySpec.js
@@ -107,7 +107,7 @@ describe('<Overlay>', function() {
 
     const cssProperty = `--overlay-${camelCaseToDash(property)}`;
 
-    function createOverlay(props={}) {
+    function createOverlay(props = {}) {
       const {
         maxHeight,
         maxWidth,

--- a/client/src/shared/ui/modal/KeyboardInteractionTrap.js
+++ b/client/src/shared/ui/modal/KeyboardInteractionTrap.js
@@ -44,7 +44,7 @@ class KeyboardInteractionTrapComponent extends PureComponent {
 
   updateMenu(element) {
 
-    const enabled = ['INPUT', 'TEXTAREA'].includes(element.tagName);
+    const enabled = [ 'INPUT', 'TEXTAREA' ].includes(element.tagName);
 
     const editMenu = [
       [

--- a/client/src/util/elementsUtil.js
+++ b/client/src/util/elementsUtil.js
@@ -24,7 +24,7 @@ function eachElement(elements, fn, depth) {
   depth = depth || 0;
 
   if (!isArray(elements)) {
-    elements = [elements];
+    elements = [ elements ];
   }
 
   forEach(elements, function(s, i) {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = {
   mode: DEV ? 'development' : (LICENSE_CHECK ? 'none' : 'production'),
   target: 'web',
   entry: {
-    bundle: ['./src/index.js']
+    bundle: [ './src/index.js' ]
   },
   output: {
     path: __dirname + '/build',
@@ -97,7 +97,7 @@ module.exports = {
           {
 
             // exclude files served otherwise
-            exclude: [/\.(js|jsx|mjs|bpmnlintrc)$/, /\.html$/, /\.json$/],
+            exclude: [ /\.(js|jsx|mjs|bpmnlintrc)$/, /\.html$/, /\.json$/ ],
             loader: 'file-loader',
             options: {
               name: 'static/media/[name].[hash:8].[ext]',
@@ -150,7 +150,7 @@ function sentryIntegration() {
     new SentryWebpackPlugin({
       release: NODE_ENV === 'production' ? version : 'dev',
       include: '.',
-      ignore: ['node_modules', 'webpack.config.js', '*Spec.js'],
+      ignore: [ 'node_modules', 'webpack.config.js', '*Spec.js' ],
     })
   ];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -165,43 +165,52 @@
       }
     },
     "@babel/generator": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.8.tgz",
-      "integrity": "sha512-cYDUpvIzhBVnMzRoY1fkSEhK/HmwEVwlyULYgn/tMQYd6Obag3ylCjONle3gdErfXBW61SVTlR9QR7uWlgeIkg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.7.tgz",
+      "integrity": "sha512-/ST3Sg8MLGY5HVYmrjOgL60ENux/HfO/CsUh7y4MalThufhE/Ff/6EibFDHi4jiDCaWfJKoqbE6oTh21c5hrRg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.8",
+        "@babel/types": "^7.16.7",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
     },
-    "@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+    "@babel/helper-environment-visitor": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+      "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+      "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -536,12 +545,12 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -680,44 +689,44 @@
       }
     },
     "@babel/parser": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.8.tgz",
-      "integrity": "sha512-syoCQFOoo/fzkWDeM0dLEZi5xqurb5vuyzwIMNZRNun+N/9A4cUZeQaE7dTrB8jGaKuJRBtEOajtnmw0I5hvvA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.7.tgz",
+      "integrity": "sha512-sR4eaSrnM7BV7QPzGfEX5paG/6wrZM3I0HDzfIAK06ESvo9oy3xBuVBxE3MbQaKNhvg8g/ixjMWo2CGpzpHsDA==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/code-frame": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+          "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.7"
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
-          "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
           "dev": true
         },
         "@babel/highlight": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.7.tgz",
+          "integrity": "sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
+            "@babel/helper-validator-identifier": "^7.16.7",
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           }
@@ -725,44 +734,45 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.8.tgz",
-      "integrity": "sha512-kexHhzCljJcFNn1KYAQ6A5wxMRzq9ebYpEDV4+WdNyr3i7O44tanbDOR/xjiG2F3sllan+LgwK+7OMk0EmydHg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.7.tgz",
+      "integrity": "sha512-8KWJPIb8c2VvY8AJrydh6+fVRo2ODx1wYBU2398xJVq0JomuLBZmVQzLPBblJgHIGYG4znCpUZUZ0Pt2vdmVYQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.8",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.14.8",
-        "@babel/types": "^7.14.8",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.16.7",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+          "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.7"
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
-          "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
           "dev": true
         },
         "@babel/highlight": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.7.tgz",
+          "integrity": "sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
+            "@babel/helper-validator-identifier": "^7.16.7",
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           }
@@ -770,19 +780,19 @@
       }
     },
     "@babel/types": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
-      "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.7.tgz",
+      "integrity": "sha512-E8HuV7FO9qLpx6OtoGfUQ2cjIYnbFwvZWYBS+87EwtdMvmUPJSwykpovFB+8insbpF0uJcpr8KMUi64XZntZcg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.8",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
         "@babel/helper-validator-identifier": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
-          "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
           "dev": true
         }
       }
@@ -3597,49 +3607,44 @@
       "dev": true
     },
     "array-includes": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
-      "integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2",
+        "es-abstract": "^1.19.1",
         "get-intrinsic": "^1.1.1",
-        "is-string": "^1.0.5"
+        "is-string": "^1.0.7"
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.4.tgz",
-          "integrity": "sha512-xjDAPJRxKc1uoTkdW8MEk7Fq/2bzz3YoCADYniDV7+KITCUdu9c90fj1aKI7nEZFZxRrHlDo3wtma/C6QkhlXQ==",
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
             "has-symbols": "^1.0.2",
             "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.3",
+            "is-callable": "^1.2.4",
             "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.1",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.1",
             "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
             "string.prototype.trimend": "^1.0.4",
             "string.prototype.trimstart": "^1.0.4",
             "unbox-primitive": "^1.0.1"
-          },
-          "dependencies": {
-            "is-string": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-              "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
-              "dev": true
-            }
           }
         },
         "es-to-primitive": {
@@ -3671,19 +3676,28 @@
           "dev": true
         },
         "is-callable": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
           "dev": true
         },
         "is-regex": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-          "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
-            "has-symbols": "^1.0.2"
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-string": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
           }
         },
         "string.prototype.trimend": {
@@ -3825,34 +3839,36 @@
       }
     },
     "array.prototype.flatmap": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz",
-      "integrity": "sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
+      "integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.19.0"
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.4.tgz",
-          "integrity": "sha512-xjDAPJRxKc1uoTkdW8MEk7Fq/2bzz3YoCADYniDV7+KITCUdu9c90fj1aKI7nEZFZxRrHlDo3wtma/C6QkhlXQ==",
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
             "has-symbols": "^1.0.2",
             "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.3",
+            "is-callable": "^1.2.4",
             "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.1",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.1",
             "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
@@ -3890,26 +3906,29 @@
           "dev": true
         },
         "is-callable": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
           "dev": true
         },
         "is-regex": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-          "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
-            "has-symbols": "^1.0.2"
+            "has-tostringtag": "^1.0.0"
           }
         },
         "is-string": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-          "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
-          "dev": true
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
         },
         "string.prototype.trimend": {
           "version": "1.0.4",
@@ -4134,14 +4153,24 @@
         "resolve": "^1.12.0"
       },
       "dependencies": {
-        "resolve": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+        "is-core-module": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+          "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
           "dev": true,
           "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
+            "has": "^1.0.3"
+          }
+        },
+        "resolve": {
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
+          "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.8.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
           }
         }
       }
@@ -9132,9 +9161,9 @@
       }
     },
     "eslint-plugin-bpmn-io": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-bpmn-io/-/eslint-plugin-bpmn-io-0.12.0.tgz",
-      "integrity": "sha512-juL2kBl9r+697VgBqQJWrsPpSkcRpDfQGHH5DPtRIvgIELI7VSkYAkXUhyW1mPPk88jjutqVcfeUAjt9p20xWw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-bpmn-io/-/eslint-plugin-bpmn-io-0.13.0.tgz",
+      "integrity": "sha512-kOLuG1FTWRv+qp6QezzY1Q8KNk1KPa2T1AgTL6q0ihA+H4K9O3ma+BaHQnJwQuDfEik3HyLu7WG0OA/N0g/aIA==",
       "dev": true,
       "requires": {
         "babel-eslint": "^10.1.0",
@@ -9403,42 +9432,47 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.24.0.tgz",
-      "integrity": "sha512-KJJIx2SYx7PBx3ONe/mEeMz4YE0Lcr7feJTCMyyKb/341NcjuAgim3Acgan89GfPv7nxXK2+0slu0CWXYM4x+Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.28.0.tgz",
+      "integrity": "sha512-IOlFIRHzWfEQQKcAD4iyYDndHwTQiCMcJVJjxempf203jnNLUnW34AXLrV33+nEXoifJE2ZEGmcjKPL8957eSw==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.3",
-        "array.prototype.flatmap": "^1.2.4",
+        "array-includes": "^3.1.4",
+        "array.prototype.flatmap": "^1.2.5",
         "doctrine": "^2.1.0",
-        "has": "^1.0.3",
+        "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
-        "object.entries": "^1.1.4",
-        "object.fromentries": "^2.0.4",
-        "object.values": "^1.1.4",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.0",
+        "object.values": "^1.1.5",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
-        "string.prototype.matchall": "^4.0.5"
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.6"
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.4.tgz",
-          "integrity": "sha512-xjDAPJRxKc1uoTkdW8MEk7Fq/2bzz3YoCADYniDV7+KITCUdu9c90fj1aKI7nEZFZxRrHlDo3wtma/C6QkhlXQ==",
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
             "has-symbols": "^1.0.2",
             "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.3",
+            "is-callable": "^1.2.4",
             "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.1",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.1",
             "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
@@ -9458,6 +9492,12 @@
             "is-symbol": "^1.0.2"
           }
         },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        },
         "get-intrinsic": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -9476,36 +9516,39 @@
           "dev": true
         },
         "is-callable": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
           "dev": true
         },
         "is-regex": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-          "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
-            "has-symbols": "^1.0.2"
+            "has-tostringtag": "^1.0.0"
           }
         },
         "is-string": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-          "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
-          "dev": true
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
         },
         "object.values": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
-          "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
+          "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3",
-            "es-abstract": "^1.18.2"
+            "es-abstract": "^1.19.1"
           }
         },
         "resolve": {
@@ -9517,6 +9560,12 @@
             "is-core-module": "^2.2.0",
             "path-parse": "^1.0.6"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         },
         "string.prototype.trimend": {
           "version": "1.0.4",
@@ -10685,6 +10734,35 @@
         "pump": "^3.0.0"
       }
     },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "dependencies": {
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        }
+      }
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -11463,6 +11541,23 @@
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        }
+      }
+    },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -11932,10 +12027,13 @@
       "dev": true
     },
     "is-bigint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
-      "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
-      "dev": true
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -11947,12 +12045,13 @@
       }
     },
     "is-boolean-object": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
-      "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.2"
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -12117,10 +12216,13 @@
       }
     },
     "is-number-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
-      "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
-      "dev": true
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-obj": {
       "version": "1.0.1",
@@ -12220,6 +12322,12 @@
       "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
       "dev": true
     },
+    "is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "dev": true
+    },
     "is-ssh": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.2.tgz",
@@ -12270,6 +12378,15 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
+    },
+    "is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -12653,12 +12770,12 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
-      "integrity": "sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
+      "integrity": "sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.2",
+        "array-includes": "^3.1.3",
         "object.assign": "^4.1.2"
       }
     },
@@ -14512,9 +14629,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
       "dev": true
     },
     "object-keys": {
@@ -14561,33 +14678,36 @@
       }
     },
     "object.entries": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
-      "integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.2"
+        "es-abstract": "^1.19.1"
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.4.tgz",
-          "integrity": "sha512-xjDAPJRxKc1uoTkdW8MEk7Fq/2bzz3YoCADYniDV7+KITCUdu9c90fj1aKI7nEZFZxRrHlDo3wtma/C6QkhlXQ==",
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
             "has-symbols": "^1.0.2",
             "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.3",
+            "is-callable": "^1.2.4",
             "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.1",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.1",
             "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
@@ -14625,26 +14745,29 @@
           "dev": true
         },
         "is-callable": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
           "dev": true
         },
         "is-regex": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-          "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
-            "has-symbols": "^1.0.2"
+            "has-tostringtag": "^1.0.0"
           }
         },
         "is-string": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-          "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
-          "dev": true
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
         },
         "string.prototype.trimend": {
           "version": "1.0.4",
@@ -14669,34 +14792,36 @@
       }
     },
     "object.fromentries": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.4.tgz",
-      "integrity": "sha512-EsFBshs5RUUpQEY1D4q/m59kMfz4YJvxuNCJcv/jWwOJr34EaVnG11ZrZa0UHB3wnzV1wx8m58T4hQL8IuNXlQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2",
-        "has": "^1.0.3"
+        "es-abstract": "^1.19.1"
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.4.tgz",
-          "integrity": "sha512-xjDAPJRxKc1uoTkdW8MEk7Fq/2bzz3YoCADYniDV7+KITCUdu9c90fj1aKI7nEZFZxRrHlDo3wtma/C6QkhlXQ==",
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
             "has-symbols": "^1.0.2",
             "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.3",
+            "is-callable": "^1.2.4",
             "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.1",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.1",
             "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
@@ -14734,26 +14859,29 @@
           "dev": true
         },
         "is-callable": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
           "dev": true
         },
         "is-regex": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-          "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
-            "has-symbols": "^1.0.2"
+            "has-tostringtag": "^1.0.0"
           }
         },
         "is-string": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-          "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
-          "dev": true
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
         },
         "string.prototype.trimend": {
           "version": "1.0.4",
@@ -14856,6 +14984,119 @@
             "define-properties": "^1.1.3",
             "has-symbols": "^1.0.1",
             "object-keys": "^1.1.1"
+          }
+        }
+      }
+    },
+    "object.hasown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
+      "integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "internal-slot": "^1.0.3",
+            "is-callable": "^1.2.4",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.1",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.1",
+            "object-inspect": "^1.11.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-string": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
           }
         }
       }
@@ -15504,14 +15745,14 @@
       }
     },
     "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.0.tgz",
+      "integrity": "sha512-fDGekdaHh65eI3lMi5OnErU6a8Ighg2KjcjQxO7m8VHyWjcPyj5kiOgV1LQDOOOgVy3+5FgjXvdSSX7B8/5/4g==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
+        "react-is": "^16.13.1"
       }
     },
     "proto-list": {
@@ -17151,14 +17392,14 @@
       }
     },
     "string.prototype.matchall": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.5.tgz",
-      "integrity": "sha512-Z5ZaXO0svs0M2xd/6By3qpeKpLKd9mO4v4q3oMEQrk8Ck4xOD5d5XeBOOjGrmVZZ/AHB1S0CgG4N5r1G9N3E2Q==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
+      "integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.2",
+        "es-abstract": "^1.19.1",
         "get-intrinsic": "^1.1.1",
         "has-symbols": "^1.0.2",
         "internal-slot": "^1.0.3",
@@ -17167,22 +17408,25 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.4.tgz",
-          "integrity": "sha512-xjDAPJRxKc1uoTkdW8MEk7Fq/2bzz3YoCADYniDV7+KITCUdu9c90fj1aKI7nEZFZxRrHlDo3wtma/C6QkhlXQ==",
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+          "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
             "has-symbols": "^1.0.2",
             "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.3",
+            "is-callable": "^1.2.4",
             "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.1",
+            "is-string": "^1.0.7",
+            "is-weakref": "^1.0.1",
             "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
@@ -17220,26 +17464,29 @@
           "dev": true
         },
         "is-callable": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
           "dev": true
         },
         "is-regex": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-          "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
-            "has-symbols": "^1.0.2"
+            "has-tostringtag": "^1.0.0"
           }
         },
         "is-string": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-          "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
-          "dev": true
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
         },
         "string.prototype.trimend": {
           "version": "1.0.4",
@@ -17395,6 +17642,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
     },
     "table": {
       "version": "6.0.7",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "electron-publisher-s3": "^20.17.2",
     "electron-reloader": "^1.2.0",
     "eslint": "^7.17.0",
-    "eslint-plugin-bpmn-io": "^0.12.0",
+    "eslint-plugin-bpmn-io": "^0.13.0",
     "eslint-plugin-camunda-licensed": "^0.4.4",
     "eslint-plugin-import": "^2.22.1",
     "execa": "^1.0.0",

--- a/resources/plugins/test-client/webpack.config.js
+++ b/resources/plugins/test-client/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: ['@babel/preset-react']
+            presets: [ '@babel/preset-react' ]
           }
         }
       }

--- a/resources/plugins/test-editor-events/webpack.config.js
+++ b/resources/plugins/test-editor-events/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: ['@babel/preset-react']
+            presets: [ '@babel/preset-react' ]
           }
         }
       }

--- a/tasks/distro.js
+++ b/tasks/distro.js
@@ -88,7 +88,7 @@ const artifactOptions = [
 // --win, --linux, --mac
 const platforms = [
   argv.win ? 'win' : null,
-  argv.linux ? 'linux': null,
+  argv.linux ? 'linux' : null,
   argv.mac ? 'mac' : null
 ].filter(f => f);
 

--- a/tasks/license-book.js
+++ b/tasks/license-book.js
@@ -116,7 +116,7 @@ async function run(args) {
     return;
   }
 
-  const changes = exec('git', ['status', '--short']).stdout.trim();
+  const changes = exec('git', [ 'status', '--short' ]).stdout.trim();
 
   if (!changes) {
     console.log('No license book changes, skipping commit');

--- a/tasks/send-license-book-summary.js
+++ b/tasks/send-license-book-summary.js
@@ -179,12 +179,12 @@ function getChangesSummary({ currentVersion, previousVersion, file }) {
 }
 
 function getDiff({ currentVersion, previousVersion, file }) {
-  const previousFile = exec('git', ['show', `${previousVersion}:${file}`]).stdout;
+  const previousFile = exec('git', [ 'show', `${previousVersion}:${file}` ]).stdout;
 
   // diff exits with <1> if a diff exists; we must account for that special behavior
   // cf. https://github.com/nodejs/node/issues/19494#issuecomment-374721063
   try {
-    return exec('diff', ['-u', '-', file], { input: previousFile }).stdout;
+    return exec('diff', [ '-u', '-', file ], { input: previousFile }).stdout;
   } catch (e) {
 
     if (e.code !== 1) {


### PR DESCRIPTION
Fixing all the issues regarding the added `space-infix-ops` and `array-bracket-spacing` rules. 

Question: Shall this also apply for single object arrays? Like

```js
const buttons = [ {
  id: 'close',
  label: 'Close'
} ];
```

or 

```js
const providers = [ {
  type: 'default',
  editor: BrokenEditor,
  defaultName: 'Default'
  ..
} ];
```

Currently, the linter would create an issue if these spaces are not set.
