### PR TITLE
Add Cloud DMN tab

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1670,6 +1670,10 @@ export class App extends PureComponent {
       return this.createDiagram('cloud-bpmn');
     }
 
+    if (action === 'create-cloud-dmn-diagram') {
+      return this.createDiagram('cloud-dmn');
+    }
+
     if (action === 'open-diagram') {
       return this.showOpenFilesDialog();
     }

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -290,6 +290,7 @@ describe('<App>', function() {
       await app.createDiagram('dmn');
       await app.createDiagram('cmmn');
       await app.createDiagram('cloud-bpmn');
+      await app.createDiagram('cloud-dmn');
       await app.createDiagram();
 
       // then
@@ -302,6 +303,7 @@ describe('<App>', function() {
         'dmn',
         'cmmn',
         'cloud-bpmn',
+        'cloud-dmn',
         'bpmn'
       ]);
 

--- a/client/src/app/__tests__/TabsProviderSpec.cloud.dmn
+++ b/client/src/app/__tests__/TabsProviderSpec.cloud.dmn
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/1.0" id="Definitions_07dtqfv" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+  <decision id="Decision_13nychf" name="Decision 1">
+    <extensionElements>
+      <biodi:bounds x="200" y="200" width="180" height="80" />
+    </extensionElements>
+    <decisionTable id="decisionTable_1">
+      <input id="input_1">
+        <inputExpression id="inputExpression_1" typeRef="string">
+          <text></text>
+        </inputExpression>
+      </input>
+      <output id="output_1" typeRef="string" />
+    </decisionTable>
+  </decision>
+</definitions>

--- a/client/src/app/__tests__/mocks/index.js
+++ b/client/src/app/__tests__/mocks/index.js
@@ -188,6 +188,19 @@ export class TabsProvider {
           return null;
         }
       },
+      'cloud-dmn': {
+        name: 'DMN',
+        encoding: ENCODING_UTF8,
+        exports: {
+          png: EXPORT_PNG,
+          jpeg: EXPORT_JPEG,
+          svg: EXPORT_SVG
+        },
+        extensions: [ 'dmn', 'xml' ],
+        getLinter() {
+          return null;
+        }
+      },
       dmn: {
         name: 'DMN',
         encoding: ENCODING_UTF8,

--- a/client/src/app/tabs/cloud-dmn/DmnEditor.js
+++ b/client/src/app/tabs/cloud-dmn/DmnEditor.js
@@ -1,0 +1,1023 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+
+import {
+  assign,
+  isFunction
+} from 'min-dash';
+
+import classNames from 'classnames';
+
+import {
+  Loader
+} from '../../primitives';
+
+import {
+  debounce
+} from '../../../util';
+
+import configureModeler from '../dmn/util/configure';
+
+import {
+  WithCache,
+  WithCachedState,
+  CachedComponent
+} from '../../cached';
+
+import OverviewContainer from '../dmn/OverviewContainer';
+
+import PropertiesContainer from '../PropertiesContainer';
+
+import CamundaDmnModeler from './modeler';
+
+import { active as isInputActive } from '../../../util/dom/isInput';
+
+import {
+  getDmnDrdEditMenu,
+  getDmnDecisionTableEditMenu,
+  getDmnLiteralExpressionEditMenu
+} from '../dmn/getDmnEditMenu';
+
+import getDmnWindowMenu from '../dmn/getDmnWindowMenu';
+
+import css from '../dmn/DmnEditor.less';
+
+import generateImage from '../../util/generateImage';
+
+import Metadata from '../../../util/Metadata';
+
+import { findUsages as findNamespaceUsages } from '../util/namespace';
+
+import { migrateDiagram } from '@bpmn-io/dmn-migrate';
+
+import { DEFAULT_LAYOUT as propertiesPanelDefaultLayout } from '../PropertiesContainer';
+
+import { DEFAULT_LAYOUT as overviewDefaultLayout } from '../dmn/OverviewContainer';
+
+import { EngineProfile } from '../EngineProfile';
+
+import { ENGINES } from '../../../util/Engines';
+
+const EXPORT_AS = [ 'png', 'jpeg', 'svg' ];
+
+const NAMESPACE_URL_DMN11 = 'http://www.omg.org/spec/DMN/20151101/dmn.xsd',
+      NAMESPACE_URL_DMN12 = 'http://www.omg.org/spec/DMN/20180521/MODEL/';
+
+const CONFIG_KEY = 'editor.askDmnMigration';
+
+export const DEFAULT_ENGINE_PROFILE = {
+  executionPlatform: ENGINES.CLOUD
+};
+
+
+export class DmnEditor extends CachedComponent {
+
+  constructor(props) {
+    super(props);
+
+    this.state = { };
+
+    this.ref = React.createRef();
+    this.overviewRef = React.createRef();
+    this.propertiesPanelRef = React.createRef();
+
+    this.handleResize = debounce(this.handleResize);
+  }
+
+  componentDidMount() {
+    this._isMounted = true;
+
+    const modeler = this.getModeler();
+
+    this.listen('on');
+
+    modeler.attachTo(this.ref.current);
+
+    const activeViewer = modeler.getActiveViewer();
+
+    let propertiesPanel;
+
+    if (activeViewer) {
+      propertiesPanel = activeViewer.get('propertiesPanel', false);
+
+      if (propertiesPanel) {
+        propertiesPanel.attachTo(this.propertiesPanelRef.current);
+      }
+
+      // attach overview
+      if (this.overviewRef.current) {
+        modeler.attachOverviewTo(this.overviewRef.current);
+
+        if (isOverviewOpen(this.props)) {
+          modeler._emit('overviewOpen');
+        }
+      }
+    }
+
+    this.checkImport();
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+
+    const modeler = this.getModeler();
+
+    this.listen('off');
+
+    modeler.detach();
+  }
+
+  componentDidUpdate(prevProps) {
+    this.checkImport(prevProps);
+
+    // We can only notify interested parties about overview open once its parent component was
+    // rendered
+    if (isOverviewOpened(this.props, prevProps)) {
+      const modeler = this.getModeler();
+
+      modeler._emit('overviewOpen');
+    }
+
+    if (isCachedStateChange(prevProps, this.props)) {
+      this.handleChanged();
+    }
+  }
+
+  ifMounted = (fn) => {
+    return (...args) => {
+      if (this._isMounted) {
+        fn(...args);
+      }
+    };
+  }
+
+  listen(fn) {
+    const modeler = this.getModeler();
+
+    [
+      'saveXML.done',
+      'attach',
+      'view.selectionChanged',
+      'view.directEditingChanged',
+      'propertiesPanel.focusin',
+      'propertiesPanel.focusout'
+    ].forEach((event) => {
+      modeler[fn](event, this.handleChanged);
+    });
+
+    modeler[fn]('views.changed', this.viewsChanged);
+
+    modeler[fn]('view.contentChanged', this.viewContentChanged);
+
+    modeler[fn]('error', this.handleError);
+  }
+
+  isDirty = () => {
+    let {
+      dirty,
+      modeler,
+      stackIdx
+    } = this.getCached();
+
+    return dirty || modeler.getStackIdx() !== stackIdx;
+  }
+
+  viewContentChanged = () => {
+    this.handleChanged();
+  }
+
+  handleImport(error, warnings) {
+    const {
+      activeSheet,
+      onImport,
+      xml
+    } = this.props;
+
+    const modeler = this.getModeler();
+
+    const stackIdx = modeler.getStackIdx();
+
+    onImport(error, warnings);
+
+    if (error) {
+      this.setCached({
+        dirty: false,
+        lastXML: null
+      });
+    } else {
+      this.setCached({
+        dirty: false,
+        lastXML: xml,
+        stackIdx
+      });
+
+      this.setState({
+        importing: false
+      });
+
+      if (activeSheet && activeSheet.element) {
+        return this.open(activeSheet.element);
+      }
+
+      const initialView = modeler._getInitialView(modeler._views);
+
+      this.open(initialView.element);
+    }
+
+  }
+
+  viewsChanged = ({ activeView }) => {
+    const {
+      activeSheet: previousActiveSheet,
+      onSheetsChanged
+    } = this.props;
+
+    const {
+      dirty,
+      stackIdx
+    } = this.getCached();
+
+    const previousActiveView = this.getCached().activeView;
+
+    const modeler = this.getModeler();
+
+    const { element } = activeView;
+
+    const activeSheet = {
+      ...activeView,
+      id: element.id,
+      name: 'Diagram',
+      order: -1
+    };
+
+    if (previousActiveSheet.id !== activeSheet.id) {
+      onSheetsChanged([ activeSheet ], activeSheet);
+    }
+
+    const activeViewer = modeler.getActiveViewer();
+
+    let propertiesPanel;
+
+    // only attach properties panel if view is switched
+    if (activeViewer &&
+      (!previousActiveView || previousActiveView.element !== activeView.element)) {
+      propertiesPanel = activeViewer.get('propertiesPanel', false);
+
+      if (propertiesPanel) {
+        propertiesPanel.attachTo(this.propertiesPanelRef.current);
+      }
+    }
+
+    // attach or detach overview
+    if (activeView.type === 'drd') {
+      modeler.detachOverview();
+    } else if (previousActiveView && previousActiveView.type === 'drd') {
+      modeler.attachOverviewTo(this.overviewRef.current);
+
+      if (isOverviewOpen(this.props)) {
+        modeler._emit('overviewOpen');
+      }
+    }
+
+    // must be called last
+    this.setCached({
+      activeView,
+      dirty: dirty || modeler.getStackIdx() !== stackIdx
+    });
+
+    this.handleChanged();
+  }
+
+  undo = () => {
+    const modeler = this.getModeler();
+
+    modeler.getActiveViewer().get('commandStack').undo();
+  }
+
+  redo = () => {
+    const modeler = this.getModeler();
+
+    modeler.getActiveViewer().get('commandStack').redo();
+  }
+
+  handleChanged = () => {
+    const modeler = this.getModeler();
+
+    const {
+      onChanged
+    } = this.props;
+
+    const activeViewer = modeler.getActiveViewer(),
+          activeView = modeler.getActiveView();
+
+    if (!activeViewer) {
+      return;
+    }
+
+    const dirty = this.isDirty();
+
+    const commandStack = activeViewer.get('commandStack');
+
+    const hasPropertiesPanel = !!activeViewer.get('propertiesPanel', false);
+
+    const hasOverview = activeView.type !== 'drd';
+
+    const inputActive = isInputActive();
+
+    const newState = {
+      close: true,
+      copy: false,
+      cut: false,
+      dirty,
+      exportAs: 'saveSVG' in activeViewer ? EXPORT_AS : false,
+      inputActive,
+      overview: hasOverview,
+      paste: false,
+      propertiesPanel: hasPropertiesPanel,
+      redo: commandStack.canRedo(),
+      save: true,
+      undo: commandStack.canUndo()
+    };
+
+    const selection = activeViewer.get('selection', false);
+
+    const hasSelection = selection && !!selection.get();
+
+    const selectionLength = hasSelection ? selection.get().length : 0;
+
+    let editMenu;
+
+    if (activeView.type === 'drd') {
+      assign(newState, {
+        align: selectionLength > 1,
+        defaultCopyCutPaste: inputActive,
+        defaultUndoRedo: inputActive,
+        distribute: selectionLength > 2,
+        editLabel: !inputActive && !!selectionLength,
+        lassoTool: !inputActive,
+        moveCanvas: !inputActive,
+        moveSelection: !inputActive && !!selectionLength,
+        removeSelected: inputActive || !!selectionLength,
+        selectAll: true,
+        zoom: true
+      });
+
+      editMenu = getDmnDrdEditMenu(newState);
+    } else if (activeView.type === 'decisionTable') {
+      assign(newState, {
+        defaultCopyCutPaste: true,
+        defaultUndoRedo: false,
+        hasSelection: activeViewer.get('selection').hasSelection(),
+        removeSelected: inputActive,
+        selectAll: inputActive
+      });
+
+      // ensure backwards compatibility
+      // https://github.com/camunda/camunda-modeler/commit/78357e3ed9e6e0255ac8225fbdf451a90457e8bf#diff-bd5be70c4e5eadf1a316c16085a72f0fL17
+      newState.dmnRuleEditing = !!selectionLength;
+      newState.dmnClauseEditing = !!selectionLength;
+
+      editMenu = getDmnDecisionTableEditMenu(newState);
+    } else if (activeView.type === 'literalExpression') {
+      assign(newState, {
+        defaultCopyCutPaste: true,
+        defaultUndoRedo: true,
+        removeSelected: true,
+        selectAll: true
+      });
+
+      // The literalExpressions editor does not fire events when
+      // elements are selected, so we always set inputActive to true.
+      // cf. https://github.com/camunda/camunda-modeler/pull/2394
+      newState.inputActive = true;
+
+      editMenu = getDmnLiteralExpressionEditMenu(newState);
+    }
+
+    // ensure backwards compatibility
+    // https://github.com/camunda/camunda-modeler/commit/78357e3ed9e6e0255ac8225fbdf451a90457e8bf#diff-bd5be70c4e5eadf1a316c16085a72f0fL17
+    newState.activeEditor = activeView.type;
+    newState.dmn = true;
+    newState.editable = true;
+    newState.elementsSelected = !!selectionLength;
+    newState.inactiveInput = !inputActive;
+
+    const windowMenu = getDmnWindowMenu(newState);
+
+    if (typeof onChanged === 'function') {
+      onChanged({
+        ...newState,
+        editMenu,
+        windowMenu
+      });
+    }
+
+    this.setState(newState);
+  }
+
+  handleError = (event) => {
+    const {
+      error
+    } = event;
+
+    const {
+      onError
+    } = this.props;
+
+    onError(error);
+  }
+
+  handleDistributeElements = (type) => {
+    this.triggerAction('distributeElements', {
+      type
+    });
+  }
+
+  handleAlignElements = (type) => {
+    this.triggerAction('alignElements', {
+      type
+    });
+  }
+
+  checkImport(prevProps) {
+    if (!this.isImportNeeded(prevProps)) {
+      return this.checkSheetChange(prevProps);
+    }
+
+    const { xml } = this.props;
+
+    this.importXML(xml);
+  }
+
+  isImportNeeded(prevProps) {
+    const {
+      importing
+    } = this.state;
+
+    if (importing) {
+      return false;
+    }
+
+    const {
+      xml
+    } = this.props;
+
+    if (prevProps && prevProps.xml === xml) {
+      return false;
+    }
+
+    const {
+      lastXML
+    } = this.getCached();
+
+    return xml !== lastXML;
+  }
+
+  async importXML(xml) {
+    const {
+      modeler
+    } = this.getCached();
+
+    this.setState({
+      importing: true
+    });
+
+    const importedXML = await this.handleMigration(xml);
+
+    if (!importedXML) {
+      this.props.onAction('close-tab');
+
+      return;
+    }
+
+    return modeler.importXML(importedXML).then(
+      this.ifMounted(({ warnings }) => this.handleImport(null, warnings)),
+      this.ifMounted((error) => this.handleImport(error, error.warnings))
+    );
+  }
+
+  handleMigration = async (xml) => {
+    const used = findNamespaceUsages(xml, NAMESPACE_URL_DMN11) ||
+      findNamespaceUsages(xml, NAMESPACE_URL_DMN12);
+
+    if (!used) {
+      return xml;
+    }
+
+    const askDmnMigration = await this.props.getConfig(CONFIG_KEY);
+
+    if (askDmnMigration !== false) {
+      const shouldMigrate = await this.shouldMigrate();
+
+      if (!shouldMigrate) {
+        return null;
+      }
+    }
+
+    const {
+      onContentUpdated
+    } = this.props;
+
+    let migratedXML;
+
+    try {
+      migratedXML = await migrateDiagram(xml);
+    } catch (err) {
+      this.handleError({
+        error: err
+      });
+
+      return null;
+    }
+
+    onContentUpdated(migratedXML);
+
+    return migratedXML;
+  }
+
+  async shouldMigrate() {
+    const { onAction } = this.props;
+
+    const { button, checkboxChecked } = await onAction('show-dialog', getMigrationDialog());
+
+    if (button === 'yes' && checkboxChecked) {
+      this.props.setConfig(CONFIG_KEY, false);
+    }
+
+    return button === 'yes';
+  }
+
+  checkSheetChange(prevProps) {
+    if (!this.shouldOpenActiveSheet(prevProps)) {
+      return;
+    }
+
+    this.open(this.props.activeSheet.element);
+  }
+
+  shouldOpenActiveSheet(prevProps) {
+    return !prevProps || prevProps.activeSheet.id !== this.props.activeSheet.id;
+  }
+
+  open = (element) => {
+    const {
+      activeView,
+      dirty,
+      modeler,
+      stackIdx
+    } = this.getCached();
+
+    let view = modeler.getView(element);
+
+    if (!view) {
+
+      // try to find view based on ID
+      // after re-import reference comparison won't work anymore
+      view = modeler.getViews().find(view => view.element.id === element.id);
+    }
+
+    if (!view) {
+      return;
+    }
+
+    if (!activeView || activeView.element !== element) {
+
+      // dirty must be cached before switching active view
+      // if active view has unsaved changes editor must still be dirty after switching active view
+      this.setCached({
+        dirty: dirty || this.getModeler().getStackIdx() !== stackIdx
+      });
+
+      modeler.open(view);
+
+      this.setCached({
+        stackIdx: this.getModeler().getStackIdx()
+      });
+    }
+  }
+
+  triggerAction = (action, context) => {
+    const {
+      layout = {},
+      onLayoutChanged: handleLayoutChange
+    } = this.props;
+
+    const {
+      propertiesPanel: propertiesPanelLayout = {}
+    } = layout;
+
+    const modeler = this.getModeler();
+
+    if (action === 'resize') {
+      return this.handleResize();
+    }
+
+    if (action === 'toggleProperties') {
+      const newLayout = {
+        propertiesPanel: {
+          ...propertiesPanelDefaultLayout,
+          ...propertiesPanelLayout,
+          open: !propertiesPanelLayout.open
+        }
+      };
+
+      return handleLayoutChange(newLayout);
+    }
+
+    if (action === 'resetProperties') {
+      const newLayout = {
+        propertiesPanel: {
+          ...propertiesPanelDefaultLayout,
+          open: true
+        }
+      };
+
+      return handleLayoutChange(newLayout);
+    }
+
+    if (action === 'zoomIn') {
+      action = 'stepZoom';
+
+      context = {
+        value: 1
+      };
+    }
+
+    if (action === 'zoomOut') {
+      action = 'stepZoom';
+
+      context = {
+        value: -1
+      };
+    }
+
+    if (action === 'resetZoom') {
+      action = 'zoom';
+
+      context = {
+        value: 1
+      };
+    }
+
+    if (action === 'zoomFit') {
+      action = 'zoom';
+
+      context = {
+        value: 'fit-viewport'
+      };
+    }
+
+    if (action === 'toggleOverview') {
+      return this.toggleOverview();
+    } else if (action === 'resetOverview') {
+      return this.resetOverview();
+    }
+
+    return modeler.getActiveViewer()
+      .get('editorActions')
+      .trigger(action, context);
+  }
+
+  /**
+   * @returns {CamundaDmnModeler}
+   */
+  getModeler() {
+    const {
+      modeler
+    } = this.getCached();
+
+    return modeler;
+  }
+
+  handleResize = () => {
+    const {
+      modeler
+    } = this.getCached();
+
+    const view = modeler.getActiveView();
+
+    const viewType = view && view.type;
+
+    if (viewType !== 'drd') {
+      return;
+    }
+
+    const viewer = modeler.getActiveViewer();
+
+    const canvas = viewer.get('canvas');
+    const eventBus = viewer.get('eventBus');
+
+    canvas.resized();
+    eventBus.fire('propertiesPanel.resized');
+  }
+
+  async getXML() {
+    const {
+      lastXML,
+      modeler
+    } = this.getCached();
+
+    if (!this.isDirty()) {
+      return lastXML || this.props.xml;
+    }
+
+    try {
+      const { xml } = await modeler.saveXML({ format: true });
+
+      const stackIdx = modeler.getStackIdx();
+
+      this.setCached({
+        dirty: false,
+        lastXML: xml,
+        stackIdx
+      });
+
+      return xml;
+    } catch (error) {
+      this.handleError({ error });
+
+      return Promise.reject(error);
+    }
+  }
+
+  async exportAs(type) {
+    let svg;
+
+    try {
+      svg = await this.exportSVG();
+    } catch (error) {
+      this.handleError({ error });
+
+      return Promise.reject(error);
+    }
+
+    if (type === 'svg') {
+      return svg;
+    }
+
+    return generateImage(type, svg);
+  }
+
+  async exportSVG() {
+    const modeler = this.getModeler();
+
+    const viewer = modeler.getActiveViewer();
+
+    if (!viewer.saveSVG) {
+      return Promise.reject(new Error('SVG export not supported in current view'));
+    }
+
+    try {
+      const { svg } = await viewer.saveSVG();
+
+      return svg;
+    } catch (err) {
+
+      return Promise.reject(err);
+    }
+  }
+
+  handleEditDrdClick = () => {
+    const modeler = this.getModeler();
+
+    const drdView = modeler._views.find(({ type }) => type === 'drd');
+
+    if (drdView) {
+      modeler.open(drdView);
+    }
+  }
+
+  toggleOverview = () => {
+    const {
+      layout,
+      onLayoutChanged
+    } = this.props;
+
+    const dmnOverview = layout.dmnOverview || overviewDefaultLayout;
+
+    onLayoutChanged({
+      dmnOverview: {
+        ...dmnOverview,
+        open: !dmnOverview.open
+      }
+    });
+  }
+
+  resetOverview() {
+    const {
+      onLayoutChanged
+    } = this.props;
+
+    onLayoutChanged({
+      dmnOverview: {
+        ...overviewDefaultLayout
+      }
+    });
+  }
+
+  render() {
+
+    const {
+      layout,
+      onLayoutChanged
+    } = this.props;
+
+    const imported = this.getModeler().getDefinitions();
+
+    const {
+      importing
+    } = this.state;
+
+    const modeler = this.getModeler();
+
+    const activeView = modeler.getActiveView();
+
+    const isDrd = activeView && activeView.type === 'drd';
+
+    const activeViewer = modeler.getActiveViewer();
+
+    const overviewOpen = isOverviewOpen(this.props);
+
+    const hasPropertiesPanel = !importing && activeViewer && !!activeViewer.get('propertiesPanel', false);
+
+    return (
+      <div className={ css.DmnEditor }>
+
+        <Loader hidden={ imported && !importing } />
+
+        {
+          !isDrd && (
+            <div className="top">
+              <button id="button-edit-drd" className="button" onClick={ this.handleEditDrdClick }>Edit DRD</button>
+              <button id="button-toggle-overview" className="button" onClick={ this.toggleOverview }>{ overviewOpen ? 'Close' : 'Open' } Overview</button>
+            </div>
+          )
+        }
+
+        <div className="bottom">
+
+          {
+            !isDrd && (
+              <OverviewContainer
+                className="overview"
+                layout={ layout }
+                ref={ this.overviewRef }
+                onLayoutChanged={ onLayoutChanged } />
+            )
+          }
+
+          <div className={
+            classNames(
+              'diagram',
+              { 'drd': isDrd }
+            )
+          } ref={ this.ref }></div>
+
+          {
+            hasPropertiesPanel && (
+              <PropertiesContainer
+                className="properties"
+                layout={ layout }
+                ref={ this.propertiesPanelRef }
+                onLayoutChanged={ onLayoutChanged } />
+            )
+          }
+
+        </div>
+
+        <EngineProfile
+          engineProfile={ DEFAULT_ENGINE_PROFILE } />
+
+      </div>
+    );
+  }
+
+  static createCachedState(props) {
+    const {
+      name,
+      version
+    } = Metadata;
+
+    const {
+      getPlugins,
+      onAction,
+      onError
+    } = props;
+
+    // notify interested parties that modeler will be configured
+    const handleMiddlewareExtensions = (middlewares) => {
+      onAction('emit-event', {
+        type: 'dmn.modeler.configure',
+        payload: {
+          middlewares
+        }
+      });
+    };
+
+    const {
+      options,
+      warnings
+    } = configureModeler(getPlugins, {
+      exporter: {
+        name,
+        version
+      }
+    }, handleMiddlewareExtensions);
+
+    if (warnings.length && isFunction(onError)) {
+      onError(
+        'Problem(s) configuring DMN editor: \n\t' +
+        warnings.map(error => error.message).join('\n\t') +
+        '\n'
+      );
+    }
+
+    const modeler = new CamundaDmnModeler({
+      ...options,
+      position: 'absolute'
+    });
+
+    const stackIdx = modeler.getStackIdx();
+
+    // notify interested parties that modeler was created
+    onAction('emit-event', {
+      type: 'dmn.modeler.created',
+      payload: {
+        modeler
+      }
+    });
+
+    return {
+      __destroy: () => {
+        modeler.destroy();
+      },
+      dirty: false,
+      lastXML: null,
+      modeler,
+      stackIdx
+    };
+  }
+
+}
+
+export default WithCache(WithCachedState(DmnEditor));
+
+// helpers //////////
+
+function isCachedStateChange(prevProps, props) {
+  return prevProps.cachedState !== props.cachedState;
+}
+
+function getMigrationDialog() {
+  return {
+    type: 'warning',
+    title: 'Deprecated DMN 1.1 Diagram Detected',
+    buttons: [
+      { id: 'cancel', label: 'Cancel' },
+      { id: 'yes', label: 'Yes' }
+    ],
+    defaultId: 1,
+    message: 'Would you like to migrate your diagram to DMN 1.3?',
+    detail: [
+      'Only DMN 1.3 diagrams can be opened with Camunda Modeler v4.0.0 or later.',
+    ].join('\n'),
+    checkboxChecked: true,
+    checkboxLabel: 'Do not ask again.'
+  };
+}
+
+/**
+ * Check layout whether overview is open.
+ *
+ * @param {Object} props
+ *
+ * @returns {boolean}
+ */
+function isOverviewOpen(props) {
+  const layout = props.layout || {};
+
+  const dmnOverview = layout.dmnOverview;
+
+  return !dmnOverview || dmnOverview.open;
+}
+
+/**
+ * Check layout whether overview was opened.
+ *
+ * @param {Object} props
+ * @param {Object} prevProps
+ *
+ * @returns {boolean}
+ */
+function isOverviewOpened(props, prevProps) {
+  return isOverviewOpen(prevProps) === false && isOverviewOpen(props) === true;
+}

--- a/client/src/app/tabs/cloud-dmn/DmnTab.js
+++ b/client/src/app/tabs/cloud-dmn/DmnTab.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import DmnEditor from './DmnEditor';
+import XMLEditor from '../xml';
+
+import { createTab } from '../EditorTab';
+
+
+const DmnTab = createTab('DmnTab', [
+  {
+    type: 'cloud-dmn',
+    editor: DmnEditor,
+    defaultName: 'Diagram (Camunda Platform 8)'
+  },
+  {
+    type: 'xml',
+    editor: XMLEditor,
+    isFallback: true,
+    defaultName: 'XML'
+  }
+]);
+
+export default DmnTab;

--- a/client/src/app/tabs/cloud-dmn/__tests__/DiagramSpec.js
+++ b/client/src/app/tabs/cloud-dmn/__tests__/DiagramSpec.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+describe('tabs/dmn', function() {
+
+  describe('initial diagram', function() {
+
+    it('should contain placeholders', function() {
+
+      // when
+      const contents = require('../diagram.dmn');
+
+      // then
+      expect(contents).to.contain('id="Definitions_{{ ID }}"');
+      expect(contents).to.contain('id="Decision_{{ ID:decision }}"');
+    });
+
+  });
+
+});

--- a/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
@@ -1,0 +1,1979 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/* global sinon */
+
+import React from 'react';
+
+import { mount } from 'enzyme';
+
+import {
+  find,
+  isArray
+} from 'min-dash';
+
+import {
+  Cache,
+  WithCachedState
+} from '../../../cached';
+
+import {
+  DmnEditor
+} from '../DmnEditor';
+
+import DmnModeler from 'test/mocks/dmn-js/Modeler';
+
+import {
+  getCanvasEntries,
+  getAlignDistributeEntries,
+  getCopyCutPasteEntries,
+  getSelectionEntries,
+  getToolEntries,
+  getUndoRedoEntries
+} from '../../getEditMenu';
+
+import diagramXML from './diagram.dmn';
+
+import diagram11XML from './diagram11.dmn';
+
+import {
+  DEFAULT_LAYOUT
+} from '../../dmn/OverviewContainer';
+
+const { spy } = sinon;
+
+
+describe('<DmnEditor>', function() {
+
+  it('should render', async function() {
+    const {
+      instance
+    } = await renderEditor(diagramXML);
+
+    expect(instance).to.exist;
+  });
+
+
+  describe('caching behavior', function() {
+
+    let createSpy;
+
+    beforeEach(function() {
+      createSpy = sinon.spy(DmnEditor, 'createCachedState');
+    });
+
+    afterEach(function() {
+      createSpy.restore();
+    });
+
+
+    it('should create modeler if not cached', async function() {
+
+      // when
+      const {
+        instance
+      } = await renderEditor(diagramXML);
+
+      // then
+      const {
+        modeler
+      } = instance.getCached();
+
+      expect(modeler).to.exist;
+      expect(createSpy).to.have.been.calledOnce;
+    });
+
+
+    it('should use cached modeler', async function() {
+
+      // given
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new DmnModeler()
+        },
+        __destroy: () => {}
+      });
+
+      // when
+      await renderEditor(diagramXML, {
+        id: 'editor',
+        cache
+      });
+
+      // then
+      expect(createSpy).not.to.have.been.called;
+    });
+
+  });
+
+
+  describe('plugins', function() {
+
+    it('should accept <drd> plugins', async function() {
+
+      // given
+      const additionalModule = {
+        __init__: [ 'foo' ],
+        foo: [ 'type', noop ]
+      };
+
+      // when
+      const {
+        instance
+      } = await renderEditor(diagramXML, {
+        getPlugins(type) {
+          switch (type) {
+          case 'dmn.modeler.drd.additionalModules':
+            return [ additionalModule ];
+          }
+
+          return [];
+        }
+      });
+
+      // then
+      const { modeler } = instance.getCached();
+
+      expect(modeler.modules.drd.additionalModules).to.include(additionalModule);
+    });
+
+
+    it('should accept <decisionTable> plugins', async function() {
+
+      // given
+      const additionalModule = {
+        __init__: [ 'foo' ],
+        foo: [ 'type', noop ]
+      };
+
+      // when
+      const {
+        instance
+      } = await renderEditor(diagramXML, {
+        getPlugins(type) {
+          switch (type) {
+          case 'dmn.modeler.decisionTable.additionalModules':
+            return [ additionalModule ];
+          }
+
+          return [];
+        }
+      });
+
+      // then
+      const { modeler } = instance.getCached();
+
+      expect(modeler.modules.decisionTable.additionalModules).to.include(additionalModule);
+    });
+
+
+    it('should accept <literalExpression> plugins', async function() {
+
+      // given
+      const additionalModule = {
+        __init__: [ 'foo' ],
+        foo: [ 'type', noop ]
+      };
+
+      // when
+      const {
+        instance
+      } = await renderEditor(diagramXML, {
+        getPlugins(type) {
+          switch (type) {
+          case 'dmn.modeler.literalExpression.additionalModules':
+            return [ additionalModule ];
+          }
+
+          return [];
+        }
+      });
+
+      // then
+      const { modeler } = instance.getCached();
+
+      expect(modeler.modules.literalExpression.additionalModules).to.include(additionalModule);
+    });
+
+
+    it('should accept <moddleExtension> plugins', async function() {
+
+      // given
+      const moddleExtension = {
+        name: 'bar',
+        uri: 'http://bar',
+        prefix: 'bar',
+        xml: {
+          tagAlias: 'lowerCase'
+        },
+        types: []
+      };
+
+      // when
+      const {
+        instance
+      } = await renderEditor(diagramXML, {
+        getPlugins(type) {
+          switch (type) {
+          case 'dmn.modeler.moddleExtension':
+            return [ moddleExtension ];
+          }
+
+          return [];
+        }
+      });
+
+      // then
+      const { modeler } = instance.getCached();
+
+      expect(modeler.modules.moddleExtensions).to.include({
+        bar: moddleExtension
+      });
+    });
+
+
+    it('should handle invalid moddle extensions', async function() {
+
+      // given
+      const onErrorSpy = sinon.spy();
+
+      const unnamedModdleExtension = {};
+
+      const circularModdleExtension = {};
+      circularModdleExtension.name = circularModdleExtension;
+
+      const props = {
+        getPlugins(type) {
+          switch (type) {
+          case 'dmn.modeler.moddleExtension':
+            return [
+              unnamedModdleExtension,
+              circularModdleExtension
+            ];
+          }
+
+          return [];
+        },
+        onError: onErrorSpy,
+        onAction: noop
+      };
+
+      // then
+      expect(() => DmnEditor.createCachedState(props)).to.not.throw();
+      expect(onErrorSpy).to.be.calledOnce;
+    });
+
+  });
+
+
+  it('#getModeler', async function() {
+
+    // given
+    const { instance } = await renderEditor(diagramXML);
+
+    // when
+    const modeler = instance.getModeler();
+
+    // then
+    expect(modeler).to.exist;
+  });
+
+
+  it('#getXML', async function() {
+
+    // given
+    const {
+      instance
+    } = await renderEditor(diagramXML);
+
+    const xml = await instance.getXML();
+
+    expect(xml).to.exist;
+    expect(xml).to.eql(diagramXML);
+  });
+
+
+  describe('#exportAs', function() {
+
+    let instance;
+
+    beforeEach(async function() {
+      instance = (await renderEditor(diagramXML)).instance;
+    });
+
+
+    it('svg', async function() {
+      const contents = await instance.exportAs('svg');
+
+      expect(contents).to.exist;
+      expect(contents).to.equal('<svg />');
+    });
+
+
+    it('png', async function() {
+      const contents = await instance.exportAs('png');
+
+      expect(contents).to.exist;
+      expect(contents).to.contain('data:image/png');
+    });
+
+
+    it('jpeg', async function() {
+      const contents = await instance.exportAs('jpeg');
+
+      expect(contents).to.exist;
+      expect(contents).to.contain('data:image/jpeg');
+    });
+
+  });
+
+
+  describe('#listen', function() {
+
+    function expectHandleChanged(event) {
+      return async function() {
+        const modeler = new DmnModeler();
+
+        const cache = new Cache();
+
+        cache.add('editor', {
+          cached: {
+            modeler
+          },
+          __destroy: () => {}
+        });
+
+        const changedSpy = spy();
+
+        await renderEditor(diagramXML, {
+          id: 'editor',
+          cache,
+          onChanged: changedSpy
+        });
+
+        modeler._emit(event);
+
+        expect(changedSpy).to.have.been.called;
+      };
+    }
+
+
+    it('saveXML.done', expectHandleChanged('saveXML.done'));
+
+
+    it('attach', expectHandleChanged('attach'));
+
+
+    it('view.selectionChanged', expectHandleChanged('view.selectionChanged'));
+
+
+    it('view.directEditingChanged', expectHandleChanged('view.directEditingChanged'));
+
+
+    it('propertiesPanel.focusin', expectHandleChanged('propertiesPanel.focusin'));
+
+
+    it('propertiesPanel.focusout', expectHandleChanged('propertiesPanel.focusout'));
+
+  });
+
+
+  describe('#handleChanged', function() {
+
+    it('should notify about changes', async function() {
+
+      // given
+      const onChangedSpy = spy((state) => {
+
+        // then
+        expect(state).to.include({
+          defaultCopyCutPaste: false,
+          defaultUndoRedo: false,
+          dirty: true,
+          editLabel: false,
+          inputActive: false,
+          redo: true,
+          removeSelected: false,
+          undo: true
+        });
+      });
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          lastXML: diagramXML,
+          modeler: new DmnModeler({
+            commandStack: {
+              canRedo: () => true,
+              canUndo: () => true,
+              _stackIdx: 1
+            },
+            selection: {
+              get: () => []
+            }
+          }),
+          stackIdx: 2
+        },
+        __destroy: () => {}
+      });
+
+      const { instance } = await renderEditor(diagramXML, {
+        id: 'editor',
+        cache,
+        onChanged: onChangedSpy,
+        waitForImport: false
+      });
+
+      // when
+      instance.handleChanged();
+
+      // then
+      expect(onChangedSpy).to.have.been.called;
+    });
+
+
+    it('should notify about plugin related changes', async function() {
+
+      // given
+      const changedSpy = sinon.spy();
+
+      const { instance } = await renderEditor(diagramXML, {
+        id: 'editor',
+        onChanged: changedSpy
+      });
+
+      changedSpy.resetHistory();
+
+      // when
+      instance.handleChanged();
+
+      // then
+      expect(changedSpy).to.be.calledOnce;
+
+      const state = changedSpy.firstCall.args[0];
+
+      expect(state).to.have.property('dmn');
+      expect(state).to.have.property('editable');
+      expect(state).to.have.property('elementsSelected');
+      expect(state).to.have.property('activeEditor');
+      expect(state).to.have.property('inactiveInput');
+    });
+
+
+    it('should notify about plugin related changes in decisionTable view', async function() {
+
+      // given
+      const changedSpy = sinon.spy();
+
+      const { instance } = await renderEditor(diagramXML, {
+        id: 'editor',
+        onChanged: changedSpy
+      });
+
+      const decisionTable = {
+        element: { id: 'foo' },
+        type: 'decisionTable'
+      };
+
+      instance.getModeler().open(decisionTable);
+
+      changedSpy.resetHistory();
+
+      // when
+      instance.handleChanged();
+
+      // then
+      expect(changedSpy).to.be.calledOnce;
+
+      const state = changedSpy.firstCall.args[0];
+
+      expect(state).to.have.property('dmnRuleEditing');
+      expect(state).to.have.property('dmnClauseEditing');
+
+    });
+
+
+    describe('edit menu', function() {
+
+      it('should provide undo/redo entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          const editMenuEntries = getUndoRedoEntries(state);
+
+          // then
+          expect(state.editMenu).to.deep.include(editMenuEntries);
+
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
+
+      it('should provide copy/paste entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          const editMenuEntries = getCopyCutPasteEntries(state);
+
+          // then
+          expect(state.editMenu).to.deep.include(editMenuEntries);
+
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
+
+      it('should provide selection entries', async function() {
+
+        // given
+        const changedSpy = (state) => {
+
+          const editMenuEntries = getSelectionEntries(state);
+
+          // then
+          expect(state.editMenu).to.deep.include(editMenuEntries);
+
+        };
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        // when
+        instance.handleChanged();
+      });
+
+
+      describe('drd', function() {
+
+        it('should provide tool entries', async function() {
+
+          // given
+          const changedSpy = (state) => {
+
+            const editMenuEntries = getToolEntries(state);
+
+            // then
+            expect(state.editMenu).to.deep.include(editMenuEntries);
+
+          };
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          // when
+          instance.handleChanged();
+        });
+
+
+        it('should provide canvas entries', async function() {
+
+          // given
+          const changedSpy = (state) => {
+
+            const editMenuEntries = getCanvasEntries(state);
+
+            // then
+            expect(state.editMenu).to.deep.include(editMenuEntries);
+
+          };
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          // when
+          instance.handleChanged();
+        });
+
+
+        it('should provide align/distribute entries', async function() {
+
+          // given
+          const changedSpy = (state) => {
+
+            const alignDistributeEntries = getAlignDistributeEntries(state);
+
+            // then
+            expect(state.editMenu).to.deep.include(alignDistributeEntries);
+          };
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          // when
+          instance.handleChanged();
+        });
+
+      });
+
+
+      describe('decision table', function() {
+
+        it('should provide select cell entries', async function() {
+
+          // given
+          const changedSpy = sinon.spy();
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          changedSpy.resetHistory();
+
+          // when
+          const modeler = instance.getModeler();
+
+          modeler.open({ type: 'decisionTable' });
+          instance.handleChanged();
+
+          // then
+          expect(changedSpy).to.be.calledOnce;
+
+          const state = changedSpy.firstCall.args[0];
+
+          expect(hasMenuEntry(state.editMenu, 'Select Cell Above')).to.be.true;
+          expect(hasMenuEntry(state.editMenu, 'Select Cell Below')).to.be.true;
+        });
+
+
+        it('should provide und/redo entries', async function() {
+
+          // given
+          const changedSpy = (state) => {
+
+            const editMenuEntries = getUndoRedoEntries(state);
+
+            // then
+            expect(state.editMenu).to.deep.include(editMenuEntries);
+
+          };
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          // when
+          instance.handleChanged();
+        });
+
+      });
+
+
+      describe('literal expression', function() {
+
+        it('Remove shortcut should always have role: delete', async function() {
+
+          // given
+          const changedSpy = sinon.spy();
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          changedSpy.resetHistory();
+
+          // when
+          const modeler = instance.getModeler();
+
+          modeler.open({ type: 'literalExpression' });
+          instance.handleChanged();
+
+          // then
+          expect(changedSpy).to.be.calledOnce;
+
+          const state = changedSpy.firstCall.args[0];
+
+          expect(hasMenuEntry(state.editMenu, 'Remove Selected')).to.be.true;
+          expect(getMenuEntry(state.editMenu, 'Remove Selected').role).to.equal('delete');
+        });
+
+      });
+
+    });
+
+
+    describe('window menu', function() {
+
+      it('should provide toggle/reset overview entries for decision table', async function() {
+
+        // given
+        const changedSpy = sinon.spy();
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        changedSpy.resetHistory();
+
+        // when
+        const modeler = instance.getModeler();
+
+        modeler.open({ type: 'decisionTable' });
+        instance.handleChanged();
+
+        // then
+        expect(changedSpy).to.be.calledOnce;
+
+        const state = changedSpy.firstCall.args[0];
+
+        expect(hasMenuEntry(state.windowMenu, 'Toggle Overview')).to.be.true;
+        expect(hasMenuEntry(state.windowMenu, 'Reset Overview')).to.be.true;
+      });
+
+
+      it('should provide toggle/reset overview entries for literal expression', async function() {
+
+        // given
+        const changedSpy = sinon.spy();
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        changedSpy.resetHistory();
+
+        // when
+        const modeler = instance.getModeler();
+
+        modeler.open({ type: 'literalExpression' });
+        instance.handleChanged();
+
+        // then
+        expect(changedSpy).to.be.calledOnce;
+
+        const state = changedSpy.firstCall.args[0];
+
+        expect(hasMenuEntry(state.windowMenu, 'Toggle Overview')).to.be.true;
+        expect(hasMenuEntry(state.windowMenu, 'Reset Overview')).to.be.true;
+      });
+
+
+      it('should NOT provide toggle/reset overview entries for DRD', async function() {
+
+        // given
+        const changedSpy = sinon.spy();
+
+        const { instance } = await renderEditor(diagramXML, {
+          onChanged: changedSpy
+        });
+
+        changedSpy.resetHistory();
+
+        // when
+        const modeler = instance.getModeler();
+
+        modeler.open({ type: 'drd' });
+        instance.handleChanged();
+
+        // then
+        expect(changedSpy).to.be.calledOnce;
+
+        const state = changedSpy.firstCall.args[0];
+
+        expect(hasMenuEntry(state.windowMenu, 'Toggle Overview')).to.be.false;
+        expect(hasMenuEntry(state.windowMenu, 'Reset Overview')).to.be.false;
+      });
+    });
+  });
+
+
+  describe('#viewsChanged', function() {
+
+    let instance;
+
+    const decisionTableView = {
+      element: { id: 'decisionTable' },
+      type: 'decisionTable'
+    };
+
+    const drdView = {
+      element: { id: 'drd' },
+      type: 'drd'
+    };
+
+    const views = [
+      drdView,
+      decisionTableView
+    ];
+
+    beforeEach(async function() {
+      ({ instance } = await renderEditor(diagramXML));
+    });
+
+
+    it('should save dirty state', function() {
+
+      // given
+      const dirtySpy = spy(instance, 'isDirty');
+
+      const modeler = instance.getModeler();
+
+      const commandStack = modeler.getActiveViewer().get('commandStack');
+
+      const oldDirty = instance.getCached().dirty;
+
+      commandStack.execute(2);
+
+      // when
+      instance.viewsChanged({
+        activeView: drdView,
+        views
+      });
+
+      const {
+        dirty
+      } = instance.getCached();
+
+      // then
+      expect(dirtySpy).to.have.been.called;
+      expect(dirty).to.be.true;
+      expect(dirty).to.not.equal(oldDirty);
+    });
+
+
+    it('should reattach properties panel on view switch', function() {
+
+      // given
+      const modeler = instance.getModeler();
+
+      const propertiesPanel = modeler.getActiveViewer().get('propertiesPanel');
+
+      const propertiesAttachSpy = sinon.spy(propertiesPanel, 'attachTo');
+
+      // when
+      instance.viewsChanged({
+        activeView: drdView,
+        views
+      });
+
+      // then
+      expect(propertiesAttachSpy).to.be.called;
+    });
+
+
+    it('should NOT reattach properties panel when stay on view', function() {
+
+      // given
+      const modeler = instance.getModeler();
+
+      instance.viewsChanged({
+        activeView: drdView,
+        views
+      });
+
+      const propertiesPanel = modeler.getActiveViewer().get('propertiesPanel');
+
+      const propertiesAttachSpy = sinon.spy(propertiesPanel, 'attachTo');
+
+      // when
+      instance.viewsChanged({
+        activeView: drdView,
+        views
+      });
+
+      // then
+      expect(propertiesAttachSpy).not.to.be.called;
+    });
+
+
+    it('should reattach overview when switching from DRD to decision table', async function() {
+
+      // given
+      instance.viewsChanged({
+        activeView: drdView,
+        views
+      });
+
+      const modeler = instance.getModeler();
+
+      sinon.stub(modeler, 'getActiveView').callsFake(() => decisionTableView);
+
+      const overviewAttachSpy = sinon.spy(modeler, 'attachOverviewTo');
+
+      // when
+      instance.viewsChanged({
+        activeView: decisionTableView,
+        views
+      });
+
+      // then
+      expect(overviewAttachSpy).to.have.been.called;
+    });
+
+
+    it('should detach overview when switching to DRD', async function() {
+
+      // given
+      instance.viewsChanged({
+        activeView: decisionTableView,
+        views
+      });
+
+      const modeler = instance.getModeler();
+
+      sinon.stub(modeler, 'getActiveView').callsFake(() => drdView);
+
+      const overviewDetachSpy = sinon.spy(modeler, 'detachOverview');
+
+      // when
+      instance.viewsChanged({
+        activeView: drdView,
+        views
+      });
+
+      // then
+      expect(overviewDetachSpy).to.have.been.called;
+    });
+
+  });
+
+
+  describe('#triggerAction', function() {
+
+    it('should return value of editor action', async function() {
+
+      // given
+      const editorActions = {
+        trigger(action, context) {
+          if (action === 'foo') {
+            return 'bar';
+          }
+        }
+      };
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new DmnModeler({
+            editorActions
+          })
+        }
+      });
+
+      // when
+      const { instance } = await renderEditor(diagramXML, { cache });
+
+      // when
+      const returnValue = instance.triggerAction('foo');
+
+      // then
+      expect(returnValue).to.equal('bar');
+    });
+
+  });
+
+
+  describe('layout', function() {
+
+    it('should open overview', async function() {
+
+      // given
+      let layout = {
+        dmnOverview: {
+          open: false
+        }
+      };
+
+      function onLayoutChanged(newLayout) {
+        layout = newLayout;
+      }
+
+      const {
+        instance,
+        wrapper
+      } = await renderEditor(diagramXML, {
+        layout,
+        onLayoutChanged
+      });
+
+      const modeler = instance.getModeler();
+
+      modeler.open({ type: 'decisionTable' });
+
+      instance.handleChanged();
+
+      wrapper.update();
+
+      const toggle = wrapper.find('#button-toggle-overview');
+
+      // when
+      toggle.simulate('click');
+
+      // then
+      expect(layout.dmnOverview.open).to.be.true;
+    });
+
+
+    it('should close overview', async function() {
+
+      // given
+      let layout = {
+        dmnOverview: {
+          open: true
+        }
+      };
+
+      function onLayoutChanged(newLayout) {
+        layout = newLayout;
+      }
+
+      const {
+        instance,
+        wrapper
+      } = await renderEditor(diagramXML, {
+        layout,
+        onLayoutChanged
+      });
+
+      const modeler = instance.getModeler();
+
+      modeler.open({ type: 'decisionTable' });
+
+      instance.handleChanged();
+
+      wrapper.update();
+
+      const toggle = wrapper.find('#button-toggle-overview');
+
+      // when
+      toggle.simulate('click');
+
+      // then
+      expect(layout.dmnOverview.open).to.be.false;
+    });
+
+
+    it('should open properties panel (no layout)', async function() {
+
+      // given
+      let layout = {};
+
+      function onLayoutChanged(newLayout) {
+        layout = newLayout;
+      }
+
+      const {
+        wrapper
+      } = await renderEditor(diagramXML, {
+        layout,
+        onLayoutChanged
+      });
+
+      wrapper.update();
+
+      const toggle = wrapper.find('.toggle');
+
+      // when
+      toggle.simulate('click');
+
+      // then
+      expect(layout.propertiesPanel.open).to.be.true;
+      expect(layout.propertiesPanel.width).to.equal(280);
+    });
+
+
+    it('should open properties panel', async function() {
+
+      // given
+      let layout = {
+        propertiesPanel: {
+          open: false
+        }
+      };
+
+      function onLayoutChanged(newLayout) {
+        layout = newLayout;
+      }
+
+      const {
+        wrapper
+      } = await renderEditor(diagramXML, {
+        layout,
+        onLayoutChanged
+      });
+
+      wrapper.update();
+
+      const toggle = wrapper.find('.toggle');
+
+      // when
+      toggle.simulate('click');
+
+      // then
+      expect(layout.propertiesPanel.open).to.be.true;
+      expect(layout.propertiesPanel.width).to.equal(280);
+    });
+
+
+    it('should close properties panel', async function() {
+
+      // given
+      let layout = {
+        propertiesPanel: {
+          open: true
+        }
+      };
+
+      function onLayoutChanged(newLayout) {
+        layout = newLayout;
+      }
+
+      const {
+        wrapper
+      } = await renderEditor(diagramXML, {
+        layout,
+        onLayoutChanged
+      });
+
+      wrapper.update();
+
+      const toggle = wrapper.find('.toggle');
+
+      // when
+      toggle.simulate('click');
+
+      // then
+      expect(layout.propertiesPanel.open).to.be.false;
+    });
+
+
+    it('should handle missing layout', async function() {
+
+      // given
+      let layout = { };
+
+      // then
+      await renderEditor(diagramXML, {
+        layout
+      });
+
+    });
+
+  });
+
+
+  describe('errors', function() {
+
+    it('should handle XML export error', async function() {
+
+      // given
+      const errorSpy = spy();
+
+      const {
+        instance
+      } = await renderEditor('export-error', {
+        onError: errorSpy
+      });
+
+      // make sure editor is dirty
+      const commandStack = instance.getModeler().getActiveViewer().get('commandStack');
+
+      commandStack.execute(1);
+
+      let err;
+
+      // when
+      try {
+        await instance.getXML();
+      } catch (e) {
+        err = e;
+      }
+
+      // then
+      expect(err).to.exist;
+      expect(errorSpy).to.have.been.calledOnce;
+    });
+
+
+    it('should handle image export error', async function() {
+
+      // given
+      const errorSpy = spy();
+
+      const { instance } = await renderEditor('export-as-error', {
+        onError: errorSpy
+      });
+
+      // when
+      let err;
+
+      try {
+        await instance.exportAs('svg');
+      } catch (e) {
+        err = e;
+      }
+
+      // then
+      expect(err).to.exist;
+      expect(err.message).to.equal('failed to save svg');
+      expect(errorSpy).to.have.been.calledOnce;
+    });
+
+
+    it('should handle image export error (SVG export not supported)', async function() {
+
+      // given
+      const errorSpy = spy();
+
+      const { instance } = await renderEditor('export-as-error', {
+        onError: errorSpy
+      });
+
+      instance.getModeler().getActiveViewer().saveSVG = false;
+
+      // when
+      let err;
+
+      try {
+        await instance.exportAs('svg');
+      } catch (e) {
+        err = e;
+      }
+
+      // then
+      expect(err).to.exist;
+      expect(err.message).to.equal('SVG export not supported in current view');
+      expect(errorSpy).to.have.been.calledOnce;
+    });
+
+  });
+
+
+  describe('sheet change', function() {
+
+    it('should switch active view on sheet change', async function() {
+
+      // given
+      const element = 'mock_element';
+      const { wrapper, instance } = await renderEditor(diagramXML);
+      const openSpy = sinon.spy(instance, 'open');
+
+      // when
+      wrapper.setProps({ activeSheet: { id: 'DecisionTable', element } });
+
+      // expect
+      expect(openSpy).to.be.calledOnceWith(element);
+    });
+
+  });
+
+
+  describe('import', function() {
+
+    afterEach(sinon.restore);
+
+
+    it('should import without errors and warnings', async function() {
+
+      // given
+      const onImportSpy = spy((error, warnings) => {
+
+        // then
+        expect(error).to.not.exist;
+        expect(warnings).to.be.empty;
+      });
+
+      // when
+      await renderEditor(diagramXML, {
+        onImport: onImportSpy
+      });
+
+      // then
+      expect(onImportSpy).to.have.been.calledOnce;
+    });
+
+
+    it('should import with warnings', async function() {
+
+      // given
+      const onImportSpy = spy((error, warnings) => {
+
+        // then
+        expect(error).to.not.exist;
+        expect(warnings).to.have.length(1);
+      });
+
+      // when
+      await renderEditor('import-warnings', {
+        onImport: onImportSpy
+      });
+
+      // then
+      expect(onImportSpy).to.have.been.calledOnce;
+    });
+
+
+    it('should import with error', async function() {
+
+      // given
+      const onImportSpy = spy((error, warnings) => {
+
+        // then
+        expect(error).to.exist;
+        expect(warnings).to.have.length(0);
+      });
+
+      // when
+      await renderEditor('import-error', {
+        onImport: onImportSpy
+      });
+
+      // then
+      expect(onImportSpy).to.have.been.calledOnce;
+    });
+
+
+    it('should not import when provided xml is the same as the cached one', async function() {
+
+      // given
+      const isImportNeededSpy = sinon.spy(DmnEditor.prototype, 'isImportNeeded');
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          lastXML: diagramXML,
+          modeler: new DmnModeler()
+        }
+      });
+
+      await renderEditor(diagramXML, {
+        cache,
+        waitForImport: false
+      });
+
+      // then
+      // DmnEditor#componentDidMount is async
+      process.nextTick(() => {
+        expect(isImportNeededSpy).to.have.been.calledOnce;
+        expect(isImportNeededSpy).to.have.always.returned(false);
+      });
+    });
+
+
+    it('should not import when props did not change', async function() {
+
+      // given
+      const {
+        instance
+      } = await renderEditor(diagramXML);
+
+      const isImportNeededSpy = sinon.spy(instance, 'isImportNeeded');
+
+      // when
+      await instance.componentDidUpdate({
+        activeSheet: defaultActiveSheet,
+        xml: diagramXML
+      });
+
+      // then
+      expect(isImportNeededSpy).to.be.called;
+      expect(isImportNeededSpy).to.have.always.returned(false);
+
+    });
+
+
+    it('should unset lastXML on import error', async function() {
+
+      // given
+      const { instance } = await renderEditor(diagramXML);
+
+      // assume
+      expect(instance.getCached().lastXML).to.equal(diagramXML);
+
+      // when
+      await instance.importXML('import-error');
+
+      // then
+      expect(instance.getCached().lastXML).to.be.null;
+    });
+
+  });
+
+
+  describe('dirty state', function() {
+
+    let instance;
+
+    beforeEach(async function() {
+      instance = (await renderEditor(diagramXML)).instance;
+    });
+
+
+    it('should NOT be dirty initially', function() {
+
+      // then
+      const dirty = instance.isDirty();
+
+      expect(dirty).to.be.false;
+    });
+
+
+    it('should be dirty after modeling', function() {
+
+      // given
+      const { modeler } = instance.getCached();
+
+      // when
+      // execute 1 command
+      modeler.getActiveViewer().get('commandStack').execute(1);
+
+      // then
+      const dirty = instance.isDirty();
+
+      expect(dirty).to.be.true;
+    });
+
+
+    it('should NOT be dirty after modeling -> undo', function() {
+
+      // given
+      const { modeler } = instance.getCached();
+
+      modeler.getActiveViewer().get('commandStack').execute(1);
+
+      // when
+      modeler.getActiveViewer().get('commandStack').undo();
+
+      // then
+      const dirty = instance.isDirty();
+
+      expect(dirty).to.be.false;
+    });
+
+
+    it('should NOT be dirty after export', async function() {
+
+      // given
+      const { modeler } = instance.getCached();
+
+      // execute 1 command
+      modeler.getActiveViewer().get('commandStack').execute(1);
+
+      // when
+      await instance.getXML();
+
+      // then
+      const dirty = instance.isDirty();
+
+      expect(dirty).to.be.false;
+    });
+
+
+    it('should be dirty after export error', async function() {
+
+      // given
+      const { instance } = await renderEditor('export-error');
+
+      const { modeler } = instance.getCached();
+
+      // execute 1 command
+      modeler.getActiveViewer().get('commandStack').execute(1);
+
+      let err;
+
+      // when
+      try {
+        await instance.getXML();
+      } catch (e) {
+        err = e;
+      }
+
+      // then
+      const dirty = instance.isDirty();
+
+      expect(err).to.exist;
+      expect(dirty).to.be.true;
+    });
+
+  });
+
+
+  describe('properties panel actions', function() {
+
+    it('should toggle properties panel', async function() {
+
+      // given
+      const onLayoutChangedSpy = sinon.spy();
+      const {
+        instance
+      } = await renderEditor(diagramXML, {
+        layout: {
+          propertiesPanel: {
+            open: false,
+          }
+        },
+        onLayoutChanged: onLayoutChangedSpy
+      });
+
+      // when
+      instance.triggerAction('toggleProperties');
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledOnceWith({
+        propertiesPanel: {
+          open: true,
+          width: 280
+        }
+      });
+    });
+
+
+    it('should reset properties panel', async function() {
+
+      // given
+      const onLayoutChangedSpy = sinon.spy();
+      const {
+        instance
+      } = await renderEditor(diagramXML, {
+        onLayoutChanged: onLayoutChangedSpy
+      });
+
+      // when
+      instance.triggerAction('resetProperties');
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledOnceWith({
+        propertiesPanel: {
+          open: true,
+          width: 280
+        }
+      });
+    });
+
+  });
+
+
+  describe('overview actions', function() {
+
+    it('should toggle overview', async function() {
+
+      // given
+      const onLayoutChangedSpy = sinon.spy();
+      const {
+        instance
+      } = await renderEditor(diagramXML, {
+        layout: {
+          dmnOverview: {
+            open: false,
+          }
+        },
+        onLayoutChanged: onLayoutChangedSpy
+      });
+
+      // when
+      instance.triggerAction('toggleOverview');
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledOnceWith({
+        dmnOverview: {
+          open: true,
+        }
+      });
+    });
+
+
+    it('should reset overview', async function() {
+
+      // given
+      const onLayoutChangedSpy = sinon.spy();
+      const {
+        instance
+      } = await renderEditor(diagramXML, {
+        onLayoutChanged: onLayoutChangedSpy
+      });
+
+      // when
+      instance.triggerAction('resetOverview');
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledOnceWith({
+        dmnOverview: DEFAULT_LAYOUT
+      });
+    });
+
+  });
+
+
+  describe('zoom actions', function() {
+
+    let editorActionsStub,
+        instance;
+
+    beforeEach(async function() {
+
+      // given
+      editorActionsStub = sinon.stub({ trigger() {} });
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new DmnModeler({
+            editorActions: editorActionsStub
+          })
+        }
+      });
+
+      instance = (await renderEditor(diagramXML, { cache })).instance;
+    });
+
+
+    afterEach(sinon.restore);
+
+
+    it('should zoom in', function() {
+
+      // when
+      instance.triggerAction('zoomIn');
+
+      // then
+      expect(editorActionsStub.trigger).to.be.calledOnceWith('stepZoom', {
+        value: 1
+      });
+    });
+
+
+    it('should zoom out', function() {
+
+      // when
+      instance.triggerAction('zoomOut');
+
+      // then
+      expect(editorActionsStub.trigger).to.be.calledOnceWith('stepZoom', {
+        value: -1
+      });
+    });
+
+
+    it('should zoom to fit diagram', function() {
+
+      // when
+      instance.triggerAction('zoomFit');
+
+      // then
+      expect(editorActionsStub.trigger).to.be.calledOnceWith('zoom', {
+        value: 'fit-viewport'
+      });
+    });
+
+
+    it('should reset zoom', async function() {
+
+      // when
+      instance.triggerAction('resetZoom');
+
+      // then
+      expect(editorActionsStub.trigger).to.be.calledOnceWith('zoom', {
+        value: 1
+      });
+    });
+
+  });
+
+
+  describe('extensions event emitting', function() {
+
+    let recordActions, emittedEvents;
+
+    beforeEach(function() {
+      emittedEvents = [];
+
+      recordActions = (action, options) => {
+        emittedEvents.push(options);
+      };
+    });
+
+    it('should notify when modeler configures', async function() {
+
+      // when
+      await renderEditor(diagramXML, {
+        onAction: recordActions
+      });
+
+      // then
+      const modelerConfigureEvent = getEvent(emittedEvents, 'dmn.modeler.configure');
+
+      const {
+        payload
+      } = modelerConfigureEvent;
+
+      expect(modelerConfigureEvent).to.exist;
+      expect(payload.middlewares).to.exist;
+    });
+
+
+    it('should notify when modeler was created', async function() {
+
+      // when
+      const {
+        instance
+      } = await renderEditor(diagramXML, {
+        onAction: recordActions
+      });
+
+      // then
+      const { modeler } = instance.getCached();
+
+      const modelerCreatedEvent = getEvent(emittedEvents, 'dmn.modeler.created');
+
+      const {
+        payload
+      } = modelerCreatedEvent;
+
+      expect(modelerCreatedEvent).to.exist;
+      expect(payload.modeler).to.eql(modeler);
+    });
+
+  });
+
+
+  describe('#handleMigration', function() {
+
+    it('should migrate to DMN 1.3', async function() {
+
+      // given
+      const onActionSpy = spy((action) => {
+        if (action === 'show-dialog') {
+          return { button: 'yes' };
+        }
+      });
+
+      const onContentUpdatedSpy = sinon.spy();
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new DmnModeler()
+        },
+        __destroy: () => {}
+      });
+
+      // when
+      await renderEditor(diagram11XML, {
+        id: 'editor',
+        cache,
+        onAction: onActionSpy,
+        onContentUpdated: onContentUpdatedSpy
+      });
+
+      // then
+      expect(onActionSpy).to.have.been.calledOnce;
+      expect(onActionSpy.firstCall.args[ 0 ]).to.eql('show-dialog');
+
+      expect(onContentUpdatedSpy).to.have.been.calledOnce;
+      expect(onContentUpdatedSpy).to.have.been.calledOnceWith(sinon.match('dmndi:DMNDI'));
+    });
+
+
+    it('shoud NOT migrate to DMN 1.3', async function() {
+
+      // given
+      const onActionSpy = spy((action) => {
+        if (action === 'show-dialog') {
+          return { button: 'cancel' };
+        }
+      });
+
+      const onContentUpdatedSpy = sinon.spy();
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new DmnModeler()
+        },
+        __destroy: () => {}
+      });
+
+      // when
+      await renderEditor(diagram11XML, {
+        id: 'editor',
+        cache,
+        onAction: onActionSpy,
+        onContentUpdated: onContentUpdatedSpy
+      });
+
+      // then
+      expect(onActionSpy).to.have.been.calledTwice;
+      expect(onActionSpy.firstCall.args[ 0 ]).to.eql('show-dialog');
+      expect(onActionSpy.secondCall.args[ 0 ]).to.eql('close-tab');
+
+      expect(onContentUpdatedSpy).not.to.have.been.called;
+    });
+
+  });
+
+
+  describe('engine profile', function() {
+
+    it('should show engine profile (no engine profile)', async function() {
+
+      // when
+      const { wrapper } = await renderEditor(diagramXML);
+
+      // then
+      expect(wrapper.find('EngineProfile').exists()).to.be.true;
+    });
+
+  });
+
+});
+
+
+// helpers //////////
+
+function noop() {}
+
+const TestEditor = WithCachedState(DmnEditor);
+
+const defaultActiveSheet = { id: 'dmn' };
+
+const defaultLayout = {
+  minimap: {
+    open: false
+  },
+  propertiesPanel: {
+    open: true
+  }
+};
+
+function renderEditor(xml, options = {}) {
+  const {
+    activeSheet = defaultActiveSheet,
+    cache = new Cache(),
+    getConfig = noop,
+    getPlugins = () => [],
+    id = 'editor',
+    isNew = true,
+    layout = defaultLayout,
+    onAction = noop,
+    onChanged = noop,
+    onContentUpdated = noop,
+    onError = noop,
+    onImport = noop,
+    onLayoutChanged = noop,
+    onModal = noop,
+    onSheetsChanged = noop,
+    onWarning = noop,
+    waitForImport = true
+  } = options;
+
+  return new Promise((resolve) => {
+    let instance,
+        wrapper;
+
+    const resolveOnImport = (...args) => {
+      onImport(...args);
+
+      resolve({
+        instance,
+        wrapper
+      });
+    };
+
+    const resolveOnAction = (action, ...args) => {
+      if (action === 'close-tab') {
+        resolve({
+          instance,
+          wrapper
+        });
+      }
+
+      return onAction(action, ...args);
+    };
+
+    wrapper = mount(
+      <TestEditor
+        activeSheet={ activeSheet }
+        cache={ cache }
+        getConfig={ getConfig }
+        getPlugins={ getPlugins }
+        id={ id }
+        isNew={ isNew }
+        layout={ layout }
+        onAction={ waitForImport ? resolveOnAction : onAction }
+        onChanged={ onChanged }
+        onContentUpdated={ onContentUpdated }
+        onError={ onError }
+        onImport={ waitForImport ? resolveOnImport : onImport }
+        onLayoutChanged={ onLayoutChanged }
+        onModal={ onModal }
+        onSheetsChanged={ onSheetsChanged }
+        onWarning={ onWarning }
+        xml={ xml }
+      />
+    );
+
+    instance = wrapper.find(DmnEditor).instance();
+
+    if (!waitForImport) {
+      resolve({
+        instance,
+        wrapper
+      });
+    }
+  });
+}
+
+function getEvent(events, eventName) {
+  return find(events, e => e.type === eventName);
+}
+
+function getMenuEntry(editMenu, label) {
+  for (let i = 0; i < editMenu.length; i++) {
+    const entry = editMenu[i];
+
+    if (isArray(entry)) {
+      const res = getMenuEntry(entry, label);
+      if (res) {
+        return res;
+      }
+    } else {
+      if (entry.label === label) {
+        return entry;
+      }
+    }
+  }
+
+  return false;
+}
+
+function hasMenuEntry(editMenu, label) {
+  return !!editMenu.find(entry => {
+    if (isArray(entry)) {
+      return hasMenuEntry(entry, label);
+    } else {
+      return entry.label === label;
+    }
+  });
+}

