### PR TITLE
fix: attach and detach DMN overview properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ ___Note:__ Yet to be released changes appear here._
 * `DEPS`: bump bpmn-js to v9.3.2 ([#3065](https://github.com/camunda/camunda-modeler/pull/3065))
 * `DEPS`: bump camunda-bpmn-js to v0.16.1 ([#3065](https://github.com/camunda/camunda-modeler/pull/3065))
 
+### DMN
+
+* `FIX`: attach and detach DMN overview properly ([#3080](https://github.com/camunda/camunda-modeler/pull/3080))
+
 ## 5.1.0
 
 _Adds a multi-element context, improves overall selection UX in diagram editors, and ships conditional element template properties (C8 only)._

--- a/client/src/app/tabs/cloud-dmn/modeler/DmnModeler.js
+++ b/client/src/app/tabs/cloud-dmn/modeler/DmnModeler.js
@@ -294,7 +294,7 @@ export default class CamundaDmnModeler extends DmnModeler {
 
     this._emit('attachOverview');
 
-    parentNode.appendChild(activeViewer._container);
+    this._overview.attachTo(parentNode);
 
     activeViewer.get('canvas').resized();
   }
@@ -306,13 +306,9 @@ export default class CamundaDmnModeler extends DmnModeler {
       return;
     }
 
-    const container = activeViewer._container;
+    this._emit('detachOverview');
 
-    if (container.parentNode) {
-      this._emit('detachOverview');
-
-      container.parentNode.removeChild(container);
-    }
+    this._overview.detach();
   }
 }
 

--- a/client/src/app/tabs/dmn/modeler/DmnModeler.js
+++ b/client/src/app/tabs/dmn/modeler/DmnModeler.js
@@ -294,7 +294,7 @@ export default class CamundaDmnModeler extends DmnModeler {
 
     this._emit('attachOverview');
 
-    parentNode.appendChild(activeViewer._container);
+    this._overview.attachTo(parentNode);
 
     activeViewer.get('canvas').resized();
   }
@@ -306,13 +306,9 @@ export default class CamundaDmnModeler extends DmnModeler {
       return;
     }
 
-    const container = activeViewer._container;
+    this._emit('detachOverview');
 
-    if (container.parentNode) {
-      this._emit('detachOverview');
-
-      container.parentNode.removeChild(container);
-    }
+    this._overview.detach();
   }
 }
 


### PR DESCRIPTION
I wasn't using the API correctly and attached the DRD viewer directly instead of attaching the dmn-js container. 🤦🏻 We don't have tests for this at the moment. 😞 I'd still like to include this fix in v5.2.

![electron_ZjEr29uHL9](https://user-images.githubusercontent.com/7633572/183458351-cb189776-1527-4ffa-900b-d495fbd8d3d7.gif)

Closes #3048

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
