### PR TITLE
fix: handle keys by KeyboardEvent.code

### DIFF
--- a/client/src/app/KeyboardBindings.js
+++ b/client/src/app/KeyboardBindings.js
@@ -9,12 +9,6 @@
  */
 
 import {
-  isCmd as isCommandOrControl,
-  isKey,
-  isShift
-} from 'diagram-js/lib/features/keyboard/KeyboardUtil';
-
-import {
   findIndex,
   forEach,
   isArray,
@@ -261,35 +255,55 @@ export default class KeyboardBindings {
 
 // helpers //////////
 
+function isKey(keys, event) {
+  keys = isArray(keys) ? keys : [ keys ];
+  return keys.indexOf(event.key) !== -1 || keys.indexOf(event.code) !== -1;
+}
+
+function isCommandOrControl(event) {
+
+  // ensure we don't react to AltGr
+  // (mapped to CTRL + ALT)
+  if (event.altKey) {
+    return false;
+  }
+
+  return event.ctrlKey || event.metaKey;
+}
+
+function isShift(event) {
+  return event.shiftKey;
+}
+
 // Ctrl + C
 function isCopy(event) {
-  return isKey([ 'c', 'C' ], event) && isCommandOrControl(event);
+  return isKey([ 'c', 'C', 'KeyC' ], event) && isCommandOrControl(event);
 }
 
 // Ctrl + X
 function isCut(event) {
-  return isKey([ 'x', 'X' ], event) && isCommandOrControl(event);
+  return isKey([ 'x', 'X', 'KeyX' ], event) && isCommandOrControl(event);
 }
 
 // Ctrl + V
 function isPaste(event) {
-  return isKey([ 'v', 'V' ], event) && isCommandOrControl(event);
+  return isKey([ 'v', 'V', 'KeyV' ], event) && isCommandOrControl(event);
 }
 
 // Ctrl + A
 function isSelectAll(event) {
-  return isKey([ 'a', 'A' ], event) && isCommandOrControl(event);
+  return isKey([ 'a', 'A', 'KeyA' ], event) && isCommandOrControl(event);
 }
 
 // Ctrl + Z
-function isUndo(event) {
-  return isKey([ 'z', 'Z' ], event) && isCommandOrControl(event) && !isShift(event);
+export function isUndo(event) {
+  return isKey([ 'z', 'Z', 'KeyZ' ], event) && isCommandOrControl(event) && !isShift(event);
 }
 
 // Ctrl + Y or Ctrl + Shift + Z
-function isRedo(event) {
+export function isRedo(event) {
   return isCommandOrControl(event) &&
-    (isKey([ 'y', 'Y' ], event) || (isKey([ 'z', 'Z' ], event) && isShift(event)));
+    (isKey([ 'y', 'Y', 'KeyY' ], event) || (isKey([ 'z', 'Z', 'KeyZ' ], event) && isShift(event)));
 }
 
 // Secondary delete shortcut

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/PropertiesPanelKeyboardBindings.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/PropertiesPanelKeyboardBindings.js
@@ -9,10 +9,9 @@
  */
 
 import {
-  isCmd as isCommandOrControl,
-  isKey,
-  isShift
-} from 'diagram-js/lib/features/keyboard/KeyboardUtil';
+  isUndo,
+  isRedo
+} from '../../../../../KeyboardBindings';
 
 
 export default class PropertiesPanelKeyboardBindings {
@@ -80,13 +79,3 @@ export default class PropertiesPanelKeyboardBindings {
 }
 
 PropertiesPanelKeyboardBindings.$inject = [ 'commandStack', 'eventBus', 'propertiesPanel' ];
-
-// helpers //////////
-
-function isUndo(event) {
-  return isCommandOrControl(event) && !isShift(event) && isKey([ 'z', 'Z' ], event);
-}
-
-function isRedo(event) {
-  return isCommandOrControl(event) && (isKey([ 'y', 'Y' ], event) || (isKey([ 'z', 'Z' ], event) && isShift(event)));
-}

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/__tests__/PropertiesPanelKeyboardBindingsSpec.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/__tests__/PropertiesPanelKeyboardBindingsSpec.js
@@ -12,7 +12,7 @@
 
 import Modeler from 'test/mocks/bpmn-js/Modeler';
 
-import PropertiesPanelKeyboardBindings from '../PropertiesPanelKeyoardBindings';
+import PropertiesPanelKeyboardBindings from '../PropertiesPanelKeyboardBindings';
 
 import {
   assign,

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/index.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/index.js
@@ -8,7 +8,7 @@
  * except in compliance with the MIT License.
  */
 
-import PropertiesPanelKeyboardBindings from './PropertiesPanelKeyoardBindings';
+import PropertiesPanelKeyboardBindings from './PropertiesPanelKeyboardBindings';
 
 export default {
   __init__: [ 'propertiesPanelKeyboardBindings' ],


### PR DESCRIPTION
closes #2724 
According to [this comment](https://github.com/camunda/camunda-modeler/pull/3256#issuecomment-1295217241) keyboard binding should be handled in this repo. The KeyboardEvent.code property represents a physical key on the keyboard, so it can be used to detect keys on non Eng layouts. Also fixed typo in file name.