### PR TITLE
Integrate cloud templates

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1174,6 +1174,11 @@
 			"resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.6.0.tgz",
 			"integrity": "sha512-sfNIOKSfx/VQesCe1+m1izfIZS64NWDZq3teyMzzfJkn37u0ngwIwEXlc7Voj8Qcg2paePT8HmEgp+TJP39V3Q=="
 		},
+		"@camunda/zeebe-element-templates-json-schema": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.1.0.tgz",
+			"integrity": "sha512-E5mie+Q+/0Rk12GerNRWZP6aIWFXo4KfC++6tFJUvKt8la4ZvsPpagB7F8Oiahd56/gUqOicJ7+yPyQ85JnFgA=="
+		},
 		"@ibm/plex": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/@ibm/plex/-/plex-6.0.0.tgz",
@@ -2846,29 +2851,101 @@
 			}
 		},
 		"camunda-bpmn-js": {
-			"version": "0.13.0-alpha.2",
-			"resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-0.13.0-alpha.2.tgz",
-			"integrity": "sha512-J2tR47ouHfIfShlrbO/Zgj9RpouM/rgHGJYM9bnV7TjZ4ktHCw74xtgHDzwIKNNSAhGKrGkg1VvqVO+2VjasFg==",
+			"version": "0.13.0-alpha.3",
+			"resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-0.13.0-alpha.3.tgz",
+			"integrity": "sha512-fyjBazCjkXfB1hgxxFFg0g9RdzPwXVDIb5eY133ruiwsW/oxaI4iyVoyiSFiZkA9GNypTzWqzdjKLAcnvkeUsQ==",
 			"requires": {
 				"@bpmn-io/align-to-origin": "^0.7.0",
-				"@bpmn-io/properties-panel": "^0.10.2",
-				"bpmn-js": "^9.0.0-alpha.2",
+				"@bpmn-io/properties-panel": "^0.11.0",
+				"bpmn-js": "^9.0.2",
 				"bpmn-js-disable-collapsed-subprocess": "^0.1.3",
 				"bpmn-js-executable-fix": "^0.1.3",
-				"bpmn-js-properties-panel": "~1.0.0-alpha.3",
+				"bpmn-js-properties-panel": "~1.0.0-alpha.5",
 				"camunda-bpmn-moddle": "^6.1.1",
 				"diagram-js": "^8.1.1",
 				"diagram-js-minimap": "^2.1.0",
 				"diagram-js-origin": "^1.3.2",
 				"inherits": "^2.0.4",
 				"min-dash": "^3.8.1",
-				"zeebe-bpmn-moddle": "^0.10.0"
+				"zeebe-bpmn-moddle": "^0.11.0"
 			},
 			"dependencies": {
+				"@bpmn-io/element-templates-validator": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.5.0.tgz",
+					"integrity": "sha512-v/gfuYs7AOsQUzGmWBEupFGZiylCzqapBoZrjavewnPPbDOzLvbHZ1bnYPre/7b/wdnf4ayx0bf/NCC/AEySVg==",
+					"requires": {
+						"@camunda/element-templates-json-schema": "^0.7.0",
+						"@camunda/zeebe-element-templates-json-schema": "^0.1.0",
+						"json-source-map": "^0.6.1",
+						"min-dash": "^3.8.1"
+					}
+				},
+				"@bpmn-io/extract-process-variables": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.4.4.tgz",
+					"integrity": "sha512-iStnEVSEtOlZoE3ADMImdwhOhxUjXFdwWsCmmJQlyWH5ISmdRvai0Cxuw0spQEYySgIwFsUB0h+ScOCdW6yEBQ==",
+					"requires": {
+						"min-dash": "^3.5.2"
+					}
+				},
+				"@bpmn-io/properties-panel": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.11.0.tgz",
+					"integrity": "sha512-/1lZiwhCdAsapXKMjzVFc6jdyzU5Ue8wq/mMSFLVvAatxlHHrxTwYAqEW9zA0ZBqIm8JQbl6wptGMG/6ICZPGA==",
+					"requires": {
+						"classnames": "^2.3.1",
+						"min-dash": "^3.7.0",
+						"min-dom": "^3.1.3"
+					}
+				},
+				"@camunda/element-templates-json-schema": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.7.0.tgz",
+					"integrity": "sha512-ylBhHzAuzQjX+ZoZTPinHCsIaMa89fqyk10sxVQjgEm63+o40KMomjKf4EM2sXwiy72vDbjeXyb3Z56a7MTETQ=="
+				},
+				"bpmn-js": {
+					"version": "9.0.2",
+					"resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-9.0.2.tgz",
+					"integrity": "sha512-dl6sErP3tTBSJAvCGcu/v7xw+QCp8UCXSVlAoCA1lSrBkfdVOcHuxyy2svGPv4nJKOUMqFAK3xcemZYyztCwoA==",
+					"requires": {
+						"bpmn-moddle": "^7.1.2",
+						"css.escape": "^1.5.1",
+						"diagram-js": "^8.1.2",
+						"diagram-js-direct-editing": "^1.6.3",
+						"ids": "^1.0.0",
+						"inherits": "^2.0.4",
+						"min-dash": "^3.5.2",
+						"min-dom": "^3.1.3",
+						"object-refs": "^0.3.0",
+						"tiny-svg": "^2.2.2"
+					}
+				},
+				"bpmn-js-properties-panel": {
+					"version": "1.0.0-alpha.5",
+					"resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.0.0-alpha.5.tgz",
+					"integrity": "sha512-AXunjjthnApd25M0A0OIVxwIWoJc/BvNVCObf0Ushh86PqESzjAbDkTdtbUGxnj4ukiFJB390K5b5NezUEL5IQ==",
+					"requires": {
+						"@bpmn-io/element-templates-validator": "^0.5.0",
+						"@bpmn-io/extract-process-variables": "^0.4.4",
+						"array-move": "^3.0.1",
+						"classnames": "^2.3.1",
+						"ids": "^1.0.0",
+						"min-dash": "^3.8.1",
+						"min-dom": "^3.1.3",
+						"preact-markup": "^2.1.1",
+						"semver": "^7.3.5"
+					}
+				},
+				"classnames": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+					"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+				},
 				"diagram-js": {
-					"version": "8.1.1",
-					"resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.1.1.tgz",
-					"integrity": "sha512-Wy4BxeqYrM7rqLpcKb97Qyz/jR1Wt/gA8IQUOGjRY8rN7CZjiCSaITY2ATW76FwnCOhUvx2oRa+quzEm+s7aVQ==",
+					"version": "8.1.2",
+					"resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.1.2.tgz",
+					"integrity": "sha512-l0UWjWA9zcO3bwGg2C3sybNEWiICdXdkFy4JRjWdPyOcO00v3T0whuNhLwz9kaS5ht67awnPyKr+RWgsx3H0Rw==",
 					"requires": {
 						"css.escape": "^1.5.1",
 						"didi": "^5.2.1",
@@ -2891,15 +2968,41 @@
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
 				"path-intersection": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
 					"integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA=="
 				},
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
 				"tiny-svg": {
 					"version": "2.2.2",
 					"resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.2.tgz",
 					"integrity": "sha512-u6zCuMkDR/3VAh83X7hDRn/pi0XhwG2ycuNS0cTFtQjGdOG2tSvEb8ds65VeGWc3H6PUjJKeunueXqgkZqtMsg=="
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+				},
+				"zeebe-bpmn-moddle": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.11.0.tgz",
+					"integrity": "sha512-ehNQa2Kt9B1bwWJCF8Fs4SkroaSe+VH5Y4ql4T1hHuOSMJiwuMekFIs3UAJyS0ZyBhcJbUW1C1NPwXcD8u5IRA=="
 				}
 			}
 		},
