### PR TITLE
fix(deploy/start): clear overlay state when activeTab changes

### DIFF
--- a/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
@@ -63,7 +63,11 @@ export default class DeploymentTool extends PureComponent {
 
   componentDidMount() {
     this.props.subscribe('app.activeTabChanged', ({ activeTab }) => {
-      this.setState({ activeTab });
+      this.setState({
+        activeTab,
+        overlayState: null,
+        activeButton: false
+      });
     });
 
     this.props.subscribe('app.focus-changed', () => {

--- a/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
@@ -62,7 +62,11 @@ export default class StartInstanceTool extends PureComponent {
      } = this.props;
 
      subscribe('app.activeTabChanged', ({ activeTab }) => {
-       this.setState({ activeTab });
+       this.setState({
+         activeTab,
+         overlayState: null,
+         activeButton: false
+       });
      });
 
    }

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
@@ -79,7 +79,8 @@ export default class DeploymentPlugin extends PureComponent {
   componentDidMount() {
     this.props.subscribe('app.activeTabChanged', ({ activeTab }) => {
       this.setState({
-        activeTab
+        activeTab,
+        overlayState: null
       });
     });
 

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
@@ -45,7 +45,9 @@ export default class StartInstancePlugin extends PureComponent {
   componentDidMount() {
     this.props.subscribe('app.activeTabChanged', ({ activeTab }) => {
       this.setState({
-        activeTab
+        activeTab,
+        overlayState: null,
+        activeButton: false
       });
     });
   }


### PR DESCRIPTION
Closes #2762

Seems like a lot of changes but just because I needed to add test structure to test this.
Added test cases for each of the deploy/start instance that test (1) if the overlay opens and (2) closes if the active tab changes.