### PR TITLE
deps: bump to `camunda-bpmn-js@0.13.0-alpha.4`

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1082,11 +1082,12 @@
 			}
 		},
 		"@bpmn-io/element-templates-validator": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.4.0.tgz",
-			"integrity": "sha512-cJtmUHn/4QpkeGQ/tUBQO020Cr1x2AILYczzMioRCGRSEekR/8wSaeEFuEx5ujFNDbHSx2lLN5P2ZmHlpD1Tmg==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.5.0.tgz",
+			"integrity": "sha512-v/gfuYs7AOsQUzGmWBEupFGZiylCzqapBoZrjavewnPPbDOzLvbHZ1bnYPre/7b/wdnf4ayx0bf/NCC/AEySVg==",
 			"requires": {
-				"@camunda/element-templates-json-schema": "^0.6.0",
+				"@camunda/element-templates-json-schema": "^0.7.0",
+				"@camunda/zeebe-element-templates-json-schema": "^0.1.0",
 				"json-source-map": "^0.6.1",
 				"min-dash": "^3.8.1"
 			}
@@ -1143,9 +1144,9 @@
 			}
 		},
 		"@bpmn-io/properties-panel": {
-			"version": "0.10.2",
-			"resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.10.2.tgz",
-			"integrity": "sha512-ljH/xMQapQ4k5NT8YQYt9O9iqRn2Mg77aQh4p5RBDdAq51VxhokClaxe6P1L3pkbB3jQUBM+SO18JhLjv/VzTw==",
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.11.0.tgz",
+			"integrity": "sha512-/1lZiwhCdAsapXKMjzVFc6jdyzU5Ue8wq/mMSFLVvAatxlHHrxTwYAqEW9zA0ZBqIm8JQbl6wptGMG/6ICZPGA==",
 			"requires": {
 				"classnames": "^2.3.1",
 				"min-dash": "^3.7.0",
@@ -1170,9 +1171,9 @@
 			"integrity": "sha512-OWe9YQx3Vtnopz0trJCJVI3y7k2EfeR4QkKHfRhukcB7yxG4PD1FGaB5LAxc1wxp66V1S3LU4bqUpJdVhQhIww=="
 		},
 		"@camunda/element-templates-json-schema": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.6.0.tgz",
-			"integrity": "sha512-sfNIOKSfx/VQesCe1+m1izfIZS64NWDZq3teyMzzfJkn37u0ngwIwEXlc7Voj8Qcg2paePT8HmEgp+TJP39V3Q=="
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.7.0.tgz",
+			"integrity": "sha512-ylBhHzAuzQjX+ZoZTPinHCsIaMa89fqyk10sxVQjgEm63+o40KMomjKf4EM2sXwiy72vDbjeXyb3Z56a7MTETQ=="
 		},
 		"@camunda/zeebe-element-templates-json-schema": {
 			"version": "0.1.0",
@@ -2433,13 +2434,13 @@
 			}
 		},
 		"bpmn-js": {
-			"version": "9.0.0-alpha.2",
-			"resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-9.0.0-alpha.2.tgz",
-			"integrity": "sha512-lZ8mkhcxMlYZdM9W/vhWhfe8o05ZOo1ZF+skMJED+bGG0gHjSOlqNHL9PhZdIMYw9eJl07i2vIlHv/3wOdihTw==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-9.0.3.tgz",
+			"integrity": "sha512-Frr0skhc3l5Sw3xj9lPkYm2gotxA2sdqNDh1uWb2P/u8jol0VaJFldlQI0aVwWmoo1ze3VVNJ0qYZs5HdDqt9g==",
 			"requires": {
 				"bpmn-moddle": "^7.1.2",
 				"css.escape": "^1.5.1",
-				"diagram-js": "^8.1.1",
+				"diagram-js": "^8.2.0",
 				"diagram-js-direct-editing": "^1.6.3",
 				"ids": "^1.0.0",
 				"inherits": "^2.0.4",
@@ -2450,9 +2451,9 @@
 			},
 			"dependencies": {
 				"diagram-js": {
-					"version": "8.1.1",
-					"resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.1.1.tgz",
-					"integrity": "sha512-Wy4BxeqYrM7rqLpcKb97Qyz/jR1Wt/gA8IQUOGjRY8rN7CZjiCSaITY2ATW76FwnCOhUvx2oRa+quzEm+s7aVQ==",
+					"version": "8.2.0",
+					"resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.2.0.tgz",
+					"integrity": "sha512-nbT6GSEbbKEVP8C4K8Olctsb5kgoDA/K+xuDZ3pnkkkmJwNW0hEyrVQGtwyYVldyUCoGFR7DI8NBJxNhleRgtg==",
 					"requires": {
 						"css.escape": "^1.5.1",
 						"didi": "^5.2.1",
@@ -2481,9 +2482,9 @@
 					"integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA=="
 				},
 				"tiny-svg": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.2.tgz",
-					"integrity": "sha512-u6zCuMkDR/3VAh83X7hDRn/pi0XhwG2ycuNS0cTFtQjGdOG2tSvEb8ds65VeGWc3H6PUjJKeunueXqgkZqtMsg=="
+					"version": "2.2.3",
+					"resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.3.tgz",
+					"integrity": "sha512-u5KGg889pD1W2c9GlLrTnAGzIkAO00/VXZGyzeiGHw+b9er8McLO0SnhxPQQDwDqFO0MrJ825AEsRUoTiDZFuQ=="
 				}
 			}
 		},
