### PR TITLE
fix(tabs): don't mark dirty after save

### DIFF
--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -512,8 +512,6 @@ export class BpmnEditor extends CachedComponent {
 
     const commandStack = modeler.get('commandStack');
 
-    const stackIdx = commandStack._stackIdx;
-
     if (!this.isDirty()) {
       return lastXML || this.props.xml;
     }
@@ -521,6 +519,7 @@ export class BpmnEditor extends CachedComponent {
     try {
 
       const { xml } = await modeler.saveXML({ format: true });
+      const stackIdx = commandStack._stackIdx;
 
       this.setCached({ lastXML: xml, stackIdx });
 

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -517,15 +517,14 @@ export class BpmnEditor extends CachedComponent {
     }
 
     try {
-
       const { xml } = await modeler.saveXML({ format: true });
+
       const stackIdx = commandStack._stackIdx;
 
       this.setCached({ lastXML: xml, stackIdx });
 
       return xml;
     } catch (error) {
-
       this.handleError({ error });
 
       return Promise.reject(error);

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -1226,6 +1226,33 @@ describe('<BpmnEditor>', function() {
       expect(dirty).to.be.false;
     });
 
+
+    it('should be dirty after export error', async function() {
+
+      // given
+      const { instance } = await renderEditor('export-error');
+
+      const { modeler } = instance.getCached();
+
+      // execute 1 command
+      modeler.get('commandStack').execute(1);
+
+      let err;
+
+      // when
+      try {
+        await instance.getXML();
+      } catch (e) {
+        err = e;
+      }
+
+      // then
+      const dirty = instance.isDirty();
+
+      expect(err).to.exist;
+      expect(dirty).to.be.true;
+    });
+
   });
 
 

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -408,15 +408,14 @@ export class BpmnEditor extends CachedComponent {
     }
 
     try {
-
       const { xml } = await modeler.saveXML({ format: true });
+
       const stackIdx = commandStack._stackIdx;
 
       this.setCached({ lastXML: xml, stackIdx });
 
       return xml;
     } catch (error) {
-
       this.handleError({ error });
 
       return Promise.reject(error);

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -403,8 +403,6 @@ export class BpmnEditor extends CachedComponent {
 
     const commandStack = modeler.get('commandStack');
 
-    const stackIdx = commandStack._stackIdx;
-
     if (!this.isDirty()) {
       return lastXML || this.props.xml;
     }
@@ -412,6 +410,7 @@ export class BpmnEditor extends CachedComponent {
     try {
 
       const { xml } = await modeler.saveXML({ format: true });
+      const stackIdx = commandStack._stackIdx;
 
       this.setCached({ lastXML: xml, stackIdx });
 

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -935,6 +935,33 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
       expect(dirty).to.be.false;
     });
 
+
+    it('should be dirty after export error', async function() {
+
+      // given
+      const { instance } = await renderEditor('export-error');
+
+      const { modeler } = instance.getCached();
+
+      // execute 1 command
+      modeler.get('commandStack').execute(1);
+
+      let err;
+
+      // when
+      try {
+        await instance.getXML();
+      } catch (e) {
+        err = e;
+      }
+
+      // then
+      const dirty = instance.isDirty();
+
+      expect(err).to.exist;
+      expect(dirty).to.be.true;
+    });
+
   });
 
 

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -597,6 +597,9 @@ export class DmnEditor extends CachedComponent {
     }
 
     if (!activeView || activeView.element !== element) {
+
+      // dirty must be cached before switching active view
+      // if active view has unsaved changes editor must still be dirty after switching active view
       this.setCached({
         dirty: dirty || this.getModeler().getStackIdx() !== stackIdx
       });

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -734,36 +734,24 @@ export class DmnEditor extends CachedComponent {
       return lastXML || this.props.xml;
     }
 
-    let xml = null;
-    let error = null;
-
     try {
-      const {
-        xml: _xml
-      } = await modeler.saveXML({ format: true });
+      const { xml } = await modeler.saveXML({ format: true });
+      const stackIdx = modeler.getStackIdx();
 
-      xml = _xml;
-    } catch (_error) {
-      error = _error;
-    }
+      this.setCached({
+        dirty: false,
+        lastXML: xml,
+        stackIdx
+      });
 
-    const stackIdx = modeler.getStackIdx();
-
-    this.setCached({
-      dirty: false,
-      lastXML: xml,
-      stackIdx
-    });
-
-    if (error) {
+      return xml;
+    } catch (error) {
       this.handleError({
         error
       });
 
       return Promise.reject(error);
     }
-
-    return xml;
   }
 
   async exportAs(type) {

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -730,8 +730,6 @@ export class DmnEditor extends CachedComponent {
       modeler
     } = this.getCached();
 
-    const stackIdx = modeler.getStackIdx();
-
     if (!this.isDirty()) {
       return lastXML || this.props.xml;
     }
@@ -748,6 +746,8 @@ export class DmnEditor extends CachedComponent {
     } catch (_error) {
       error = _error;
     }
+
+    const stackIdx = modeler.getStackIdx();
 
     this.setCached({
       dirty: false,

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -736,6 +736,7 @@ export class DmnEditor extends CachedComponent {
 
     try {
       const { xml } = await modeler.saveXML({ format: true });
+
       const stackIdx = modeler.getStackIdx();
 
       this.setCached({
@@ -746,9 +747,7 @@ export class DmnEditor extends CachedComponent {
 
       return xml;
     } catch (error) {
-      this.handleError({
-        error
-      });
+      this.handleError({ error });
 
       return Promise.reject(error);
     }

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -1489,6 +1489,34 @@ describe('<DmnEditor>', function() {
       expect(dirty).to.be.false;
     });
 
+
+    it('should be dirty after failed save', async function() {
+
+      // given
+      let err;
+      const {
+        instance
+      } = await renderEditor('export-error');
+
+      const { modeler } = instance.getCached();
+
+      // execute 1 command
+      modeler.getActiveViewer().get('commandStack').execute(1);
+
+      // when
+      try {
+        await instance.getXML();
+      } catch (e) {
+        err = e;
+      }
+
+      // then
+      const dirty = instance.isDirty();
+
+      expect(err).to.exist;
+      expect(dirty).to.be.true;
+    });
+
   });
 
 

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -422,9 +422,7 @@ describe('<DmnEditor>', function() {
               get: () => []
             }
           }),
-          stackIdx: {
-            drd: 2
-          }
+          stackIdx: 2
         },
         __destroy: () => {}
       });
@@ -1472,7 +1470,7 @@ describe('<DmnEditor>', function() {
     });
 
 
-    it('should NOT be dirty after save', async function() {
+    it('should NOT be dirty after export', async function() {
 
       // given
       const { modeler } = instance.getCached();
@@ -1490,18 +1488,17 @@ describe('<DmnEditor>', function() {
     });
 
 
-    it('should be dirty after failed save', async function() {
+    it('should be dirty after export error', async function() {
 
       // given
-      let err;
-      const {
-        instance
-      } = await renderEditor('export-error');
+      const { instance } = await renderEditor('export-error');
 
       const { modeler } = instance.getCached();
 
       // execute 1 command
       modeler.getActiveViewer().get('commandStack').execute(1);
+
+      let err;
 
       // when
       try {

--- a/client/test/mocks/bpmn-js/Modeler.js
+++ b/client/test/mocks/bpmn-js/Modeler.js
@@ -117,7 +117,7 @@ export default class Modeler {
 
     const xml = this.xml;
 
-    // execute align to origin
+    // commands may be executed during export
     this.get('commandStack').execute(1);
 
     return new Promise((resolve, reject) => {

--- a/client/test/mocks/bpmn-js/Modeler.js
+++ b/client/test/mocks/bpmn-js/Modeler.js
@@ -117,6 +117,9 @@ export default class Modeler {
 
     const xml = this.xml;
 
+    // execute align to origin
+    this.get('commandStack').execute(1);
+
     return new Promise((resolve, reject) => {
 
       if (xml === 'export-error') {

--- a/client/test/mocks/dmn-js/Modeler.js
+++ b/client/test/mocks/dmn-js/Modeler.js
@@ -159,6 +159,8 @@ export default class Modeler {
 
     const xml = this.xml;
 
+    this.viewer.get('commandStack').execute(1);
+
     if (xml === 'export-error') {
       throw new Error('failed to save xml');
     }

--- a/client/test/mocks/dmn-js/Modeler.js
+++ b/client/test/mocks/dmn-js/Modeler.js
@@ -159,6 +159,7 @@ export default class Modeler {
 
     const xml = this.xml;
 
+    // commands may be executed during export
     this.viewer.get('commandStack').execute(1);
 
     if (xml === 'export-error') {


### PR DESCRIPTION
closes #2654

Tests were already present for this behavior, but because we mocked bpmn-js it was not caught:
https://github.com/camunda/camunda-modeler/blob/ff14d9615b8fb78ea1e41b17a24cf7a330f24840/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js#L1212-L1227


I adjusted the modeler mock accordingly

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
