### PR TITLE
feat: supplying default target type for platform deployment telemetry

### DIFF
--- a/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
@@ -37,6 +37,8 @@ const DEPLOYMENT_DETAILS_CONFIG_KEY = 'deployment-tool';
 const ENGINE_ENDPOINTS_CONFIG_KEY = 'camundaEngineEndpoints';
 const PROCESS_DEFINITION_CONFIG_KEY = 'process-definition';
 
+const SELF_HOSTED = 'selfHosted';
+
 const DEFAULT_ENDPOINT = {
   url: 'http://localhost:8080/rest',
   authType: AuthTypes.basic,
@@ -195,6 +197,7 @@ export default class DeploymentTool extends PureComponent {
       type: 'deployment.done',
       payload: {
         deployment,
+        targetType: SELF_HOSTED,
         deployedTo: {
           executionPlatformVersion: version,
           executionPlatform: ENGINES.PLATFORM
@@ -254,6 +257,7 @@ export default class DeploymentTool extends PureComponent {
       type: 'deployment.error',
       payload: {
         error,
+        targetType: SELF_HOSTED,
         context: 'deploymentTool',
         ...(deployedTo && { deployedTo: deployedTo })
       }

--- a/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentToolSpec.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentToolSpec.js
@@ -594,6 +594,36 @@ describe('<DeploymentTool>', () => {
         expect(actionSpy).to.have.been.calledOnce;
       });
 
+      it('should send target type on deployment.done', async () => {
+
+        // given
+        const configuration = createConfiguration(),
+              activeTab = createTab({ name: 'foo.bpmn' });
+
+        const actionSpy = sinon.spy(),
+              actionTriggered = {
+                emitEvent: 'emit-event',
+                type: 'deployment.done',
+                handler: actionSpy
+              };
+
+        const {
+          instance
+        } = createDeploymentTool({ activeTab, actionTriggered, ...configuration });
+
+        // when
+        await instance.deploy(({
+          isStart: true,
+          onClose: () => { }
+        }));
+
+        const targetType = actionSpy.getCall(0).args[0].payload.targetType;
+
+        // then
+        expect(actionSpy).to.have.been.calledOnce;
+        expect(targetType).to.eql('selfHosted');
+      });
+
 
       it('should include executionPlatform metrics in deployment.done', async () => {
 


### PR DESCRIPTION
There was some discussion here as if further unit testing was needed. The way I see it not in this case, as the deployment tool  (platform plugin) doesn't conditionally provide that targetType, and the deployment event handler simply tunnels the targetType to a payload, irrespective of its nature (and we have a test which checks that this works). 

I'd love some thoughts here, give me a shout if you'd like me to clarify some things. 

Closes #2238 
