### PR TITLE
feat(overlay-dropdown): add arrow key navigation

### DIFF
--- a/client/src/plugins/tab-context-action/__tests__/TabContextActionSpec.js
+++ b/client/src/plugins/tab-context-action/__tests__/TabContextActionSpec.js
@@ -220,7 +220,7 @@ describe('<TabContextAction>', function() {
         tree.find('button').simulate('click');
 
         // when
-        const item = tree.find('Overlay li').at(index);
+        const item = tree.find('Overlay li button').at(index);
         item.simulate('click');
 
         // then
@@ -241,7 +241,7 @@ describe('<TabContextAction>', function() {
       tree.find('button').simulate('click');
 
       // when
-      const item = tree.find('Overlay li').at(4);
+      const item = tree.find('Overlay li button').at(4);
       item.simulate('click');
 
       // then

--- a/client/src/shared/ui/__tests__/OverlayDropdownSpec.js
+++ b/client/src/shared/ui/__tests__/OverlayDropdownSpec.js
@@ -164,4 +164,105 @@ describe('<OverlayDropdown>', function() {
     });
   });
 
+
+  describe('arrow navigation', () => {
+
+    let wrapper;
+
+    function expectFocus(selector) {
+      const newFocus = wrapper.find(selector).getDOMNode();
+      expect(document.activeElement).to.eql(newFocus);
+    }
+
+    function focusAndNavigate(selector, keyCode) {
+      const item = wrapper.find(selector);
+
+      item.getDOMNode().focus();
+      item.simulate('keyDown', { keyCode });
+    }
+
+    beforeEach(() => {
+
+      const items = [
+        { key: 'section1', items: [ { text: 'item1' }, { text: 'item2' } ] },
+        { key: 'section2', items: [ { text: 'item3' }, { text: 'item4' } ] },
+        { key: 'section3', items: [ { text: 'item5' }, { text: 'item6' } ] }
+      ];
+
+      wrapper = mount((
+        <OverlayDropdown shouldOpen={ true } items={ items } buttonRef={ mockButtonRef }>
+          foo
+        </OverlayDropdown>
+      ));
+    });
+
+
+    it('should auto-focus first element', () => {
+
+      // then
+      expectFocus('button[title="item1"]', wrapper);
+    });
+
+
+    it('should focus next item', () => {
+
+      // when
+      focusAndNavigate('button[title="item1"]', 40);
+
+      // then
+      expectFocus('button[title="item2"]', wrapper);
+    });
+
+
+    it('should focus next section', () => {
+
+      // when
+      focusAndNavigate('button[title="item2"]', 40);
+
+      // then
+      expectFocus('button[title="item3"]', wrapper);
+    });
+
+
+    it('should focus first section', () => {
+
+      // when
+      focusAndNavigate('button[title="item6"]', 40);
+
+      // then
+      expectFocus('button[title="item1"]', wrapper);
+    });
+
+
+    it('should focus previous item', () => {
+
+      // when
+      focusAndNavigate('button[title="item2"]', 38);
+
+      // then
+      expectFocus('button[title="item1"]', wrapper);
+    });
+
+
+    it('should focus previous section', () => {
+
+      // when
+      focusAndNavigate('button[title="item3"]', 38);
+
+      // then
+      expectFocus('button[title="item2"]', wrapper);
+    });
+
+
+    it('should focus last section', () => {
+
+      // when
+      focusAndNavigate('button[title="item1"]', 38);
+
+      // then
+      expectFocus('button[title="item6"]', wrapper);
+    });
+
+  });
+
 });

--- a/client/src/shared/ui/overlay/OverlayDropdown.js
+++ b/client/src/shared/ui/overlay/OverlayDropdown.js
@@ -179,8 +179,8 @@ function Option(props) {
   };
 
   return (
-    <li role="menuitem" onClick={ onClick } onKeyDown={ handleKeydown }>
-      <button type="button" title={ text }>
+    <li role="menuitem" onKeyDown={ handleKeydown }>
+      <button type="button" title={ text } onClick={ onClick }>
         { IconComponent && <IconComponent /> }
         { text }
       </button>

--- a/client/src/shared/ui/overlay/OverlayDropdown.less
+++ b/client/src/shared/ui/overlay/OverlayDropdown.less
@@ -50,7 +50,7 @@
     background-color: var(--overlay-dropdown-option-hover-background-color);
   }
 
-  li button:focus-visible {
+  li button:focus {
     background-color: var(--overlay-dropdown-focus-hover-background-color);
     outline: none;
     box-shadow: none;


### PR DESCRIPTION
This adds arrow key navigation for all overlay dropdowns (e.g. create tab, context action, ...). It mirrors the behavior we already have with tab navigation.

Closes #2626

**Build on demand artefacts** (_[Build is running](https://github.com/camunda/camunda-modeler/actions/runs/1707490832) ..._)

- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2626-navigate-with-arrow-keys/camunda-modeler-2626-navigate-with-arrow-keys-linux-x64.tar.gz
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2626-navigate-with-arrow-keys/camunda-modeler-2626-navigate-with-arrow-keys-mac.dmg
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2626-navigate-with-arrow-keys/camunda-modeler-2626-navigate-with-arrow-keys-mac.zip
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2626-navigate-with-arrow-keys/camunda-modeler-2626-navigate-with-arrow-keys-win-ia32.zip
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2626-navigate-with-arrow-keys/camunda-modeler-2626-navigate-with-arrow-keys-win-x64.zip

![Kapture 2022-01-17 at 11 43 29](https://user-images.githubusercontent.com/9433996/149755436-b56ead90-a340-4377-aae4-77cbaa6d0f10.gif)

