### PR TITLE
Sort Lint Reports by Category

### DIFF
--- a/client/src/app/tabs/panel/tabs/LintingTab.js
+++ b/client/src/app/tabs/panel/tabs/LintingTab.js
@@ -23,53 +23,53 @@ import WarningIcon from '../../../../../resources/icons/Warning.svg';
 export default function LintingTab(props) {
   const {
     layout,
-    linting,
+    linting: reports,
     onAction,
     onLayoutChanged
   } = props;
 
-  const onClick = (issue) => () => {
-    onAction('showLintError', issue);
+  const onClick = (report) => () => {
+    onAction('showLintError', report);
   };
 
   return <Panel.Tab
     id="linting"
     label="Problems"
     layout={ layout }
-    number={ linting.length }
+    number={ reports.length }
     onLayoutChanged={ onLayoutChanged }
     priority={ 1 }>
-    { linting.length
+    { reports.length
       ? null
       : (
-        <div className={ classnames(css.LintingIssue, 'linting-issue--empty') }>
-          <div className="linting-issue__header">
+        <div className={ classnames(css.LintingTabItem, 'linting-tab-item--empty') }>
+          <div className="linting-tab-item__header">
             <SuccessIcon width="16" height="16" />
-            <span className="linting-issue__label">No problems found.</span>
+            <span className="linting-tab-item__label">No problems found.</span>
           </div>
         </div>
       )
     }
     {
-      sortIssues(linting).map((issue => {
+      sortReports(reports).map((report => {
         const {
           id,
           message
-        } = issue;
+        } = report;
 
-        return <LintingIssue
+        return <LintingTabItem
           key={ `${ id }-${ message }` }
-          issue={ issue }
-          onClick={ onClick(issue) }
+          report={ report }
+          onClick={ onClick(report) }
         />;
       }))
     }
   </Panel.Tab>;
 }
 
-function LintingIssue(props) {
+function LintingTabItem(props) {
   const {
-    issue,
+    report,
     onClick
   } = props;
 
@@ -78,30 +78,30 @@ function LintingIssue(props) {
     id,
     name,
     message
-  } = issue;
+  } = report;
 
   return <div
     onClick={ onClick }
-    className={ classnames(css.LintingIssue, 'linting-issue', {
-      'linting-issue--error': category === 'error',
-      'linting-issue--warning': category === 'warn'
+    className={ classnames(css.LintingTabItem, 'linting-tab-item', {
+      'linting-tab-item--error': category === 'error',
+      'linting-tab-item--warning': category === 'warn'
     }) }>
-    <div className="linting-issue__header">
+    <div className="linting-tab-item__header">
       { category === 'error' ? <ErrorIcon width="16" height="16" /> : null }
       { category === 'warn' ? <WarningIcon width="16" height="16" /> : null }
-      <span className="linting-issue__label">{ name || id }</span>
+      <span className="linting-tab-item__label">{ name || id }</span>
     </div>
-    <div className="linting-issue__content">
+    <div className="linting-tab-item__content">
       { message }
     </div>
   </div>;
 }
 
-function getName(issue) {
+function getReportName(report) {
   const {
     id,
     name
-  } = issue;
+  } = report;
 
   if (name) {
     return name.toLowerCase();
@@ -110,16 +110,34 @@ function getName(issue) {
   return id.toLowerCase();
 }
 
-function sortIssues(issues) {
-  return issues.sort((a, b) => {
-    a = getName(a),
-    b = getName(b);
+/**
+ * Sort reports by:
+ *
+ * 1. category
+ * 2. name or ID
+ *
+ * @param {Object[]} reports
+ *
+ * @returns {Object[]}
+ */
+function sortReports(reports) {
+  return [ ...reports ].sort((a, b) => {
+    if (a.category === b.category) {
 
-    if (a === b) {
-      return 0;
-    } else if (a < b) {
+      a = getReportName(a),
+      b = getReportName(b);
+
+      if (a === b) {
+        return 0;
+      } else if (a < b) {
+        return -1;
+      } else {
+        return 1;
+      }
+
+    } else if (a.category === 'error') {
       return -1;
-    } else {
+    } else if (b.category === 'error') {
       return 1;
     }
   });

--- a/client/src/app/tabs/panel/tabs/LintingTab.less
+++ b/client/src/app/tabs/panel/tabs/LintingTab.less
@@ -1,14 +1,14 @@
 :root {
-  --linting-issue-background-color: var(--color-grey-225-10-95);
-  --linting-issue-border-color: var(--color-grey-225-10-95);
+  --linting-tab-item-background-color: var(--color-grey-225-10-95);
+  --linting-tab-item-border-color: var(--color-grey-225-10-95);
 
-  --linting-issue-padding: 6px 8px;
+  --linting-tab-item-padding: 6px 8px;
 }
 
-:local(.LintingIssue) {
+:local(.LintingTabItem) {
   display: flex;
   align-items: stretch;
-  border-bottom: solid 1px var(--linting-issue-border-color);
+  border-bottom: solid 1px var(--linting-tab-item-border-color);
   font-size: 14px;
   cursor: default;
 
@@ -16,24 +16,24 @@
     user-select: text;
   }
 
-  &.linting-issue--selected,
-  &:not(.linting-issue--empty):hover {
-    background-color: var(--linting-issue-background-color);
+  &.linting-tab-item--selected,
+  &:not(.linting-tab-item--empty):hover {
+    background-color: var(--linting-tab-item-background-color);
   }
 
-  .linting-issue__header {
+  .linting-tab-item__header {
     display: flex;
     align-items: flex-start;
     width: 200px;
-    padding: var(--linting-issue-padding);
-    background-color: var(--linting-issue-error-background-color);
-    border-right: solid 1px var(--linting-issue-border-color);
+    padding: var(--linting-tab-item-padding);
+    background-color: var(--linting-tab-item-error-background-color);
+    border-right: solid 1px var(--linting-tab-item-border-color);
 
     svg {
       margin-top: 1px;
     }
 
-    .linting-issue__label {
+    .linting-tab-item__label {
       display: inline-block;
       max-width: 150px;
       overflow: hidden;
@@ -44,23 +44,23 @@
     }
   }
 
-  .linting-issue__content {
+  .linting-tab-item__content {
     display: flex;
     width: calc(100% - 200px);
-    padding: var(--linting-issue-padding);
+    padding: var(--linting-tab-item-padding);
 
-    &.linting-issue__content--empty {
+    &.linting-tab-item__content--empty {
       font-weight: bold;
     }
   }
 
-  &.linting-issue--empty {
+  &.linting-tab-item--empty {
     border-bottom: none !important;
 
-    .linting-issue__header {
+    .linting-tab-item__header {
       border-right: none;
 
-      .linting-issue__label {
+      .linting-tab-item__label {
         font-weight: normal;
       }
     }

--- a/client/src/app/tabs/panel/tabs/__tests__/LintingTabSpec.js
+++ b/client/src/app/tabs/panel/tabs/__tests__/LintingTabSpec.js
@@ -40,8 +40,8 @@ describe('<LintingTab>', function() {
     expect(wrapper.find('.panel__link-number')).to.have.length(1);
     expect(wrapper.find('.panel__link-number').text()).to.equal('1');
 
-    expect(wrapper.find('.linting-issue__content')).to.have.length(1);
-    expect(wrapper.find('.linting-issue__content').text()).to.equal('Foo message');
+    expect(wrapper.find('.linting-tab-item__content')).to.have.length(1);
+    expect(wrapper.find('.linting-tab-item__content').text()).to.equal('Foo message');
   });
 
 
@@ -62,8 +62,8 @@ describe('<LintingTab>', function() {
     expect(wrapper.find('.panel__link-number')).to.have.length(1);
     expect(wrapper.find('.panel__link-number').text()).to.equal('0');
 
-    expect(wrapper.find('.linting-issue--empty')).to.have.length(1);
-    expect(wrapper.find('.linting-issue--empty').text()).to.equal('No problems found.');
+    expect(wrapper.find('.linting-tab-item--empty')).to.have.length(1);
+    expect(wrapper.find('.linting-tab-item--empty').text()).to.equal('No problems found.');
   });
 
 
@@ -104,12 +104,12 @@ describe('<LintingTab>', function() {
     });
 
     // then
-    expect(wrapper.find('.linting-issue__content')).to.have.length(5);
-    expect(wrapper.find('.linting-issue__content').at(0).text()).to.equal('bar 1 error');
-    expect(wrapper.find('.linting-issue__content').at(1).text()).to.equal('bar 2 error');
-    expect(wrapper.find('.linting-issue__content').at(2).text()).to.equal('baz 1 warning');
-    expect(wrapper.find('.linting-issue__content').at(3).text()).to.equal('baz 2 error');
-    expect(wrapper.find('.linting-issue__content').at(4).text()).to.equal('foo error');
+    expect(wrapper.find('.linting-tab-item__content')).to.have.length(5);
+    expect(wrapper.find('.linting-tab-item__content').at(0).text()).to.equal('bar 1 error');
+    expect(wrapper.find('.linting-tab-item__content').at(1).text()).to.equal('bar 2 error');
+    expect(wrapper.find('.linting-tab-item__content').at(2).text()).to.equal('baz 2 error');
+    expect(wrapper.find('.linting-tab-item__content').at(3).text()).to.equal('foo error');
+    expect(wrapper.find('.linting-tab-item__content').at(4).text()).to.equal('baz 1 warning');
   });
 
 
@@ -123,7 +123,7 @@ describe('<LintingTab>', function() {
     });
 
     // then
-    wrapper.find('.linting-issue').at(0).simulate('click');
+    wrapper.find('.linting-tab-item').at(0).simulate('click');
 
     // then
     expect(onActionSpy).to.have.been.calledOnce;


### PR DESCRIPTION
Sort lint reports by

1. category
2. name or ID

thus ensuring that errors will be shown first.

![electron_Wb88YuE7Gx](https://user-images.githubusercontent.com/7633572/199922612-a18e78cf-2cbb-456f-beee-1684aa991a1d.gif)

---

Closes https://github.com/camunda/camunda-modeler/issues/3272
