### PR TITLE
Form Playground Tracking

### DIFF
--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -357,7 +357,15 @@ class MenuBuilder {
     if (action) {
       menuItemOptions = {
         ...menuItemOptions,
-        click: wrapActionInactiveInDevtools(() => app.emit('menu:action', action, options))
+        click: wrapActionInactiveInDevtools((...args) => {
+
+          const event = args[2];
+
+          app.emit('menu:action', action, {
+            ...options,
+            triggeredByShortcut: event.triggeredByAccelerator
+          });
+        })
       };
     }
 
@@ -710,7 +718,16 @@ function mapMenuEntryTemplate(entry) {
     label: entry.label,
     accelerator: entry.accelerator,
     enabled: entry.enabled !== undefined ? entry.enabled : true,
-    click: () => app.emit('menu:action', entry.action, entry.options),
+    click: (...args) => {
+      const event = args[2];
+
+      const options = {
+        ...entry.options,
+        triggeredByShortcut: event.triggeredByAccelerator
+      };
+
+      app.emit('menu:action', entry.action, options);
+    },
     icon: entry.icon ?
       getIconImage(entry.icon)
       : null

--- a/app/test/spec/menu/menu-builder-spec.js
+++ b/app/test/spec/menu/menu-builder-spec.js
@@ -329,6 +329,70 @@ describe('MenuBuilder', () => {
     });
 
 
+    it('should inform about triggered by shortcut', () => {
+
+      // given
+      const action = sinon.spy(ElectronApp, 'emit');
+      const menuBuilder = new MenuBuilder({
+        state: {
+          editMenu: [ {
+            label: 'label',
+            enabled: true,
+            action
+          } ]
+        }
+      });
+
+      // when
+      const { menu } = menuBuilder.build();
+
+      // then
+      const editMenu = menu.find(item => item.label === 'Edit');
+      const { click } = editMenu.submenu[0];
+
+      expect(click).to.exist;
+
+      callAction(click, {}, true);
+
+      const call = action.getCall(0).args[2];
+      expect(call).to.eql({ triggeredByShortcut: true });
+    });
+
+
+    it('should inform about triggered by shortcut - sub menu', () => {
+
+      // given
+      const action = sinon.spy(ElectronApp, 'emit');
+      const menuBuilder = new MenuBuilder({
+        state: {
+          editMenu: [ {
+            submenu: [
+              {
+                label: 'label',
+                enabled: true,
+                action
+              }
+            ]
+          } ]
+        }
+      });
+
+      // when
+      const { menu } = menuBuilder.build();
+
+      // then
+      const editMenu = menu.find(item => item.label === 'Edit');
+      const { click } = editMenu.submenu[0].submenu[0];
+
+      expect(click).to.exist;
+
+      callAction(click, {}, true);
+
+      const call = action.getCall(0).args[2];
+      expect(call).to.eql({ triggeredByShortcut: true });
+    });
+
+
     it('should NOT call action if triggered via shortcut with no browser window', () => {
 
       // given

--- a/client/src/app/tabs/form/FormEditor.js
+++ b/client/src/app/tabs/form/FormEditor.js
@@ -84,6 +84,8 @@ export class FormEditor extends CachedComponent {
     this.ref = createRef();
 
     this.state = {
+      lastFormPreviewState: null,
+      lastInputData: null,
       importing: false,
       previewOpen: isValidation(getInitialFormLayout(layout)),
       triggeredBy: null
@@ -291,79 +293,85 @@ export class FormEditor extends CachedComponent {
     }
   }
 
-  handleDataEditorInteraction(fn) {
+  handleDataEditorInteractionStart = () => {
+    this.setState({
+      lastInputData: this.getInputData()
+    });
+  };
+
+  handleDataEditorInteractionEnd = () => {
     const {
       onAction
     } = this.props;
 
+    const newData = this.getInputData();
+
+    // fire event once data was touched (changed)
+    if (this.state.lastInputData !== newData) {
+      onAction('emit-event', {
+        type: 'form.modeler.inputDataChanged'
+      });
+    }
+
+    this.setState({
+      lastInputData: null
+    });
+  };
+
+  handleDataEditorInteraction(fn) {
     const dataEditorNode = this.ref.current.querySelector('.cfp-data-container');
 
     if (!dataEditorNode) {
       return;
     }
 
-    let data;
-
-    const handleInteractionStart = () => {
-      data = this.getInputData();
-    };
-
-    const handleInteractionEnd = () => {
-      const newData = this.getInputData();
-
-      // fire event once data was touched (changed)
-      if (data !== newData) {
-        onAction('emit-event', {
-          type: 'form.modeler.inputDataChanged'
-        });
-      }
-    };
-
     if (fn === 'on') {
-      dataEditorNode.addEventListener('focusin', handleInteractionStart);
-      dataEditorNode.addEventListener('focusout', handleInteractionEnd);
+      dataEditorNode.addEventListener('focusin', this.handleDataEditorInteractionStart);
+      dataEditorNode.addEventListener('focusout', this.handleDataEditorInteractionEnd);
     } else {
-      dataEditorNode.removeEventListener('focusin', handleInteractionStart);
-      dataEditorNode.removeEventListener('focusout', handleInteractionEnd);
+      dataEditorNode.removeEventListener('focusin', this.handleDataEditorInteractionStart);
+      dataEditorNode.removeEventListener('focusout', this.handleDataEditorInteractionEnd);
     }
   }
 
-  handleFormPreviewInteraction(fn) {
+  handleFormPreviewInteractionStart = () => {
+    this.setState({
+      lastFormPreviewState: this.getFormPreviewState()
+    });
+  };
+
+  handleFormPreviewInteractionEnd = () => {
     const {
       onAction
     } = this.props;
 
+    const newformPreviewState = this.getFormPreviewState();
+
+    // fire event once preview was touched (changed)
+    if (this.state.lastFormPreviewState !== newformPreviewState) {
+      onAction('emit-event', {
+        type: 'form.modeler.previewChanged'
+      });
+    }
+
+    this.setState({
+      lastFormPreviewState: null
+    });
+  };
+
+  handleFormPreviewInteraction(fn) {
     const formPreviewNode = this.ref.current.querySelector('.cfp-preview-container');
 
     if (!formPreviewNode) {
       return;
     }
 
-    let formPreviewState;
-
-    const handleInteractionStart = () => {
-      formPreviewState = this.getFormPreviewState();
-    };
-
-    const handleInteractionEnd = () => {
-      const newformPreviewState = this.getFormPreviewState();
-
-      // fire event once preview was touched (changed)
-      if (formPreviewState !== newformPreviewState) {
-        onAction('emit-event', {
-          type: 'form.modeler.previewChanged'
-        });
-      }
-
-      formPreviewState = null;
-    };
-
     if (fn === 'on') {
-      formPreviewNode.addEventListener('focusin', handleInteractionStart);
-      formPreviewNode.addEventListener('focusout', handleInteractionEnd);
+      formPreviewNode.addEventListener('focusin', this.handleFormPreviewInteractionStart);
+      formPreviewNode.addEventListener('focusout', this.handleFormPreviewInteractionEnd);
     } else {
-      formPreviewNode.removeEventListener('focusin', handleInteractionStart);
-      formPreviewNode.removeEventListener('focusout', handleInteractionEnd);
+      formPreviewNode.removeEventListener('focusin', this.handleFormPreviewInteractionStart);
+      formPreviewNode.removeEventListener('focusout', this.handleFormPreviewInteractionEnd);
     }
   }
 

--- a/client/src/app/tabs/form/FormPreviewToggle.js
+++ b/client/src/app/tabs/form/FormPreviewToggle.js
@@ -17,6 +17,8 @@ import { Fill } from '../../slot-fill';
 import DesignIcon from '../../../../resources/icons/Design.svg';
 import ValidateIcon from '../../../../resources/icons/Validate.svg';
 
+import { FORM_PREVIEW_TRIGGER } from './FormEditor';
+
 import css from './FormPreviewToggle.less';
 
 
@@ -28,19 +30,31 @@ export function FormPreviewToggle(props) {
     previewOpen
   } = props;
 
+  const handleCollapse = () => {
+    onCollapsePreview({
+      triggeredBy: FORM_PREVIEW_TRIGGER.STATUS_BAR
+    });
+  };
+
+  const handleOpen = () => {
+    onOpenPreview({
+      triggeredBy: FORM_PREVIEW_TRIGGER.STATUS_BAR
+    });
+  };
+
   return <Fill slot="status-bar__app" group="1_form-preview">
     <div className={ classnames(css.FormPreviewToggle) }>
       <button
         className={ classnames('btn', { 'btn--active': !previewOpen }) }
         title="Open design mode"
-        onClick={ onCollapsePreview }
+        onClick={ handleCollapse }
       >
         <DesignIcon /> Design
       </button>
       <button
         className={ classnames('btn', { 'btn--active': previewOpen }) }
         title="Open validation mode"
-        onClick={ onOpenPreview }
+        onClick={ handleOpen }
       >
         <ValidateIcon /> Validate
       </button>

--- a/client/src/app/tabs/form/__tests__/FormEditorSpec.js
+++ b/client/src/app/tabs/form/__tests__/FormEditorSpec.js
@@ -21,6 +21,7 @@ import {
 
 import {
   DEFAULT_ENGINE_PROFILE,
+  FORM_PREVIEW_TRIGGER,
   FormEditor
 } from '../FormEditor';
 
@@ -1062,6 +1063,81 @@ describe('<FormEditor>', function() {
 
       expect(modelerCreatedEvent).to.exist;
       expect(payload).to.eql(form);
+    });
+
+
+    it('should notify on playground layout changes', async function() {
+
+      // given
+      const {
+        instance
+      } = await renderEditor(schema, {
+        onAction: recordActions
+      });
+
+      const {
+        form
+      } = instance.getCached();
+
+      const layout = {
+        'form-preview': { open: true },
+        'form-input': { open: false },
+        'form-output': { open: false }
+      };
+
+      // when
+      form.emit('formPlayground.layoutChanged', {
+        layout
+      });
+
+      // then
+      const playgroundChangedEvent = getEvent(emittedEvents, 'form.modeler.playgroundLayoutChanged');
+
+      const {
+        payload
+      } = playgroundChangedEvent;
+
+      expect(playgroundChangedEvent).to.exist;
+      expect(payload).to.eql({
+        layout,
+        triggeredBy: FORM_PREVIEW_TRIGGER.PREVIEW_PANEL
+      });
+    });
+
+
+    it('should add <triggeredBy> to layout changes', async function() {
+
+      // given
+      const {
+        instance
+      } = await renderEditor(schema, {
+        onAction: recordActions
+      });
+
+      const layout = {
+        'form-preview': { open: true },
+        'form-input': { open: false },
+        'form-output': { open: false }
+      };
+
+      // when
+      instance.setState({ triggeredBy: 'foo' });
+      instance.handlePlaygroundLayoutChanged({
+        layout
+      });
+
+      // then
+      const playgroundChangedEvent = getEvent(emittedEvents, 'form.modeler.playgroundLayoutChanged');
+
+      const {
+        payload
+      } = playgroundChangedEvent;
+
+      expect(playgroundChangedEvent).to.exist;
+      expect(payload).to.eql({
+        layout,
+        triggeredBy: 'foo'
+      });
     });
 
   });

--- a/client/src/app/tabs/form/__tests__/FormEditorSpec.js
+++ b/client/src/app/tabs/form/__tests__/FormEditorSpec.js
@@ -138,6 +138,20 @@ describe('<FormEditor>', function() {
   });
 
 
+  it('#getFormPreviewState', async function() {
+
+    // given
+    const { instance } = await renderEditor(schema);
+
+    // when
+    const previewState = instance.getFormPreviewState();
+
+    // then
+    expect(previewState).not.to.be.undefined;
+    expect(previewState).to.equal(null);
+  });
+
+
   describe('#listen', function() {
 
     function expectHandleChanged(event) {
@@ -1152,6 +1166,68 @@ describe('<FormEditor>', function() {
         layout,
         triggeredBy: 'foo'
       });
+    });
+
+
+    it('should notify when form preview was touched', async function() {
+
+      // given
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          form: new FormPlaygroundMock({
+            form: {
+              _getState: () => Math.random()
+            }
+          })
+        },
+        __destroy: () => {}
+      });
+
+      const {
+        wrapper
+      } = await renderEditor(engineProfileSchema, {
+        cache,
+        onAction: recordActions
+      });
+
+      const editor = wrapper.find(FormEditor).getDOMNode();
+
+      const previewContainer = editor.querySelector('.cfp-preview-container');
+
+      // when
+      previewContainer.dispatchEvent(new Event('focusin', { 'bubbles': true }));
+      previewContainer.dispatchEvent(new Event('focusout', { 'bubbles': true }));
+
+      // then
+      const previewChangedEvent = getEvent(emittedEvents, 'form.modeler.previewChanged');
+
+      expect(previewChangedEvent).to.exist;
+    });
+
+
+    it('should NOT notify when form preview was not touched', async function() {
+
+      // given
+      const {
+        wrapper
+      } = await renderEditor(engineProfileSchema, {
+        onAction: recordActions
+      });
+
+      const editor = wrapper.find(FormEditor).getDOMNode();
+
+      const previewContainer = editor.querySelector('.cfp-preview-container');
+
+      // when
+      previewContainer.dispatchEvent(new Event('focusin', { 'bubbles': true }));
+      previewContainer.dispatchEvent(new Event('focusout', { 'bubbles': true }));
+
+      // then
+      const previewChangedEvent = getEvent(emittedEvents, 'form.modeler.previewChanged');
+
+      expect(previewChangedEvent).to.not.exist;
     });
 
 

--- a/client/src/app/tabs/form/__tests__/FormEditorSpec.js
+++ b/client/src/app/tabs/form/__tests__/FormEditorSpec.js
@@ -124,6 +124,20 @@ describe('<FormEditor>', function() {
   });
 
 
+  it('#getInputData', async function() {
+
+    // given
+    const { instance } = await renderEditor(schema);
+
+    // when
+    const inputData = instance.getInputData();
+
+    // then
+    expect(inputData).not.to.be.undefined;
+    expect(inputData).to.equal(null);
+  });
+
+
   describe('#listen', function() {
 
     function expectHandleChanged(event) {
@@ -1138,6 +1152,68 @@ describe('<FormEditor>', function() {
         layout,
         triggeredBy: 'foo'
       });
+    });
+
+
+    it('should notify when form input editor was touched', async function() {
+
+      // given
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          form: new FormPlaygroundMock({
+            dataEditor: {
+              getValue: () => Math.random()
+            }
+          })
+        },
+        __destroy: () => {}
+      });
+
+      const {
+        wrapper
+      } = await renderEditor(engineProfileSchema, {
+        cache,
+        onAction: recordActions
+      });
+
+      const editor = wrapper.find(FormEditor).getDOMNode();
+
+      const dataContainer = editor.querySelector('.cfp-data-container');
+
+      // when
+      dataContainer.dispatchEvent(new Event('focusin', { 'bubbles': true }));
+      dataContainer.dispatchEvent(new Event('focusout', { 'bubbles': true }));
+
+      // then
+      const inputDataChangedEvent = getEvent(emittedEvents, 'form.modeler.inputDataChanged');
+
+      expect(inputDataChangedEvent).to.exist;
+    });
+
+
+    it('should NOT notify when form input editor was not touched', async function() {
+
+      // given
+      const {
+        wrapper
+      } = await renderEditor(engineProfileSchema, {
+        onAction: recordActions
+      });
+
+      const editor = wrapper.find(FormEditor).getDOMNode();
+
+      const dataContainer = editor.querySelector('.cfp-data-container');
+
+      // when
+      dataContainer.dispatchEvent(new Event('focusin', { 'bubbles': true }));
+      dataContainer.dispatchEvent(new Event('focusout', { 'bubbles': true }));
+
+      // then
+      const inputDataChangedEvent = getEvent(emittedEvents, 'form.modeler.inputDataChanged');
+
+      expect(inputDataChangedEvent).to.not.exist;
     });
 
   });