@@ -4108,9 +4211,9 @@
 			}
 		},
 		"diagram-js-minimap": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/diagram-js-minimap/-/diagram-js-minimap-2.1.0.tgz",
-			"integrity": "sha512-BgNb2P7iIkl2FxUF+InZsLWdJ6TF7vTfAieWcqULR+FbklAF+JPySErQfegQclXt+ra0QybIQgjzIOUMJnvzvA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/diagram-js-minimap/-/diagram-js-minimap-2.1.1.tgz",
+			"integrity": "sha512-H+UM6qoIVgJAOJgm3kZ57zpPyTx41YtAQAs0c/rrRube25ljygA0PSO5x42CJNulJdgK0AEWdsnhefMzlxyKfQ==",
 			"requires": {
 				"css.escape": "^1.5.1",
 				"min-dash": "^3.5.2",

--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
     "bpmn-js-properties-panel": "^1.0.0-alpha.3",
     "bpmn-moddle": "^7.1.2",
     "bpmnlint": "^7.2.1",
-    "camunda-bpmn-js": "^0.13.0-alpha.2",
+    "camunda-bpmn-js": "^0.13.0-alpha.3",
     "camunda-bpmn-moddle": "^6.1.1",
     "camunda-cmmn-moddle": "^1.0.0",
     "camunda-dmn-moddle": "^1.1.0",

--- a/client/src/app/tabs/bpmn-shared/modeler/features/apply-default-templates/__tests__/applyDefaultTemplatesSpec.js
+++ b/client/src/app/tabs/bpmn-shared/modeler/features/apply-default-templates/__tests__/applyDefaultTemplatesSpec.js
@@ -158,6 +158,7 @@ function getDependencies(mockModules = {}) {
       eventBus: {
         on(_, callback) { callback(); }
       },
+      'config.changeTemplateCommand': 'propertiesPanel.camunda.changeTemplate',
       ...mockModules
     }
   });