@@ -2501,11 +2502,11 @@
 			"integrity": "sha512-dXvRIUD+NuB/fByFP8r4/Vr8L9Buv/hdRQt0g5wzCHAoF+nW0C/Uv+EjRjwqqFr7AQr1XR+L1ADL3BDyKgeuWw=="
 		},
 		"bpmn-js-properties-panel": {
-			"version": "1.0.0-alpha.3",
-			"resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.0.0-alpha.3.tgz",
-			"integrity": "sha512-aDnuxMS1rFmrR6EKhihCm7luf9yokcY9nXa1zELQ0CH8eVbFr4SIyRmSvfBPuJbuB7uYnH9gjG0W5uqjiwtQfw==",
+			"version": "1.0.0-alpha.5",
+			"resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.0.0-alpha.5.tgz",
+			"integrity": "sha512-AXunjjthnApd25M0A0OIVxwIWoJc/BvNVCObf0Ushh86PqESzjAbDkTdtbUGxnj4ukiFJB390K5b5NezUEL5IQ==",
 			"requires": {
-				"@bpmn-io/element-templates-validator": "^0.4.0",
+				"@bpmn-io/element-templates-validator": "^0.5.0",
 				"@bpmn-io/extract-process-variables": "^0.4.4",
 				"array-move": "^3.0.1",
 				"classnames": "^2.3.1",
@@ -2879,16 +2880,14 @@
 			}
 		},
 		"camunda-bpmn-js": {
-			"version": "0.13.0-alpha.3",
-			"resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-0.13.0-alpha.3.tgz",
-			"integrity": "sha512-fyjBazCjkXfB1hgxxFFg0g9RdzPwXVDIb5eY133ruiwsW/oxaI4iyVoyiSFiZkA9GNypTzWqzdjKLAcnvkeUsQ==",
+			"version": "0.13.0-alpha.4",
+			"resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-0.13.0-alpha.4.tgz",
+			"integrity": "sha512-0COCkStS95+UekTMXgEbCpcOsjdR8tPNtKRejkgh8mvtlccLe+CatnY3TQWYuV0iHsGtgxLph9a4lOgDFg7/VQ==",
 			"requires": {
 				"@bpmn-io/align-to-origin": "^0.7.0",
-				"@bpmn-io/properties-panel": "^0.11.0",
-				"bpmn-js": "^9.0.2",
+				"bpmn-js": "^9.0.3",
 				"bpmn-js-disable-collapsed-subprocess": "^0.1.3",
 				"bpmn-js-executable-fix": "^0.1.3",
-				"bpmn-js-properties-panel": "~1.0.0-alpha.5",
 				"camunda-bpmn-moddle": "^6.1.1",
 				"diagram-js": "^8.1.1",
 				"diagram-js-minimap": "^2.1.0",
@@ -2898,82 +2897,10 @@
 				"zeebe-bpmn-moddle": "^0.11.0"
 			},
 			"dependencies": {
-				"@bpmn-io/element-templates-validator": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.5.0.tgz",
-					"integrity": "sha512-v/gfuYs7AOsQUzGmWBEupFGZiylCzqapBoZrjavewnPPbDOzLvbHZ1bnYPre/7b/wdnf4ayx0bf/NCC/AEySVg==",
-					"requires": {
-						"@camunda/element-templates-json-schema": "^0.7.0",
-						"@camunda/zeebe-element-templates-json-schema": "^0.1.0",
-						"json-source-map": "^0.6.1",
-						"min-dash": "^3.8.1"
-					}
-				},
-				"@bpmn-io/extract-process-variables": {
-					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.4.4.tgz",
-					"integrity": "sha512-iStnEVSEtOlZoE3ADMImdwhOhxUjXFdwWsCmmJQlyWH5ISmdRvai0Cxuw0spQEYySgIwFsUB0h+ScOCdW6yEBQ==",
-					"requires": {
-						"min-dash": "^3.5.2"
-					}
-				},
-				"@bpmn-io/properties-panel": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.11.0.tgz",
-					"integrity": "sha512-/1lZiwhCdAsapXKMjzVFc6jdyzU5Ue8wq/mMSFLVvAatxlHHrxTwYAqEW9zA0ZBqIm8JQbl6wptGMG/6ICZPGA==",
-					"requires": {
-						"classnames": "^2.3.1",
-						"min-dash": "^3.7.0",
-						"min-dom": "^3.1.3"
-					}
-				},
-				"@camunda/element-templates-json-schema": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.7.0.tgz",
-					"integrity": "sha512-ylBhHzAuzQjX+ZoZTPinHCsIaMa89fqyk10sxVQjgEm63+o40KMomjKf4EM2sXwiy72vDbjeXyb3Z56a7MTETQ=="
-				},
-				"bpmn-js": {
-					"version": "9.0.2",
-					"resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-9.0.2.tgz",
-					"integrity": "sha512-dl6sErP3tTBSJAvCGcu/v7xw+QCp8UCXSVlAoCA1lSrBkfdVOcHuxyy2svGPv4nJKOUMqFAK3xcemZYyztCwoA==",
-					"requires": {
-						"bpmn-moddle": "^7.1.2",
-						"css.escape": "^1.5.1",
-						"diagram-js": "^8.1.2",
-						"diagram-js-direct-editing": "^1.6.3",
-						"ids": "^1.0.0",
-						"inherits": "^2.0.4",
-						"min-dash": "^3.5.2",
-						"min-dom": "^3.1.3",
-						"object-refs": "^0.3.0",
-						"tiny-svg": "^2.2.2"
-					}
-				},
-				"bpmn-js-properties-panel": {
-					"version": "1.0.0-alpha.5",
-					"resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.0.0-alpha.5.tgz",
-					"integrity": "sha512-AXunjjthnApd25M0A0OIVxwIWoJc/BvNVCObf0Ushh86PqESzjAbDkTdtbUGxnj4ukiFJB390K5b5NezUEL5IQ==",
-					"requires": {
-						"@bpmn-io/element-templates-validator": "^0.5.0",
-						"@bpmn-io/extract-process-variables": "^0.4.4",
-						"array-move": "^3.0.1",
-						"classnames": "^2.3.1",
-						"ids": "^1.0.0",
-						"min-dash": "^3.8.1",
-						"min-dom": "^3.1.3",
-						"preact-markup": "^2.1.1",
-						"semver": "^7.3.5"
-					}
-				},
-				"classnames": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-					"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
-				},
 				"diagram-js": {
-					"version": "8.1.2",
-					"resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.1.2.tgz",
-					"integrity": "sha512-l0UWjWA9zcO3bwGg2C3sybNEWiICdXdkFy4JRjWdPyOcO00v3T0whuNhLwz9kaS5ht67awnPyKr+RWgsx3H0Rw==",
+					"version": "8.2.0",
+					"resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.2.0.tgz",
+					"integrity": "sha512-nbT6GSEbbKEVP8C4K8Olctsb5kgoDA/K+xuDZ3pnkkkmJwNW0hEyrVQGtwyYVldyUCoGFR7DI8NBJxNhleRgtg==",
 					"requires": {
 						"css.escape": "^1.5.1",
 						"didi": "^5.2.1",
@@ -2996,41 +2923,15 @@
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 				},
-				"lru-cache": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
 				"path-intersection": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
 					"integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA=="
 				},
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
 				"tiny-svg": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.2.tgz",
