### PR TITLE
feat(updateChecks): always include versionInfo prior to releaseNote

### DIFF
--- a/client/src/plugins/update-checks/NewVersionInfoView.js
+++ b/client/src/plugins/update-checks/NewVersionInfoView.js
@@ -38,11 +38,13 @@ class NewVersionInfoView extends PureComponent {
         releaseNoteHTML
       } = release;
 
-      return (<div
-        className="htmlSnippetItem"
-        key={ version }
-        dangerouslySetInnerHTML={ { __html: releaseNoteHTML } }
-      />);
+      return (
+        <div
+          className="htmlSnippetItem"
+          key={ version }>
+          <div><b>{ version }</b></div>
+          <div dangerouslySetInnerHTML={ { __html: releaseNoteHTML } } />
+        </div>);
     });
   }
 


### PR DESCRIPTION
* Note: when this is released, we shall not include the releaseVersion
  in the releaseNoteBody in updateServer anymore
* closes #2422

I will also add a note to updateServer

![Screenshot_20220119_090649](https://user-images.githubusercontent.com/42800119/150089438-5a538f53-44bf-4ff8-9783-9566fb08701e.png)


<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
