### PR TITLE
Prevent duplicated help menu entries

### DIFF
--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -22,6 +22,7 @@ const {
 const {
   assign,
   find,
+  filter,
   flatten,
   groupBy,
   isFunction,
@@ -598,9 +599,17 @@ class MenuBuilder {
       .filter(menu => Boolean(menu.length));
 
     const middlePart = providedMenus.reduce((helpMenus, current) => {
+
+      // check for duplicates
+      const withoutDuplicates = filter(current, e => !findHelpMenuEntry(helpMenus, e));
+
+      if (!withoutDuplicates.length) {
+        return helpMenus;
+      }
+
       return [
         ...helpMenus,
-        ...current.map(mapHelpMenuTemplate),
+        ...withoutDuplicates.map(mapHelpMenuTemplate),
         getSeparatorTemplate()
       ];
     }, []);
@@ -687,8 +696,8 @@ class MenuBuilder {
 module.exports = MenuBuilder;
 
 
-
 // helpers //////
+
 function mapMenuEntryTemplate(entry) {
   if (entry.type === 'separator') {
     return getSeparatorTemplate();
@@ -757,4 +766,8 @@ function wrapActionInactiveInDevtools(fn) {
 function getIconImage(iconPath) {
   iconPath = path.join(__dirname, '/../../', iconPath);
   return electron.nativeImage.createFromPath(iconPath).resize({ width:12, height:12 });
+}
+
+function findHelpMenuEntry(helpMenus, entry) {
+  return find(helpMenus, (menu) => entry.label === menu.label);
 }

--- a/app/test/spec/menu/menu-builder-spec.js
+++ b/app/test/spec/menu/menu-builder-spec.js
@@ -400,11 +400,55 @@ describe('MenuBuilder', () => {
 
   });
 
+
+  describe('help menu', () => {
+
+    it('should prevent duplicates', () => {
+
+      // given
+      const providers = [
+        {
+          newFileMenu: [],
+          helpMenu: [
+            {
+              label: 'foo'
+            },
+            {
+              label: 'bar'
+            }
+          ]
+        },
+        {
+          newFileMenu: [],
+          helpMenu: [
+            {
+              label: 'bar'
+            },
+            {
+              label: 'foobar'
+            }
+          ]
+        },
+      ];
+
+      const menuBuilder = new MenuBuilder({ providers });
+
+      // when
+      const { menu } = menuBuilder.build();
+
+      const helpMenu = menu.find(item => item.label === 'Help');
+      const barEntry = helpMenu.submenu.filter(menu => menu.label === 'bar');
+
+      // then
+      expect(barEntry).to.have.length(1);
+    });
+  });
+
 });
 
 
-
 // helper /////////
+
 function getOptionsWithPlugins(plugins) {
   return {
     providers: {

--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -55,6 +55,21 @@ import BPMNIcon from '../../resources/icons/file-types/BPMN-16x16.svg';
 import DMNIcon from '../../resources/icons/file-types/DMN-16x16.svg';
 import FormIcon from '../../resources/icons/file-types/Form-16x16.svg';
 
+const BPMN_HELP_MENU = [
+  {
+    label: 'BPMN 2.0 Tutorial',
+    action: 'https://camunda.org/bpmn/tutorial/'
+  },
+  {
+    label: 'BPMN Modeling Reference',
+    action: 'https://camunda.org/bpmn/reference/'
+  }
+];
+
+const DMN_HELP_MENU = [
+
+];
+
 const createdByType = {};
 
 const noopProvider = {
@@ -161,7 +176,7 @@ export default class TabsProvider {
           return `diagram_${suffix}.bpmn`;
         },
         getHelpMenu() {
-          return [];
+          return BPMN_HELP_MENU;
         },
         getNewFileMenu() {
           return [ {
@@ -199,14 +214,7 @@ export default class TabsProvider {
           return `diagram_${suffix}.bpmn`;
         },
         getHelpMenu() {
-          return [ {
-            label: 'BPMN 2.0 Tutorial',
-            action: 'https://camunda.org/bpmn/tutorial/'
-          },
-          {
-            label: 'BPMN Modeling Reference',
-            action: 'https://camunda.org/bpmn/reference/'
-          } ];
+          return BPMN_HELP_MENU;
         },
         getNewFileMenu() {
           return [ {
@@ -306,10 +314,7 @@ export default class TabsProvider {
           return `diagram_${suffix}.dmn`;
         },
         getHelpMenu() {
-          return [ {
-            label: 'DMN Tutorial',
-            action: 'https://camunda.org/dmn/tutorial/'
-          } ];
+          return DMN_HELP_MENU;
         },
         getNewFileMenu() {
           return [ {
@@ -347,10 +352,7 @@ export default class TabsProvider {
           return `diagram_${suffix}.dmn`;
         },
         getHelpMenu() {
-          return [ {
-            label: 'DMN Tutorial',
-            action: 'https://camunda.org/dmn/tutorial/'
-          } ];
+          return DMN_HELP_MENU;
         },
         getNewFileMenu() {
           return [ {


### PR DESCRIPTION
_Originated from https://github.com/camunda/camunda-modeler/pull/3035._

This prevents duplicated help menu entries in the backend.

Closes #3032
