### PR TITLE
chore(telemetry): track plugins usage

### DIFF
--- a/client/src/plugins/usage-statistics/event-handlers/BaseEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/BaseEventHandler.js
@@ -29,10 +29,10 @@ export default class BaseEventHandler {
     return this._isEnabled;
   }
 
-  enable() {
+  async enable() {
     this._isEnabled = true;
 
-    this.onAfterEnable();
+    await this.onAfterEnable();
   }
 
   disable() {

--- a/client/src/plugins/usage-statistics/event-handlers/PingEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/PingEventHandler.js
@@ -24,6 +24,17 @@ export default class PingEventHandler extends BaseEventHandler {
     this._intervalID = null;
 
     this.sentInitially = false;
+    this.config = params.config;
+  }
+
+  getPlugins = async (config) => {
+    const plugins = await config.get('plugins');
+
+    if (plugins) {
+      return Object.keys(plugins);
+    } else {
+      return [];
+    }
   }
 
   setInterval = (func) => {
@@ -34,15 +45,17 @@ export default class PingEventHandler extends BaseEventHandler {
     clearInterval(this._intervalID);
   }
 
-  onAfterEnable = () => {
+  onAfterEnable = async () => {
+    const plugins = await this.getPlugins(this.config);
+
     if (!this.sentInitially) {
-      this.sendToET();
+      this.sendToET({ plugins });
 
       this.sentInitially = true;
     }
 
     if (this._intervalID === null) {
-      this._intervalID = this.setInterval(() => this.sendToET());
+      this._intervalID = this.setInterval(() => this.sendToET({ plugins }));
     }
   }
 


### PR DESCRIPTION
Closes #2818

To be able to use `config.get()`, I made the `enable` function async. I tested manually and ran the tests and it doesn't seem to mess up anything. But let me know if there is a better way to do this. 

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
