### PR TITLE
deps(app): bump to `zeebe-node@8.0.3`

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -17,7 +17,7 @@
         "mri": "^1.1.6",
         "node-fetch": "^2.6.1",
         "parents": "^1.0.1",
-        "zeebe-node": "^8.0.1"
+        "zeebe-node": "^8.0.3"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -1144,9 +1144,9 @@
       }
     },
     "node_modules/zeebe-node": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.0.1.tgz",
-      "integrity": "sha512-67Ow0246twQ6rO7oNf39iptAx7TQ91EBnw3Cc5f+vYNY8kFnsFHf8CwWWcfWgN+EPnVZzAQ+wITHjZiZcmIleQ==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.0.3.tgz",
+      "integrity": "sha512-/5bxH0vZUIKLE5TVktcoVEvQIqKCGQWQ9i9ghJJ+UL99046kEInldnmQzqnBL3BKnUFxTjzpl0eCsRpRpdc/hA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.6.7",
         "@grpc/proto-loader": "^0.6.12",
@@ -2054,9 +2054,9 @@
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
     },
     "zeebe-node": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.0.1.tgz",
-      "integrity": "sha512-67Ow0246twQ6rO7oNf39iptAx7TQ91EBnw3Cc5f+vYNY8kFnsFHf8CwWWcfWgN+EPnVZzAQ+wITHjZiZcmIleQ==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.0.3.tgz",
+      "integrity": "sha512-/5bxH0vZUIKLE5TVktcoVEvQIqKCGQWQ9i9ghJJ+UL99046kEInldnmQzqnBL3BKnUFxTjzpl0eCsRpRpdc/hA==",
       "requires": {
         "@grpc/grpc-js": "^1.6.7",
         "@grpc/proto-loader": "^0.6.12",

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "mri": "^1.1.6",
     "node-fetch": "^2.6.1",
     "parents": "^1.0.1",
-    "zeebe-node": "^8.0.1"
+    "zeebe-node": "^8.0.3"
   },
   "homepage": "https://github.com/camunda/camunda-modeler",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "mri": "^1.1.6",
         "node-fetch": "^2.6.1",
         "parents": "^1.0.1",
-        "zeebe-node": "^8.0.1"
+        "zeebe-node": "^8.0.3"
       }
     },
     "app/node_modules/@sentry/core": {
@@ -29685,7 +29685,7 @@
         "mri": "^1.1.6",
         "node-fetch": "^2.6.1",
         "parents": "^1.0.1",
-        "zeebe-node": "^8.0.1"
+        "zeebe-node": "^8.0.3"
       },
       "dependencies": {
         "@sentry/core": {


### PR DESCRIPTION
Follow up of https://github.com/camunda/camunda-modeler/pull/3116

Seems like I missed this one after latest `rebase`... 