--- a/client/src/app/tabs/cloud-dmn/__tests__/diagram.dmn
+++ b/client/src/app/tabs/cloud-dmn/__tests__/diagram.dmn
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="definitions_0pm5f1p" name="Decision" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="Decision_13nychf" name="Which Season">
+    <informationRequirement id="InformationRequirement_14co6no">
+      <requiredInput href="#InputData_1srou0x" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_0xrkotr">
+      <output id="OutputClause_0op0fkk" typeRef="string" />
+    </decisionTable>
+  </decision>
+  <decision id="Decision_17gs2k3" name="Which Region">
+    <variable id="InformationItem_1xcwjob" name="InformationItem_1xcwjob" />
+    <literalExpression id="LiteralExpression_169mwud" />
+  </decision>
+  <inputData id="InputData_1srou0x" name="Regional Weather" />
+  <decision id="Decision_1kizwj6" name="Go on Holidays?">
+    <informationRequirement id="InformationRequirement_00ajgoz">
+      <requiredDecision href="#Decision_13nychf" />
+    </informationRequirement>
+    <informationRequirement id="InformationRequirement_1ugvlci">
+      <requiredDecision href="#Decision_17gs2k3" />
+    </informationRequirement>
+  </decision>
+  <textAnnotation id="TextAnnotation_1ytoitl">
+    <text>We decide for holidays when we agreed on
+season + region</text>
+  </textAnnotation>
+  <association id="Association_0ni2cyy">
+    <sourceRef href="#Decision_11sdtl8" />
+    <targetRef href="#TextAnnotation_1ytoitl" />
+  </association>
+  <association id="Association_11uhskx">
+    <sourceRef href="#Decision_1kizwj6" />
+    <targetRef href="#TextAnnotation_1ytoitl" />
+  </association>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="Decision_13nychf">
+        <dc:Bounds height="80" width="180" x="61" y="261" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge dmnElementRef="InformationRequirement_14co6no">
+        <di:waypoint x="105" y="447" />
+        <di:waypoint x="149" y="341" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNShape dmnElementRef="Decision_17gs2k3">
+        <dc:Bounds height="80" width="180" x="360" y="252" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape dmnElementRef="InputData_1srou0x">
+        <dc:Bounds height="45" width="125" x="37" y="447" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape dmnElementRef="Decision_1kizwj6">
+        <dc:Bounds height="80" width="180" x="198" y="68" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge dmnElementRef="InformationRequirement_00ajgoz">
+        <di:waypoint x="196" y="261" />
+        <di:waypoint x="274" y="148" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge dmnElementRef="InformationRequirement_1ugvlci">
+        <di:waypoint x="405" y="252" />
+        <di:waypoint x="345" y="148" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNShape dmnElementRef="TextAnnotation_1ytoitl">
+        <dc:Bounds height="80" width="100" x="484" y="36" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge dmnElementRef="Association_0ni2cyy">
+        <di:waypoint x="389" y="113" />
+        <di:waypoint x="567" y="63" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge dmnElementRef="Association_11uhskx">
+        <di:waypoint x="378" y="98" />
+        <di:waypoint x="484" y="86" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/client/src/app/tabs/cloud-dmn/__tests__/diagram11.dmn
+++ b/client/src/app/tabs/cloud-dmn/__tests__/diagram11.dmn
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/1.0" id="definitions_0pm5f1p" name="Decision" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="Decision_13nychf" name="Which Season">
+    <extensionElements>
+      <biodi:bounds x="61" y="261" width="180" height="80" />
+      <biodi:edge source="InputData_1srou0x">
+        <biodi:waypoints x="105" y="447" />
+        <biodi:waypoints x="149" y="341" />
+      </biodi:edge>
+    </extensionElements>
+    <informationRequirement>
+      <requiredInput href="#InputData_1srou0x" />
+    </informationRequirement>
+    <decisionTable>
+      <output typeRef="string" />
+    </decisionTable>
+  </decision>
+  <decision id="Decision_17gs2k3" name="Which Region">
+    <extensionElements>
+      <biodi:bounds x="360" y="252" width="180" height="80" />
+    </extensionElements>
+    <variable id="InformationItem_1xcwjob" />
+    <literalExpression id="LiteralExpression_169mwud" />
+  </decision>
+  <inputData id="InputData_1srou0x" name="Regional Weather">
+    <extensionElements>
+      <biodi:bounds x="37" y="447" width="125" height="45" />
+    </extensionElements>
+  </inputData>
+  <decision id="Decision_1kizwj6" name="Go on Holidays?">
+    <extensionElements>
+      <biodi:bounds x="198" y="68" width="180" height="80" />
+      <biodi:edge source="Decision_13nychf">
+        <biodi:waypoints x="196" y="261" />
+        <biodi:waypoints x="274" y="148" />
+      </biodi:edge>
+      <biodi:edge source="Decision_17gs2k3">
+        <biodi:waypoints x="405" y="252" />
+        <biodi:waypoints x="345" y="148" />
+      </biodi:edge>
+    </extensionElements>
+    <informationRequirement>
+      <requiredDecision href="#Decision_13nychf" />
+    </informationRequirement>
+    <informationRequirement>
+      <requiredDecision href="#Decision_17gs2k3" />
+    </informationRequirement>
+  </decision>
+  <textAnnotation id="TextAnnotation_1ytoitl">
+    <extensionElements>
+      <biodi:bounds x="484" y="36" width="100" height="80" />
+    </extensionElements>
+    <text><![CDATA[We decide for holidays when we agreed on
+season + region]]></text>
+  </textAnnotation>
+  <association id="Association_0ni2cyy">
+    <extensionElements>
+      <biodi:edge source="Decision_11sdtl8">
+        <biodi:waypoints x="389" y="113" />
+        <biodi:waypoints x="567" y="63" />
+      </biodi:edge>
+    </extensionElements>
+    <sourceRef href="#Decision_11sdtl8" />
+    <targetRef href="#TextAnnotation_1ytoitl" />
+  </association>
+  <association id="Association_11uhskx">
+    <extensionElements>
+      <biodi:edge source="Decision_1kizwj6">
+        <biodi:waypoints x="378" y="98" />
+        <biodi:waypoints x="484" y="86" />
+      </biodi:edge>
+    </extensionElements>
+    <sourceRef href="#Decision_1kizwj6" />
+    <targetRef href="#TextAnnotation_1ytoitl" />
+  </association>
+</definitions>

