### PR TITLE
fix: create C8 diagram from empty bpmn file

### DIFF
--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -646,8 +646,8 @@ export default class TabsProvider {
     if (providersForExtension.length > 1) {
       const provider = findProviderForFile(providersForExtension, file);
 
-      // return the matching provider or the last provider as fallback
-      return provider || providersForExtension[providersForExtension.length - 1];
+      // return the matching provider or the first by priority provider as fallback
+      return provider || sortByPriority(providersForExtension)[0];
     }
 
     // no providers specified for the extension; return the first that can open the file

--- a/client/src/app/__tests__/TabsProviderSpec.js
+++ b/client/src/app/__tests__/TabsProviderSpec.js
@@ -151,7 +151,7 @@ describe('TabsProvider', function() {
       const tab = tabsProvider.createTabForFile(file);
 
       // then
-      expect(tab.type).to.eql('bpmn');
+      expect(tab.type).to.eql('cloud-bpmn');
       expect(tab.file.contents).to.exist;
       expect(tab.file.contents).to.have.lengthOf.above(0);
     });
@@ -170,7 +170,7 @@ describe('TabsProvider', function() {
       const tab = tabsProvider.createTabForFile(file);
 
       // then
-      expect(tab.type).to.eql('dmn');
+      expect(tab.type).to.eql('cloud-dmn');
       expect(tab.file.contents).to.exist;
       expect(tab.file.contents).to.have.lengthOf.above(0);
     });
@@ -347,7 +347,7 @@ describe('TabsProvider', function() {
       // then
       expect(tab.name).to.eql(file.name);
       expect(tab.title).to.eql(file.path);
-      expect(tab.type).to.eql('bpmn');
+      expect(tab.type).to.eql('cloud-bpmn');
     });
 
 
@@ -367,7 +367,7 @@ describe('TabsProvider', function() {
       // then
       expect(tab.name).to.eql(file.name);
       expect(tab.title).to.eql(file.path);
-      expect(tab.type).to.eql('bpmn');
+      expect(tab.type).to.eql('cloud-bpmn');
     });
 
 


### PR DESCRIPTION
sort by priority when multiple providers specified for the extension
closes #2957 