--- a/client/src/app/tabs/bpmn-shared/modeler/features/apply-default-templates/applyDefaultTemplates.js
+++ b/client/src/app/tabs/bpmn-shared/modeler/features/apply-default-templates/applyDefaultTemplates.js
@@ -8,7 +8,7 @@
  * except in compliance with the MIT License.
  */
 
-export default function applyDefaultTemplates(elementRegistry, elementTemplates, commandStack) {
+export default function applyDefaultTemplates(elementRegistry, elementTemplates, commandStack, changeTemplateCommand) {
   const elements = elementRegistry.getAll();
 
   const commands = elements.reduce((currentCommands, element) => {
@@ -18,7 +18,7 @@ export default function applyDefaultTemplates(elementRegistry, elementTemplates,
       return currentCommands;
     }
 
-    const command = getChangeTemplateCommand(element, template);
+    const command = getChangeTemplateCommand(element, template, changeTemplateCommand);
 
     return [ ...currentCommands, command ];
   }, []);
@@ -41,9 +41,9 @@ applyDefaultTemplates.$inject = [
 
 
 // helpers //////////
-function getChangeTemplateCommand(element, template) {
+function getChangeTemplateCommand(element, template, cmd) {
   return {
-    cmd: 'propertiesPanel.camunda.changeTemplate',
+    cmd: cmd,
     context: {
       element,
       newTemplate: template

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -42,7 +42,7 @@ import css from './BpmnEditor.less';
 
 import generateImage from '../../util/generateImage';
 
-import applyDefaultTemplates from './modeler/features/apply-default-templates/applyDefaultTemplates';
+import applyDefaultTemplates from '../bpmn-shared/modeler/features/apply-default-templates/applyDefaultTemplates';
 
 import {
   findUsages as findNamespaceUsages,
@@ -71,6 +71,8 @@ import LintingTab from '../panel/tabs/LintingTab';
 import {
   ENGINES
 } from '../../../util/Engines';
+
+import { getPlatformTemplates } from '../../../util/elementTemplates';
 
 const NAMESPACE_URL_ACTIVITI = 'http://activiti.org/bpmn';
 
@@ -230,7 +232,7 @@ export class BpmnEditor extends CachedComponent {
 
     const templates = await getConfig('bpmn.elementTemplates');
 
-    templatesLoader.setTemplates(templates);
+    templatesLoader.setTemplates(getPlatformTemplates(templates));
 
     const propertiesPanel = modeler.get('propertiesPanel', false);
 
@@ -846,7 +848,8 @@ export class BpmnEditor extends CachedComponent {
 
     const modeler = new BpmnModeler({
       ...options,
-      position: 'absolute'
+      position: 'absolute',
+      changeTemplateCommand: 'propertiesPanel.camunda.changeTemplate'
     });
 
     const commandStack = modeler.get('commandStack');

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -233,16 +233,6 @@ export class BpmnEditor extends CachedComponent {
     const templates = await getConfig('bpmn.elementTemplates');
 
     templatesLoader.setTemplates(getPlatformTemplates(templates));
-
-    const propertiesPanel = modeler.get('propertiesPanel', false);
-
-    if (propertiesPanel) {
-      const currentElement = propertiesPanel._current && propertiesPanel._current.element;
-
-      if (currentElement) {
-        propertiesPanel.update(currentElement);
-      }
-    }
   }
 
   undo = () => {

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -41,7 +41,7 @@ import missingPatchEngineProfileXML from '../../__tests__/EngineProfile.missing-
 import patchEngineProfileXML from '../../__tests__/EngineProfile.patch.platform.bpmn';
 import namespaceEngineProfileXML from '../../__tests__/EngineProfile.namespace.platform.bpmn';
 
-import applyDefaultTemplates from '../modeler/features/apply-default-templates/applyDefaultTemplates';
+import applyDefaultTemplates from '../../bpmn-shared/modeler/features/apply-default-templates/applyDefaultTemplates';
 
 import {
   getCanvasEntries,
@@ -1119,6 +1119,66 @@ describe('<BpmnEditor>', function() {
       expect(getConfigSpy).to.be.always.calledWith('bpmn.elementTemplates');
       expect(elementTemplatesLoaderStub.setTemplates).to.be.calledTwice;
       expect(updateSpy).to.have.been.called;
+    });
+
+
+    it('should only load platform templates', async function() {
+
+      // given
+      const platformTemplates = [
+        {
+          '$schema': 'https://unpkg.com/@camunda/element-templates-json-schema/resources/schema.json',
+          'id': 'one'
+        },
+        {
+          'id': 'two'
+        },
+        {
+          '$schema': 'https://unpkg.com/@camunda/element-templates-json-schema0.6.0/resources/schema.json',
+          'id': 'three'
+        },
+        {
+          '$schema': 'https://cdn.jsdelivr.net/npm/@camunda/element-templates-json-schema/resources/schema.json',
+          'id': 'four'
+        }
+      ];
+
+      const otherTemplates = [
+        {
+          '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+          'id': 'five'
+        }
+      ];
+
+      const allTemplates = [
+        ...platformTemplates, ...otherTemplates
+      ];
+
+      const getConfig = () => allTemplates;
+
+      const elementTemplatesLoaderStub = sinon.stub({ setTemplates() {} });
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: elementTemplatesLoaderStub
+            }
+          })
+        }
+      });
+
+      // when
+      await renderEditor(diagramXML, {
+        cache,
+        getConfig
+      });
+
+      // expect
+      expect(elementTemplatesLoaderStub.setTemplates).not.to.be.calledWith(allTemplates);
+      expect(elementTemplatesLoaderStub.setTemplates).to.be.calledWith(platformTemplates);
     });
 
 

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -1108,17 +1108,12 @@ describe('<BpmnEditor>', function() {
         getConfig: getConfigSpy
       });
 
-      const propertiesPanel = instance.getModeler().get('propertiesPanel');
-
-      const updateSpy = spy(propertiesPanel, 'update');
-
       await instance.triggerAction('elementTemplates.reload');
 
       // expect
       expect(getConfigSpy).to.be.calledTwice;
       expect(getConfigSpy).to.be.always.calledWith('bpmn.elementTemplates');
       expect(elementTemplatesLoaderStub.setTemplates).to.be.calledTwice;
-      expect(updateSpy).to.have.been.called;
     });
 
 

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -221,16 +221,6 @@ export class BpmnEditor extends CachedComponent {
     let templates = await getConfig('bpmn.elementTemplates');
 
     templatesLoader.setTemplates(getCloudTemplates(templates));
-
-    const propertiesPanel = modeler.get('propertiesPanel', false);
-
-    if (propertiesPanel) {
-      const currentElement = propertiesPanel._current && propertiesPanel._current.element;
-
-      if (currentElement) {
-        propertiesPanel.update(currentElement);
-      }
-    }
   }
 
   undo = () => {

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -1029,17 +1029,12 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
         getConfig: getConfigSpy
       });
 
-      const propertiesPanel = instance.getModeler().get('propertiesPanel');
-
-      const updateSpy = spy(propertiesPanel, 'update');
-
       await instance.triggerAction('elementTemplates.reload');
 
       // expect
       expect(getConfigSpy).to.be.calledTwice;
       expect(getConfigSpy).to.be.always.calledWith('bpmn.elementTemplates');
       expect(elementTemplatesLoaderStub.setTemplates).to.be.calledTwice;
-      expect(updateSpy).to.have.been.called;
     });
 
 

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -39,6 +39,8 @@ import missingPatchEngineProfileXML from '../../__tests__/EngineProfile.missing-
 import patchEngineProfileXML from '../../__tests__/EngineProfile.patch.cloud.bpmn';
 import namespaceEngineProfileXML from '../../__tests__/EngineProfile.namespace.cloud.bpmn';
 
+import applyDefaultTemplates from '../../bpmn-shared/modeler/features/apply-default-templates/applyDefaultTemplates';
+
 import {
   getCanvasEntries,
   getCopyCutPasteEntries,
@@ -924,8 +926,11 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
       });
 
       // then
