### PR TITLE
Update to Electron@21.0.0

### DIFF
--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -420,7 +420,8 @@ app.createEditorWindow = function() {
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
-      nodeIntegration
+      nodeIntegration,
+      sandbox: false
     }
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       ],
       "devDependencies": {
         "archiver": "^3.0.3",
-        "builder-util": "^22.3.3",
         "chai": "^4.2.0",
         "cpx": "^1.5.0",
         "del": "^3.0.0",
@@ -8680,11 +8679,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/app-builder-bin": {
-      "version": "3.7.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/app-builder-lib": {
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.6.0.tgz",
@@ -9730,106 +9724,6 @@
       "version": "1.1.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/builder-util": {
-      "version": "22.14.13",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/debug": "^4.1.6",
-        "@types/fs-extra": "^9.0.11",
-        "7zip-bin": "~5.1.1",
-        "app-builder-bin": "3.7.1",
-        "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "8.9.2",
-        "chalk": "^4.1.1",
-        "cross-spawn": "^7.0.3",
-        "debug": "^4.3.2",
-        "fs-extra": "^10.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "is-ci": "^3.0.0",
-        "js-yaml": "^4.1.0",
-        "source-map-support": "^0.5.19",
-        "stat-mode": "^1.0.0",
-        "temp-file": "^3.4.0"
-      }
-    },
-    "node_modules/builder-util-runtime": {
-      "version": "8.9.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.2",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/builder-util/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/builder-util/node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/builder-util/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/builder-util/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/builder-util/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/builder-util/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/builtins": {
       "version": "5.0.1",
@@ -29541,10 +29435,6 @@
         }
       }
     },
-    "app-builder-bin": {
-      "version": "3.7.1",
-      "dev": true
-    },
     "app-builder-lib": {
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.6.0.tgz",
@@ -30283,76 +30173,6 @@
     "buffer-from": {
       "version": "1.1.2",
       "dev": true
-    },
-    "builder-util": {
-      "version": "22.14.13",
-      "dev": true,
-      "requires": {
-        "@types/debug": "^4.1.6",
-        "@types/fs-extra": "^9.0.11",
-        "7zip-bin": "~5.1.1",
-        "app-builder-bin": "3.7.1",
-        "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "8.9.2",
-        "chalk": "^4.1.1",
-        "cross-spawn": "^7.0.3",
-        "debug": "^4.3.2",
-        "fs-extra": "^10.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "is-ci": "^3.0.0",
-        "js-yaml": "^4.1.0",
-        "source-map-support": "^0.5.19",
-        "stat-mode": "^1.0.0",
-        "temp-file": "^3.4.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "builder-util-runtime": {
-      "version": "8.9.2",
-      "dev": true,
-      "requires": {
-        "debug": "^4.3.2",
-        "sax": "^1.2.4"
-      }
     },
     "builtins": {
       "version": "5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "del": "^3.0.0",
         "del-cli": "^5.0.0",
         "diff2html": "^3.4.19",
-        "electron": "19.1.1",
+        "electron": "^21.1.0",
         "electron-builder": "^23.6.0",
         "electron-devtools-installer": "^3.1.1",
         "electron-notarize": "^1.2.1",
@@ -10698,47 +10698,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "dev": true,
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/concat-stream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/concat-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/config-chain": {
       "version": "1.1.13",
       "dev": true,
@@ -13088,21 +13047,21 @@
       }
     },
     "node_modules/electron": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.1.1.tgz",
-      "integrity": "sha512-cVjX+vYH431iNdIpDXU1cfx83heS/lkPVorpaiERSPcycwiZYFtE5xjL8XAARV11TG+AmN4gxBFMSb9R7DhStw==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-21.1.0.tgz",
+      "integrity": "sha512-CM5VZpZPtAoPgTPcmEbRaZWXlxGuD5a5DTeAwm0F0F6/k6R3HZAi8vZnE77gwuHK/Qqcinw4/MAbiCwAKh2W+g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^1.14.1",
         "@types/node": "^16.11.26",
-        "extract-zip": "^1.0.3"
+        "extract-zip": "^2.0.1"
       },
       "bin": {
         "electron": "cli.js"
       },
       "engines": {
-        "node": ">= 8.6"
+        "node": ">= 10.17.0"
       }
     },
     "node_modules/electron-builder": {
@@ -14868,31 +14827,39 @@
       }
     },
     "node_modules/extract-zip": {
-      "version": "1.7.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
-        "concat-stream": "^1.6.2",
-        "debug": "^2.6.9",
-        "mkdirp": "^0.5.4",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
       },
       "bin": {
         "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
       }
     },
-    "node_modules/extract-zip/node_modules/debug": {
-      "version": "2.6.9",
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/extract-zip/node_modules/ms": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/extsprintf": {
       "version": "1.4.1",
@@ -22234,41 +22201,6 @@
       },
       "engines": {
         "node": ">=14.1.0"
-      }
-    },
-    "node_modules/puppeteer/node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/puppeteer/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/puppeteer/node_modules/rimraf": {
@@ -33909,42 +33841,6 @@
       "version": "0.0.1",
       "dev": true
     },
-    "concat-stream": {
-      "version": "1.6.2",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "config-chain": {
       "version": "1.1.13",
       "dev": true,
@@ -35522,14 +35418,14 @@
       }
     },
     "electron": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.1.1.tgz",
-      "integrity": "sha512-cVjX+vYH431iNdIpDXU1cfx83heS/lkPVorpaiERSPcycwiZYFtE5xjL8XAARV11TG+AmN4gxBFMSb9R7DhStw==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-21.1.0.tgz",
+      "integrity": "sha512-CM5VZpZPtAoPgTPcmEbRaZWXlxGuD5a5DTeAwm0F0F6/k6R3HZAi8vZnE77gwuHK/Qqcinw4/MAbiCwAKh2W+g==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.14.1",
         "@types/node": "^16.11.26",
-        "extract-zip": "^1.0.3"
+        "extract-zip": "^2.0.1"
       },
       "dependencies": {
         "@types/node": {
@@ -36800,25 +36696,25 @@
       }
     },
     "extract-zip": {
-      "version": "1.7.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.6.2",
-        "debug": "^2.6.9",
-        "mkdirp": "^0.5.4",
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "pump": "^3.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "dev": true
         }
       }
     },
@@ -41641,27 +41537,6 @@
         "ws": "8.8.1"
       },
       "dependencies": {
-        "extract-zip": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-          "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-          "dev": true,
-          "requires": {
-            "@types/yauzl": "^2.9.1",
-            "debug": "^4.1.1",
-            "get-stream": "^5.1.0",
-            "yauzl": "^2.10.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
         "rimraf": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   },
   "devDependencies": {
     "archiver": "^3.0.3",
-    "builder-util": "^22.3.3",
     "chai": "^4.2.0",
     "cpx": "^1.5.0",
     "del": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "del": "^3.0.0",
     "del-cli": "^5.0.0",
     "diff2html": "^3.4.19",
-    "electron": "19.1.1",
+    "electron": "^21.1.0",
     "electron-builder": "^23.6.0",
     "electron-devtools-installer": "^3.1.1",
     "electron-notarize": "^1.2.1",


### PR DESCRIPTION
I had to explicitly disable the new sandboxing behavior shipped with Electron@20 (cf. [breaking docs](https://www.electronjs.org/docs/latest/breaking-changes#default-changed-renderers-without-nodeintegration-true-are-sandboxed-by-default), [preload documentation](https://www.electronjs.org/docs/latest/tutorial/sandbox#preload-scripts)).

Otherwise our existing preload script fails to execute. 