--- a/client/src/app/tabs/cloud-dmn/diagram.dmn
+++ b/client/src/app/tabs/cloud-dmn/diagram.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="Definitions_{{ ID }}" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" exporter="{{ EXPORTER_NAME }}" exporterVersion="{{ EXPORTER_VERSION }}" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="{{ CAMUNDA_PLATFORM_VERSION }}">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="Definitions_{{ ID }}" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" exporter="{{ EXPORTER_NAME }}" exporterVersion="{{ EXPORTER_VERSION }}" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="{{ CAMUNDA_CLOUD_VERSION }}">
   <decision id="Decision_{{ ID:decision }}" name="Decision 1">
     <decisionTable id="DecisionTable_{{ ID }}">
       <input id="Input_1">

--- a/client/src/app/tabs/cloud-dmn/index.js
+++ b/client/src/app/tabs/cloud-dmn/index.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+export { default } from './DmnTab';

--- a/client/src/app/tabs/cloud-dmn/modeler/DmnModeler.js
+++ b/client/src/app/tabs/cloud-dmn/modeler/DmnModeler.js
@@ -1,0 +1,327 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { CamundaCloudModeler as DmnModeler } from 'camunda-dmn-js';
+import DrdViewer from '../../dmn/modeler/DrdViewer';
+
+import addExporter from '@bpmn-io/add-exporter/add-exporter';
+
+import completeDirectEditingModule from '../../bpmn/modeler/features/complete-direct-editing';
+
+import propertiesPanelKeyboardBindingsModule from '../../bpmn/modeler/features/properties-panel-keyboard-bindings';
+import decisionTableKeyboardModule from '../../dmn/modeler/features/decision-table-keyboard';
+
+import Flags, { DISABLE_ADJUST_ORIGIN } from '../../../../util/Flags';
+
+import openDrgElementModule from '../../dmn/modeler/features/overview/open-drg-element';
+import overviewRendererModule from '../../dmn/modeler/features/overview/overview-renderer';
+
+import 'camunda-dmn-js/dist/assets/camunda-cloud-modeler.css';
+
+const NOOP_MODULE = [ 'value', null ];
+
+const poweredByModule = {
+  poweredBy: NOOP_MODULE
+};
+
+const OVERVIEW_ZOOM_SCALE = 0.66;
+
+const LOW_PRIORITY = 500,
+      HIGH_PRIORITY = 2500;
+
+
+export default class CamundaDmnModeler extends DmnModeler {
+
+  constructor(options = {}) {
+
+    const {
+      moddleExtensions = {},
+      drd: drdConfig,
+      decisionTable,
+      literalExpression,
+      exporter,
+      overview,
+      ...otherOptions
+    } = options;
+
+    const drd = {
+      ...drdConfig,
+      disableAdjustOrigin: Flags.get(DISABLE_ADJUST_ORIGIN)
+    };
+
+    super({
+      ...otherOptions,
+      drd: mergeModules(drd, [
+        propertiesPanelKeyboardBindingsModule
+      ]),
+      decisionTable: mergeModules(decisionTable, [
+        decisionTableKeyboardModule,
+        poweredByModule,
+        {
+          viewDrd: NOOP_MODULE
+        }
+      ]),
+      literalExpression: mergeModules(literalExpression, [
+        poweredByModule,
+        {
+          viewDrd: NOOP_MODULE
+        }
+      ]),
+      moddleExtensions
+    });
+
+    this.on('viewer.created', ({ viewer }) => {
+
+      viewer.on('commandStack.changed', event => {
+        this._emit('view.contentChanged', event);
+      });
+
+      viewer.on('selection.changed', event => {
+        this._emit('view.selectionChanged', event);
+      });
+
+      viewer.on([ 'directEditing.activate', 'directEditing.deactivate' ], event => {
+        this._emit('view.directEditingChanged', event);
+      });
+
+      viewer.on('error', ({ error }) => {
+        this._emit('error', {
+          viewer,
+          error
+        });
+      });
+
+      viewer.on('propertiesPanel.focusin', event => {
+        this._emit('propertiesPanel.focusin', event);
+      });
+
+      viewer.on('propertiesPanel.focusout', event => {
+        this._emit('propertiesPanel.focusout', event);
+      });
+
+    });
+
+    addExporter(exporter, this);
+
+    this._addOverview(overview);
+  }
+
+  showOverview(xml) {
+    return this._overview.importXML(xml).then(
+      () => {}, err => err
+    ).then(err => this._handleOverviewImport(err));
+  }
+
+  /**
+   * Get stack index of active viewer.
+   *
+   * @returns {?number} Stack index or null.
+   */
+  getStackIdx() {
+    const viewer = this.getActiveViewer();
+
+    if (!viewer) {
+      return null;
+    }
+
+    const commandStack = viewer.get('commandStack', false);
+
+    if (!commandStack) {
+      return null;
+    }
+
+    return commandStack._stackIdx;
+  }
+
+  _addOverview(options = {}) {
+    const { layout } = options;
+
+    const overview = this._overview = new DrdViewer({
+      drd: {
+        additionalModules: [
+          openDrgElementModule,
+          overviewRendererModule
+        ],
+        openDrgElement: {
+          layout
+        }
+      }
+    });
+
+    // (1) import overview initially
+    this.on('import.parse.start', ({ xml }) => {
+      this.showOverview(xml);
+    });
+
+    // keep track of view type
+    let previousActiveViewType;
+
+    this.on('views.changed', LOW_PRIORITY, ({ activeView }) => {
+      previousActiveViewType = activeView.type;
+    });
+
+    // (2) update overview on changes in modeler
+    let offCommandStackChanged;
+
+    this.on('views.changed', ({ activeView }) => {
+      if (previousActiveViewType === activeView.type) {
+        return;
+      }
+
+      // (2.1) remove previous listener
+      if (offCommandStackChanged) {
+        offCommandStackChanged();
+      }
+
+      const handleCommandStackChanged = () => {
+
+        // (2.3) stop listening until save XML done
+        offCommandStackChanged();
+
+        // (2.4) start listening again when save XML done
+        this.once('saveXML.done', onCommandStackChanged);
+
+        this._updateOverview();
+      };
+
+      const viewer = this._viewers[ activeView.type ];
+
+      const eventBus = viewer.get('eventBus', false);
+
+      const onCommandStackChanged = () => {
+        eventBus.on('commandStack.changed', handleCommandStackChanged);
+      };
+
+      offCommandStackChanged = () => {
+        eventBus.off('commandStack.changed', handleCommandStackChanged);
+      };
+
+      // (2.2) add new listener
+      onCommandStackChanged();
+    });
+
+    // (3) highlight current open DRG element on views changed
+    this.on('views.changed', ({ activeView }) => {
+      if (activeView.type !== 'drd') {
+        const activeViewer = overview.getActiveViewer();
+
+        if (activeViewer) {
+          activeViewer.get('eventBus').fire('drgElementOpened', {
+            id: activeView.element.id
+          });
+        }
+      }
+    });
+
+    // (4) propagate layout changes
+    this.on('overviewOpen', () => {
+      const activeViewer = this._overview.getActiveViewer();
+
+      if (activeViewer) {
+        activeViewer.get('eventBus').fire('overviewOpen');
+      }
+    });
+
+    overview.once('import.done', () => {
+      const activeViewer = overview.getActiveViewer();
+
+      if (!activeViewer) {
+        return;
+      }
+
+      // (5) open DRG element on click
+      activeViewer.on('openDrgElement', ({ id }) => {
+        const view = this.getViews().find(({ element }) => {
+          return element.id === id;
+        });
+
+        if (view && view.type !== 'drd') {
+          this.open(view);
+        }
+      });
+    });
+  }
+
+  _updateOverview = () => {
+    if (!this._overview) {
+      return;
+    }
+
+    // Prevent others from hooking in when updating overview
+    this.once('saveXML.start', HIGH_PRIORITY, () => false);
+
+    return this.saveXML().then(
+      ({ xml }) => this.showOverview(xml)
+    ).catch(err => {
+      console.error(err);
+    });
+  }
+
+  _handleOverviewImport = err => {
+    if (!this._overview || !this._overview.getActiveViewer()) {
+      return;
+    }
+
+    if (err) {
+      console.error(err);
+    } else {
+      this._overview.getActiveViewer().get('canvas').zoom(OVERVIEW_ZOOM_SCALE);
+    }
+  }
+
+  attachOverviewTo = (parentNode) => {
+    this.detachOverview();
+
+    const activeViewer = this._overview.getActiveViewer();
+
+    if (!activeViewer) {
+      return;
+    }
+
+    this._emit('attachOverview');
+
+    parentNode.appendChild(activeViewer._container);
+
+    activeViewer.get('canvas').resized();
+  }
+
+  detachOverview = () => {
+    const activeViewer = this._overview.getActiveViewer();
+
+    if (!activeViewer) {
+      return;
+    }
+
+    const container = activeViewer._container;
+
+    if (container.parentNode) {
+      this._emit('detachOverview');
+
+      container.parentNode.removeChild(container);
+    }
+  }
+}
+
+
+// helpers ///////////////////////
+
+function mergeModules(editorConfig = {}, additionalModules) {
+
+  const editorModules = editorConfig.additionalModules || [];
+
+  return {
+    ...editorConfig,
+    additionalModules: [
+      completeDirectEditingModule,
+      ...editorModules,
+      ...additionalModules
+    ]
+  };
+}

