### PR TITLE
Reusable resize container

### DIFF
--- a/client/src/app/tabs/Linting.js
+++ b/client/src/app/tabs/Linting.js
@@ -16,6 +16,8 @@ import { Fill } from '../slot-fill';
 
 import ErrorIcon from '../../../resources/icons/Error.svg';
 
+import { DEFAULT_LAYOUT } from './panel/Panel';
+
 import css from './Linting.less';
 
 
@@ -34,6 +36,7 @@ export function Linting(props) {
     if (!panel.open) {
       onLayoutChanged({
         panel: {
+          ...DEFAULT_LAYOUT,
           open: true,
           tab: 'linting'
         }
@@ -45,6 +48,7 @@ export function Linting(props) {
     if (panel.tab === 'linting') {
       onLayoutChanged({
         panel: {
+          height: 0,
           open: false,
           tab: 'linting'
         }
@@ -55,6 +59,7 @@ export function Linting(props) {
 
     onLayoutChanged({
       panel: {
+        ...DEFAULT_LAYOUT,
         open: true,
         tab: 'linting'
       }

--- a/client/src/app/tabs/PropertiesContainer.js
+++ b/client/src/app/tabs/PropertiesContainer.js
@@ -10,17 +10,9 @@
 
 import React, { PureComponent } from 'react';
 
-import classNames from 'classnames';
-
-import { isFunction } from 'min-dash';
-
-import dragger from '../../util/dom/dragger';
+import ResizableContainer from './ResizableContainer';
 
 import css from './PropertiesContainer.less';
-
-import HandleBar from '../../../resources/icons/HandleBar.svg';
-
-import { throttle } from '../../util';
 
 export const MIN_WIDTH = 280;
 
@@ -35,209 +27,28 @@ export const DEFAULT_LAYOUT = {
 class PropertiesContainerWrapped extends PureComponent {
   constructor(props) {
     super(props);
-
-    this.handlePanelResize = throttle(this.handlePanelResize);
-
-    this.containerRef = new React.createRef();
-    this.resizeHandlerRef = new React.createRef();
-
-    this.context = {};
-
-    this.state = {
-      lastSetWidth: this.getStartWidth()
-    };
-  }
-
-  componentDidMount() {
-    window.addEventListener('resize', this.handleResize);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
-  }
-
-  getStartWidth = () => {
-    const layout = this.props.layout || {};
-
-    const propertiesPanel = layout.propertiesPanel || DEFAULT_LAYOUT;
-
-    const width = propertiesPanel.width || DEFAULT_LAYOUT.width;
-
-    return width;
-  }
-
-  handleResizeStart = (event) => {
-    adjustHandlerDragStyles(
-      this.resizeHandlerRef.current,
-      { dragging: true }
-    );
-
-    const onDragStart = dragger(this.handlePanelResize);
-
-    onDragStart(event);
-
-    const {
-      open,
-      width,
-      fullWidth
-    } = getLayoutFromProps(this.props);
-
-    this.context = {
-      open,
-      startWidth: width,
-      fullWidth
-    };
-  }
-
-  handleResize = () => {
-    const width = getCurrentWidth(this.containerRef.current);
-
-    if (width >= getMaxWidth()) {
-
-      const newWidth = getWindowWidth();
-      this.containerRef.current.style.width = `${newWidth}px`;
-
-      this.changeLayout({
-        propertiesPanel: {
-          open: true,
-          width: newWidth,
-          fullWidth: true
-        }
-      });
-    }
-  }
-
-  handlePanelResize = (_, delta) => {
-    const { x: dx } = delta;
-
-    if (dx === 0) {
-      return;
-    }
-
-    const { startWidth } = this.context;
-
-    const {
-      open,
-      width,
-      fullWidth
-    } = getLayout(dx, startWidth);
-
-    this.context = {
-      ...this.context,
-      open,
-      width: width === 0 ? this.state.lastSetWidth : width,
-      fullWidth
-    };
-
-    const styledWidth = open ? `${width}px` : 0;
-
-    if (this.containerRef.current) {
-      this.containerRef.current.classList.toggle('open', open);
-      this.containerRef.current.style.width = styledWidth;
-    }
-
-    if (this.resizeHandlerRef.current) {
-      adjustHandlerSnapStyles(this.resizeHandlerRef.current, this.context);
-    }
-  }
-
-  handleResizeEnd = () => {
-    adjustHandlerDragStyles(
-      this.resizeHandlerRef.current,
-      { dragging: false }
-    );
-
-    const {
-      open,
-      width,
-      fullWidth
-    } = this.context;
-
-    this.context = {};
-
-    if (open) {
-      this.setState ({ lastSetWidth: width });
-    }
-
-    this.changeLayout({
-      propertiesPanel: {
-        open,
-        width,
-        fullWidth
-      }
-    });
-  }
-
-  handleToggle = () => {
-    const { layout = {} } = this.props;
-
-    const { propertiesPanel = {} } = layout;
-
-    this.changeLayout({
-      propertiesPanel: {
-        ...DEFAULT_LAYOUT,
-        ...propertiesPanel,
-        open: !propertiesPanel.open,
-        width: this.state.lastSetWidth
-      }
-    });
-  }
-
-  changeLayout = (layout = {}) => {
-    const { onLayoutChanged } = this.props;
-
-    if (isFunction(onLayoutChanged)) {
-      onLayoutChanged(layout);
-    }
   }
 
   render() {
     const {
       className,
-      forwardedRef
+      forwardedRef,
+      layout,
+      onLayoutChanged
     } = this.props;
 
-    const {
-      open,
-      width,
-      fullWidth
-    } = getLayoutFromProps(this.props);
-
     return (
-      <div
-        ref={ this.containerRef }
-        className={ classNames(
-          css.PropertiesContainer,
-          className,
-          { open }
-        ) }
-        style={ { width } }>
-        <div
-          className="toggle"
-          onClick={ this.handleToggle }
-          draggable
-          onDragStart={ this.handleResizeStart }
-          onDragEnd={ this.handleResizeEnd }
-        >
-          {!open && <HandleBar />}
-        </div>
-
-        <div
-          ref={ this.resizeHandlerRef }
-          className={ classNames(
-            'resize-area',
-            { 'snapped-right': !open },
-            { 'snapped-left': fullWidth },
-          ) }
-          draggable
-          onDragStart={ this.handleResizeStart }
-          onDragEnd={ this.handleResizeEnd }
-        >
-          <div className="resize-handle" />
-        </div>
-
-        <div className="properties-container" ref={ forwardedRef }></div>
-      </div>
+      <ResizableContainer
+        className={ className }
+        defaultLayout={ DEFAULT_LAYOUT }
+        layout={ layout }
+        layoutProp="propertiesPanel"
+        minWidth={ MIN_WIDTH }
+        onLayoutChanged={ onLayoutChanged }
+        position="right"
+      >
+        <div className={ css.PropertiesContainer } ref={ forwardedRef }></div>
+      </ResizableContainer>
     );
   }
 
@@ -248,106 +59,3 @@ export default React.forwardRef(
     return <PropertiesContainerWrapped { ...props } forwardedRef={ ref } />;
   }
 );
-
-// helpers //////////
-
-function getLayout(dx, initialWidth) {
-  let width = initialWidth - dx;
-  const max_width = getMaxWidth();
-
-  let open = width > MIN_WIDTH;
-  let fullWidth = width > max_width;
-
-  if (!open) {
-
-    // if was already closed and drags 40px
-    if (initialWidth < MIN_WIDTH && dx < -40) {
-
-      // snap to min_width
-      width = MIN_WIDTH;
-      open = true;
-
-    } else {
-      width = 0;
-    }
-  }
-
-  if (fullWidth) {
-
-    // if was already fulled and drags 40px
-    if (initialWidth > max_width && dx > 40) {
-
-      // snap to max_width
-      width = max_width;
-      fullWidth = false;
-
-    } else {
-      width = getWindowWidth();
-    }
-  }
-
-  return {
-    open,
-    fullWidth,
-    width
-  };
-}
-
-function getLayoutFromProps(props) {
-  const layout = props.layout || {};
-
-  const propertiesPanel = layout.propertiesPanel || DEFAULT_LAYOUT;
-
-  const { open, fullWidth } = propertiesPanel;
-
-  const width = open ? propertiesPanel.width : 0;
-
-  return {
-    open,
-    width,
-    fullWidth
-  };
-}
-
-function adjustHandlerSnapStyles(handle, context) {
-  const {
-    open,
-    fullWidth
-  } = context;
-
-  handle.classList.remove('snapped-right');
-  handle.classList.remove('snapped-left');
-
-  if (!open) {
-    handle.classList.add('snapped-right');
-  }
-
-  if (fullWidth) {
-    handle.classList.add('snapped-left');
-  }
-}
-
-function adjustHandlerDragStyles(handle, context) {
-
-  Object.keys(context).forEach(state => {
-
-    if (context[state]) {
-      handle.classList.add(state);
-    } else {
-      handle.classList.remove(state);
-    }
-
-  });
-}
-
-function getWindowWidth() {
-  return window.innerWidth;
-}
-
-function getMaxWidth() {
-  return getWindowWidth() * 0.8;
-}
-
-function getCurrentWidth(panel) {
-  return panel.getBoundingClientRect().width;
-}

--- a/client/src/app/tabs/PropertiesContainer.less
+++ b/client/src/app/tabs/PropertiesContainer.less
@@ -1,103 +1,16 @@
 :local(.PropertiesContainer) {
-
-  position: relative;
-  outline: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow-y: auto;
 
   background: var(--color-grey-225-10-97);
-
-  &.open {
-    outline: solid 1px var(--color-grey-225-10-75);
-
-    & > .toggle {
-      display: none;
-    }
-  }
-
-  .toggle {
-    position: absolute;
-    left: -23px;
-    top: calc(50% - 31px);
-    padding: 7px 10px;
-    transform-origin: top left;
-    z-index: 12;
-    fill:var(--color-grey-225-10-85);
-
-    &:hover{
-      fill: var(--color-grey-225-10-75);
-
-      & + .resize-area  .resize-handle {
-        background-color:  var(--color-blue-205-100-50);
-      } 
-
-    }
-  }
-
-  .resize-area {
-    cursor: ew-resize;
-    z-index: 11;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    transform: translateX(-50%);
-    width: 16px;
-    user-select: none;
-    transition: 0s border;
-    display: flex;
-    justify-content: center;
-
-    &.snapped-right {
-      transform: translateX(-100%);
-      cursor: w-resize;
-
-      & > .resize-handle {
-        margin-left: auto;
-      }
-    }
-
-    &.snapped-left {
-      transform: translateX(-6px);
-      cursor: e-resize;
-    
-      & > .resize-handle {
-        margin-right: auto;
-        transform: translateX(6px)
-      }
-    }
-
-    &:hover > .resize-handle  {
-      background-color:  var(--color-blue-205-100-50);
-      transition-delay: 200ms;
-    }
-
-    &.dragging {
-
-      & > .resize-handle {
-        background-color:  var(--color-blue-205-100-50);
-      }
-  
-      & + .toggle {
-        opacity: 0;
-      }
-    }
-  }
-
-  .resize-handle {
-    width: 3px;
-  }
-
-  .properties-container {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    overflow-y: auto;
-  }
 
   .bio-properties-panel {
     --font-family: inherit;
     --font-family-monospace: inherit;
     background: var(--color-white);
   }
-
 }

--- a/client/src/app/tabs/ResizableContainer.js
+++ b/client/src/app/tabs/ResizableContainer.js
@@ -1,0 +1,604 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React, { PureComponent } from 'react';
+
+import classNames from 'classnames';
+
+import { isFunction } from 'min-dash';
+
+import dragger from '../../util/dom/dragger';
+
+import css from './ResizableContainer.less';
+
+import HandleBar from '../../../resources/icons/HandleBar.svg';
+
+import { throttle } from '../../util';
+
+const DEFAULT_POSITION = 'right';
+
+
+/**
+ * Container that can be resized and toggled.
+ *
+ * @typedef {object} ResizableContainerProps
+ * @prop {object} defaultLayout
+ * @prop {object} layout
+ * @prop {string} layoutProp
+ * @prop {number} [minHeight]
+ * @prop {number} [minWidth]
+ * @prop {bottom|right} [position]
+ * @prop {function} [onLayoutChanged]
+ *
+ * @extends {PureComponent<ResizableContainerProps>}
+ */
+export default class ResizableContainer extends PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.handleContainerResize = throttle(this.handleContainerResize);
+
+    this.containerRef = new React.createRef();
+    this.resizeHandlerRef = new React.createRef();
+
+    this.context = {};
+
+    this.state = {
+      lastSetWidth: this.getStartWidth(),
+      lastSetHeight: this.getStartHeight()
+    };
+  }
+
+  componentDidMount() {
+    window.addEventListener('resize', this.handleResize);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  getStartWidth = () => {
+    const {
+      defaultLayout = {},
+      layout = {},
+      layoutProp
+    } = this.props;
+
+    const containerLayout = layout[layoutProp] || defaultLayout;
+
+    const width = containerLayout.width || defaultLayout.width;
+
+    return width;
+  }
+
+  getStartHeight = () => {
+    const {
+      defaultLayout = {},
+      layout = {},
+      layoutProp
+    } = this.props;
+
+    const containerLayout = layout[layoutProp] || defaultLayout;
+
+    const height = containerLayout.height || defaultLayout.height;
+
+    return height;
+  }
+
+  calculateNewLayout = (options) => {
+    const {
+      minWidth,
+      minHeight,
+      position = DEFAULT_POSITION
+    } = this.props;
+
+    if (position === 'right') {
+      return calculateRightLayout({ ...options, minWidth });
+    }
+
+    if (position === 'bottom') {
+      return calculateBottomLayout({ ...options, minHeight });
+    }
+  }
+
+  handleResizeStart = (event) => {
+    adjustHandlerDragStyles(
+      this.resizeHandlerRef.current,
+      { dragging: true }
+    );
+
+    const onDragStart = dragger(this.handleContainerResize);
+
+    onDragStart(event);
+
+    const {
+      fullHeight,
+      fullWidth,
+      height,
+      open,
+      position,
+      width
+    } = getLayoutFromProps(this.props);
+
+    this.context = {
+      fullHeight,
+      fullWidth,
+      open,
+      position,
+      startHeight: height,
+      startWidth: width
+    };
+  }
+
+  snapToLeft = () => {
+    const {
+      layoutProp
+    } = this.props;
+
+    const newWidth = getWindowWidth();
+    this.containerRef.current.style.width = `${newWidth}px`;
+
+    this.changeLayout({
+      [layoutProp]: {
+        open: true,
+        width: newWidth,
+        fullWidth: true
+      }
+    });
+  }
+
+  snapToTop = () => {
+    const {
+      layoutProp
+    } = this.props;
+
+    const newHeight = getWindowHeight();
+    this.containerRef.current.style.height = `${newHeight}px`;
+
+    this.changeLayout({
+      [layoutProp]: {
+        open: true,
+        height: newHeight,
+        fullHeight: true
+      }
+    });
+  }
+
+  handleResize = () => {
+    const {
+      position = DEFAULT_POSITION
+    } = this.props;
+
+    // snap on
+    // a) position <right> => snap to left
+    // b) position <bottom> => snap to top
+    if (position === 'right') {
+      const width = getCurrentWidth(this.containerRef.current);
+      width >= getMaxWidth() && this.snapToLeft();
+    }
+
+    if (position === 'bottom') {
+      const height = getCurrentHeight(this.containerRef.current);
+      height >= getMaxHeight() && this.snapToTop();
+    }
+  }
+
+  setContainerHeight = (options) => {
+    const {
+      fullHeight,
+      height
+    } = options;
+
+    this.context = {
+      ...this.context,
+      height: height === 0 ? this.state.lastSetHeight : height,
+      fullHeight
+    };
+
+    const styledHeight = open ? `${height}px` : 0;
+
+    if (this.containerRef.current) {
+      this.containerRef.current.classList.toggle('open', open);
+      this.containerRef.current.style.height = styledHeight;
+    }
+  }
+
+  setContainerWidth = (options) => {
+    const {
+      fullWidth,
+      width
+    } = options;
+
+    this.context = {
+      ...this.context,
+      width: width === 0 ? this.state.lastSetWidth : width,
+      fullWidth
+    };
+
+    const styledWidth = open ? `${width}px` : 0;
+
+    if (this.containerRef.current) {
+      this.containerRef.current.classList.toggle('open', open);
+      this.containerRef.current.style.width = styledWidth;
+    }
+  }
+
+  handleContainerResize = (_, delta) => {
+    const { x: dx, y: dy } = delta;
+
+    if (dx === 0 && dy === 0) {
+      return;
+    }
+
+    const {
+      position,
+      startWidth,
+      startHeight
+    } = this.context;
+
+    const {
+      open,
+      height,
+      width,
+      fullHeight,
+      fullWidth
+    } = this.calculateNewLayout({
+      dx,
+      dy,
+      startWidth,
+      startHeight
+    });
+
+    this.context = {
+      ...this.context,
+      open
+    };
+
+    if (position === 'right') {
+      this.setContainerWidth({ fullWidth, width });
+    }
+
+    if (position === 'bottom') {
+      this.setContainerHeight({ fullHeight, height });
+    }
+
+    if (this.resizeHandlerRef.current) {
+      adjustHandlerSnapStyles(this.resizeHandlerRef.current, this.context);
+    }
+  }
+
+  handleResizeEnd = () => {
+    const {
+      layoutProp
+    } = this.props;
+
+    adjustHandlerDragStyles(
+      this.resizeHandlerRef.current,
+      { dragging: false }
+    );
+
+    const {
+      fullWidth,
+      fullHeight,
+      open,
+      position,
+      height,
+      width
+    } = this.context;
+
+    this.context = {};
+
+    if (open) {
+      this.setState ({
+        ...(position === 'right' && { lastSetWidth: width }),
+        ...(position === 'bottom' && { lastSetHeight: height })
+      });
+    }
+
+    this.changeLayout({
+      [layoutProp]: {
+        open,
+        ...(position === 'right' && { width, fullWidth }),
+        ...(position === 'bottom' && { height, fullHeight })
+      }
+    });
+  }
+
+  handleToggle = () => {
+    const {
+      defaultLayout = {},
+      layout = {},
+      layoutProp,
+      position = DEFAULT_POSITION
+    } = this.props;
+
+    const containerLayout = layout[layoutProp] || {};
+
+    this.changeLayout({
+      [layoutProp]: {
+        ...defaultLayout,
+        ...containerLayout,
+        open: !containerLayout.open,
+        ...(position === 'right' && { width: this.state.lastSetWidth }),
+        ...(position === 'bottom' && { height: this.state.lastSetHeight })
+      }
+    });
+  }
+
+  changeLayout = (layout = {}) => {
+    const { onLayoutChanged } = this.props;
+
+    if (isFunction(onLayoutChanged)) {
+      onLayoutChanged(layout);
+    }
+  }
+
+  render() {
+    const {
+      className,
+      children,
+      position = DEFAULT_POSITION
+    } = this.props;
+
+    const {
+      open,
+      height,
+      width,
+      fullWidth,
+      fullHeight
+    } = getLayoutFromProps(this.props);
+
+    const style = {
+      ...(position === 'right' && { width }),
+      ...(position === 'bottom' && { height })
+    };
+
+    return (
+      <div
+        ref={ this.containerRef }
+        className={ classNames(
+          css.ResizableContainer,
+          className,
+          { open },
+          `position--${position}`
+        ) }
+        style={ style }>
+        <div
+          className="toggle"
+          onClick={ this.handleToggle }
+          draggable
+          onDragStart={ this.handleResizeStart }
+          onDragEnd={ this.handleResizeEnd }
+        >
+          {!open && <HandleBar />}
+        </div>
+
+        <div
+          ref={ this.resizeHandlerRef }
+          className={ classNames(
+            'resize-area',
+            { 'snapped--right': position === 'right' && !open },
+            { 'snapped--left': fullWidth },
+            { 'snapped--bottom': position === 'bottom' && !open },
+            { 'snapped--top': fullHeight },
+          ) }
+          draggable
+          onDragStart={ this.handleResizeStart }
+          onDragEnd={ this.handleResizeEnd }
+        >
+          <div className="resize-handle" />
+        </div>
+        { children }
+      </div>
+    );
+  }
+
+}
+
+
+// helpers //////////
+
+function getLayoutFromProps(props) {
+  const {
+    defaultLayout = {},
+    layout = {},
+    layoutProp,
+    minHeight,
+    minWidth,
+    position = DEFAULT_POSITION
+  } = props;
+
+  const containerLayout = layout[layoutProp] || defaultLayout;
+
+  const { open } = containerLayout;
+
+  let calculatedLayout = {
+    open,
+    position
+  };
+
+  // todo(pinussilvestrus): support position=(left | top)
+  if (position === 'right') {
+    calculatedLayout = {
+      ...calculatedLayout,
+      fullWidth: containerLayout.fullWidth,
+      width: open ? (containerLayout.width || minWidth) : 0
+    };
+  }
+
+  if (position === 'bottom') {
+    calculatedLayout = {
+      ...calculatedLayout,
+      fullHeight: containerLayout.fullHeight,
+      height: open ? (containerLayout.height || minHeight) : 0
+    };
+  }
+
+  return calculatedLayout;
+}
+
+function calculateBottomLayout(options) {
+  const {
+    dy,
+    minHeight,
+    startHeight
+  } = options;
+
+  let height = startHeight - dy;
+  const maxHeight = getMaxHeight();
+
+  let open = height > minHeight;
+  let fullHeight = height > maxHeight;
+
+  if (!open) {
+
+    // if was already closed and drags 40px
+    if (startHeight < minHeight && dy < -40) {
+
+      // snap to min height
+      height = minHeight;
+      open = true;
+
+    } else {
+      height = 0;
+    }
+  }
+
+  if (fullHeight) {
+
+    // if was already fulled and drags 40px
+    if (startHeight > maxHeight && dy > 40) {
+
+      // snap to max height
+      height = maxHeight;
+      fullHeight = false;
+
+    } else {
+
+      // calculate for status + tab bar
+      height = getWindowHeight() - 60;
+    }
+  }
+
+  return {
+    open,
+    fullHeight,
+    height
+  };
+}
+
+function calculateRightLayout(options) {
+  const {
+    dx,
+    minWidth,
+    startWidth
+  } = options;
+
+  let width = startWidth - dx;
+  const maxWidth = getMaxWidth();
+
+  let open = width > minWidth;
+  let fullWidth = width > maxWidth;
+
+  if (!open) {
+
+    // if was already closed and drags 40px
+    if (startWidth < minWidth && dx < -40) {
+
+      // snap to min_width
+      width = minWidth;
+      open = true;
+
+    } else {
+      width = 0;
+    }
+  }
+
+  if (fullWidth) {
+
+    // if was already fulled and drags 40px
+    if (startWidth > maxWidth && dx > 40) {
+
+      // snap to max_width
+      width = maxWidth;
+      fullWidth = false;
+
+    } else {
+      width = getWindowWidth();
+    }
+  }
+
+  return {
+    open,
+    fullWidth,
+    width
+  };
+}
+
+function adjustHandlerSnapStyles(handle, context) {
+  const {
+    fullHeight,
+    fullWidth,
+    open,
+    position,
+  } = context;
+
+  handle.classList.remove('snapped-right');
+  handle.classList.remove('snapped-left');
+
+  if (!open) {
+    handle.classList.add(position === 'right' ? 'snapped-right' : 'snapped-bottom');
+  }
+
+  if (fullWidth) {
+    handle.classList.add('snapped-left');
+  }
+
+  if (fullHeight) {
+    handle.classList.add('snapped-top');
+  }
+}
+
+function adjustHandlerDragStyles(handle, context) {
+
+  Object.keys(context).forEach(state => {
+
+    if (context[state]) {
+      handle.classList.add(state);
+    } else {
+      handle.classList.remove(state);
+    }
+
+  });
+}
+
+function getWindowWidth() {
+  return window.innerWidth;
+}
+
+function getWindowHeight() {
+  return window.innerHeight;
+}
+
+function getMaxWidth() {
+  return getWindowWidth() * 0.8;
+}
+
+function getMaxHeight() {
+  return getWindowHeight() * 0.8;
+}
+
+function getCurrentWidth(panel) {
+  return panel.getBoundingClientRect().width;
+}
+
+function getCurrentHeight(panel) {
+  return panel.getBoundingClientRect().height;
+}

--- a/client/src/app/tabs/ResizableContainer.less
+++ b/client/src/app/tabs/ResizableContainer.less
@@ -133,7 +133,7 @@
     }
 
     .toggle {
-      left: calc(50% - 40px);
+      left: calc(50% + 40px);
       transform: rotate(90deg);
       top: -23px;
       padding: 7px 10px;

--- a/client/src/app/tabs/ResizableContainer.less
+++ b/client/src/app/tabs/ResizableContainer.less
@@ -1,0 +1,143 @@
+:root {
+  --resizable-container-outline-color: var(--color-grey-225-10-75);
+  --resizable-container-toggle-fill-color: var(--color-grey-225-10-85);
+  --resizable-container-toggle-hover-fill-color: var(--color-grey-225-10-75);
+  --resizable-container-resizer-hover-background-color: var(--color-blue-205-100-50);
+}
+
+:local(.ResizableContainer) {
+
+  position: relative;
+  outline: none;
+
+  &.open {
+    outline: solid 1px var(--resizable-container-outline-color);
+
+    & > .toggle {
+      display: none;
+    }
+  }
+
+  .toggle {
+    position: absolute;
+    z-index: 12;
+    fill: var(--resizable-container-toggle-fill-color);
+
+    &:hover {
+      fill: var(--resizable-container-toggle-hover-fill-color);
+
+      & + .resize-area .resize-handle {
+        background-color: var(--resizable-container-resizer-hover-background-color);
+      } 
+
+    }
+  }
+
+  .resize-area {
+    z-index: 11;
+    position: absolute;
+    user-select: none;
+    transition: 0s border;
+    display: flex;
+    justify-content: center;
+
+    &:hover > .resize-handle  {
+      background-color:  var(--resizable-container-resizer-hover-background-color);
+      transition-delay: 200ms;
+    }
+
+    &.dragging {
+
+      & > .resize-handle {
+        background-color:  var(--resizable-container-resizer-hover-background-color);
+      }
+  
+      & + .toggle {
+        opacity: 0;
+      }
+    }
+  }
+
+  &.position--right {
+    .resize-area {
+      cursor: ew-resize;
+      transform: translateX(-50%);
+      width: 16px;
+      top: 0;
+      bottom: 0;
+
+      &.snapped--right {
+        transform: translateX(-100%);
+        cursor: w-resize;
+  
+        & > .resize-handle {
+          margin-left: auto;
+        }
+      }
+  
+      &.snapped--left {
+        transform: translateX(-6px);
+        cursor: e-resize;
+      
+        & > .resize-handle {
+          margin-right: auto;
+          transform: translateX(6px)
+        }
+      }
+    }
+
+    .resize-handle {
+      width: 3px;
+    }
+
+    .toggle {
+      left: -23px;
+      top: calc(50% - 31px);
+      padding: 7px 10px;
+      transform-origin: top left;
+    }
+  }
+
+  &.position--bottom {
+    .resize-area {
+      cursor: ns-resize;
+      transform: translateY(-50%);
+      height: 16px;
+      left: 0;
+      right: 0;
+
+      &.snapped--bottom {
+        transform: translateY(-100%);
+        cursor: n-resize;
+  
+        & > .resize-handle {
+          margin-top: auto;
+        }
+      }
+  
+      &.snapped--top {
+        transform: translateY(-6px);
+        cursor: s-resize;
+      
+        & > .resize-handle {
+          margin-bottom: auto;
+          transform: translateY(1px)
+        }
+      }
+    }
+
+    .resize-handle {
+      width: 100%;
+      height: 3px;
+      margin-top: 5px;
+    }
+
+    .toggle {
+      left: calc(50% - 40px);
+      transform: rotate(90deg);
+      top: -23px;
+      padding: 7px 10px;
+      transform-origin: top left;
+    }
+  }
+}

--- a/client/src/app/tabs/__tests__/LintingSpec.js
+++ b/client/src/app/tabs/__tests__/LintingSpec.js
@@ -21,6 +21,8 @@ import {
 
 import { Linting } from '../Linting';
 
+import { MIN_HEIGHT } from '../panel/Panel';
+
 const spy = sinon.spy;
 
 
@@ -116,7 +118,8 @@ describe('Linting', function() {
       expect(onLayoutChangedSpy).to.have.been.calledOnceWith({
         panel: {
           open: true,
-          tab: 'linting'
+          tab: 'linting',
+          height: MIN_HEIGHT
         }
       });
     });
@@ -144,7 +147,8 @@ describe('Linting', function() {
       expect(onLayoutChangedSpy).to.have.been.calledOnceWith({
         panel: {
           open: true,
-          tab: 'linting'
+          tab: 'linting',
+          height: MIN_HEIGHT
         }
       });
     });
@@ -172,7 +176,8 @@ describe('Linting', function() {
       expect(onLayoutChangedSpy).to.have.been.calledOnceWith({
         panel: {
           open: false,
-          tab: 'linting'
+          tab: 'linting',
+          height: 0
         }
       });
     });

--- a/client/src/app/tabs/__tests__/PropertiesContainerSpec.js
+++ b/client/src/app/tabs/__tests__/PropertiesContainerSpec.js
@@ -12,7 +12,7 @@
 
 import React from 'react';
 
-import PropertiesContainer, { MIN_WIDTH } from '../PropertiesContainer';
+import PropertiesContainer from '../PropertiesContainer';
 
 import { mount } from 'enzyme';
 
@@ -34,302 +34,42 @@ describe('<PropertiesContainer>', function() {
   });
 
 
-  it('should resize', function() {
+  it('should update layout on resize', function() {
 
     // given
+    const onLayoutChangedSpy = spy();
+
     const layout = {
       propertiesPanel: {
         open: true,
-        width: 500
+        width: 300
       }
     };
 
-    const onLayoutChangedSpy = spy();
-
-    const {
-      instance,
-      wrapper
-    } = createPropertiesContainer({
+    const { wrapper } = createPropertiesContainer({
       layout,
       onLayoutChanged: onLayoutChangedSpy
     });
 
+    const resizableContainer = wrapper.find('ResizableContainer').first().instance();
+
     // when
-    instance.handleResizeStart(createMouseEvent('dragstart', 0, 0));
+    resizableContainer.handleResizeStart(createMouseEvent('dragstart', 0, 0));
 
-    instance.handlePanelResize(null, { x: -50 });
+    resizableContainer.handleContainerResize(null, { x: -50 });
 
-    instance.handleResizeEnd();
+    resizableContainer.handleResizeEnd();
 
     // then
     expect(onLayoutChangedSpy).to.be.calledWith({
       propertiesPanel: {
         open: true,
-        width: 550,
+        width: 350,
         fullWidth: false
       }
     });
-
-    // clean
-    wrapper.unmount();
   });
 
-
-  it('should close when resized to smaller than minimum size', function() {
-
-    // given
-    const layout = {
-      propertiesPanel: {
-        open: true,
-        width: 500
-      }
-    };
-
-    const onLayoutChangedSpy = spy();
-
-    const {
-      instance,
-      wrapper
-    } = createPropertiesContainer({
-      layout,
-      onLayoutChanged: onLayoutChangedSpy
-    });
-
-    // when
-    instance.handleResizeStart(createMouseEvent('dragstart', 0, 0));
-
-    instance.handlePanelResize(null, { x: 400 });
-
-    instance.handleResizeEnd();
-
-    // then
-    expect(onLayoutChangedSpy).to.be.calledWith({
-      propertiesPanel: {
-        open: false,
-        width: 500,
-        fullWidth: false
-      }
-    });
-
-    // clean
-    wrapper.unmount();
-  });
-
-
-  it('should resize to full width when larger than maximum size', function() {
-
-    // given
-    const layout = {
-      propertiesPanel: {
-        open: true,
-        width: 500
-      }
-    };
-
-    global.innerWidth = 1000;
-
-    const onLayoutChangedSpy = spy();
-
-    const {
-      instance,
-      wrapper
-    } = createPropertiesContainer({
-      layout,
-      onLayoutChanged: onLayoutChangedSpy
-    });
-
-    // when
-    instance.handleResizeStart(createMouseEvent('dragstart', 0, 0));
-
-    instance.handlePanelResize(null, { x: -1000 });
-
-    instance.handleResizeEnd();
-
-    // then
-    expect(onLayoutChangedSpy).to.be.calledWith({
-      propertiesPanel: {
-        open: true,
-        width: 1000,
-        fullWidth: true
-      }
-    });
-
-    // clean
-    wrapper.unmount();
-  });
-
-
-  it('should open to min width after dragging at least 40 px to open', function() {
-
-    // given
-    const layout = {
-      propertiesPanel: {
-        open: false,
-        width: 0
-      }
-    };
-
-    const onLayoutChangedSpy = spy();
-
-    const {
-      instance,
-      wrapper
-    } = createPropertiesContainer({
-      layout,
-      onLayoutChanged: onLayoutChangedSpy
-    });
-
-    // when
-    instance.handleResizeStart(createMouseEvent('dragstart', 0, 0));
-    instance.handlePanelResize(null, { x: -50 });
-    instance.handleResizeEnd();
-
-    // then
-    expect(onLayoutChangedSpy).to.be.calledWith({
-      propertiesPanel: {
-        open: true,
-        width: MIN_WIDTH,
-        fullWidth: false
-      }
-    });
-
-    // clean
-    wrapper.unmount();
-  });
-
-
-  it('should close to max width after dragging at least 40 px', function() {
-
-    // given
-    const layout = {
-      propertiesPanel: {
-        open: true,
-        width: 1000,
-        fullWidth: true
-      }
-    };
-
-    global.innerWidth = 1000;
-
-    const onLayoutChangedSpy = spy();
-
-    const {
-      instance,
-      wrapper
-    } = createPropertiesContainer({
-      layout,
-      onLayoutChanged: onLayoutChangedSpy
-    });
-
-    // when
-    instance.handleResizeStart(createMouseEvent('dragstart', 0, 0));
-    instance.handlePanelResize(null, { x: 50 });
-    instance.handleResizeEnd();
-
-    // then
-    expect(onLayoutChangedSpy).to.be.calledWith({
-      propertiesPanel: {
-        open: true,
-        width: 1000 * 0.8,
-        fullWidth: false
-      }
-    });
-
-    // clean
-    wrapper.unmount();
-  });
-
-
-  it('should toggle', function() {
-
-    // given
-    const layout = {
-      propertiesPanel: {
-        open: true,
-        width: 500
-      }
-    };
-
-    const onLayoutChangedSpy = spy();
-
-    const {
-      instance,
-      wrapper
-    } = createPropertiesContainer({
-      layout,
-      onLayoutChanged: onLayoutChangedSpy
-    });
-
-    // when
-    instance.handleToggle();
-
-    // then
-    expect(onLayoutChangedSpy).to.be.calledWith({ propertiesPanel: { open: false, width: 500 } });
-
-    // clean
-    wrapper.unmount();
-  });
-
-
-  it('should have default width', function() {
-
-    // given
-    const layout = {
-      propertiesPanel: {
-        open: false
-      }
-    };
-
-    const onLayoutChangedSpy = spy();
-
-    const {
-      instance,
-      wrapper
-    } = createPropertiesContainer({
-      layout,
-      onLayoutChanged: onLayoutChangedSpy
-    });
-
-    // when
-    instance.handleToggle();
-
-    // then
-    expect(onLayoutChangedSpy).to.be.calledWith({ propertiesPanel: { open: true, width: 280 } });
-
-    // clean
-    wrapper.unmount();
-  });
-
-});
-
-it('should toggle', function() {
-
-  // given
-  const layout = {
-    propertiesPanel: {
-      open: true,
-      width: 500
-    }
-  };
-
-  const onLayoutChangedSpy = spy();
-
-  const {
-    instance,
-    wrapper
-  } = createPropertiesContainer({
-    layout,
-    onLayoutChanged: onLayoutChangedSpy
-  });
-
-  // when
-  instance.handleToggle();
-
-  // then
-  expect(onLayoutChangedSpy).to.be.calledWith({ propertiesPanel: { open: false, width: 500 } });
-
-  // clean
-  wrapper.unmount();
 });
 
 
@@ -355,8 +95,6 @@ function createPropertiesContainer(props = {}, mountFn = mount) {
     wrapper
   };
 }
-
-// helpers //////////
 
 function createMouseEvent(type, clientX, clientY) {
   const event = document.createEvent('MouseEvent');

--- a/client/src/app/tabs/__tests__/ResizableContainerSpec.js
+++ b/client/src/app/tabs/__tests__/ResizableContainerSpec.js
@@ -1,0 +1,712 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/* global sinon */
+
+import React from 'react';
+
+import ResizableContainer from '../ResizableContainer';
+
+import { mount } from 'enzyme';
+
+import { omit } from 'min-dash';
+
+const { spy } = sinon;
+
+const LAYOUT_PROP = 'my-panel';
+
+const MIN_WIDTH = 200;
+
+const MIN_HEIGHT = 200;
+
+const DEFAULT_LAYOUT = {
+  open: false,
+  height: MIN_HEIGHT,
+  width: MIN_WIDTH,
+};
+
+const POSITION = 'right';
+
+
+describe('<ResizableContainer>', function() {
+
+  it('should render', function() {
+
+    // given
+    const { wrapper } = createContainer();
+
+    // then
+    expect(wrapper).to.exist;
+
+    // clean
+    wrapper.unmount();
+  });
+
+
+  describe('position=right', function() {
+
+    it('should resize', function() {
+
+      // given
+      const layout = {
+        [LAYOUT_PROP]: {
+          open: true,
+          width: 500
+        }
+      };
+
+      const onLayoutChangedSpy = spy();
+
+      const {
+        instance,
+        wrapper
+      } = createContainer({
+        layout,
+        onLayoutChanged: onLayoutChangedSpy
+      });
+
+      // when
+      instance.handleResizeStart(createMouseEvent('dragstart', 0, 0));
+
+      instance.handleContainerResize(null, { x: -50 });
+
+      instance.handleResizeEnd();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({
+        [LAYOUT_PROP]: {
+          open: true,
+          width: 550,
+          fullWidth: false
+        }
+      });
+
+      // clean
+      wrapper.unmount();
+    });
+
+
+    it('should close when resized to smaller than minimum size', function() {
+
+      // given
+      const layout = {
+        [LAYOUT_PROP]: {
+          open: true,
+          width: 500
+        }
+      };
+
+      const onLayoutChangedSpy = spy();
+
+      const {
+        instance,
+        wrapper
+      } = createContainer({
+        layout,
+        onLayoutChanged: onLayoutChangedSpy
+      });
+
+      // when
+      instance.handleResizeStart(createMouseEvent('dragstart', 0, 0));
+
+      instance.handleContainerResize(null, { x: 400 });
+
+      instance.handleResizeEnd();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({
+        [LAYOUT_PROP]: {
+          open: false,
+          width: 500,
+          fullWidth: false
+        }
+      });
+
+      // clean
+      wrapper.unmount();
+    });
+
+
+    it('should resize to full width when larger than maximum size', function() {
+
+      // given
+      const layout = {
+        [LAYOUT_PROP]: {
+          open: true,
+          width: 500
+        }
+      };
+
+      global.innerWidth = 1000;
+
+      const onLayoutChangedSpy = spy();
+
+      const {
+        instance,
+        wrapper
+      } = createContainer({
+        layout,
+        onLayoutChanged: onLayoutChangedSpy
+      });
+
+      // when
+      instance.handleResizeStart(createMouseEvent('dragstart', 0, 0));
+
+      instance.handleContainerResize(null, { x: -1000 });
+
+      instance.handleResizeEnd();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({
+        [LAYOUT_PROP]: {
+          open: true,
+          width: 1000,
+          fullWidth: true
+        }
+      });
+
+      // clean
+      wrapper.unmount();
+    });
+
+
+    it('should open to min width after dragging at least 40 px to open', function() {
+
+      // given
+      const layout = {
+        [LAYOUT_PROP]: {
+          open: false,
+          width: 0
+        }
+      };
+
+      const onLayoutChangedSpy = spy();
+
+      const {
+        instance,
+        wrapper
+      } = createContainer({
+        layout,
+        onLayoutChanged: onLayoutChangedSpy
+      });
+
+      // when
+      instance.handleResizeStart(createMouseEvent('dragstart', 0, 0));
+      instance.handleContainerResize(null, { x: -50 });
+      instance.handleResizeEnd();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({
+        [LAYOUT_PROP]: {
+          open: true,
+          width: MIN_WIDTH,
+          fullWidth: false
+        }
+      });
+
+      // clean
+      wrapper.unmount();
+    });
+
+
+    it('should close to max width after dragging at least 40 px', function() {
+
+      // given
+      const layout = {
+        [LAYOUT_PROP]: {
+          open: true,
+          width: 1000,
+          fullWidth: true
+        }
+      };
+
+      global.innerWidth = 1000;
+
+      const onLayoutChangedSpy = spy();
+
+      const {
+        instance,
+        wrapper
+      } = createContainer({
+        layout,
+        onLayoutChanged: onLayoutChangedSpy
+      });
+
+      // when
+      instance.handleResizeStart(createMouseEvent('dragstart', 0, 0));
+      instance.handleContainerResize(null, { x: 50 });
+      instance.handleResizeEnd();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({
+        [LAYOUT_PROP]: {
+          open: true,
+          width: 1000 * 0.8,
+          fullWidth: false
+        }
+      });
+
+      // clean
+      wrapper.unmount();
+    });
+
+
+    it('should toggle (open)', function() {
+
+      // given
+      const layout = {
+        [LAYOUT_PROP]: {
+          open: false,
+          width: 500
+        }
+      };
+
+      const onLayoutChangedSpy = spy();
+
+      const {
+        instance,
+        wrapper
+      } = createContainer({
+        layout,
+        onLayoutChanged: onLayoutChangedSpy
+      });
+
+      // when
+      instance.handleToggle();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({ [LAYOUT_PROP]: { open: true, width: 500 } });
+
+      // clean
+      wrapper.unmount();
+    });
+
+
+    it('should toggle (close)', function() {
+
+      // given
+      const layout = {
+        [LAYOUT_PROP]: {
+          open: true,
+          width: 500
+        }
+      };
+
+      const onLayoutChangedSpy = spy();
+
+      const {
+        instance,
+        wrapper
+      } = createContainer({
+        layout,
+        onLayoutChanged: onLayoutChangedSpy
+      });
+
+      // when
+      instance.handleToggle();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({ [LAYOUT_PROP]: { open: false, width: 500 } });
+
+      // clean
+      wrapper.unmount();
+    });
+
+
+    it('should have default width', function() {
+
+      // given
+      const layout = {
+        [LAYOUT_PROP]: {
+          open: false
+        }
+      };
+
+      const onLayoutChangedSpy = spy();
+
+      const {
+        instance,
+        wrapper
+      } = createContainer({
+        layout,
+        onLayoutChanged: onLayoutChangedSpy
+      });
+
+      // when
+      instance.handleToggle();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({
+        [LAYOUT_PROP]: { open: true, width: MIN_WIDTH }
+      });
+
+      // clean
+      wrapper.unmount();
+    });
+
+  });
+
+
+  describe('position=bottom', function() {
+
+    it('should resize', function() {
+
+      // given
+      const layout = {
+        [LAYOUT_PROP]: {
+          open: true,
+          height: 300
+        }
+      };
+
+      const onLayoutChangedSpy = spy();
+
+      const {
+        instance,
+        wrapper
+      } = createContainer({
+        layout,
+        onLayoutChanged: onLayoutChangedSpy,
+        position: 'bottom'
+      });
+
+      // when
+      instance.handleResizeStart(createMouseEvent('dragstart', 0, 0));
+
+      instance.handleContainerResize(null, { y: -50 });
+
+      instance.handleResizeEnd();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({
+        [LAYOUT_PROP]: {
+          open: true,
+          height: 350,
+          fullHeight: false
+        }
+      });
+
+      // clean
+      wrapper.unmount();
+    });
+
+
+    it('should close when resized to smaller than minimum size', function() {
+
+      // given
+      const layout = {
+        [LAYOUT_PROP]: {
+          height: 300,
+          open: true
+        }
+      };
+
+      const onLayoutChangedSpy = spy();
+
+      const {
+        instance,
+        wrapper
+      } = createContainer({
+        layout,
+        onLayoutChanged: onLayoutChangedSpy,
+        position: 'bottom'
+      });
+
+      // when
+      instance.handleResizeStart(createMouseEvent('dragstart', 0, 0));
+
+      instance.handleContainerResize(null, { y: 200 });
+
+      instance.handleResizeEnd();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({
+        [LAYOUT_PROP]: {
+          open: false,
+          height: 300,
+          fullHeight: false
+        }
+      });
+
+      // clean
+      wrapper.unmount();
+    });
+
+
+    it('should resize to full width when larger than maximum size', function() {
+
+      // given
+      const layout = {
+        [LAYOUT_PROP]: {
+          open: true,
+          height: 500
+        }
+      };
+
+      global.innerHeight = 1000;
+
+      const onLayoutChangedSpy = spy();
+
+      const {
+        instance,
+        wrapper
+      } = createContainer({
+        layout,
+        onLayoutChanged: onLayoutChangedSpy,
+        position: 'bottom'
+      });
+
+      // when
+      instance.handleResizeStart(createMouseEvent('dragstart', 0, 0));
+
+      instance.handleContainerResize(null, { y: -1000 });
+
+      instance.handleResizeEnd();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({
+        [LAYOUT_PROP]: {
+          open: true,
+          height: 940, // 60px compensate for status + tab bar
+          fullHeight: true
+        }
+      });
+
+      // clean
+      wrapper.unmount();
+    });
+
+
+    it('should open to min height after dragging at least 40 px to open', function() {
+
+      // given
+      const layout = {
+        [LAYOUT_PROP]: {
+          open: false,
+          height: 0
+        }
+      };
+
+      const onLayoutChangedSpy = spy();
+
+      const {
+        instance,
+        wrapper
+      } = createContainer({
+        layout,
+        onLayoutChanged: onLayoutChangedSpy,
+        position: 'bottom'
+      });
+
+      // when
+      instance.handleResizeStart(createMouseEvent('dragstart', 0, 0));
+      instance.handleContainerResize(null, { y: -50 });
+      instance.handleResizeEnd();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({
+        [LAYOUT_PROP]: {
+          open: true,
+          height: MIN_HEIGHT,
+          fullHeight: false
+        }
+      });
+
+      // clean
+      wrapper.unmount();
+    });
+
+
+    it('should open to max height after dragging at least 40 px', function() {
+
+      // given
+      const layout = {
+        [LAYOUT_PROP]: {
+          open: true,
+          height: 1000,
+          fullHeight: true
+        }
+      };
+
+      global.innerHeight = 1000;
+
+      const onLayoutChangedSpy = spy();
+
+      const {
+        instance,
+        wrapper
+      } = createContainer({
+        layout,
+        onLayoutChanged: onLayoutChangedSpy,
+        position: 'bottom'
+      });
+
+      // when
+      instance.handleResizeStart(createMouseEvent('dragstart', 0, 0));
+      instance.handleContainerResize(null, { y: 50 });
+      instance.handleResizeEnd();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({
+        [LAYOUT_PROP]: {
+          open: true,
+          height: 1000 * 0.8,
+          fullHeight: false
+        }
+      });
+
+      // clean
+      wrapper.unmount();
+    });
+
+
+    it('should toggle (open)', function() {
+
+      // given
+      const layout = {
+        [LAYOUT_PROP]: {
+          open: false,
+          height: 300
+        }
+      };
+
+      const onLayoutChangedSpy = spy();
+
+      const {
+        instance,
+        wrapper
+      } = createContainer({
+        layout,
+        onLayoutChanged: onLayoutChangedSpy,
+        position: 'bottom'
+      });
+
+      // when
+      instance.handleToggle();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({ [LAYOUT_PROP]: { open: true, height: 300 } });
+
+      // clean
+      wrapper.unmount();
+    });
+
+
+    it('should toggle (close)', function() {
+
+      // given
+      const layout = {
+        [LAYOUT_PROP]: {
+          open: true,
+          height: 300
+        }
+      };
+
+      const onLayoutChangedSpy = spy();
+
+      const {
+        instance,
+        wrapper
+      } = createContainer({
+        layout,
+        onLayoutChanged: onLayoutChangedSpy,
+        position: 'bottom'
+      });
+
+      // when
+      instance.handleToggle();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({ [LAYOUT_PROP]: { open: false, height: 300 } });
+
+      // clean
+      wrapper.unmount();
+    });
+
+
+    it('should have default height', function() {
+
+      // given
+      const layout = {
+        [LAYOUT_PROP]: {
+          open: false
+        }
+      };
+
+      const onLayoutChangedSpy = spy();
+
+      const {
+        instance,
+        wrapper
+      } = createContainer({
+        layout,
+        onLayoutChanged: onLayoutChangedSpy,
+        position: 'bottom'
+      });
+
+      // when
+      instance.handleToggle();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({
+        [LAYOUT_PROP]: { open: true, height: MIN_HEIGHT }
+      });
+
+      // clean
+      wrapper.unmount();
+    });
+
+  });
+
+});
+
+
+
+// helpers //////////
+
+function createContainer(props = {}, mountFn = mount) {
+  props = {
+    defaultLayout: getDefaultLayout(props.position),
+    layout: {},
+    layoutProp: LAYOUT_PROP,
+    minHeight: MIN_HEIGHT,
+    minWidth: MIN_WIDTH,
+    position: POSITION,
+    ...props
+  };
+
+  const wrapper = mountFn(<ResizableContainer { ...props } />);
+
+  const instance = wrapper.find('ResizableContainer').first().instance();
+
+  return {
+    instance,
+    wrapper
+  };
+}
+
+function createMouseEvent(type, clientX, clientY) {
+  const event = document.createEvent('MouseEvent');
+
+  if (event.initMouseEvent) {
+    event.initMouseEvent(
+      type, true, true, window, 0, 0, 0, clientX, clientY, false, false, false, false, 0, null);
+  }
+
+  return event;
+}
+
+function getDefaultLayout(position) {
+  const layout = {
+    ...DEFAULT_LAYOUT
+  };
+
+  return omit(layout, [ position === 'bottom' ? 'width' : 'height' ]);
+}

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -780,6 +780,7 @@ export class BpmnEditor extends CachedComponent {
           engineProfile && <Fragment>
             <Panel
               layout={ layout }
+              onLayoutChanged={ onLayoutChanged }
               onUpdateMenu={ onUpdateMenu }>
               <LintingTab
                 layout={ layout }

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -23,6 +23,8 @@ import {
   WithCachedState
 } from '../../../cached';
 
+import { SlotFillRoot } from '../../../slot-fill';
+
 import {
   BpmnEditor,
   DEFAULT_ENGINE_PROFILE
@@ -813,7 +815,7 @@ describe('<BpmnEditor>', function() {
 
       wrapper.update();
 
-      const toggle = wrapper.find('.toggle');
+      const toggle = wrapper.find('.properties .toggle');
 
       // when
       toggle.simulate('click');
@@ -846,7 +848,7 @@ describe('<BpmnEditor>', function() {
 
       wrapper.update();
 
-      const toggle = wrapper.find('.toggle');
+      const toggle = wrapper.find('.properties .toggle');
 
       // when
       toggle.simulate('click');
@@ -877,7 +879,7 @@ describe('<BpmnEditor>', function() {
         onLayoutChanged
       });
 
-      const toggle = wrapper.find('.toggle');
+      const toggle = wrapper.find('.properties .toggle');
 
       // when
       toggle.simulate('click');
@@ -1732,23 +1734,25 @@ function renderEditor(xml, options = {}) {
     };
 
     wrapper = mount(
-      <TestEditor
-        cache={ cache }
-        getConfig={ getConfig }
-        getPlugins={ getPlugins }
-        id={ id }
-        isNew={ isNew }
-        layout={ layout }
-        onAction={ onAction }
-        onChanged={ onChanged }
-        onContentUpdated={ onContentUpdated }
-        onError={ onError }
-        onImport={ waitForImport ? resolveOnImport : onImport }
-        onLayoutChanged={ onLayoutChanged }
-        onModal={ onModal }
-        onWarning={ onWarning }
-        xml={ xml }
-      />
+      <SlotFillRoot>
+        <TestEditor
+          cache={ cache }
+          getConfig={ getConfig }
+          getPlugins={ getPlugins }
+          id={ id }
+          isNew={ isNew }
+          layout={ layout }
+          onAction={ onAction }
+          onChanged={ onChanged }
+          onContentUpdated={ onContentUpdated }
+          onError={ onError }
+          onImport={ waitForImport ? resolveOnImport : onImport }
+          onLayoutChanged={ onLayoutChanged }
+          onModal={ onModal }
+          onWarning={ onWarning }
+          xml={ xml }
+        />
+      </SlotFillRoot>
     );
 
     instance = wrapper.find(BpmnEditor).instance();

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -741,6 +741,7 @@ export class BpmnEditor extends CachedComponent {
           engineProfile && <Fragment>
             <Panel
               layout={ layout }
+              onLayoutChanged={ onLayoutChanged }
               onUpdateMenu={ onUpdateMenu }>
               <LintingTab
                 layout={ layout }

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -23,6 +23,8 @@ import {
   WithCachedState
 } from '../../../cached';
 
+import { SlotFillRoot } from '../../../slot-fill';
+
 import {
   BpmnEditor,
   DEFAULT_ENGINE_PROFILE
@@ -801,7 +803,7 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
 
       wrapper.update();
 
-      const toggle = wrapper.find('.toggle');
+      const toggle = wrapper.find('.properties .toggle');
 
       // when
       toggle.simulate('click');
@@ -834,7 +836,7 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
 
       wrapper.update();
 
-      const toggle = wrapper.find('.toggle');
+      const toggle = wrapper.find('.properties .toggle');
 
       // when
       toggle.simulate('click');
@@ -865,7 +867,7 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
         onLayoutChanged
       });
 
-      const toggle = wrapper.find('.toggle');
+      const toggle = wrapper.find('.properties .toggle');
 
       // when
       toggle.simulate('click');
@@ -1720,23 +1722,25 @@ function renderEditor(xml, options = {}) {
     };
 
     wrapper = mount(
-      <TestEditor
-        cache={ cache }
-        getConfig={ getConfig }
-        getPlugins={ getPlugins }
-        id={ id }
-        isNew={ isNew }
-        layout={ layout }
-        onAction={ onAction }
-        onChanged={ onChanged }
-        onContentUpdated={ onContentUpdated }
-        onError={ onError }
-        onImport={ waitForImport ? resolveOnImport : onImport }
-        onLayoutChanged={ onLayoutChanged }
-        onModal={ onModal }
-        onWarning={ onWarning }
-        xml={ xml }
-      />
+      <SlotFillRoot>
+        <TestEditor
+          cache={ cache }
+          getConfig={ getConfig }
+          getPlugins={ getPlugins }
+          id={ id }
+          isNew={ isNew }
+          layout={ layout }
+          onAction={ onAction }
+          onChanged={ onChanged }
+          onContentUpdated={ onContentUpdated }
+          onError={ onError }
+          onImport={ waitForImport ? resolveOnImport : onImport }
+          onLayoutChanged={ onLayoutChanged }
+          onModal={ onModal }
+          onWarning={ onWarning }
+          xml={ xml }
+        />
+      </SlotFillRoot>
     );
 
     instance = wrapper.find(BpmnEditor).instance();

--- a/client/src/app/tabs/form/FormEditor.js
+++ b/client/src/app/tabs/form/FormEditor.js
@@ -373,6 +373,7 @@ export class FormEditor extends CachedComponent {
           engineProfile && <Fragment>
             <Panel
               layout={ layout }
+              onLayoutChanged={ onLayoutChanged }
               onUpdateMenu={ onUpdateMenu }>
               <LintingTab
                 layout={ layout }

--- a/client/src/app/tabs/form/__tests__/FormEditorSpec.js
+++ b/client/src/app/tabs/form/__tests__/FormEditorSpec.js
@@ -19,6 +19,8 @@ import {
   WithCachedState
 } from '../../../cached';
 
+import { SlotFillRoot } from '../../../slot-fill';
+
 import {
   DEFAULT_ENGINE_PROFILE,
   FormEditor
@@ -847,21 +849,23 @@ async function renderEditor(schema, options = {}) {
     };
 
     wrapper = mount(
-      <TestEditor
-        cache={ cache }
-        getConfig={ getConfig }
-        id={ id }
-        layout={ layout }
-        linting={ linting }
-        onAction={ onAction }
-        onChanged={ onChanged }
-        onContentUpdated={ onContentUpdated }
-        onError={ onError }
-        onImport={ waitForImport ? resolveOnImport : onImport }
-        onLayoutChanged={ onLayoutChanged }
-        onModal={ onModal }
-        xml={ schema }
-      />
+      <SlotFillRoot>
+        <TestEditor
+          cache={ cache }
+          getConfig={ getConfig }
+          id={ id }
+          layout={ layout }
+          linting={ linting }
+          onAction={ onAction }
+          onChanged={ onChanged }
+          onContentUpdated={ onContentUpdated }
+          onError={ onError }
+          onImport={ waitForImport ? resolveOnImport : onImport }
+          onLayoutChanged={ onLayoutChanged }
+          onModal={ onModal }
+          xml={ schema }
+        />
+      </SlotFillRoot>
     );
 
     instance = wrapper.find(FormEditor).instance();

--- a/client/src/app/tabs/panel/Panel.js
+++ b/client/src/app/tabs/panel/Panel.js
@@ -19,7 +19,16 @@ import {
   Slot
 } from '../../slot-fill';
 
+import ResizableContainer from '../ResizableContainer';
+
 import css from './Panel.less';
+
+export const MIN_HEIGHT = 100;
+
+export const DEFAULT_LAYOUT = {
+  open: false,
+  height: MIN_HEIGHT
+};
 
 
 export default class Panel extends PureComponent {
@@ -70,33 +79,56 @@ export default class Panel extends PureComponent {
     onUpdateMenu({ editMenu });
   }
 
+  handleResizeContainer = (newLayout) => {
+    const {
+      layout = {},
+      onLayoutChanged
+    } = this.props;
+
+    const panel = layout.panel || {};
+    const newPanel = newLayout.panel || {};
+
+    onLayoutChanged({
+      panel: {
+        ...panel,
+        ...newPanel
+      }
+    });
+  }
+
   render() {
     const {
       children,
-      layout = {}
+      layout,
     } = this.props;
 
     const { panel = {} } = layout;
 
-    const { open } = panel;
-
-    if (!open) {
-      return null;
-    }
-
-    return <div className={ classnames(css.Panel, { open }) }>
-      <div className="panel__links">
-        <Slot name="panel-link" />
-      </div>
-      <div tabIndex="0" className="panel__body" onFocus={ this.updateMenu }>
-        <div className="panel__inner">
-          <Slot name="panel-body" />
+    return (
+      <ResizableContainer
+        className={ css.Panel }
+        defaultLayout={ DEFAULT_LAYOUT }
+        layout={ layout }
+        layoutProp="panel"
+        minHeight={ MIN_HEIGHT }
+        onLayoutChanged={ this.handleResizeContainer }
+        position="bottom"
+      >
+        <div className="panel__container">
+          <div className={ classnames('panel__links', { open: panel.open }) }>
+            <Slot name="panel-link" />
+          </div>
+          <div tabIndex="0" className="panel__body" onFocus={ this.updateMenu }>
+            <div className="panel__inner">
+              <Slot name="panel-body" />
+            </div>
+          </div>
+          {
+            children
+          }
         </div>
-      </div>
-      {
-        children
-      }
-    </div>;
+      </ResizableContainer>
+    );
   }
 }
 

--- a/client/src/app/tabs/panel/Panel.less
+++ b/client/src/app/tabs/panel/Panel.less
@@ -1,17 +1,32 @@
-:local(.Panel) {
-  display: flex;
-  flex-direction: column;
+:root {
+  --panel-background-color: var(--color-white);
+  --panel-links-background-color: var(--color-grey-225-10-95);
+  --panel-links-border-bottom-color: var(--color-grey-225-10-75);
+  --panel-link-active-border-bottom-color: var(--color-grey-225-10-15);
+  --panel-link-number-color: var(--color-white);
+  --panel-link-number-background-color: var(--color-grey-225-10-15);
+}
 
-  &.open {
-    height: 200px;
+:local(.Panel) {
+ 
+  z-index: 101;
+
+  .panel__container {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    background-color: var(--panel-background-color);
   }
 
   .panel__links {
-    background-color: var(--color-grey-225-10-95);
-    border-bottom: solid 1px var(--color-grey-225-10-75);
-    border-top: solid 1px var(--color-grey-225-10-75);
+    background-color: var(--panel-links-background-color);
+    border-bottom: solid 1px var(--panel-links-border-bottom-color);
     display: flex;
     flex-direction: row;
+
+    &:not(.open) {
+      display: none;
+    }
 
     .panel__link {
       background: none;
@@ -21,13 +36,13 @@
       padding: 4px 8px;
 
       &.panel__link--active {
-        border-bottom: solid 2px var(--color-grey-225-10-15);
+        border-bottom: solid 2px var(--panel-link-active-border-bottom-color);
       }
 
       .panel__link-number {
-        background-color: var(--color-grey-225-10-15);
+        background-color: var(--panel-link-number-background-color);
         border-radius: 9px;
-        color: var(--color-white);
+        color: var(--panel-link-number-color);
         display: inline-block;
         margin-left: 4px;
         padding: 2px 6px;

--- a/client/src/app/tabs/panel/__tests__/PanelSpec.js
+++ b/client/src/app/tabs/panel/__tests__/PanelSpec.js
@@ -35,7 +35,7 @@ describe('<Panel>', function() {
   });
 
 
-  it('should not render (closed)', function() {
+  it('should render (closed)', function() {
 
     // when
     const wrapper = renderPanel({
@@ -47,7 +47,7 @@ describe('<Panel>', function() {
     });
 
     // then
-    expect(wrapper.find('.panel__body')).to.have.length(0);
+    expect(wrapper.find('.panel__body')).to.have.length(1);
   });
 
 
@@ -195,6 +195,46 @@ describe('<Panel>', function() {
     });
 
 
+    it('should change layout on resize', function() {
+
+      // given
+      const onLayoutChangedSpy = spy();
+
+      const layout = {
+        panel: {
+          open: true,
+          height: 300
+        }
+      };
+
+      const wrapper = renderPanel({
+        children: createTab({
+          children: <div className="foo" />
+        }),
+        layout,
+        onLayoutChanged: onLayoutChangedSpy
+      });
+
+      const resizableContainer = wrapper.find('ResizableContainer').first().instance();
+
+      // when
+      resizableContainer.handleResizeStart(createMouseEvent('dragstart', 0, 0));
+
+      resizableContainer.handleContainerResize(null, { y: -50 });
+
+      resizableContainer.handleResizeEnd();
+
+      // then
+      expect(onLayoutChangedSpy).to.be.calledWith({
+        panel: {
+          open: true,
+          height: 350,
+          fullHeight: false
+        }
+      });
+    });
+
+
     it('should update edit menu', async function() {
 
       // given
@@ -270,16 +310,29 @@ function renderPanel(options = {}) {
   const {
     children,
     layout = defaultLayout,
-    onUpdateMenu = noop
+    onUpdateMenu = noop,
+    onLayoutChanged = noop
   } = options;
 
   return mount(
     <SlotFillRoot>
       <Panel
         layout={ layout }
-        onUpdateMenu={ onUpdateMenu }>
+        onUpdateMenu={ onUpdateMenu }
+        onLayoutChanged={ onLayoutChanged }>
         { children }
       </Panel>
     </SlotFillRoot>
   );
+}
+
+function createMouseEvent(type, clientX, clientY) {
+  const event = document.createEvent('MouseEvent');
+
+  if (event.initMouseEvent) {
+    event.initMouseEvent(
+      type, true, true, window, 0, 0, 0, clientX, clientY, false, false, false, false, 0, null);
+  }
+
+  return event;
 }


### PR DESCRIPTION
Closes #2959 
Depends on https://github.com/camunda/camunda-modeler-design/issues/90

* moves properties panel resize handlers to reusable component (supported positions for now: `right`, `bottom`)
* use resizable container for bottom panel

![Kapture 2022-05-17 at 10 39 31](https://user-images.githubusercontent.com/9433996/168768819-5146ac58-05e5-4f95-bddc-7cef6f04a920.gif)

- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2959-resize-container/camunda-modeler-2959-resize-container-linux-x64.tar.gz
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2959-resize-container/camunda-modeler-2959-resize-container-mac.dmg
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2959-resize-container/camunda-modeler-2959-resize-container-mac.zip
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2959-resize-container/camunda-modeler-2959-resize-container-win-ia32.zip
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/2959-resize-container/camunda-modeler-2959-resize-container-win-x64.zip