### PR TITLE
fix: set explicitly `useTLS=false` for http endpoints

### DIFF
--- a/app/lib/zeebe-api/zeebe-api.js
+++ b/app/lib/zeebe-api/zeebe-api.js
@@ -283,8 +283,7 @@ class ZeebeAPI {
           clientId: endpoint.clientId,
           clientSecret: endpoint.clientSecret,
           cacheOnDisk: false
-        },
-        useTLS: true
+        }
       };
     } else if (type === endpointTypes.CAMUNDA_CLOUD) {
       options = {
@@ -308,11 +307,10 @@ class ZeebeAPI {
   async _withTLSConfig(url, options) {
     const rootCerts = [];
 
-    // (0) force TLS only for https endpoints; don't parse the URL to avoid errors at this step
-    const tlsOptions = {};
-    if (/^https:\/\//.test(url)) {
-      tlsOptions.useTLS = true;
-    }
+    // (0) set `useTLS` according to the protocol
+    const tlsOptions = {
+      useTLS: options.useTLS || /^https:\/\//.test(url)
+    };
 
     // (1) use certificate from flag
     const customCertificatePath = this._flags.get('zeebe-ssl-certificate');

--- a/app/test/spec/zeebe-api-spec.js
+++ b/app/test/spec/zeebe-api-spec.js
@@ -1529,7 +1529,7 @@ describe('ZeebeAPI', function() {
     });
 
 
-    it('should set NOT `useTLS=false` for no protocol endpoint (cloud)', async () => {
+    it('should set `useTLS=true` for no protocol endpoint (cloud)', async () => {
 
       // given
       let usedConfig;

--- a/app/test/spec/zeebe-api-spec.js
+++ b/app/test/spec/zeebe-api-spec.js
@@ -1469,7 +1469,7 @@ describe('ZeebeAPI', function() {
     });
 
 
-    it('should NOT set `useTLS` for http endpoint', async () => {
+    it('should set `useTLS=false` for http endpoint (no auth)', async () => {
 
       // given
       let usedConfig;
@@ -1495,7 +1495,67 @@ describe('ZeebeAPI', function() {
       await zeebeAPI.deploy(parameters);
 
       // then
-      expect(usedConfig[1]).not.to.have.property('useTLS');
+      expect(usedConfig[1]).to.have.property('useTLS', false);
+    });
+
+
+    it('should set `useTLS=false` for http endpoint (oauth)', async () => {
+
+      // given
+      let usedConfig;
+
+      const zeebeAPI = mockZeebeNode({
+        ZBClient: function(...args) {
+          usedConfig = args;
+
+          return {
+            deployProcess: noop
+          };
+        }
+      });
+
+      const parameters = {
+        endpoint: {
+          type: 'oauth',
+          url: 'http://camunda.com'
+        }
+      };
+
+      // when
+      await zeebeAPI.deploy(parameters);
+
+      // then
+      expect(usedConfig[1]).to.have.property('useTLS', false);
+    });
+
+
+    it('should set NOT `useTLS=false` for no protocol endpoint (cloud)', async () => {
+
+      // given
+      let usedConfig;
+
+      const zeebeAPI = mockZeebeNode({
+        ZBClient: function(...args) {
+          usedConfig = args;
+
+          return {
+            deployProcess: noop
+          };
+        }
+      });
+
+      const parameters = {
+        endpoint: {
+          type: 'camundaCloud',
+          url: 'camunda.com'
+        }
+      };
+
+      // when
+      await zeebeAPI.deploy(parameters);
+
+      // then
+      expect(usedConfig[1]).to.have.property('useTLS', true);
     });
   });
 


### PR DESCRIPTION
* [x] Verified to work with oAuth + http
* [x] Verified to work with C8 SaaS
* [x] Verified to work with no auth + http

Closes #3152