-					"integrity": "sha512-u6zCuMkDR/3VAh83X7hDRn/pi0XhwG2ycuNS0cTFtQjGdOG2tSvEb8ds65VeGWc3H6PUjJKeunueXqgkZqtMsg=="
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				},
-				"zeebe-bpmn-moddle": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.11.0.tgz",
-					"integrity": "sha512-ehNQa2Kt9B1bwWJCF8Fs4SkroaSe+VH5Y4ql4T1hHuOSMJiwuMekFIs3UAJyS0ZyBhcJbUW1C1NPwXcD8u5IRA=="
+					"version": "2.2.3",
+					"resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.3.tgz",
+					"integrity": "sha512-u5KGg889pD1W2c9GlLrTnAGzIkAO00/VXZGyzeiGHw+b9er8McLO0SnhxPQQDwDqFO0MrJ825AEsRUoTiDZFuQ=="
 				}
 			}
 		},
@@ -4382,9 +4283,9 @@
 			},
 			"dependencies": {
 				"tiny-svg": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.2.tgz",
-					"integrity": "sha512-u6zCuMkDR/3VAh83X7hDRn/pi0XhwG2ycuNS0cTFtQjGdOG2tSvEb8ds65VeGWc3H6PUjJKeunueXqgkZqtMsg=="
+					"version": "2.2.3",
+					"resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.3.tgz",
+					"integrity": "sha512-u5KGg889pD1W2c9GlLrTnAGzIkAO00/VXZGyzeiGHw+b9er8McLO0SnhxPQQDwDqFO0MrJ825AEsRUoTiDZFuQ=="
 				}
 			}
 		},
