### PR TITLE
2873 reopen last tab startup

### DIFF
--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -44,7 +44,8 @@ class MenuBuilder {
         save: false,
         exportAs: false,
         development: process.env.NODE_ENV === 'development',
-        devtools: false
+        devtools: false,
+        lastTab: false
       },
       providers: {}
     }, options);


### PR DESCRIPTION
Closes #2873 

`lastTab` was only set on tab driven menu updates, which don't happen on a blank start
For menu entries, `enabled: undefined` defaults to `true`, as it should (if we're not defining it the menu entry should just always work)