### PR TITLE
fix(telemetry): get plugins with `getGlobal`

### DIFF
--- a/client/src/plugins/usage-statistics/UsageStatistics.js
+++ b/client/src/plugins/usage-statistics/UsageStatistics.js
@@ -58,7 +58,8 @@ export default class UsageStatistics extends PureComponent {
       this._eventHandlers.push(new eventHandlerConstructor({
         onSend: this.sendRequest,
         subscribe: props.subscribe,
-        config: props.config
+        config: props.config,
+        getGlobal: props._getGlobal
       }));
     });
 

--- a/client/src/plugins/usage-statistics/__tests__/UsageStatisticsSpec.js
+++ b/client/src/plugins/usage-statistics/__tests__/UsageStatisticsSpec.js
@@ -454,7 +454,8 @@ function createUsageStatistics(props = {}) {
           resolve(configValues[key] || null);
         });
       }
-    }
+    },
+    _getGlobal: () => ({})
   });
 }
 

--- a/client/src/plugins/usage-statistics/event-handlers/BaseEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/BaseEventHandler.js
@@ -29,10 +29,10 @@ export default class BaseEventHandler {
     return this._isEnabled;
   }
 
-  async enable() {
+  enable() {
     this._isEnabled = true;
 
-    await this.onAfterEnable();
+    this.onAfterEnable();
   }
 
   disable() {

--- a/client/src/plugins/usage-statistics/event-handlers/PingEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/PingEventHandler.js
@@ -25,16 +25,17 @@ export default class PingEventHandler extends BaseEventHandler {
 
     this.sentInitially = false;
     this.config = params.config;
+    this.getGlobal = params.getGlobal;
   }
 
-  getPlugins = async (config) => {
-    const plugins = await config.get('plugins');
+  getPlugins = () => {
+    const { appPlugins } = this.getGlobal('plugins');
 
-    if (plugins) {
-      return Object.keys(plugins);
-    } else {
+    if (!appPlugins) {
       return [];
     }
+
+    return appPlugins.map(plugin => plugin.name);
   }
 
   setInterval = (func) => {
@@ -45,8 +46,8 @@ export default class PingEventHandler extends BaseEventHandler {
     clearInterval(this._intervalID);
   }
 
-  onAfterEnable = async () => {
-    const plugins = await this.getPlugins(this.config);
+  onAfterEnable = () => {
+    const plugins = this.getPlugins();
 
     if (!this.sentInitially) {
       this.sendToET({ plugins });

--- a/client/src/plugins/usage-statistics/event-handlers/__tests__/PingEventHandlerSpec.js
+++ b/client/src/plugins/usage-statistics/event-handlers/__tests__/PingEventHandlerSpec.js
@@ -16,21 +16,19 @@ const noop = () => {};
 
 describe('<PingEventHandler>', () => {
 
-  let config = {
-    get: () => {}
-  };
+  let getGlobal = () => ([ ]);
 
   it('should send initially after enabling', async () => {
 
     // given
     const onSend = sinon.spy();
 
-    const pingEventHandler = new PingEventHandler({ onSend, config });
+    const pingEventHandler = new PingEventHandler({ onSend, getGlobal });
 
     pingEventHandler.setTimeout = noop;
 
     // when
-    await pingEventHandler.enable();
+    pingEventHandler.enable();
 
     // then
     expect(onSend).to.have.been.calledWith({ event: 'ping', plugins: [] });
@@ -42,12 +40,12 @@ describe('<PingEventHandler>', () => {
     // given
     const onSend = noop;
 
-    const pingEventHandler = new PingEventHandler({ onSend, config });
+    const pingEventHandler = new PingEventHandler({ onSend, getGlobal });
 
     pingEventHandler.setInterval = sinon.stub().returns('testIntervalID');
 
     // when
-    await pingEventHandler.enable();
+    pingEventHandler.enable();
 
     // then
     expect(pingEventHandler.setInterval).to.have.been.called;
@@ -60,13 +58,13 @@ describe('<PingEventHandler>', () => {
     // given
     const onSend = noop;
 
-    const pingEventHandler = new PingEventHandler({ onSend, config });
+    const pingEventHandler = new PingEventHandler({ onSend, getGlobal });
 
     pingEventHandler.setInterval = noop;
     pingEventHandler.clearInterval = sinon.spy();
 
     // when
-    await pingEventHandler.enable();
+    pingEventHandler.enable();
     pingEventHandler.disable();
 
     // then
@@ -79,15 +77,15 @@ describe('<PingEventHandler>', () => {
     // given
     const onSend = sinon.spy();
 
-    const pingEventHandler = new PingEventHandler({ onSend, config });
+    const pingEventHandler = new PingEventHandler({ onSend, getGlobal });
 
     pingEventHandler.setInterval = noop;
     pingEventHandler.clearInterval = sinon.spy();
 
     // when
-    await pingEventHandler.enable();
+    pingEventHandler.enable();
     pingEventHandler.disable();
-    await pingEventHandler.enable();
+    pingEventHandler.enable();
 
     // then
     expect(onSend).to.have.been.calledOnce;
@@ -99,20 +97,16 @@ describe('<PingEventHandler>', () => {
     // given
     const onSend = sinon.spy();
 
-    config = {
-      get: () => new Promise((resolve, reject) => {
-        setTimeout(() => {
-          resolve({ pluginName: {} });
-        }, 1000);
-      })
-    };
+    getGlobal = () => ({
+      appPlugins: [ { name: 'pluginName' } ]
+    });
 
-    const pingEventHandler = new PingEventHandler({ onSend, config });
+    const pingEventHandler = new PingEventHandler({ onSend, getGlobal });
 
     pingEventHandler.setTimeout = noop;
 
     // when
-    await pingEventHandler.enable();
+    pingEventHandler.enable();
 
     // then
 


### PR DESCRIPTION
Fix https://github.com/camunda/camunda-modeler/pull/2857

After merging, I realised that `config` only stores the plugins properties.  So if a plugin doesn't store any properties, it would not appear there. The proper way to do this is to use `_getGlobal("plugins")`, which also fixes the async problem in #2857 since it's synchronous.