@@ -12270,9 +12171,9 @@
 			}
 		},
 		"zeebe-bpmn-moddle": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.10.0.tgz",
-			"integrity": "sha512-1wnUWYPVLFxAEM78hiN7kO2NmKK0OHGnT0DcI/MP6KO6HcmdHBgTjsSY4qRNM3G1MeKA/zVJ1OZ0Onz9krbeZg=="
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.11.0.tgz",
+			"integrity": "sha512-ehNQa2Kt9B1bwWJCF8Fs4SkroaSe+VH5Y4ql4T1hHuOSMJiwuMekFIs3UAJyS0ZyBhcJbUW1C1NPwXcD8u5IRA=="
 		}
 	}
 }

--- a/client/package.json
+++ b/client/package.json
@@ -11,15 +11,15 @@
     "@bpmn-io/dmn-migrate": "^0.4.3",
     "@bpmn-io/extract-process-variables": "^0.4.3",
     "@bpmn-io/form-js": "^0.7.0",
-    "@bpmn-io/properties-panel": "^0.10.2",
+    "@bpmn-io/properties-panel": "^0.11.0",
     "@bpmn-io/replace-ids": "^0.2.0",
     "@ibm/plex": "^6.0.0",
     "@sentry/browser": "^6.3.6",
-    "bpmn-js": "^9.0.0-alpha.2",
-    "bpmn-js-properties-panel": "^1.0.0-alpha.3",
+    "bpmn-js": "^9.0.3",
+    "bpmn-js-properties-panel": "^1.0.0-alpha.5",
     "bpmn-moddle": "^7.1.2",
     "bpmnlint": "^7.2.1",
-    "camunda-bpmn-js": "^0.13.0-alpha.3",
+    "camunda-bpmn-js": "^0.13.0-alpha.4",
     "camunda-bpmn-moddle": "^6.1.1",
     "camunda-cmmn-moddle": "^1.0.0",
     "camunda-dmn-moddle": "^1.1.0",
