### PR TITLE
Remove `$current_url` from Mixpanel tracking

### DIFF
--- a/client/src/plugins/user-journey-statistics/MixpanelHandler.js
+++ b/client/src/plugins/user-journey-statistics/MixpanelHandler.js
@@ -36,7 +36,9 @@ export default class MixpanelHandler {
   }
 
   enable(token, id, stage) {
-    mixpanel.init(token);
+    mixpanel.init(token, {
+      property_blacklist: [ '$current_url' ]
+    });
 
     mixpanel.identify(id);
 


### PR DESCRIPTION
We recently discovered we were tracking user's paths to the application (which we shouldn't). This was because Mixpanel tracks `$current_url` automatically.

This PR blacklists that property