--- a/client/src/app/tabs/form/__tests__/FormEditorSpec.js
+++ b/client/src/app/tabs/form/__tests__/FormEditorSpec.js
@@ -1231,6 +1231,48 @@ describe('<FormEditor>', function() {
     });
 
 
+    it('should NOT notify when form preview changed - unlisten', async function() {
+
+      // given
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          form: new FormPlaygroundMock({
+            form: {
+              _getState: () => Math.random()
+            }
+          })
+        },
+        __destroy: () => {}
+      });
+
+      const {
+        instance,
+        wrapper
+      } = await renderEditor(engineProfileSchema, {
+        cache,
+        onAction: recordActions
+      });
+
+      // when
+      instance.listen('off');
+
+      const editor = wrapper.find(FormEditor).getDOMNode();
+
+      const previewContainer = editor.querySelector('.cfp-preview-container');
+
+      // when
+      previewContainer.dispatchEvent(new Event('focusin', { 'bubbles': true }));
+      previewContainer.dispatchEvent(new Event('focusout', { 'bubbles': true }));
+
+      // then
+      const previewChangedEvent = getEvent(emittedEvents, 'form.modeler.previewChanged');
+
+      expect(previewChangedEvent).to.not.exist;
+    });
+
+
     it('should notify when form input editor was touched', async function() {
 
       // given
@@ -1283,6 +1325,47 @@ describe('<FormEditor>', function() {
       const dataContainer = editor.querySelector('.cfp-data-container');
 
       // when
+      dataContainer.dispatchEvent(new Event('focusin', { 'bubbles': true }));
+      dataContainer.dispatchEvent(new Event('focusout', { 'bubbles': true }));
+
+      // then
+      const inputDataChangedEvent = getEvent(emittedEvents, 'form.modeler.inputDataChanged');
+
+      expect(inputDataChangedEvent).to.not.exist;
+    });
+
+
+    it('should NOT notify when form input editor changed - unlisten', async function() {
+
+      // given
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          form: new FormPlaygroundMock({
+            dataEditor: {
+              getValue: () => Math.random()
+            }
+          })
+        },
+        __destroy: () => {}
+      });
+
+      const {
+        instance,
+        wrapper
+      } = await renderEditor(engineProfileSchema, {
+        cache,
+        onAction: recordActions
+      });
+
+      // when
+      instance.listen('off');
+
+      const editor = wrapper.find(FormEditor).getDOMNode();
+
+      const dataContainer = editor.querySelector('.cfp-data-container');
+
       dataContainer.dispatchEvent(new Event('focusin', { 'bubbles': true }));
       dataContainer.dispatchEvent(new Event('focusout', { 'bubbles': true }));
 

--- a/client/src/app/tabs/form/getFormWindowMenu.js
+++ b/client/src/app/tabs/form/getFormWindowMenu.js
@@ -8,6 +8,8 @@
  * except in compliance with the MIT License.
  */
 
+import { FORM_PREVIEW_TRIGGER } from './FormEditor';
+
 export function getFormWindowMenu(state) {
   return [
     ...getPreviewEntries(state)
@@ -18,6 +20,9 @@ function getPreviewEntries({ previewOpen }) {
   return [ {
     label: previewOpen ? 'Open design mode' : 'Open validation mode',
     accelerator: 'CommandOrControl+P',
-    action: previewOpen ? 'collapsePreview' : 'openPreview'
+    action: previewOpen ? 'collapsePreview' : 'openPreview',
+    options: {
+      triggeredBy: FORM_PREVIEW_TRIGGER.WINDOW_MENU
+    }
   } ];
 }

--- a/client/src/plugins/user-journey-statistics/__tests__/UserJourneyStatisticsSpec.js
+++ b/client/src/plugins/user-journey-statistics/__tests__/UserJourneyStatisticsSpec.js
@@ -316,11 +316,12 @@ describe('<UserJourneyStatistics>', () => {
     const eventHandlers = instance._eventHandlers;
 
     // expect
-    expect(eventHandlers).to.have.length(4);
+    expect(eventHandlers).to.have.length(5);
     expectHandler(eventHandlers[0], 'DeploymentEventHandler');
-    expectHandler(eventHandlers[1], 'LinkEventHandler');
-    expectHandler(eventHandlers[2], 'OverlayEventHandler');
-    expectHandler(eventHandlers[3], 'TabEventHandler');
+    expectHandler(eventHandlers[1], 'FormEditorEventHandler');
+    expectHandler(eventHandlers[2], 'LinkEventHandler');
+    expectHandler(eventHandlers[3], 'OverlayEventHandler');
+    expectHandler(eventHandlers[4], 'TabEventHandler');
   });
 
 });

--- a/client/src/plugins/user-journey-statistics/event-handlers/FormEditorEventHandler.js
+++ b/client/src/plugins/user-journey-statistics/event-handlers/FormEditorEventHandler.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  getEngineProfile
+} from '../../../util/parse';
+
+export const LAYOUT_CHANGED_EVENT_NAME = 'formEditor:layoutChanged';
+export const INPUT_DATA_CHANGED_EVENT_NAME = 'formEditor:inputDataChanged';
+export const PREVIEW_CHANGED_EVENT_NAME = 'formEditor:previewChanged';
+
+
+export default class FormEditorEventHandler {
+  constructor(props) {
+
+    const {
+      subscribe,
+      track
+    } = props;
+
+    this.track = track;
+
+    this.subscribeToEditorEvents(subscribe);
+  }
+
+  subscribeToEditorEvents = (subscribe) => {
+    subscribe('form.modeler.playgroundLayoutChanged', this.trackLayoutChanges);
+    subscribe('form.modeler.inputDataChanged', this.trackInputDataChanges);
+    subscribe('form.modeler.previewChanged', this.trackPreviewChanges);
+  };
+
+  trackLayoutChanges = async (event) => {
+    const {
+      layout,
+      tab,
+      triggeredBy
+    } = event;
+
+    let payload = {
+      layout
+    };
+
+    if (triggeredBy) {
+      payload = {
+        ...payload,
+        triggeredBy
+      };
+    }
+
+    this.trackWithEngineProfile(tab, LAYOUT_CHANGED_EVENT_NAME, payload);
+  };
+
+  trackInputDataChanges = async (event) => {
+    const {
+      tab
+    } = event;
+
+    let payload = {};
+
+    this.trackWithEngineProfile(tab, INPUT_DATA_CHANGED_EVENT_NAME, payload);
+  };
+
+  trackPreviewChanges = async (event) => {
+    const {
+      tab
+    } = event;
+
+    let payload = {};
+
+    this.trackWithEngineProfile(tab, PREVIEW_CHANGED_EVENT_NAME, payload);
+  };
+
+  trackWithEngineProfile = async (tab, eventName, payload) => {
+    const {
+      file
+    } = tab;
+
+    const {
+      contents
+    } = file;
+
+    const engineProfile = await getEngineProfile(contents, 'form');
+
+    if (engineProfile) {
+      payload = {
+        ...payload,
+        ...engineProfile
+      };
+    }
+
+    this.track(eventName, payload);
+  };
+
+}

