### PR TITLE
feat(GHA): add GHA to comment on fix commits to develop

### DIFF
--- a/.github/workflows/COMMENT_DEVELOP_FIX.yml
+++ b/.github/workflows/COMMENT_DEVELOP_FIX.yml
@@ -23,7 +23,7 @@ jobs:
           fi
       - name: Create comment
         if: ${{ env.FIX_COMMITS_PRESENT == 'true' }}
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@c9fcb64660bc90ec1cc535646af190c992007c32
         with:
           issue-number: ${{ github.event.number }}
           body: |

--- a/.github/workflows/COMMENT_DEVELOP_FIX.yml
+++ b/.github/workflows/COMMENT_DEVELOP_FIX.yml
@@ -1,0 +1,32 @@
+name: COMMENT_DEVELOP_FIX
+on:
+  pull_request:
+    branches:
+      - develop
+permissions:
+  pull-requests: write
+jobs:
+  comment-on-fix-to-develop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for fix commits
+        env:
+          COMMITS_URL: ${{ github.event.pull_request.commits_url }}
+        run: |
+          echo "Checking commits via $COMMITS_URL"
+
+          if [[ $(curl $COMMITS_URL) =~ ."\"message\": \"fix".* ]]
+          then
+            echo "FIX_COMMITS_PRESENT=true" >> $GITHUB_ENV
+          else
+            echo "FIX_COMMITS_PRESENT=false" >> $GITHUB_ENV
+          fi
+      - name: Create comment
+        if: ${{ env.FIX_COMMITS_PRESENT == 'true' }}
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.number }}
+          body: |
+            This Pull Request targets `develop` branch, but contains `fix` commits.
+
+            Consider targeting `master` instead.


### PR DESCRIPTION
* I realized that we in some cases don't follow our best-pratice to do fixes for camunda-modeler on `master` rather than on `develop`
  * example: https://github.com/camunda/camunda-modeler/pull/2893
* This GHA is meant to support us with this, by notifying us via a comment:
![Screenshot_20220506_170451](https://user-images.githubusercontent.com/42800119/167160241-acfce833-43f7-48e9-a9d9-17c806cd832d.png)
