### PR TITLE
Allow to connect to Zeebe with a custom certificate

### DIFF
--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -658,7 +658,7 @@ function bootstrap() {
   errorTracking.setTag(Sentry, 'plugins', generatePluginsTag(plugins));
 
   // (9) zeebe API
-  const zeebeAPI = new ZeebeAPI({ readFile }, ZeebeNode);
+  const zeebeAPI = new ZeebeAPI({ readFile }, ZeebeNode, flags);
 
   return {
     config,

--- a/app/lib/zeebe-api/get-system-certificates.js
+++ b/app/lib/zeebe-api/get-system-certificates.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/**
+ * This file contains code adapted from https://github.com/microsoft/vscode-proxy-agent
+ *
+ * MIT License
+ *
+ * Copyright (c) 2014 Nathan Rajlich &lt;nathan@tootallnate.net&gt;
+ * Copyright (c) 2015 Félicien François &lt;felicien@tweakstyle.com&gt;
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * 'Software'), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+const cp = require('child_process');
+const os = require('os');
+const fs = require('fs/promises');
+let _cachedCertificates;
+
+module.exports = getSystemCertificates;
+
+/**
+ * Get certificates from the system keychain.
+ *
+ * @returns {Promise<string[]>}
+ */
+async function getSystemCertificates() {
+  if (_cachedCertificates) {
+    return _cachedCertificates;
+  }
+
+  _cachedCertificates = await readCaCertificates() || [];
+
+  return _cachedCertificates;
+}
+
+async function readCaCertificates() {
+  if (process.platform === 'win32') {
+    return readWindowsCaCertificates();
+  }
+  if (process.platform === 'darwin') {
+    return readMacCaCertificates();
+  }
+  if (process.platform === 'linux') {
+    return readLinuxCaCertificates();
+  }
+}
+
+async function readWindowsCaCertificates() {
+  const winCA = require('vscode-windows-ca-certs');
+
+  let ders = [];
+  const store = new winCA.Crypt32();
+  try {
+    let der = store.next();
+    while (der) {
+      ders.push(der);
+      der = store.next();
+    }
+  } finally {
+    store.done();
+  }
+
+  const certs = new Set(ders.map(derToPem));
+
+  return Array.from(certs);
+}
+
+async function readMacCaCertificates() {
+  const args = [ 'find-certificate', '-a', '-p' ];
+  const systemRootCertsPath = '/System/Library/Keychains/SystemRootCertificates.keychain';
+
+  const trusted = await spawnPromise('/usr/bin/security', args);
+  const systemTrusted = await spawnPromise('/usr/bin/security', [ ...args, systemRootCertsPath ]);
+
+  const certs = new Set(splitCerts(trusted).concat(splitCerts(systemTrusted)));
+
+  return Array.from(certs);
+}
+
+const linuxCaCertificatePaths = [
+  '/etc/ssl/certs/ca-certificates.crt',
+  '/etc/ssl/certs/ca-bundle.crt',
+];
+
+async function readLinuxCaCertificates() {
+  for (const certPath of linuxCaCertificatePaths) {
+    try {
+      const content = await fs.readFile(certPath, { encoding: 'utf8' });
+      const certs = new Set(splitCerts(content));
+
+      return Array.from(certs);
+    } catch (err) {
+      if (err?.code !== 'ENOENT') {
+        throw err;
+      }
+    }
+  }
+}
+
+// helper /////////////////
+
+function spawnPromise(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = cp.spawn(command, args);
+    const stdout = [];
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', str => stdout.push(str));
+    child.on('error', reject);
+    child.on('exit', code => code ? reject(code) : resolve(stdout.join('')));
+  });
+}
+
+function derToPem(blob) {
+  const lines = [ '-----BEGIN CERTIFICATE-----' ];
+  const der = blob.toString('base64');
+  for (let i = 0; i < der.length; i += 64) {
+    lines.push(der.substr(i, 64));
+  }
+  lines.push('-----END CERTIFICATE-----', '');
+  return lines.join(os.EOL);
+}
+
+function splitCerts(certs) {
+  return certs.split(/(?=-----BEGIN CERTIFICATE-----)/g).filter(pem => !!pem.length);
+}

--- a/app/lib/zeebe-api/index.js
+++ b/app/lib/zeebe-api/index.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+module.exports = require('./zeebe-api');