--- a/client/src/plugins/user-journey-statistics/event-handlers/__tests__/FormEditorEventHandlerSpec.js
+++ b/client/src/plugins/user-journey-statistics/event-handlers/__tests__/FormEditorEventHandlerSpec.js
@@ -1,0 +1,304 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/* global sinon */
+
+import MixpanelHandler from '../../MixpanelHandler';
+
+import {
+  LAYOUT_CHANGED_EVENT_NAME,
+  INPUT_DATA_CHANGED_EVENT_NAME,
+  PREVIEW_CHANGED_EVENT_NAME,
+  default as FormEditorEventHandler
+} from '../FormEditorEventHandler';
+
+import engineProfilePlatform from './fixtures/engine-platform.form';
+
+import engineProfileCloud from './fixtures/engine-cloud.form';
+
+
+describe('<FormEditorEventHandler>', () => {
+
+  let subscribe, track;
+
+  beforeEach(() => {
+
+    subscribe = sinon.spy();
+
+    track = sinon.spy();
+
+    new FormEditorEventHandler({
+      track,
+      subscribe
+    });
+
+    MixpanelHandler.getInstance().enable('token', 'id', 'stage');
+  });
+
+
+  describe('formEditor:layoutChanged', () => {
+
+
+    it('should subscribe to form.modeler.playgroundLayoutChanged', () => {
+
+      // then
+      expect(subscribe.getCall(0).args[0]).to.eql('form.modeler.playgroundLayoutChanged');
+    });
+
+
+    it('should send layout', async () => {
+
+      // given
+      const tab = createTab({
+        file: {},
+        type: 'form'
+      });
+
+      const layout = {
+        'form-preview': { open: true },
+        'form-input': { open: false },
+        'form-output': { open: true }
+      };
+
+      const handleLayoutChanged = subscribe.getCall(0).args[1];
+
+      // when
+      await handleLayoutChanged({
+        tab,
+        layout
+      });
+
+      // then
+      expect(track).to.have.been.calledWith(LAYOUT_CHANGED_EVENT_NAME, {
+        layout
+      });
+
+    });
+
+
+    it('should send triggeredBy', async () => {
+
+      // given
+      const tab = createTab({
+        file: {},
+        type: 'form'
+      });
+
+      const layout = {
+        'form-preview': { open: true },
+        'form-input': { open: false },
+        'form-output': { open: true }
+      };
+
+      const triggeredBy = 'foo';
+
+      const handleLayoutChanged = subscribe.getCall(0).args[1];
+
+      // when
+      await handleLayoutChanged({
+        tab,
+        layout,
+        triggeredBy
+      });
+
+      // then
+      expect(track).to.have.been.calledWith(LAYOUT_CHANGED_EVENT_NAME, {
+        layout,
+        triggeredBy
+      });
+
+    });
+
+
+    it('should send engine profile - C7', async () => {
+
+      // given
+      const tab = createTab({
+        file: { contents: engineProfilePlatform },
+        type: 'form'
+      });
+
+      const handleLayoutChanged = subscribe.getCall(0).args[1];
+
+      // when
+      await handleLayoutChanged({
+        tab
+      });
+
+      // then
+      expect(track).to.have.been.calledWith(LAYOUT_CHANGED_EVENT_NAME, {
+        layout: undefined,
+        executionPlatform: 'Camunda Platform',
+        executionPlatformVersion: '7.15'
+      });
+    });
+
+
+    it('should send engine profile - C8', async () => {
+
+      // given
+      const tab = createTab({
+        file: { contents: engineProfileCloud },
+        type: 'form'
+      });
+
+      const handleLayoutChanged = subscribe.getCall(0).args[1];
+
+      // when
+      await handleLayoutChanged({
+        tab
+      });
+
+      expect(track).to.have.been.calledWith(LAYOUT_CHANGED_EVENT_NAME, {
+        layout: undefined,
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '1.1'
+      });
+
+    });
+
+  });
+
+
+  describe('formEditor:inputDataChanged', () => {
+
+
+    it('should subscribe to form.modeler.inputDataChanged', () => {
+
+      // then
+      expect(subscribe.getCall(1).args[0]).to.eql('form.modeler.inputDataChanged');
+    });
+
+
+    it('should send engine profile - C7', async () => {
+
+      // given
+      const tab = createTab({
+        file: { contents: engineProfilePlatform },
+        type: 'form'
+      });
+
+      const handleInputDataChanged = subscribe.getCall(1).args[1];
+
+      // when
+      await handleInputDataChanged({
+        tab
+      });
+
+      // then
+      expect(track).to.have.been.calledWith(INPUT_DATA_CHANGED_EVENT_NAME, {
+        executionPlatform: 'Camunda Platform',
+        executionPlatformVersion: '7.15'
+      });
+    });
+
+
+    it('should send engine profile - C8', async () => {
+
+      // given
+      const tab = createTab({
+        file: { contents: engineProfileCloud },
+        type: 'form'
+      });
+
+      const handleInputDataChanged = subscribe.getCall(1).args[1];
+
+      // when
+      await handleInputDataChanged({
+        tab
+      });
+
+      expect(track).to.have.been.calledWith(INPUT_DATA_CHANGED_EVENT_NAME, {
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '1.1'
+      });
+
+    });
+
+  });
+
+
+  describe('formEditor:previewChanged', () => {
+
+
+    it('should subscribe to form.modeler.previewChanged', () => {
+
+      // then
+      expect(subscribe.getCall(2).args[0]).to.eql('form.modeler.previewChanged');
+    });
+
+
+    it('should send engine profile - C7', async () => {
+
+      // given
+      const tab = createTab({
+        file: { contents: engineProfilePlatform },
+        type: 'form'
+      });
+
+      const handleInputDataChanged = subscribe.getCall(2).args[1];
+
+      // when
+      await handleInputDataChanged({
+        tab
+      });
+
+      // then
+      expect(track).to.have.been.calledWith(PREVIEW_CHANGED_EVENT_NAME, {
+        executionPlatform: 'Camunda Platform',
+        executionPlatformVersion: '7.15'
+      });
+    });
+
+
+    it('should send engine profile - C8', async () => {
+
+      // given
+      const tab = createTab({
+        file: { contents: engineProfileCloud },
+        type: 'form'
+      });
+
+      const handleInputDataChanged = subscribe.getCall(2).args[1];
+
+      // when
+      await handleInputDataChanged({
+        tab
+      });
+
+      expect(track).to.have.been.calledWith(PREVIEW_CHANGED_EVENT_NAME, {
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '1.1'
+      });
+
+    });
+
+  });
+
+});
+
+
+
+// helpers //////
+
+function createTab(overrides = {}) {
+  return {
+    id: 42,
+    name: 'foo.bar',
+    type: 'bar',
+    title: 'foo',
+    file: {
+      name: 'foo.bar',
+      contents: '',
+      path: null
+    },
+    ...overrides
+  };
+}

