### PR TITLE
fix: toggle linting only when error panel toggled

### DIFF
--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -188,6 +188,10 @@ export class BpmnEditor extends CachedComponent {
     if (isCacheStateChanged(prevProps, this.props)) {
       this.handleChanged();
     }
+
+    if (prevProps.linting !== this.props.linting) {
+      this.getModeler().get('linting').setErrors(this.props.linting || []);
+    }
   }
 
   listen(fn) {
@@ -471,42 +475,34 @@ export class BpmnEditor extends CachedComponent {
     onAction('lint-tab', { contents });
   }
 
-  onToggleLinting = () => {
-    const {
-      layout = {},
-      onLayoutChanged
-    } = this.props;
+  isLintingActive = () => {
+    return this.getModeler().get('linting').isActive();
+  }
 
-    const { panel = {} } = layout;
+  handleToggleLinting = () => {
+    const { onLayoutChanged } = this.props;
 
-    if (!panel.open) {
-      onLayoutChanged({
-        panel: {
-          open: true,
-          tab: 'linting'
-        }
-      });
+    const linting = this.getModeler().get('linting');
 
-      return;
-    }
+    if (linting.isActive()) {
+      linting.deactivate();
 
-    if (panel.tab === 'linting') {
       onLayoutChanged({
         panel: {
           open: false,
           tab: 'linting'
         }
       });
+    } else {
+      linting.activate();
 
-      return;
+      onLayoutChanged({
+        panel: {
+          open: true,
+          tab: 'linting'
+        }
+      });
     }
-
-    onLayoutChanged({
-      panel: {
-        open: true,
-        tab: 'linting'
-      }
-    });
   }
 
   isDirty() {
@@ -828,7 +824,7 @@ export class BpmnEditor extends CachedComponent {
             <Linting
               layout={ layout }
               linting={ linting }
-              onToggleLinting={ this.onToggleLinting } />
+              onToggleLinting={ this.handleToggleLinting } />
           </Fragment>
         }
       </div>
@@ -845,7 +841,8 @@ export class BpmnEditor extends CachedComponent {
     const {
       getPlugins,
       onAction,
-      onError
+      onError,
+      layout = {}
     } = props;
 
     // notify interested parties that modeler will be configured
@@ -879,7 +876,10 @@ export class BpmnEditor extends CachedComponent {
     const modeler = new BpmnModeler({
       ...options,
       position: 'absolute',
-      changeTemplateCommand: 'propertiesPanel.camunda.changeTemplate'
+      changeTemplateCommand: 'propertiesPanel.camunda.changeTemplate',
+      linting: {
+        active: layout.panel && layout.panel.open && layout.panel.tab === 'linting'
+      }
     });
 
     const commandStack = modeler.get('commandStack');

--- a/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
+++ b/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
@@ -16,6 +16,7 @@ import completeDirectEditingModule from './features/complete-direct-editing';
 import globalClipboardModule from './features/global-clipboard';
 import handToolOnSpaceModule from './features/hand-tool-on-space';
 import propertiesPanelKeyboardBindingsModule from './features/properties-panel-keyboard-bindings';
+import lintingAnnotationsModule from '@camunda/linting/modeler';
 
 import Flags, { DISABLE_ADJUST_ORIGIN } from '../../../../util/Flags';
 
@@ -46,7 +47,8 @@ const extensionModules = [
   completeDirectEditingModule,
   globalClipboardModule,
   handToolOnSpaceModule,
-  propertiesPanelKeyboardBindingsModule
+  propertiesPanelKeyboardBindingsModule,
+  lintingAnnotationsModule
 ];
 
 PlatformBpmnModeler.prototype._modules = [

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -410,35 +410,43 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
       });
 
 
-      it('should call linting on change', async function() {
+      it('should lint on import', async function() {
 
-        // assume
-        // lint on import
+        // then
         expect(onActionSpy).to.have.been.calledOnce;
+        expect(onActionSpy).to.have.been.calledWithMatch('lint-tab');
+      });
+
+
+      it('should lint on change', async function() {
+
+        onActionSpy.resetHistory();
 
         // when
         modeler._emit('commandStack.changed');
 
         // then
-        expect(onActionSpy).to.have.been.calledTwice;
-      });
-
-
-      it('should only register once', async function() {
-
-        // assume
-        // lint on import
         expect(onActionSpy).to.have.been.calledOnce;
-
-        // when
-        wrapper.unmount();
-        wrapper.mount();
-
-        modeler._emit('commandStack.changed');
-
-        // then
-        expect(onActionSpy).to.have.been.calledTwice;
+        expect(onActionSpy).to.have.been.calledWithMatch('lint-tab');
       });
+
+
+      it('should subscribe on mount and unsubscribe on unmount',
+        async function() {
+
+          onActionSpy.resetHistory();
+
+          // when
+          wrapper.unmount();
+          wrapper.mount();
+
+          modeler._emit('commandStack.changed');
+
+          // then
+          expect(onActionSpy).to.have.been.calledOnce;
+          expect(onActionSpy).to.have.been.calledWithMatch('lint-tab');
+        }
+      );
 
     });
 
@@ -451,7 +459,8 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
         const { instance } = await renderEditor(diagramXML, {
           layout: {
             panel: {
-              open: true
+              open: true,
+              tab: 'linting'
             }
           }
         });
@@ -461,7 +470,7 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
       });
 
 
-      it('should not be active', async function() {
+      it('should not be active (open=false)', async function() {
 
         // when
         const { instance } = await renderEditor(diagramXML, {
@@ -476,10 +485,27 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
         expect(instance.isLintingActive()).to.be.false;
       });
 
+
+      it('should not be active (tab!=linting)', async function() {
+
+        // when
+        const { instance } = await renderEditor(diagramXML, {
+          layout: {
+            panel: {
+              open: true,
+              tab: 'foo'
+            }
+          }
+        });
+
+        // then
+        expect(instance.isLintingActive()).to.be.false;
+      });
+
     });
 
 
-    describe('#onToggleLinting', function() {
+    describe('#handleToggleLinting', function() {
 
       it('should open', async function() {
 
@@ -496,7 +522,7 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
         });
 
         // when
-        instance.onToggleLinting();
+        instance.handleToggleLinting();
 
         // then
         expect(onLayoutChangedSpy).to.have.been.calledOnceWith({
@@ -524,7 +550,7 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
         });
 
         // when
-        instance.onToggleLinting();
+        instance.handleToggleLinting();
 
         // then
         expect(onLayoutChangedSpy).to.have.been.calledOnceWith({
@@ -552,7 +578,7 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
         });
 
         // when
-        instance.onToggleLinting();
+        instance.handleToggleLinting();
 
         // then
         expect(onLayoutChangedSpy).to.have.been.calledOnceWith({
@@ -631,7 +657,7 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
         const { instance } = await renderEditor(diagramXML, {
           layout: {
             panel: {
-              open: true
+              open: false
             }
           }
         });
@@ -639,7 +665,7 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
         const activateSpy = spy(instance.getModeler().get('linting'), 'activate');
 
         // when
-        instance.componentDidUpdate(instance.props);
+        instance.handleToggleLinting();
 
         // then
         expect(activateSpy).to.have.been.calledOnce;
@@ -652,7 +678,8 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
         const { instance } = await renderEditor(diagramXML, {
           layout: {
             panel: {
-              open: false
+              open: true,
+              tab: 'linting'
             }
           }
         });
@@ -660,7 +687,7 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
         const deactivateSpy = spy(instance.getModeler().get('linting'), 'deactivate');
 
         // when
-        instance.componentDidUpdate(instance.props);
+        instance.handleToggleLinting();
 
         // then
         expect(deactivateSpy).to.have.been.calledOnce;

--- a/client/test/mocks/bpmn-js/Modeler.js
+++ b/client/test/mocks/bpmn-js/Modeler.js
@@ -61,6 +61,28 @@ class PropertiesPanel {
   update() {}
 }
 
+class Linting {
+  constructor(options = {}) {
+    this._isActive = options.active;
+  }
+
+  activate() {
+    this._isActive = true;
+  }
+
+  deactivate() {
+    this._isActive = false;
+  }
+
+  isActive() {
+    return this._isActive;
+  }
+
+  setErrors() {}
+
+  showError() {}
+}
+
 class Selection {
   constructor() {
     this._selectedElements = [];
@@ -79,14 +101,14 @@ export default class Modeler {
   constructor(options = {}) {
     this.options = options;
 
-    this.modules = assign(this._getDefaultModules(), options.modules || {});
+    this.modules = assign(this._getDefaultModules(options), options.modules || {});
 
     this.xml = null;
 
     this.listeners = {};
   }
 
-  _getDefaultModules() {
+  _getDefaultModules(options = {}) {
     return {
       eventBus: {
         fire() {}
@@ -107,12 +129,7 @@ export default class Modeler {
       },
       propertiesPanel: new PropertiesPanel(),
       selection: new Selection(),
-      linting: {
-        activate() {},
-        deactivate() {},
-        setErrors() {},
-        showError() {}
-      }
+      linting: new Linting(options.linting)
     };
   }
 


### PR DESCRIPTION
* activate and deactivate linting only on toggle error panel
* simplify implementation
* rename #onToggleLinting to #handleToggleLinting
* add linting annotations to Camunda 7 BPMN editor

---

Closes #3127

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