@@ -49,7 +49,7 @@
     "semver-compare": "^1.0.0",
     "sourcemapped-stacktrace": "^1.1.9",
     "ua-parser-js": "^0.7.28",
-    "zeebe-bpmn-moddle": "^0.10.0"
+    "zeebe-bpmn-moddle": "^0.11.0"
   },
   "homepage": ".",
   "devDependencies": {

--- a/client/src/plugins/usage-statistics/event-handlers/DeploymentEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/DeploymentEventHandler.js
@@ -81,7 +81,7 @@ export default class DeploymentEventHandler extends BaseEventHandler {
 
     const {
       executionPlatform
-    } = await parseEngineProfile(contents);
+    } = await parseEngineProfile(contents, type);
 
     return {
       executionPlatform: executionPlatform || getDefaultExecutionPlatform(type)

--- a/client/src/plugins/usage-statistics/event-handlers/DiagramOpenEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/DiagramOpenEventHandler.js
@@ -105,7 +105,7 @@ export default class DiagramOpenEventHandler extends BaseEventHandler {
 
     const {
       executionPlatform
-    } = await parseEngineProfile(contents);
+    } = await parseEngineProfile(contents, type);
 
     return {
       executionPlatform: executionPlatform || getDefaultExecutionPlatform(type)

--- a/client/src/util/metrics/processVariables.js
+++ b/client/src/util/metrics/processVariables.js
@@ -25,7 +25,7 @@ export async function getProcessVariablesCount(file, type) {
 
   const processVariables = [];
 
-  const definitions = await getBpmnDefinitions(contents);
+  const definitions = await getBpmnDefinitions(contents, type);
 
   const rootElements = definitions.get('rootElements');
 

--- a/client/src/util/metrics/serviceTasks.js
+++ b/client/src/util/metrics/serviceTasks.js
@@ -21,7 +21,7 @@ import {
 } from '../extensionElementsHelpers';
 
 export async function getServiceTaskMetrics(file, type) {
-  const serviceTasks = await getServiceTasks(file);
+  const serviceTasks = await getServiceTasks(file, type);
 
   const parseServiceTasks = parseFormHandlers[type];
 
@@ -39,8 +39,8 @@ export async function getServiceTaskMetrics(file, type) {
   return metrics;
 }
 
-async function getServiceTasks(file) {
-  const serviceTasks = await getAllElementsByType(file.contents, 'bpmn:ServiceTask');
+async function getServiceTasks(file, type) {
+  const serviceTasks = await getAllElementsByType(file.contents, 'bpmn:ServiceTask', type);
 
   return serviceTasks;
 }

--- a/client/src/util/metrics/subprocessPlanes.js
+++ b/client/src/util/metrics/subprocessPlanes.js
@@ -22,7 +22,7 @@ export async function getSubprocessPlaneMetrics(file, type) {
     nesting: 0
   };
 
-  const definitions = await getBpmnDefinitions(contents);
+  const definitions = await getBpmnDefinitions(contents, type);
 
   const diagrams = definitions.diagrams;
 

--- a/client/src/util/metrics/userTasks.js
+++ b/client/src/util/metrics/userTasks.js
@@ -22,7 +22,7 @@ import {
 } from '../formHelpers';
 
 export async function getUserTaskMetrics(file, type) {
-  const userTasks = await getUserTasks(file);
+  const userTasks = await getUserTasks(file, type);
 
   const parseUserTaskForms = parseFormHandlers[type];
 
@@ -40,8 +40,8 @@ export async function getUserTaskMetrics(file, type) {
   return metrics;
 }
 
-async function getUserTasks(file) {
-  const userTasks = await getAllElementsByType(file.contents, 'bpmn:UserTask');
+async function getUserTasks(file, type) {
+  const userTasks = await getAllElementsByType(file.contents, 'bpmn:UserTask', type);
 
   return userTasks;
 }


### PR DESCRIPTION
With the latest `zeebe-bpmn-moddle` extension version, both Camunda and Zeebe define the `modelerTemplate` attrribute. Therefore, we can no longer use both when parsing XML and have to pass the diagram type to the parser.

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
