### PR TITLE
feat(usage-statistics): track icons usage

### DIFF
--- a/client/src/plugins/usage-statistics/event-handlers/DiagramOpenEventHandler.js
+++ b/client/src/plugins/usage-statistics/event-handlers/DiagramOpenEventHandler.js
@@ -215,7 +215,7 @@ export default class DiagramOpenEventHandler extends BaseEventHandler {
     const elementTemplateFilter = getElementTemplatesFilter(type);
 
     return elementTemplateFilter(elementTemplates).map((elementTemplate) => {
-      const { appliesTo, properties } = elementTemplate;
+      const { appliesTo, properties, icon } = elementTemplate;
 
       const propertyCounts = properties.map((property) => {
 
@@ -240,7 +240,16 @@ export default class DiagramOpenEventHandler extends BaseEventHandler {
         return propertyCounts;
       }, {});
 
-      return { appliesTo, properties: propertyCounts };
+      const reducedTemplate = {
+        appliesTo,
+        properties: propertyCounts
+      };
+
+      if (icon) {
+        reducedTemplate.icon = true;
+      }
+
+      return reducedTemplate;
     });
   }
 }

--- a/client/src/plugins/usage-statistics/event-handlers/__tests__/DiagramOpenEventHandlerSpec.js
+++ b/client/src/plugins/usage-statistics/event-handlers/__tests__/DiagramOpenEventHandlerSpec.js
@@ -454,6 +454,39 @@ describe('<DiagramOpenEventHandler>', () => {
       expect(elementTemplateCount).to.equal(1);
     });
 
+
+    it('should send icon usage', async () => {
+
+      // given
+      const elementTemplates = mockCloudElementTemplates({
+        icon: {
+          'contents': 'data:image/svg+xml,%3Csvg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3C/svg%3E'
+        }
+      });
+
+      const type = 'cloud-bpmn';
+
+      const expected = [
+        {
+          appliesTo: [ 'bpmn:ServiceTask' ],
+          properties: {
+            'zeebe:input': 3,
+            'zeebe:output': 1,
+            'zeebe:taskDefinition:type': 1,
+            'zeebe:taskHeader': 1
+          },
+          icon: true
+        }
+      ];
+
+      // then
+      await expectTemplatesSent(
+        elementTemplates,
+        type,
+        expected
+      );
+    });
+
   });
 
 
@@ -1729,7 +1762,7 @@ function mockPlatformElementTemplates() {
   ];
 }
 
-function mockCloudElementTemplates() {
+function mockCloudElementTemplates(overrides = {}) {
   return [
     {
       $schema: 'https://example.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
@@ -1741,7 +1774,8 @@ function mockCloudElementTemplates() {
         { binding: { name: 'messageBody', type: 'zeebe:input' } },
         { binding: { source: 'result', type: 'zeebe:output' } },
         { binding: { key: 'header', type: 'zeebe:taskHeader' } }
-      ]
+      ],
+      ...overrides
     }
   ];
 }


### PR DESCRIPTION
This is a preparation for once we support template icons in the Modeler.

Related to https://github.com/bpmn-io/internal-docs/issues/445