### PR TITLE
feat(usageStatistics): track userTask formRef implementation

### DIFF
--- a/client/src/plugins/usage-statistics/event-handlers/__tests__/DeploymentEventHandlerSpec.js
+++ b/client/src/plugins/usage-statistics/event-handlers/__tests__/DeploymentEventHandlerSpec.js
@@ -358,11 +358,11 @@ describe('<DeploymentEventHandler>', () => {
           const metrics = onSend.getCall(0).args[0].diagramMetrics;
 
           expect(metrics.tasks.userTask).to.eql({
-            count: 9,
+            count: 10,
             form: {
-              count: 7,
+              count: 8,
               embedded: 3,
-              camundaForms: 1,
+              camundaForms: 2,
               external: 1,
               generated: 1,
               other: 1

--- a/client/src/plugins/usage-statistics/event-handlers/__tests__/DiagramOpenEventHandlerSpec.js
+++ b/client/src/plugins/usage-statistics/event-handlers/__tests__/DiagramOpenEventHandlerSpec.js
@@ -502,11 +502,11 @@ describe('<DiagramOpenEventHandler>', () => {
 
           // then
           expect(diagramMetrics.tasks.userTask).to.eql({
-            count: 9,
+            count: 10,
             form: {
-              count: 7,
+              count: 8,
               embedded: 3,
-              camundaForms: 1,
+              camundaForms: 2,
               external: 1,
               generated: 1,
               other: 1

--- a/client/src/plugins/usage-statistics/event-handlers/__tests__/fixtures/user-tasks.bpmn
+++ b/client/src/plugins/usage-statistics/event-handlers/__tests__/fixtures/user-tasks.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0sqedad" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.5.0-rc.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0sqedad" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1">
   <bpmn:process id="Process_1554m1f" isExecutable="true">
     <bpmn:userTask id="Activity_1xf1ap9" name="generic">
       <bpmn:extensionElements>
@@ -25,6 +25,7 @@
     <bpmn:userTask id="Activity_0i0rung" name="blank" />
     <bpmn:userTask id="Activity_1bwo0vq" name="blank" />
     <bpmn:userTask id="Activity_1aq3x2x" name="camunda-forms" camunda:formKey="camunda-forms:deployment:forms/userTask.form" />
+    <bpmn:userTask id="camunda-forms-formRef" name="camunda-forms-formRef" camunda:formRef="foo" camunda:formRefBinding="latest" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1554m1f">
@@ -54,6 +55,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1aq3x2x_di" bpmnElement="Activity_1aq3x2x">
         <dc:Bounds x="720" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0v24o7g_di" bpmnElement="camunda-forms-formRef">
+        <dc:Bounds x="880" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/client/src/util/metrics/userTasks.js
+++ b/client/src/util/metrics/userTasks.js
@@ -56,16 +56,18 @@ function parseCamundaUserTaskForms(userTasks) {
 
   const hasFormField = (userTask) => !!(getFormFields(userTask).length);
   const hasFormKey = (userTask) => ('formKey' in userTask);
+  const hasFormRef = (userTask) => ('formRef' in userTask);
   const isEmbedded = (formKey) => formKey.startsWith('embedded:');
   const isExternal = (formKey) => formKey.startsWith('app:');
-  const isCamundaForm = (formKey) => formKey.startsWith('camunda-forms:');
-  const isOther = (formKey) => !isEmbedded(formKey) && !isExternal(formKey) && !isCamundaForm(formKey);
+  const isCamundaFormKey = (formKey) => formKey.startsWith('camunda-forms:');
+  const isOther = (formKey) => !isEmbedded(formKey) && !isExternal(formKey) && !isCamundaFormKey(formKey);
 
   return {
-    count: userTasks.filter((userTask) => hasFormKey(userTask) || hasFormField(userTask)).length,
+    count: userTasks.filter((userTask) => hasFormKey(userTask) || hasFormField(userTask) || hasFormRef(userTask)).length,
     embedded: userTasks.filter((userTask) => hasFormKey(userTask) && isEmbedded(userTask.formKey)).length,
     external: userTasks.filter((userTask) => hasFormKey(userTask) && isExternal(userTask.formKey)).length,
-    camundaForms: userTasks.filter((userTask) => hasFormKey(userTask) && isCamundaForm(userTask.formKey)).length,
+    camundaForms: userTasks.filter((userTask) => ((hasFormKey(userTask) && isCamundaFormKey(userTask.formKey))
+     || hasFormRef(userTask))).length,
     generated: userTasks.filter((userTask) => !hasFormKey(userTask) && hasFormField(userTask)).length,
     other: userTasks.filter((userTask) => hasFormKey(userTask) && isOther(userTask.formKey)).length,
   };


### PR DESCRIPTION
* Working with telemetry data, I realized that we have not updated our logic to also track `formRef` userTask form implementations