### PR TITLE
Fix color icon path in edit menu

### DIFF
--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const electron = require('electron');
+const path = require('path');
 
 const {
   app,
@@ -752,7 +753,7 @@ function wrapActionInactiveInDevtools(fn) {
   return wrapped;
 }
 
-function getIconImage(path) {
-  path = 'app/' + path;
-  return electron.nativeImage.createFromPath(path).resize({ width:12, height:12 });
+function getIconImage(iconPath) {
+  iconPath = path.join(__dirname, '/../../', iconPath);
+  return electron.nativeImage.createFromPath(iconPath).resize({ width:12, height:12 });
 }


### PR DESCRIPTION
Closes #2733

Works in built artifacts:
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2733-colors-file-menu/camunda-modeler-2733-colors-file-menu-linux-x64.tar.gz
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2733-colors-file-menu/camunda-modeler-2733-colors-file-menu-mac.dmg
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2733-colors-file-menu/camunda-modeler-2733-colors-file-menu-mac.zip
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2733-colors-file-menu/camunda-modeler-2733-colors-file-menu-win-ia32.zip
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2733-colors-file-menu/camunda-modeler-2733-colors-file-menu-win-x64.zip