--- a/client/src/app/tabs/cloud-dmn/modeler/index.js
+++ b/client/src/app/tabs/cloud-dmn/modeler/index.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+export { default } from './DmnModeler';

--- a/client/test/bpmn-io-modelers/dmn/CloudDmnModelerSpec.js
+++ b/client/test/bpmn-io-modelers/dmn/CloudDmnModelerSpec.js
@@ -1,0 +1,440 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/* global sinon */
+
+import TestContainer from 'mocha-test-container-support';
+
+import DmnModeler from '../../../src/app/tabs/cloud-dmn/modeler/DmnModeler';
+import DrdViewer from '../../../src/app/tabs/dmn/modeler/DrdViewer';
+
+import diagramXML from './diagram.dmn';
+
+const DEFAULT_OPTIONS = {
+  exporter: {
+    name: 'my-tool',
+    version: '120-beta.100'
+  }
+};
+
+const OVERVIEW_ZOOM_SCALE = 0.66;
+
+const VERY_LOW_PRIORITY = 100;
+
+inlineCSS(require('camunda-dmn-js/dist/assets/camunda-cloud-modeler.css'));
+
+inlineCSS(`
+  .test-content-container {
+    display: flex;
+    flex-direction: row;
+  }
+
+  .modeler-container,
+  .overview-container {
+    height: 100%;
+  }
+
+  .overview-container {
+    width: 200px;
+  }
+`);
+
+
+describe('DmnModeler', function() {
+
+  this.timeout(10000);
+
+  let modelerContainer,
+      overviewContainer;
+
+  beforeEach(function() {
+    modelerContainer = document.createElement('div');
+    modelerContainer.classList.add('modeler-container');
+
+    overviewContainer = document.createElement('div');
+    overviewContainer.classList.add('overview-container');
+
+    const container = TestContainer.get(this);
+
+    container.appendChild(overviewContainer);
+    container.appendChild(modelerContainer);
+  });
+
+
+  it('should bootstrap', async function() {
+
+    // when
+    const modeler = await createModeler({
+      container: modelerContainer
+    });
+
+    // then
+    expect(modeler).to.exist;
+  });
+
+
+  describe('events', function() {
+
+    let modeler;
+
+    beforeEach(async function() {
+      modeler = await createModeler({
+        container: modelerContainer
+      });
+    });
+
+
+    it('view.contentChanged', function() {
+
+      // given
+      const eventBus = modeler.getActiveViewer().get('eventBus');
+
+      const spy = sinon.spy();
+
+      modeler.on('view.contentChanged', spy);
+
+      // when
+      eventBus.fire('commandStack.changed');
+
+      // then
+      expect(spy).to.have.been.called;
+    });
+
+
+    it('view.selectionChanged', function() {
+
+      // given
+      const eventBus = modeler.getActiveViewer().get('eventBus');
+
+      const spy = sinon.spy();
+
+      modeler.on('view.selectionChanged', spy);
+
+      // when
+      eventBus.fire('selection.changed', { oldSelection: [], newSelection: [] });
+
+      // then
+      expect(spy).to.have.been.called;
+    });
+
+
+    it('view.directEditingChanged', function() {
+
+      // given
+      const eventBus = modeler.getActiveViewer().get('eventBus');
+
+      const spy = sinon.spy();
+
+      modeler.on('view.directEditingChanged', spy);
+
+      // when
+      eventBus.fire('directEditing.activate');
+
+      // then
+      expect(spy).to.have.been.called;
+    });
+
+
+    it('error', function() {
+
+      // given
+      const eventBus = modeler.getActiveViewer().get('eventBus');
+
+      const spy = sinon.spy();
+
+      modeler.on('error', spy);
+
+      // when
+      eventBus.fire('error');
+
+      // then
+      expect(spy).to.have.been.called;
+    });
+
+
+    it('propertiesPanel.focusin', function() {
+
+      // given
+      const eventBus = modeler.getActiveViewer().get('eventBus');
+
+      const spy = sinon.spy();
+
+      modeler.on('propertiesPanel.focusin', spy);
+
+      // when
+      eventBus.fire('propertiesPanel.focusin');
+
+      // then
+      expect(spy).to.have.been.called;
+    });
+
+
+    it('propertiesPanel.focusout', function() {
+
+      // given
+      const eventBus = modeler.getActiveViewer().get('eventBus');
+
+      const spy = sinon.spy();
+
+      modeler.on('propertiesPanel.focusout', spy);
+
+      // when
+      eventBus.fire('propertiesPanel.focusout');
+
+      // then
+      expect(spy).to.have.been.called;
+    });
+
+  });
+
+
+  it('#getStackIdx', async function() {
+
+    // when
+    const modeler = await createModeler({
+      container: modelerContainer
+    });
+
+    // then
+    expect(modeler.getStackIdx()).to.equal(-1);
+  });
+
+
+  describe('overview', function() {
+
+    let modeler;
+
+    beforeEach(async function() {
+      modeler = await createModeler({
+        container: modelerContainer
+      });
+
+      modeler.attachOverviewTo(overviewContainer);
+    });
+
+
+    it('should have overview', function() {
+
+      // then
+      expect(modeler._overview).to.exist;
+      expect(modeler._overview).to.be.instanceof(DrdViewer);
+    });
+
+
+    it('should import XML initially', function() {
+
+      // then
+      expect(modeler._overview.getDefinitions()).to.exist;
+    });
+
+
+    it('should set default zoom scale on import', function() {
+      const overviewCanvas = modeler._overview.getActiveViewer().get('canvas');
+
+      // then
+      expect(overviewCanvas.zoom()).to.equal(OVERVIEW_ZOOM_SCALE);
+    });
+
+
+    it('should update overview on command stack changed', async function() {
+
+      // given
+      const spy = sinon.spy(modeler, '_updateOverview');
+
+      // assume
+      expect(modeler.getActiveView().type).to.equal('drd');
+
+      // when
+      modeler.getActiveViewer().get('eventBus').fire('commandStack.changed');
+
+      // then
+      expect(spy).to.have.been.called;
+    });
+
+
+    it('should listen to current command stack changed', async function() {
+
+      // given
+      await openDecisionTable(modeler);
+
+      const spy = sinon.spy(modeler, '_updateOverview');
+
+      // assume
+      expect(modeler.getActiveView().type).to.equal('decisionTable');
+
+      // when
+      modeler.getActiveViewer().get('eventBus').fire('commandStack.changed');
+
+      // then
+      expect(spy).to.have.been.called;
+    });
+
+
+    it('should prevent others from hooking in when updating overview', async function() {
+
+      // given
+      const LOWER_PRIORITY = 1000,
+            spy = sinon.spy();
+
+      modeler.on('saveXML.start', LOWER_PRIORITY, spy);
+
+      await openDecisionTable(modeler);
+
+      // when
+      modeler.getActiveViewer().get('eventBus').fire('commandStack.changed');
+
+      // then
+      expect(spy).not.to.have.been.called;
+    });
+
+
+    it('should highlight currently open DRG element', async function() {
+
+      // when
+      await openDecisionTable(modeler);
+
+      // then
+      expect(modeler.getActiveView().type).to.equal('decisionTable');
+
+      expect(overviewContainer.querySelectorAll('.djs-element.open')).to.have.length(1);
+    });
+
+
+    it('should open DRG element on click', async function() {
+
+      // given
+      await openLiteralExpression(modeler);
+
+      // assume
+      expect(modeler.getActiveView().type).to.equal('literalExpression');
+
+      // when
+      modeler._overview.getActiveViewer().get('eventBus').fire('openDrgElement', {
+        id: 'Decision_13nychf'
+      });
+
+      // then
+      expect(modeler.getActiveView().element.id).to.equal('Decision_13nychf');
+    });
+
+
+    it('should center viewbox', async function() {
+
+      // given
+      await openDecisionTable(modeler);
+
+      const openDrgElement = modeler._overview.getActiveViewer().get('openDrgElement');
+
+      const spy = sinon.spy(openDrgElement, 'centerViewbox');
+
+      // assume
+      expect(modeler.getActiveView().type).to.equal('decisionTable');
+
+      // when
+      modeler._overview.getActiveViewer().get('eventBus').fire('overviewOpen');
+
+      // then
+      expect(spy).to.have.been.called;
+    });
+
+  });
+
+});
+
+// helpers //////////
+
+/**
+ * Create modeler and wait for modeler and overview import to finish before returning modeler.
+ *
+ * @param {Object} [options]
+ *
+ * @returns {Object}
+ */
+async function createModeler(options = {}) {
+  const modeler = new DmnModeler({
+    ...DEFAULT_OPTIONS,
+    ...options
+  });
+
+  const overviewImport = new Promise(resolve => {
+    modeler._overview.once('views.changed', VERY_LOW_PRIORITY, resolve);
+
+    modeler._overview.on('import.done', ({ err, warnings }) => {
+
+      // assume
+      expect(err).not.to.exist;
+      expect(warnings).to.be.empty;
+    });
+  });
+
+  const modelerImport = new Promise(resolve => {
+    modeler.once('views.changed', VERY_LOW_PRIORITY, resolve);
+
+    modeler.importXML(diagramXML, (err, warnings) => {
+
+      // assume
+      expect(err).not.to.exist;
+      expect(warnings).to.be.empty;
+    });
+  });
+
+  return Promise.all([ overviewImport, modelerImport ]).then(() => modeler);
+}
+
+function inlineCSS(css) {
+  var head = document.head || document.getElementsByTagName('head')[ 0 ],
+      style = document.createElement('style');
+
+  style.type = 'text/css';
+
+  if (style.styleSheet) {
+    style.styleSheet.cssText = css;
+  } else {
+    style.appendChild(document.createTextNode(css));
+  }
+
+  head.appendChild(style);
+}
+
+function openDecisionTable(modeler) {
+  const views = modeler.getViews();
+
+  const view = views.find(({ type }) => type === 'decisionTable');
+
+  return new Promise(resolve => {
+    modeler.once('views.changed', VERY_LOW_PRIORITY, ({ activeView }) => {
+
+      // assume
+      expect(activeView.type).to.equal('decisionTable');
+
+      resolve(activeView);
+    });
+
+    modeler.open(view);
+  });
+}
+
+function openLiteralExpression(modeler) {
+  const views = modeler.getViews();
+
+  const view = views.find(({ type }) => type === 'literalExpression');
+
+  return new Promise(resolve => {
+    modeler.once('views.changed', VERY_LOW_PRIORITY, ({ activeView }) => {
+
+      // assume
+      expect(activeView.type).to.equal('literalExpression');
+
+      resolve(activeView);
+    });
+
+    modeler.open(view);
+  });
+}