--- a/client/src/plugins/user-journey-statistics/event-handlers/index.js
+++ b/client/src/plugins/user-journey-statistics/event-handlers/index.js
@@ -12,9 +12,11 @@ import DeploymentEventHandler from './DeploymentEventHandler';
 import LinkEventHandler from './LinkEventHandler';
 import OverlayEventHandler from './OverlayEventHandler';
 import TabEventHandler from './TabEventHandler';
+import FormEditorEventHandler from './FormEditorEventHandler';
 
 export default [
   DeploymentEventHandler,
+  FormEditorEventHandler,
   LinkEventHandler,
   OverlayEventHandler,
   TabEventHandler

--- a/client/src/util/parse.js
+++ b/client/src/util/parse.js
@@ -52,7 +52,7 @@ export async function getEngineProfile(contents, diagramType) {
   }
 
   if (diagramType === 'form') {
-    engineProfile = parseForm(contents);
+    engineProfile = parsFormExecutionPlatform(contents);
 
     if (!engineProfile) return null;
 
@@ -101,9 +101,14 @@ function getDefaultExecutionPlatform(type) {
   return ENGINES.PLATFORM;
 }
 
-function parseForm(contents) {
+function parsFormExecutionPlatform(contents) {
   try {
-    return JSON.parse(contents);
+    const value = JSON.parse(contents);
+
+    return {
+      executionPlatform: value.executionPlatform,
+      executionPlatformVersion: value.executionPlatformVersion
+    };
 
   } catch (error) {
     return null;

--- a/client/test/mocks/form-js/index.js
+++ b/client/test/mocks/form-js/index.js
@@ -10,6 +10,8 @@
 
 import { assign } from 'min-dash';
 
+import { domify } from 'min-dom';
+
 import { CommandStack } from '../bpmn-js/Modeler';
 
 export class FormEditor {
@@ -108,16 +110,34 @@ export class FormPlayground {
 
     this._editor = new FormEditor(options);
 
+    this._dataEditor = options.dataEditor || {
+      getValue: () => null
+    };
+
+    this._form = options.form || {
+      _getState: () => null
+    };
+
     this._emitLayoutChanged = options.emitLayoutChanged;
+
+    // mock playground DOM elements
+    this._container = domify('<div class="forms-playground"></div>');
+    this._container.appendChild(domify('<input class="cfp-data-container" />"'));
+    this._container.appendChild(domify('<input class="cfp-preview-container" />"'));
 
     this.schema = null;
 
     this.listeners = {};
   }
 
-  attachTo() {}
+  attachTo(parent) {
+    parent.appendChild(this._container);
+  }
 
-  detach() {}
+  detach() {
+    const parent = this._container.parentNode;
+    parent && parent.removeChild(this._container);
+  }
 
   on(event, priority, callback) {
     if (!callback) {
@@ -149,6 +169,14 @@ export class FormPlayground {
 
   getEditor() {
     return this._editor;
+  }
+
+  getForm() {
+    return this._form;
+  }
+
+  getDataEditor() {
+    return this._dataEditor;
   }
 
   getSchema() {


### PR DESCRIPTION
Closes #3247 

This one
* exposes `triggeredByShortcut` to menu click events. This is needed to distinguish whether menu actions are triggered by keyboard shortcuts or not.
* adds the following three Mixpanel events 

> Every time a playground panel got collapsed or expanded.

```json
{
  "event": "desktopModeler:formEditor:layoutChanged",
  "properties": {
    "executionPlatform": "Camunda Platform|Camunda Cloud",
    "executionPlatformVersion": "x.y",
    "layout": {
      "form-input": {
        "open": true
      },
      "form-output": {
        "open": true
      },
      "form-preview": {
        "open": true
      }
    },
    "triggeredBy": "keyboardShortcut|previewPanel|statusBar|windowMenu", 
  }
}
```    
    
> Interactions with the Form Input Data panel (not every edit, but focusin + focusout + changed)

```json
{
  "event": "desktopModeler:formEditor:inputDataChanged",
  "properties": {
    "executionPlatform": "Camunda Platform|Camunda Cloud",
    "executionPlatformVersion": "x.y"
  }
}
```    

> Interactions with the Form Preview panel (not every edit, but focusin + focusout + changed).

```json
{
  "event": "desktopModeler:formEditor:previewChanged",
  "properties": {
    "executionPlatform": "Camunda Platform|Camunda Cloud",
    "executionPlatformVersion": "x.y"
  }
}
```    

Related:
* Update docs: https://github.com/camunda/camunda-platform-docs/pull/1463