### PR TITLE
CI: pin windows version to `windows-2019`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-10.15, windows-latest ]
+        os: [ ubuntu-latest, macos-10.15, windows-2019 ]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
closes #2779 

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