--- a/client/test/mocks/dmn-js/Modeler.js
+++ b/client/test/mocks/dmn-js/Modeler.js
@@ -233,3 +233,4 @@ export default class Modeler {
 Modeler.prototype._modules = [];
 
 export const CamundaPlatformModeler = Modeler;
+export const CamundaCloudModeler = Modeler;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28307541/160142989-89ebd09a-f4ba-4ad5-b517-168d6e3b4575.png)

Closes #2525 

---

Built on top of https://github.com/camunda/camunda-modeler/pull/2838

The Cloud DMN diagrams can be created via menu; the welcome page button will be implemented via https://github.com/camunda/camunda-modeler/issues/2844

Use [cloud.dmn.txt](https://github.com/camunda/camunda-modeler/files/8351505/cloud.dmn.txt) to open existing file.

Artifacts:

- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2525-add-cloud-dmn-tab/camunda-modeler-2525-add-cloud-dmn-tab-linux-x64.tar.gz
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2525-add-cloud-dmn-tab/camunda-modeler-2525-add-cloud-dmn-tab-mac.dmg
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2525-add-cloud-dmn-tab/camunda-modeler-2525-add-cloud-dmn-tab-mac.zip
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2525-add-cloud-dmn-tab/camunda-modeler-2525-add-cloud-dmn-tab-win-ia32.zip
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2525-add-cloud-dmn-tab/camunda-modeler-2525-add-cloud-dmn-tab-win-x64.zip