-      expect(isImportNeededSpy).to.have.been.calledOnce;
-      expect(isImportNeededSpy).to.have.always.returned(false);
+      // BpmnEditor#componentDidMount is async
+      process.nextTick(() => {
+        expect(isImportNeededSpy).to.have.been.calledOnce;
+        expect(isImportNeededSpy).to.have.always.returned(false);
+      });
     });
 
 
@@ -963,6 +968,241 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
 
       // then
       expect(instance.getCached().lastXML).to.be.null;
+    });
+
+  });
+
+
+  describe('element templates', function() {
+
+    it('should load templates when mounted', async function() {
+
+      // given
+      const getConfigSpy = sinon.spy(),
+            elementTemplatesLoaderMock = { setTemplates() {} };
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: elementTemplatesLoaderMock
+            }
+          })
+        }
+      });
+
+      // when
+      await renderEditor(diagramXML, {
+        cache,
+        getConfig: getConfigSpy
+      });
+
+      // expect
+      expect(getConfigSpy).to.be.called;
+      expect(getConfigSpy).to.be.calledWith('bpmn.elementTemplates');
+    });
+
+
+    it('should reload templates on action triggered', async function() {
+
+      // given
+      const getConfigSpy = sinon.spy(),
+            elementTemplatesLoaderStub = sinon.stub({ setTemplates() {} });
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: elementTemplatesLoaderStub
+            }
+          })
+        }
+      });
+
+      // when
+      const { instance } = await renderEditor(diagramXML, {
+        cache,
+        getConfig: getConfigSpy
+      });
+
+      const propertiesPanel = instance.getModeler().get('propertiesPanel');
+
+      const updateSpy = spy(propertiesPanel, 'update');
+
+      await instance.triggerAction('elementTemplates.reload');
+
+      // expect
+      expect(getConfigSpy).to.be.calledTwice;
+      expect(getConfigSpy).to.be.always.calledWith('bpmn.elementTemplates');
+      expect(elementTemplatesLoaderStub.setTemplates).to.be.calledTwice;
+      expect(updateSpy).to.have.been.called;
+    });
+
+
+    it('should ONLY load platform templates', async function() {
+
+      // given
+      const cloudTemplates = [
+        {
+          '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+          'id': 'one'
+        },
+        {
+          '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema0.1.0/resources/schema.json',
+          'id': 'two'
+        },
+        {
+          '$schema': 'https://cdn.jsdelivr.net/npm/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+          'id': 'three'
+        }
+      ];
+
+      const otherTemplates = [
+        {
+          '$schema': 'https://unpkg.com/@camunda/element-templates-json-schema/resources/schema.json',
+          'id': 'four'
+        },
+        {
+          'id': 'five'
+        }
+      ];
+
+      const allTemplates = [
+        ...cloudTemplates, ...otherTemplates
+      ];
+
+      const getConfig = () => allTemplates;
+
+      const elementTemplatesLoaderStub = sinon.stub({ setTemplates() {} });
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: elementTemplatesLoaderStub
+            }
+          })
+        }
+      });
+
+      // when
+      await renderEditor(diagramXML, {
+        cache,
+        getConfig
+      });
+
+      // expect
+      expect(elementTemplatesLoaderStub.setTemplates).not.to.be.calledWith(allTemplates);
+      expect(elementTemplatesLoaderStub.setTemplates).to.be.calledWith(cloudTemplates);
+    });
+
+
+    it('should apply default templates to unsaved diagram', async function() {
+
+      // given
+      const modeler = new BpmnModeler();
+
+      const invokeSpy = sinon.spy(modeler, 'invoke');
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler
+        }
+      });
+
+      // when
+      await renderEditor(diagramXML, {
+        cache,
+        isNew: true
+      });
+
+      // then
+      expect(invokeSpy).to.have.been.calledWith(applyDefaultTemplates);
+    });
+
+
+    it('should NOT apply default templates to unsaved diagram twice', async function() {
+
+      // given
+      const modeler = new BpmnModeler();
+
+      const invokeSpy = sinon.spy(modeler, 'invoke');
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler,
+          defaultTemplatesApplied: true
+        }
+      });
+
+      // when
+      await renderEditor(diagramXML, {
+        cache,
+        isNew: true
+      });
+
+      // then
+      expect(invokeSpy).not.to.have.been.called;
+    });
+
+
+    it('should NOT apply default templates to saved diagram', async function() {
+
+      // given
+      const modeler = new BpmnModeler();
+
+      const invokeSpy = sinon.spy(modeler, 'invoke');
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler
+        }
+      });
+
+      // when
+      renderEditor(diagramXML, {
+        cache,
+        isNew: false
+      });
+
+      // then
+      expect(invokeSpy).not.to.have.been.called;
+    });
+
+
+    it('should handle template errors as warning', async function() {
+
+      // given
+      const warningSpy = spy();
+
+      const error1 = new Error('template error 1');
+      const error2 = new Error('template error 2');
+      const error3 = new Error('template error 3');
+
+      const { instance } = await renderEditor(diagramXML, {
+        onWarning: warningSpy
+      });
+
+      // when
+      await instance.handleElementTemplateErrors({ errors: [ error1, error2, error3 ] });
+
+      // then
+      expect(warningSpy).to.have.been.calledThrice;
+      expect(warningSpy).to.have.been.calledWith({ message: error1.message });
+      expect(warningSpy).to.have.been.calledWith({ message: error2.message });
+      expect(warningSpy).to.have.been.calledWith({ message: error3.message });
     });
 
   });

