### PR TITLE
chore: adjust release info

### DIFF
--- a/client/src/plugins/version-info/ReleaseInfo.js
+++ b/client/src/plugins/version-info/ReleaseInfo.js
@@ -48,8 +48,8 @@ export function ReleaseInfo(props) {
           This release adds syntax highlighting and autosuggestion for FEEL expressions to the properties panel.
         </li>
         <li>
-          <h4>Lint errors in the properties panel</h4>
-          All lint errors are shown in the properties panel as of this release. Open the error panel for the errors to be shown.
+          <h4>Diagram errors in the properties panel</h4>
+          All diagram errors are shown in the properties panel as of this release. Open the error panel for the errors to be shown.
         </li>
       </ul>
     </div>


### PR DESCRIPTION
As suggested by @christian-konrad I changed it to say _diagram errors_.

![image](https://user-images.githubusercontent.com/7633572/183459567-7e7b3367-40cc-4d68-9d76-f2dfdb1561bc.png)
