### PR TITLE
chore(CHANGELOG): link to blogpost guiding plugin migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ ___Note:__ Yet to be released changes appear here._
 ### Breaking Changes
 
 * The properties panel extensions for `0.x` series don't work with the new properties panel. Check out [the project's changelog](https://github.com/bpmn-io/bpmn-js-properties-panel/blob/master/CHANGELOG.md#breaking-changes) with the example migration for guidance.
-* The `toolbar` slot has been removed. Consider moving your plugin's buttons to the status bar.
+* The `toolbar` slot has been removed. Consider moving your plugin's buttons to the status bar. Check out [the `how to migrate your Camunda Modeler plugin` blog post](https://camunda.com/blog/2022/01/how-to-migrate-your-camunda-modeler-plugins-to-work-with-camunda-modeler-5-x/) for guidance.
 
 ## 4.12.0
 


### PR DESCRIPTION
* I noticed that Valentin for example was not aware of the blog post
* Hopefully this helps users, to better find the guidance we have in place