--- a/app/lib/zeebe-api/zeebe-api.js
+++ b/app/lib/zeebe-api/zeebe-api.js
@@ -322,7 +322,9 @@ class ZeebeAPI {
 
     if (customCertificatePath) {
       try {
-        const cert = this._fs.readFile(customCertificatePath);
+        const absolutePath = path.isAbsolute(customCertificatePath) ?
+          customCertificatePath : path.join(process.cwd(), customCertificatePath);
+        const cert = this._fs.readFile(absolutePath);
 
         rootCerts.push(cert.contents);
       } catch (err) {

--- a/app/package.json
+++ b/app/package.json
@@ -25,5 +25,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/camunda/camunda-modeler"
+  },
+  "optionalDependencies": {
+    "vscode-windows-ca-certs": "^0.3.0"
   }
 }

--- a/app/test/spec/zeebe-api-spec.js
+++ b/app/test/spec/zeebe-api-spec.js
@@ -1437,6 +1437,66 @@ describe('ZeebeAPI', function() {
       console.log(rootCerts.toString('utf8'));
       expect(Buffer.from('CERTIFICATE').equals(rootCerts)).to.be.true;
     });
+
+
+    it('should set `useTLS` to true for https endpoint', async () => {
+
+      // given
+      let usedConfig;
+
+      const zeebeAPI = mockZeebeNode({
+        ZBClient: function(...args) {
+          usedConfig = args;
+
+          return {
+            deployWorkflow: noop
+          };
+        }
+      });
+
+      const parameters = {
+        endpoint: {
+          type: 'selfHosted',
+          url: 'https://camunda.com'
+        }
+      };
+
+      // when
+      await zeebeAPI.deploy(parameters);
+
+      // then
+      expect(usedConfig[1]).to.have.property('useTLS', true);
+    });
+
+
+    it('should NOT set `useTLS` for http endpoint', async () => {
+
+      // given
+      let usedConfig;
+
+      const zeebeAPI = mockZeebeNode({
+        ZBClient: function(...args) {
+          usedConfig = args;
+
+          return {
+            deployWorkflow: noop
+          };
+        }
+      });
+
+      const parameters = {
+        endpoint: {
+          type: 'selfHosted',
+          url: 'http://camunda.com'
+        }
+      };
+
+      // when
+      await zeebeAPI.deploy(parameters);
+
+      // then
+      expect(usedConfig[1]).not.to.have.property('useTLS');
+    });
   });
 
 });

