### PR TITLE
fix(ci): don't run ADD_TO_PROJECT for fork PRs

### DIFF
--- a/.github/workflows/ADD_TO_PROJECT.yaml
+++ b/.github/workflows/ADD_TO_PROJECT.yaml
@@ -14,6 +14,7 @@ on:
 jobs:
   Exec:
     name: Add issue to project
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@d79571d8737ce0caa0120f44b15f2bc8f193d11a


### PR DESCRIPTION
This is to prevent action runs for community PRs (which fortunately fail due to missing secrets): https://github.com/camunda/camunda-modeler/actions/runs/3335186161/jobs/5518891113