### PR TITLE
fix(versionOverlay): link to desktop modeler docs

### DIFF
--- a/client/src/plugins/version-info/VersionInfoOverlay.js
+++ b/client/src/plugins/version-info/VersionInfoOverlay.js
@@ -15,7 +15,7 @@ import { Overlay, Section } from '../../shared/ui';
 import { ReleaseInfo } from './ReleaseInfo';
 
 const RELEASE_NOTES_LINK = 'https://camunda.com/blog/category/modeling/?tag=camunda-modeler&release-note';
-const DOCS_LINK = 'https://docs.camunda.org/manual/latest/modeler/';
+const DOCS_LINK = 'https://docs.camunda.io/docs/components/modeler/desktop-modeler/';
 const CHANGELOG_LINK = 'https://github.com/camunda/camunda-modeler/blob/master/CHANGELOG.md';
 
 const OFFSET = { right: 0 };


### PR DESCRIPTION
* We should link to desktop modeler rather than generic "Modeler" docs
  from the Camunda Modeler

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