--- a/app/test/spec/zeebe-api-spec.js
+++ b/app/test/spec/zeebe-api-spec.js
@@ -17,6 +17,11 @@ const ZeebeAPI = require('../../lib/zeebe-api');
 
 describe('ZeebeAPI', function() {
 
+
+  // TODO(barmac): remove when system keychain certificates are tested
+  setupPlatformStub();
+
+
   describe('#checkConnection', function() {
 
     it('should set success=true for correct check', async () => {
@@ -1438,6 +1443,17 @@ describe('ZeebeAPI', function() {
 
 
 // helpers //////////////////////
+function setupPlatformStub() {
+  let platformStub;
+
+  before(() => {
+    platformStub = sinon.stub(process, 'platform').value('CI');
+  });
+
+  after(() => {
+    platformStub.restore();
+  });
+}
 
 function mockZeebeNode(options = {}) {
   const fs = options.fs || {

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginConstants.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginConstants.js
@@ -31,6 +31,7 @@ export const REMEMBER_CREDENTIALS = 'Remember credentials';
 
 export const MUST_PROVIDE_A_VALUE = 'Must provide a value.';
 export const CONTACT_POINT_MUST_NOT_BE_EMPTY = 'Cluster endpoint must not be empty.';
+export const CONTACT_POINT_MUST_START_WITH_PROTOCOL = 'Cluster endpoint must start with "http://" or "https://".';
 export const CONTACT_POINT_MUST_BE_URL_OR_IP = 'Cluster endpoint must a valid URL or IP address with a valid port.';
 export const OAUTH_URL_MUST_NOT_BE_EMPTY = 'OAuth URL must not be empty.';
 export const AUDIENCE_MUST_NOT_BE_EMPTY = 'Audience must not be empty.';

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginValidator.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginValidator.js
@@ -16,7 +16,8 @@ import {
   CLIENT_ID_MUST_NOT_BE_EMPTY,
   CLIENT_SECRET_MUST_NOT_BE_EMPTY,
   CLUSTER_URL_MUST_BE_VALID_CLOUD_URL,
-  CONTACT_POINT_MUST_BE_URL_OR_IP
+  CONTACT_POINT_MUST_BE_URL_OR_IP,
+  CONTACT_POINT_MUST_START_WITH_PROTOCOL
 } from './DeploymentPluginConstants';
 
 import { AUTH_TYPES } from '../shared/ZeebeAuthTypes';
@@ -42,8 +43,7 @@ export default class DeploymentPluginValidator {
 
   validateZeebeContactPoint = (value) => {
     return this.validateNonEmpty(value, CONTACT_POINT_MUST_NOT_BE_EMPTY) ||
-      validateUrl(value, CONTACT_POINT_MUST_BE_URL_OR_IP) ||
-      checkPort(value, CONTACT_POINT_MUST_BE_URL_OR_IP);
+      validateUrl(value, CONTACT_POINT_MUST_BE_URL_OR_IP);
   };
 
   validateOAuthURL = (value) => {
@@ -312,29 +312,13 @@ function validCloudUrl(url) {
 }
 
 const validateUrl = (value, message) => {
-  let fullURL = value;
-
-  if (!(value.startsWith('https://') || value.startsWith('http://'))) {
-    fullURL = 'http://' + value;
+  if (!/^https?:\/\//.test(value)) {
+    return CONTACT_POINT_MUST_START_WITH_PROTOCOL;
   }
 
   try {
-    new URL(fullURL);
-    return null;
-
+    new URL(value);
   } catch (e) {
     return message;
   }
-};
-
-const checkPort = (value, message) => {
-  var parts = value.split(':');
-  var port = (parts.length > 1) ? parts[parts.length - 1] : null;
-
-  if (port) {
-    const number = parseInt(port);
-    return isNaN(number) ? message : null;
-  }
-
-  return message;
 };

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginValidatorSpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginValidatorSpec.js
@@ -14,6 +14,7 @@ import DeploymentPluginValidator from '../DeploymentPluginValidator';
 
 import {
   CONTACT_POINT_MUST_NOT_BE_EMPTY,
+  CONTACT_POINT_MUST_START_WITH_PROTOCOL,
   OAUTH_URL_MUST_NOT_BE_EMPTY,
   AUDIENCE_MUST_NOT_BE_EMPTY,
   CLIENT_ID_MUST_NOT_BE_EMPTY,
@@ -34,11 +35,16 @@ describe('<DeploymentPluginValidator> (Zeebe)', () => {
       // given
       const emptyZeebeContactPoint = '';
       const noPortZeebeContactPoint = '0.0.0.0';
-      const validZeebeContactPoint = '0.0.0.0:0001';
+      const noProtocolZeebeContactPoint = '0.0.0.0:0001';
+      const invalidUrlZeebeContactPoint = 'http://\\';
+      const validZeebeContactPoint = 'http://localhost:26500';
 
       // then
       expect(validator.validateZeebeContactPoint(emptyZeebeContactPoint)).to.eql(CONTACT_POINT_MUST_NOT_BE_EMPTY);
-      expect(validator.validateZeebeContactPoint(noPortZeebeContactPoint)).to.eql(CONTACT_POINT_MUST_BE_URL_OR_IP);
+      expect(validator.validateZeebeContactPoint(noProtocolZeebeContactPoint)).to.eql(CONTACT_POINT_MUST_START_WITH_PROTOCOL);
+      expect(validator.validateZeebeContactPoint(noPortZeebeContactPoint)).to.eql(CONTACT_POINT_MUST_START_WITH_PROTOCOL);
+      expect(validator.validateZeebeContactPoint(noPortZeebeContactPoint)).to.eql(CONTACT_POINT_MUST_START_WITH_PROTOCOL);
+      expect(validator.validateZeebeContactPoint(invalidUrlZeebeContactPoint)).to.eql(CONTACT_POINT_MUST_BE_URL_OR_IP);
       expect(validator.validateZeebeContactPoint(validZeebeContactPoint)).to.not.exist;
     });
 
@@ -48,13 +54,13 @@ describe('<DeploymentPluginValidator> (Zeebe)', () => {
       // given
       const emptyZeebeContactPoint = '';
       const noPortZeebeContactPoint = 'foo.bar';
-      const validZeebeContactPoint = 'foo.bar:0001';
+      const missingProtocolZeebeContactPoint = 'foo.bar:0001';
       const validZeebeContactPointFullURL = 'https://foo.bar:0001';
 
       // then
       expect(validator.validateZeebeContactPoint(emptyZeebeContactPoint)).to.eql(CONTACT_POINT_MUST_NOT_BE_EMPTY);
-      expect(validator.validateZeebeContactPoint(noPortZeebeContactPoint)).to.eql(CONTACT_POINT_MUST_BE_URL_OR_IP);
-      expect(validator.validateZeebeContactPoint(validZeebeContactPoint)).to.not.exist;
+      expect(validator.validateZeebeContactPoint(noPortZeebeContactPoint)).to.eql(CONTACT_POINT_MUST_START_WITH_PROTOCOL);
+      expect(validator.validateZeebeContactPoint(missingProtocolZeebeContactPoint)).to.eql(CONTACT_POINT_MUST_START_WITH_PROTOCOL);
       expect(validator.validateZeebeContactPoint(validZeebeContactPointFullURL)).to.not.exist;
 
     });
@@ -181,7 +187,7 @@ describe('<DeploymentPluginValidator> (Zeebe)', () => {
         endpoint: {
           targetType: 'selfHosted',
           authType: 'none',
-          contactPoint: 'https://camunda.com'
+          contactPoint: 'ftp://camunda.com'
         }
       };
 
@@ -216,7 +222,7 @@ describe('<DeploymentPluginValidator> (Zeebe)', () => {
         endpoint: {
           targetType: 'selfHosted',
           authType: 'oauth',
-          contactPoint: 'https://camunda.com',
+          contactPoint: 'ftp://camunda.com',
           oauthURL: 'https://camunda.com'
         }
       };

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,11 @@
         "mri": "^1.1.6",
         "node-fetch": "^2.6.1",
         "parents": "^1.0.1",
+        "vscode-windows-ca-certs": "0.3.0",
         "zeebe-node": "^8.0.3"
+      },
+      "optionalDependencies": {
+        "vscode-windows-ca-certs": "^0.3.0"
       }
     },
     "app/node_modules/@sentry/core": {
@@ -24879,6 +24883,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/vscode-windows-ca-certs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/vscode-windows-ca-certs/-/vscode-windows-ca-certs-0.3.0.tgz",
+      "integrity": "sha512-CYrpCEKmAFQJoZNReOrelNL+VKyebOVRCqL9evrBlVcpWQDliliJgU5RggGS8FPGtQ3jAKLQt9frF0qlxYYPKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "node-addon-api": "^3.0.2"
+      }
+    },
+    "node_modules/vscode-windows-ca-certs/node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "optional": true
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.6",
       "license": "MIT"
@@ -29620,6 +29643,7 @@
         "mri": "^1.1.6",
         "node-fetch": "^2.6.1",
         "parents": "^1.0.1",
+        "vscode-windows-ca-certs": "0.3.0",
         "zeebe-node": "^8.0.3"
       },
       "dependencies": {
@@ -42338,6 +42362,23 @@
     "void-elements": {
       "version": "2.0.1",
       "dev": true
+    },
+    "vscode-windows-ca-certs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/vscode-windows-ca-certs/-/vscode-windows-ca-certs-0.3.0.tgz",
+      "integrity": "sha512-CYrpCEKmAFQJoZNReOrelNL+VKyebOVRCqL9evrBlVcpWQDliliJgU5RggGS8FPGtQ3jAKLQt9frF0qlxYYPKA==",
+      "optional": true,
+      "requires": {
+        "node-addon-api": "^3.0.2"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+          "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+          "optional": true
+        }
+      }
     },
     "w3c-keyname": {
       "version": "2.2.6"


### PR DESCRIPTION
This adds a flag for custom SSL certificate: `--zeebe-ssl-certificate=<path-to-file>`.

Protocol http(s) is now required for the contact points of self-hosted Zeebe instances.

Closes #3028

---

# How to test this in action

## Prerequisites

* Running Docker.
* Installed openssl.

## Steps

1. Clone this repo: https://github.com/barmac/zeebe-tls-connection-test
2. In the repo, run `npm run cert`. This will generate `cert.pem` file which will be our certificate. Note that you may need to adjust the `generate-cert.sh` file, namely the `/usr/local/opt/openssl/bin/openssl` part to work on your OS. This is done specifically for MacOS.
3. Run `npm run zeebe` in a separate terminal window. This will run locally a Zeebe instance which will use the certificate for SSL.

### Flag

Run Camunda Modeler with flag `--zeebe-ssl-certificate=<path-to-cert.pem>`, and try to deploy and start instance of self-managed C8. Use `https://localhost:26500` as the contact point.

### System keychain

After the flag part succeeds, add the certificate to the system keychain and make sure to mark it as trusted. Then, run Camunda Modeler with the flag, and try to deploy and start instance as in the previous part.