### PR TITLE
chore: update electron to v12.1.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -798,15 +798,15 @@
       }
     },
     "@electron/get": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.12.4.tgz",
-      "integrity": "sha512-6nr9DbJPUR9Xujw6zD3y+rS95TyItEVM0NVjt1EehY2vUWfIgPiIPVHxCvaTS0xr2B+DRxovYVKbuOWqC35kjg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.13.1.tgz",
+      "integrity": "sha512-U5vkXDZ9DwXtkPqlB45tfYnnYBN8PePp1z/XDCupnSpdrxT8/ThCv9WCwPLf9oqiSGZTkH6dx2jDUPuoXpjkcA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
         "fs-extra": "^8.1.0",
-        "global-agent": "^2.0.2",
+        "global-agent": "^3.0.0",
         "global-tunnel-ng": "^2.7.1",
         "got": "^9.6.0",
         "progress": "^2.0.3",
@@ -4284,9 +4284,9 @@
       }
     },
     "boolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.3.tgz",
-      "integrity": "sha512-EqrTKXQX6Z3A2nRmMEIlAIfjQOgFnVO2nqZGpbcsPnYGWBwpFqzlrozU1dy+S2iqfYDLh26ef4KrgTxu9xQrxA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.4.tgz",
+      "integrity": "sha512-3hx0kwU3uzG6ReQ3pnaFQPSktpBw6RHN3/ivDKEuU8g1XSfafowyvDnadjv1xp8IZqhtSukxlwv9bF6FhX8m0w==",
       "dev": true,
       "optional": true
     },
@@ -6680,9 +6680,9 @@
       "dev": true
     },
     "detect-node": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.5.tgz",
-      "integrity": "sha512-qi86tE6hRcFHy8jI1m2VG+LaPUR1LhqDa5G8tVjuUXmOrpuAgqsA1pN0+ldgr3aKUH+QLI9hCY/OcRYisERejw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true,
       "optional": true
     },
@@ -7155,9 +7155,9 @@
       }
     },
     "electron": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.5.tgz",
-      "integrity": "sha512-z0xYB3sPr0qZcDrHUUWqooPKe3yUzBDxQcgQe3f2TLstA84JIFXBoaIJCPh/fJW0+JdF/ZFVeK2SNgLhYtRV+Q==",
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-12.1.2.tgz",
+      "integrity": "sha512-yWlnKfJYDsvJjV2GyiBqpbqYI4DkTwk1OP/YRVodp9tfDLqAp9VdE8VZXbl1y29pZtIY+/YtUedBQc1RY3RMqQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -7166,9 +7166,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.14.41",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
-          "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
+          "version": "14.18.9",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.9.tgz",
+          "integrity": "sha512-j11XSuRuAlft6vLDEX4RvhqC0KxNxx6QIyMXNb0vHHSNPXTPeiy3algESWmOOIzEtiEL0qiowPU3ewW9hHVa7Q==",
           "dev": true
         }
       }
@@ -11164,14 +11164,13 @@
       }
     },
     "global-agent": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.2.0.tgz",
-      "integrity": "sha512-+20KpaW6DDLqhG7JDiJpD1JvNvb8ts+TNl7BPOYcURqCrXqnN1Vf+XVOrkKJAFPqfX+oEhsdzOj1hLWkBTdNJg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
       "dev": true,
       "optional": true,
       "requires": {
         "boolean": "^3.0.1",
-        "core-js": "^3.6.5",
         "es6-error": "^4.1.1",
         "matcher": "^3.0.0",
         "roarr": "^2.15.3",
@@ -11179,13 +11178,6 @@
         "serialize-error": "^7.0.1"
       },
       "dependencies": {
-        "core-js": {
-          "version": "3.10.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.2.tgz",
-          "integrity": "sha512-W+2oVYeNghuBr3yTzZFQ5rfmjZtYB/Ubg87R5YOmlGrIb+Uw9f7qjUbhsj+/EkXhcV7eOD3jiM4+sgraX3FZUw==",
-          "dev": true,
-          "optional": true
-        },
         "lru-cache": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "del": "^3.0.0",
     "del-cli": "^1.1.0",
     "diff2html": "^2.11.2",
-    "electron": "^12.0.5",
+    "electron": "^12.1.2",
     "electron-builder": "^22.10.5",
     "electron-devtools-installer": "^3.1.1",
     "electron-notarize": "^1.0.0",


### PR DESCRIPTION
Electron was updated recently on `develop` (cf. https://github.com/camunda/camunda-modeler/commit/599b1948d71d89e4ee1429f96cd2ca69744bef7b). However, only `package-lock.json` was updated. When running `npm i` and `npm run dev` I get an error saying that the GRPC dependency was built for the wrong platform (`electron@12.1` instead of `electron@12.0`). The goal of this pull request is to update the versions specified in `package.json` and `package-lock.json` and to eventually merge `master` into `develop` to algin the versions.
