### PR TITLE
fix: improved file dialog consistency across OSes

### DIFF
--- a/client/src/remote/Dialog.js
+++ b/client/src/remote/Dialog.js
@@ -113,6 +113,8 @@ export default class Dialog {
       name
     } = options;
 
+    const isLinux = this.backend.getPlatform() == 'linux';
+
     const buttons = [
       { id: 'save', label: 'Save' },
       { id: 'discard', label: 'Don\'t Save' },
@@ -120,12 +122,13 @@ export default class Dialog {
     ];
 
     // Re-order buttons for linux
-    if (this.backend.getPlatform() == 'linux') {
+    if (isLinux) {
       buttons.push(buttons.shift());
     }
 
     return this.show({
       buttons,
+      defaultId: isLinux ? 2 : 0,
       message: `Save changes to "${ name }" before closing?`,
       type: 'question',
       title: 'Close File'
@@ -147,11 +150,21 @@ export default class Dialog {
 
     const typeUpperCase = type.toUpperCase();
 
+    const isLinux = this.backend.getPlatform() == 'linux';
+
+    const buttons = [
+      { id: 'create', label: 'Create' },
+      { id: 'cancel', label: 'Cancel' }
+    ];
+
+    // Re-order buttons for linux
+    if (isLinux) {
+      buttons.push(buttons.shift());
+    }
+
     return this.show({
-      buttons: [
-        { id: 'cancel', label: 'Cancel' },
-        { id: 'create', label: 'Create' }
-      ],
+      buttons,
+      defaultId: isLinux ? 1 : 0,
       detail: `Would you like to create a new ${ typeUpperCase } file?`,
       message: `The file "${ file.name }" is empty.`,
       title: [

--- a/client/src/remote/__tests__/DialogSpec.js
+++ b/client/src/remote/__tests__/DialogSpec.js
@@ -167,9 +167,11 @@ describe('dialog', function() {
       // then
       expect(type).to.equal('dialog:show');
 
+      const isLinux = process.platform === 'linux';
+
       let buttons;
 
-      if (process.platform == 'linux') {
+      if (isLinux) {
         buttons = [
           { id: 'discard', label: 'Don\'t Save' },
           { id: 'cancel', label: 'Cancel' },
@@ -184,10 +186,11 @@ describe('dialog', function() {
       }
 
       expect(opts).to.eql({
+        buttons,
+        defaultId: isLinux ? 2 : 0,
         type: 'question',
         title: 'Close File',
         message: 'Save changes to "foo" before closing?',
-        buttons
       });
     };
 
@@ -211,13 +214,27 @@ describe('dialog', function() {
       // then
       expect(type).to.equal('dialog:show');
 
-      expect(opts).to.eql({
-        type: 'info',
-        title: 'Empty FOO file',
-        buttons: [
+      const isLinux = process.platform === 'linux';
+
+      let buttons;
+
+      if (isLinux) {
+        buttons = [
           { id: 'cancel', label: 'Cancel' },
           { id: 'create', label: 'Create' }
-        ],
+        ];
+      } else {
+        buttons = [
+          { id: 'create', label: 'Create' },
+          { id: 'cancel', label: 'Cancel' }
+        ];
+      }
+
+      expect(opts).to.eql({
+        buttons,
+        defaultId: isLinux ? 1 : 0,
+        type: 'info',
+        title: 'Empty FOO file',
         message: 'The file "foo" is empty.\nWould you like to create a new FOO diagram?'
       });
     };


### PR DESCRIPTION
Closes #2970

  **Artefacts**
  
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/file-dialog-consistency/camunda-modeler-file-dialog-consistency-linux-x64.tar.gz
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/file-dialog-consistency/camunda-modeler-file-dialog-consistency-mac.dmg
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/file-dialog-consistency/camunda-modeler-file-dialog-consistency-mac.zip
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/file-dialog-consistency/camunda-modeler-file-dialog-consistency-win-ia32.zip
- https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/file-dialog-consistency/camunda-modeler-file-dialog-consistency-win-x64.zip
    
Could you have a look if the appropriate action button is focused and potentially colored in for both the empty file dialog (open an empty file) as well as the saveFileDialog (edit a saved bpmn diagram and close without saving).

@barmac for mac
@MaxTru for linux

Please do not merge until we see it's good for both :D. Windows works as expected. 
    