### PR TITLE
fix(zeebe): use non-deprecated zeebe-node API

### DIFF
--- a/app/lib/zeebe-api/zeebe-api.js
+++ b/app/lib/zeebe-api/zeebe-api.js
@@ -120,7 +120,7 @@ class ZeebeAPI {
 
   /**
    * @public
-   * Deploy workflow.
+   * Deploy Process.
    *
    * @param {ZeebeClientParameters & { name: string, filePath: string }} parameters
    * @returns {{ success: boolean, response: object }}
@@ -141,7 +141,7 @@ class ZeebeAPI {
     const client = await this._getZeebeClient(endpoint);
 
     try {
-      const response = await client.deployWorkflow({
+      const response = await client.deployProcess({
         definition: contents,
         name: prepareDeploymentName(name, filePath, diagramType)
       });
@@ -179,10 +179,7 @@ class ZeebeAPI {
 
     try {
 
-      const response = await client.createWorkflowInstance({
-        bpmnProcessId: processId,
-        variables
-      });
+      const response = await client.createProcessInstance(processId, variables);
 
       return {
         success: true,

--- a/app/test/spec/zeebe-api-spec.js
+++ b/app/test/spec/zeebe-api-spec.js
@@ -447,7 +447,7 @@ describe('ZeebeAPI', function() {
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            createWorkflowInstance: function() {
+            createProcessInstance: function() {
               throw new Error('TEST ERROR.');
             }
           };
@@ -478,7 +478,7 @@ describe('ZeebeAPI', function() {
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            createWorkflowInstance: function() {
+            createProcessInstance: function() {
               throw new Error('TEST ERROR.');
             }
           };
@@ -534,7 +534,7 @@ describe('ZeebeAPI', function() {
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployWorkflow: function() {
+            deployProcess: function() {
               throw error;
             }
           };
@@ -566,7 +566,7 @@ describe('ZeebeAPI', function() {
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployWorkflow: function() {
+            deployProcess: function() {
               throw error;
             }
           };
@@ -620,12 +620,12 @@ describe('ZeebeAPI', function() {
     it('should suffix deployment name with .bpmn if necessary', async () => {
 
       // given
-      const deployWorkflowSpy = sinon.spy();
+      const deployProcessSpy = sinon.spy();
 
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployWorkflow: deployWorkflowSpy,
+            deployProcess: deployProcessSpy,
           };
         }
       });
@@ -640,7 +640,7 @@ describe('ZeebeAPI', function() {
         }
       });
 
-      const { args } = deployWorkflowSpy.getCall(0);
+      const { args } = deployProcessSpy.getCall(0);
 
       // then
       expect(args[0].name).to.eql('not_suffixed.bpmn');
@@ -650,12 +650,12 @@ describe('ZeebeAPI', function() {
     it('should suffix deployment name with .dmn if necessary', async () => {
 
       // given
-      const deployWorkflowSpy = sinon.spy();
+      const deployProcessSpy = sinon.spy();
 
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployWorkflow: deployWorkflowSpy,
+            deployProcess: deployProcessSpy,
           };
         }
       });
@@ -671,7 +671,7 @@ describe('ZeebeAPI', function() {
         diagramType: 'dmn'
       });
 
-      const { args } = deployWorkflowSpy.getCall(0);
+      const { args } = deployProcessSpy.getCall(0);
 
       // then
       expect(args[0].name).to.eql('not_suffixed.dmn');
@@ -681,12 +681,12 @@ describe('ZeebeAPI', function() {
     it('should not suffix deployment name with .bpmn if not necessary', async () => {
 
       // given
-      const deployWorkflowSpy = sinon.spy();
+      const deployProcessSpy = sinon.spy();
 
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployWorkflow: deployWorkflowSpy,
+            deployProcess: deployProcessSpy,
           };
         }
       });
@@ -701,7 +701,7 @@ describe('ZeebeAPI', function() {
         }
       });
 
-      const { args } = deployWorkflowSpy.getCall(0);
+      const { args } = deployProcessSpy.getCall(0);
 
       // then
       expect(args[0].name).to.eql('suffixed.bpmn');
@@ -711,12 +711,12 @@ describe('ZeebeAPI', function() {
     it('should not suffix deployment name with .dmn if not necessary', async () => {
 
       // given
-      const deployWorkflowSpy = sinon.spy();
+      const deployProcessSpy = sinon.spy();
 
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployWorkflow: deployWorkflowSpy,
+            deployProcess: deployProcessSpy,
           };
         }
       });
@@ -732,7 +732,7 @@ describe('ZeebeAPI', function() {
         diagramType: 'dmn'
       });
 
-      const { args } = deployWorkflowSpy.getCall(0);
+      const { args } = deployProcessSpy.getCall(0);
 
       // then
       expect(args[0].name).to.eql('suffixed.dmn');
@@ -742,12 +742,12 @@ describe('ZeebeAPI', function() {
     it('should use file path if deployment name is empty', async () => {
 
       // given
-      const deployWorkflowSpy = sinon.spy();
+      const deployProcessSpy = sinon.spy();
 
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployWorkflow: deployWorkflowSpy,
+            deployProcess: deployProcessSpy,
           };
         }
       });
@@ -762,7 +762,7 @@ describe('ZeebeAPI', function() {
         }
       });
 
-      const { args } = deployWorkflowSpy.getCall(0);
+      const { args } = deployProcessSpy.getCall(0);
 
       // then
       expect(args[0].name).to.eql('process.bpmn');
@@ -772,12 +772,12 @@ describe('ZeebeAPI', function() {
     it('should add bpmn suffix to filename if extension is other than bpmn', async () => {
 
       // given
-      const deployWorkflowSpy = sinon.spy();
+      const deployProcessSpy = sinon.spy();
 
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployWorkflow: deployWorkflowSpy,
+            deployProcess: deployProcessSpy,
           };
         }
       });
@@ -792,7 +792,7 @@ describe('ZeebeAPI', function() {
         }
       });
 
-      const { args } = deployWorkflowSpy.getCall(0);
+      const { args } = deployProcessSpy.getCall(0);
 
       // then
       expect(args[0].name).to.eql('xmlFile.bpmn');
@@ -802,12 +802,12 @@ describe('ZeebeAPI', function() {
     it('should add dmn suffix if extension is other than dmn and diagramType=dmn', async () => {
 
       // given
-      const deployWorkflowSpy = sinon.spy();
+      const deployProcessSpy = sinon.spy();
 
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployWorkflow: deployWorkflowSpy,
+            deployProcess: deployProcessSpy,
           };
         }
       });
@@ -823,7 +823,7 @@ describe('ZeebeAPI', function() {
         diagramType: 'dmn'
       });
 
-      const { args } = deployWorkflowSpy.getCall(0);
+      const { args } = deployProcessSpy.getCall(0);
 
       // then
       expect(args[0].name).to.eql('xmlFile.dmn');
@@ -1254,7 +1254,7 @@ describe('ZeebeAPI', function() {
           usedConfig = args;
 
           return {
-            deployWorkflow: noop
+            deployProcess: noop
           };
         }
       });
@@ -1327,7 +1327,7 @@ describe('ZeebeAPI', function() {
 
       // given
       const createSpy = sinon.stub().returns({
-        deployWorkflow: noop,
+        deployProcess: noop,
         close: noop
       });
 
@@ -1366,7 +1366,7 @@ describe('ZeebeAPI', function() {
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployWorkflow: noop,
+            deployProcess: noop,
             close: closeSpy
           };
         }
@@ -1414,7 +1414,7 @@ describe('ZeebeAPI', function() {
           usedConfig = args;
 
           return {
-            deployWorkflow: noop
+            deployProcess: noop
           };
         }
       });
@@ -1449,7 +1449,7 @@ describe('ZeebeAPI', function() {
           usedConfig = args;
 
           return {
-            deployWorkflow: noop
+            deployProcess: noop
           };
         }
       });
@@ -1479,7 +1479,7 @@ describe('ZeebeAPI', function() {
           usedConfig = args;
 
           return {
-            deployWorkflow: noop
+            deployProcess: noop
           };
         }
       });
@@ -1527,8 +1527,8 @@ function mockZeebeNode(options = {}) {
     ZBClient: options.ZBClient || function() {
       return {
         topology: noop,
-        deployWorkflow: noop,
-        createWorkflowInstance: noop,
+        deployProcess: noop,
+        createProcessInstance: noop,
         close: noop
       };
     }

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
@@ -691,7 +691,7 @@ function createCamundaCloudClusterUrl(camundaCloudClusterId) {
 }
 
 function getProcessId(response) {
-  return response.workflows && response.workflows[0] && response.workflows[0].bpmnProcessId || null;
+  return response.processes && response.processes[0] && response.processes[0].bpmnProcessId || null;
 }
 
 function patchWithProtocol(config = {}) {

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
@@ -632,7 +632,7 @@ describe('<DeploymentPlugin> (Zeebe)', () => {
     // given
     const displayNotification = sinon.spy();
     const { instance } = createDeploymentPlugin({
-      zeebeAPI: new MockZeebeAPI({ deploymentResult: { success: true, response: { workflows: [] } } }),
+      zeebeAPI: new MockZeebeAPI({ deploymentResult: { success: true, response: { processes: [] } } }),
       displayNotification,
       endpoint : {
         targetType: CAMUNDA_CLOUD,
@@ -1503,7 +1503,7 @@ function MockZeebeAPI(options = {}) {
     }
 
     const result = deploymentResult ||
-      { success: true, response: { workflows: [ { bpmnProcessId: 'test' } ] } };
+      { success: true, response: { processes: [ { bpmnProcessId: 'test' } ] } };
 
     return Promise.resolve(result);
   };

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
@@ -141,7 +141,7 @@ export default class StartInstancePlugin extends PureComponent {
     } = this.props;
 
     const zeebeAPI = _getGlobal('zeebeAPI');
-    const processId = deploymentResult.response.workflows[0].bpmnProcessId;
+    const processId = deploymentResult.response.processes[0].bpmnProcessId;
     const decoratedConfig = this.decorateVariables(startInstanceConfig);
 
     try {

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginSpec.js
@@ -218,7 +218,7 @@ describe('<StartInstancePlugin> (Zeebe)', () => {
       // given
       const processId = '123';
       const deploymentResult = {
-        success: true, response: { workflows: [ { bpmnProcessId: processId } ] }
+        success: true, response: { processes: [ { bpmnProcessId: processId } ] }
       };
       const runSpy = sinon.spy();
       const zeebeAPI = new MockZeebeAPI({ runSpy });
@@ -417,7 +417,7 @@ function createStartInstancePlugin({
   zeebeAPI = new MockZeebeAPI(),
   activeTab = createTab(),
   deploymentResult = {
-    success: true, response: { workflows: [ { bpmnProcessId: 'test' } ] }
+    success: true, response: { processes: [ { bpmnProcessId: 'test' } ] }
   },
   deploymentEndpoint = {},
   ...props


### PR DESCRIPTION
closes https://github.com/camunda/camunda-modeler/issues/3223

Changes:
- rename `workflow` -> `process`
- API: `createProcessInstance({bpmnProcessId, variables})` -> `createProcessInstance(bpmnProcessId, variables)`

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
