### PR TITLE
chore(codecov): make PR checks more lenient

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,3 +3,12 @@ comment: off
 parsers:
   javascript:
     enable_partials: yes
+coverage:
+  status:
+    patch:
+      default:
+        informational: false
+        threshold: 5.0
+    project:
+      default:
+        informational: true


### PR DESCRIPTION
Adjust codecov to allow slight regressions in patch coverage. Repositories in the camunda github org are not covered by our global bpmn-io yaml.

related to https://github.com/bpmn-io/internal-docs/issues/459
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