--- a/client/src/plugins/element-templates-modal/ElementTemplatesModal.js
+++ b/client/src/plugins/element-templates-modal/ElementTemplatesModal.js
@@ -46,9 +46,7 @@ export default class ElementTemplatesModal extends PureComponent {
 
   handleBpmnModelerConfigure = async ({ middlewares, tab }) => {
 
-    // todo(Skaiir): workaround to deal with the co-dependencies between cloud element templates and plugins
-    // cf. https://github.com/camunda/camunda-modeler/issues/2731
-    if (tab.type !== 'bpmn') {
+    if (!isBpmnTab(tab)) {
       return;
     }
 
@@ -72,7 +70,7 @@ export default class ElementTemplatesModal extends PureComponent {
 
     const { activeTab } = this.state;
 
-    if (!activeTab || activeTab.type !== 'bpmn') {
+    if (!isBpmnTab(activeTab)) {
       return;
     }
 
@@ -103,4 +101,11 @@ export default class ElementTemplatesModal extends PureComponent {
       )
       : null;
   }
+}
+
+
+// helper /////////////////
+
+function isBpmnTab(tab) {
+  return tab && (tab.type === 'bpmn' || tab.type === 'cloud-bpmn');
 }

--- a/client/src/plugins/element-templates-modal/__tests__/ElementTemplatesModalSpec.js
+++ b/client/src/plugins/element-templates-modal/__tests__/ElementTemplatesModalSpec.js
@@ -76,6 +76,69 @@ describe('<ElementTemplatesModal>', function() {
       expect(handleBpmnModelerConfigureSpy).to.have.been.called;
     });
 
+
+    it('should configure on <bpmn> tab', async function() {
+
+      // given
+      const {
+        callSubscriber,
+        subscribe
+      } = createSubscribe('bpmn.modeler.configure');
+
+      const middlewares = [];
+      const tab = { type: 'bpmn' };
+
+      await createElementTemplatesModal({ subscribe });
+
+      // when
+      callSubscriber({ middlewares, tab });
+
+      // then
+      expect(middlewares).not.to.be.empty;
+    });
+
+
+    it('should configure on <cloud-bpmn> tab', async function() {
+
+      // given
+      const {
+        callSubscriber,
+        subscribe
+      } = createSubscribe('bpmn.modeler.configure');
+
+      const middlewares = [];
+      const tab = { type: 'cloud-bpmn' };
+
+      await createElementTemplatesModal({ subscribe });
+
+      // when
+      callSubscriber({ middlewares, tab });
+
+      // then
+      expect(middlewares).not.to.be.empty;
+    });
+
+
+    it('should NOT configure on <foo> tab', async function() {
+
+      // given
+      const {
+        callSubscriber,
+        subscribe
+      } = createSubscribe('bpmn.modeler.configure');
+
+      const middlewares = [];
+      const tab = { type: 'foo' };
+
+      await createElementTemplatesModal({ subscribe });
+
+      // when
+      callSubscriber({ middlewares, tab });
+
+      // then
+      expect(middlewares).to.be.empty;
+    });
+
   });
 
 

--- a/client/src/plugins/element-templates-modal/modeler/EditorActions.js
+++ b/client/src/plugins/element-templates-modal/modeler/EditorActions.js
@@ -9,14 +9,14 @@
  */
 
 export default class EditorActions {
-  constructor(commandStack, editorActions, selection, canvas, elementTemplates) {
+  constructor(commandStack, editorActions, selection, canvas, elementTemplates, changeTemplateCommand) {
 
     // Register action to apply an element template to the selected element
     editorActions.register('applyElementTemplate', elementTemplate => {
       const element = getSelectedElement();
 
       if (element) {
-        commandStack.execute('propertiesPanel.camunda.changeTemplate', {
+        commandStack.execute(changeTemplateCommand, {
           element,
           newTemplate: elementTemplate
         });
@@ -39,7 +39,9 @@ export default class EditorActions {
       if (selectedElement) {
         const { businessObject } = selectedElement;
 
-        return businessObject.get('camunda:modelerTemplate') || null;
+        // todo: elementTemplates._getTemplateId
+        // https://github.com/bpmn-io/bpmn-js-properties-panel/pull/585/files#diff-c59c24ee0669c0f08660111bc3669a775eacc41e5edd877a04beb71560cba11dR17
+        return businessObject.get('modelerTemplate') || null;
       }
 
       return null;
@@ -80,5 +82,6 @@ EditorActions.$inject = [
   'editorActions',
   'selection',
   'canvas',
-  'elementTemplates'
+  'elementTemplates',
+  'config.changeTemplateCommand'
 ];

--- a/client/src/plugins/element-templates-modal/modeler/__tests__/bpmn-io-modelers/EditorActionsSpec.js
+++ b/client/src/plugins/element-templates-modal/modeler/__tests__/bpmn-io-modelers/EditorActionsSpec.js
@@ -31,7 +31,8 @@ const DEFAULT_OPTIONS = {
   exporter: {
     name: 'my-tool',
     version: '120-beta.100'
-  }
+  },
+  changeTemplateCommand: 'propertiesPanel.camunda.changeTemplate'
 };
 
 

--- a/client/src/util/__tests__/elementTemplatesSpec.js
+++ b/client/src/util/__tests__/elementTemplatesSpec.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { map } from 'min-dash';
+
+import templates from './fixtures/templates.json';
+
+import { getPlatformTemplates, getCloudTemplates } from '../elementTemplates';
+
+
+describe('util - elementTemplates', function() {
+
+  it('should get platform templates', function() {
+
+    // when
+    const platformTemplates = getPlatformTemplates(templates);
+
+    // then
+    expect(withNames(platformTemplates)).to.eql([
+      'Platform Task 1',
+      'Platform Task 2',
+      'No schema',
+      'Platform Task 3'
+    ]);
+  });
+
+
+  it('should get cloud templates', function() {
+
+    // when
+    const cloudTemplates = getCloudTemplates(templates);
+
+    // then
+    expect(withNames(cloudTemplates)).to.eql([
+      'Cloud Task 1',
+      'Cloud Task 2',
+      'Cloud Task 3'
+    ]);
+  });
+
+});
+
+
+// helper /////////////
+
+function withNames(templates) {
+  return map(templates, template => template.name);
+}

--- a/client/src/util/__tests__/fixtures/templates.json
+++ b/client/src/util/__tests__/fixtures/templates.json
@@ -1,0 +1,64 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/element-templates-json-schema@0.6.0/resources/schema.json",
+    "name": "Platform Task 1",
+    "id": "com.camunda.example.PlatformTask-1",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/element-templates-json-schema@0.6.0/resources/schema.json",
+    "name": "Platform Task 2",
+    "id": "com.camunda.example.PlatformTask-1",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.1.0/resources/schema.json",
+    "name": "Cloud Task 1",
+    "id": "com.camunda.example.CloudTask-1",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.1.0/resources/schema.json",
+    "name": "Cloud Task 2",
+    "id": "com.camunda.example.CloudTask-2",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": []
+  },
+  {
+    "name": "No schema",
+    "id": "com.camunda.example.NoSchema",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/element-templates-json-schema@0.6.0/resources/schema.json",
+    "name": "Platform Task 3",
+    "id": "com.camunda.example.PlatformTask-3",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": []
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema@0.1.0/resources/schema.json",
+    "name": "Cloud Task 3",
+    "id": "com.camunda.example.CloudTask-3",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": []
+  }
+]

--- a/client/src/util/elementTemplates.js
+++ b/client/src/util/elementTemplates.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { CloudElementTemplatesValidator } from 'camunda-bpmn-js/lib/camunda-cloud/ElementTemplatesValidator';
+
+import { filter } from 'min-dash';
+
+const elementTemplatesValidator = new CloudElementTemplatesValidator();
+
+export function getCloudTemplates(templates) {
+  return filterTemplatesBySchema(templates, true);
+}
+
+export function getPlatformTemplates(templates) {
+  return filterTemplatesBySchema(templates, false);
+}
+
+function filterTemplatesBySchema(templates, shouldApply) {
+  return filter(templates, template => {
+    const { $schema } = template;
+    return !!elementTemplatesValidator.isSchemaValid($schema) === shouldApply;
+  });
+}

--- a/resources/element-templates/cloud-samples.json
+++ b/resources/element-templates/cloud-samples.json
@@ -1,0 +1,432 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Email Connector",
+    "id": "io.camunda.examples.EmailConnector",
+    "description": "A Email sending task.",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "send-email",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "Hostname",
+        "description": "Specify the email server (SMTP) host name",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "HOST_NAME"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
+      },
+      {
+        "label": "Port",
+        "description": "Specify the email server (SMTP) port (default=25)",
+        "type": "String",
+        "value": "= 25",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "PORT"
+        }
+      },
+      {
+        "label": "Username",
+        "description": "Specify the user name to authenticate with",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "USER_NAME"
+        }
+      },
+      {
+        "label": "Password",
+        "description": "Specify the password to authenticate with",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "PASSWORD"
+        }
+      },
+      {
+        "label": "Sender",
+        "description": "Enter the FROM field",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "sender"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
+      },
+      {
+        "label": "Recipient",
+        "description": "Enter the TO field",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "recipient"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
+      },
+      {
+        "label": "Subject",
+        "description": "Enter the mail subject",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "subject"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
+      },
+      {
+        "label": "Body",
+        "description": "Enter the email message body",
+        "type": "Text",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "message"
+        },
+        "constraints": {
+          "notEmpty": true
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "REST Connector",
+    "id": "io.camunda.examples.RestConnector",
+    "description": "A REST API invocation task.",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "http",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "REST Endpoint URL",
+        "description": "Specify the url of the REST API to talk to.",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "url"
+        },
+        "constraints": {
+          "notEmpty": true,
+          "pattern": {
+            "value": "^https?://.*",
+            "message": "Must be http(s) URL."
+          }
+        }
+      },
+      {
+        "label": "REST Method",
+        "description": "Specify the HTTP method to use.",
+        "type": "Dropdown",
+        "value": "get",
+        "choices": [
+          { "name": "GET", "value": "get" },
+          { "name": "POST", "value": "post" },
+          { "name": "PATCH", "value": "patch" },
+          { "name": "DELETE", "value": "delete" }
+        ],
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "method"
+        }
+      },
+      {
+        "label": "Request Body",
+        "description": "Data to send to the endpoint.",
+        "value": "",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "body"
+        }
+      },
+      {
+        "label": "Result Variable",
+        "description": "Name of variable to store the response data in.",
+        "value": "response",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:output",
+          "source": "= body"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Groups",
+    "id": "io.camunda.examples.Groups",
+    "description": "Example template to provide groups.",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "http",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "REST Endpoint URL",
+        "description": "Specify the url of the REST API to talk to.",
+        "group": "headers",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "url"
+        },
+        "constraints": {
+          "notEmpty": true,
+          "pattern": {
+            "value": "^https?://.*",
+            "message": "Must be http(s) URL."
+          }
+        }
+      },
+      {
+        "label": "REST Method",
+        "description": "Specify the HTTP method to use.",
+        "group": "headers",
+        "type": "Dropdown",
+        "value": "get",
+        "choices": [
+          { "name": "GET", "value": "get" },
+          { "name": "POST", "value": "post" },
+          { "name": "PATCH", "value": "patch" },
+          { "name": "DELETE", "value": "delete" }
+        ],
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "method"
+        }
+      },
+      {
+        "label": "Request Body",
+        "description": "Data to send to the endpoint.",
+        "value": "",
+        "group": "payload",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:input",
+          "name": "body"
+        }
+      },
+      {
+        "label": "Result Variable",
+        "description": "Name of variable to store the response data in.",
+        "group": "mapping",
+        "value": "response",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:output",
+          "source": "= body"
+        }
+      }
+    ],
+    "groups": [
+      {
+        "id": "headers",
+        "label": "Request headers"
+      },
+      {
+        "id": "payload",
+        "label": "Request payload"
+      },
+      {
+        "id": "mapping",
+        "label": "Response mapping"
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "io.camunda.examples.ScriptWorker",
+    "name": "Script Worker",
+    "description": "A script task worker",
+    "appliesTo": [
+      "bpmn:ScriptTask"
+    ],
+    "properties":[
+      {
+        "label": "Job type",
+        "type": "String",
+        "value": "script",
+        "group": "job-definition",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "Language",
+        "value": "javascript",
+        "type": "Dropdown",
+        "choices": [
+          {
+            "name": "FEEL",
+            "value": "feel"
+          },
+          {
+            "name": "Groovy",
+            "value": "groovy"
+          },
+          {
+            "name": "JavaScript",
+            "value": "javascript"
+          },
+          {
+            "name": "Kotlin",
+            "value": "kotlin"
+          },
+          {
+            "name": "Mustache",
+            "value": "mustache"
+          }
+        ],
+        "group": "script",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "language"
+        }
+      },
+      {
+        "label": "Script",
+        "value": "a + b",
+        "type": "Text",
+        "group": "script",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "script"
+        }
+      }
+    ],
+    "groups": [
+      {
+        "id": "job-definition",
+        "label": "Job definition"
+      },
+      {
+        "id": "script",
+        "label": "Script"
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "io.camunda.examples.PaymentTask",
+    "name": "Payment task",
+    "description": "A payment task worker",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties":[
+      {
+        "label": "Job type",
+        "type": "String",
+        "value": "payment-service",
+        "group": "job-definition",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "Method",
+        "value": "visa",
+        "type": "Dropdown",
+        "choices": [
+          {
+            "name": "American Express",
+            "value": "american-express"
+          },
+          {
+            "name": "Mastercard",
+            "value": "mastercard"
+          },
+          {
+            "name": "Visa",
+            "value": "visa"
+          }
+        ],
+        "group": "headers",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "method"
+        }
+      }
+    ],
+    "groups": [
+      {
+        "id": "job-definition",
+        "label": "Job definition"
+      },
+      {
+        "id": "headers",
+        "label": "Headers"
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "id": "io.camunda.examples.KafkaTask",
+    "name": "Kafka worker",
+    "description": "A kafka task worker",
+    "appliesTo": [
+      "bpmn:ServiceTask",
+      "bpmn:SendTask"
+    ],
+    "properties":[
+      {
+        "type": "Hidden",
+        "value": "kafka",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "Method",
+        "value": "payment",
+        "type": "String",
+        "group": "headers",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "kafka-topic"
+        }
+      }
+    ],
+    "groups": [
+      {
+        "id": "headers",
+        "label": "Headers"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Closes #2731 
Closes https://github.com/camunda/camunda-modeler/issues/2496
Closes https://github.com/camunda/camunda-modeler/issues/2749
Closes https://github.com/camunda/camunda-modeler/issues/2673

* Updates to `camunda-bpmn-js@0.13.0-alpha.3`
* Adds the `cloud-element-templates` feature to `cloud-bpmn` tabs
* Makes sure we only load specific element templates in the respective editors
  * by using the cloud `ElementTemplatesValidator` provided via `camunda-bpmn-js`
  * by checking the `$schema` attribute => needs to be provided + reference `@camunda/zeebe-element-templates-json-schema` (that needs to be documented, cf. #2723) 
* Enabled the catalog select plugin for `cloud-bpmn` tabs
* Adds samples for cloud templates

Some samples to try out, note that `$schema` needs to be set for cloud templates (cf. above).

* https://github.com/bpmn-io/bpmn-js-properties-panel/blob/master/test/spec/provider/cloud-element-templates/fixtures/complex.json
* https://github.com/camunda/camunda-modeler/blob/2731-rollout-cloud-templates/resources/element-templates/cloud-samples.json

![Kapture 2022-02-25 at 15 26 57](https://user-images.githubusercontent.com/9433996/155731920-6cd1d81c-766f-43db-8e73-cec394a93f67.gif)



