### PR TITLE
feat(Engines): add Camunda 8.2 profile

### DIFF
--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -29,7 +29,7 @@ import cloudForm from './tabs/form/initial-cloud.form';
 
 import {
   ENGINES,
-  ENGINE_PROFILES
+  getLatestStable as getLatestStablePlatformVersion
 } from '../util/Engines';
 
 import EmptyTab from './EmptyTab';
@@ -692,13 +692,8 @@ function sortByPriority(providers) {
 
 function replaceVersions(contents) {
 
-  const latestPlatformVersion = ENGINE_PROFILES.find(
-    p => p.executionPlatform === ENGINES.PLATFORM
-  ).latestStable;
-
-  const latestCloudVersion = ENGINE_PROFILES.find(
-    p => p.executionPlatform === ENGINES.CLOUD
-  ).latestStable;
+  const latestPlatformVersion = getLatestStablePlatformVersion(ENGINES.PLATFORM);
+  const latestCloudVersion = getLatestStablePlatformVersion(ENGINES.CLOUD);
 
   return (
     contents

--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -694,11 +694,11 @@ function replaceVersions(contents) {
 
   const latestPlatformVersion = ENGINE_PROFILES.find(
     p => p.executionPlatform === ENGINES.PLATFORM
-  ).executionPlatformVersions[0];
+  ).latestStable;
 
   const latestCloudVersion = ENGINE_PROFILES.find(
     p => p.executionPlatform === ENGINES.CLOUD
-  ).executionPlatformVersions[0];
+  ).latestStable;
 
   return (
     contents

--- a/client/src/app/__tests__/TabsProviderSpec.js
+++ b/client/src/app/__tests__/TabsProviderSpec.js
@@ -181,9 +181,26 @@ describe('TabsProvider', function() {
       // given
       const tabsProvider = new TabsProvider();
 
+      const latestPlatformVersion = ENGINE_PROFILES.find(
+        p => p.executionPlatform === ENGINES.PLATFORM
+      ).latestStable;
+
+      // when
+      const { file: { contents } } = tabsProvider.createTab('bpmn');
+
+      // then
+      expect(contents).to.include(`modeler:executionPlatformVersion="${ latestPlatformVersion }"`);
+    });
+
+
+    it('should replace version placeholder with actual latest version (Cloud BPMN)', function() {
+
+      // given
+      const tabsProvider = new TabsProvider();
+
       const latestCloudVersion = ENGINE_PROFILES.find(
         p => p.executionPlatform === ENGINES.CLOUD
-      ).executionPlatformVersions[0];
+      ).latestStable;
 
       // when
       const { file: { contents } } = tabsProvider.createTab('cloud-bpmn');
@@ -217,7 +234,7 @@ describe('TabsProvider', function() {
 
       const latestCloudVersion = ENGINE_PROFILES.find(
         p => p.executionPlatform === ENGINES.CLOUD
-      ).executionPlatformVersions[0];
+      ).latestStable;
 
       // when
       const { file: { contents } } = tabsProvider.createTab('cloud-dmn');

--- a/client/src/app/__tests__/TabsProviderSpec.js
+++ b/client/src/app/__tests__/TabsProviderSpec.js
@@ -13,7 +13,7 @@ import TabsProvider from '../TabsProvider';
 import Flags, { DISABLE_DMN, DISABLE_ZEEBE, DISABLE_PLATFORM, DISABLE_CMMN } from '../../util/Flags';
 
 import {
-  ENGINE_PROFILES,
+  getLatestStable as getLatestStablePlatformVersion,
   ENGINES
 } from '../../util/Engines';
 
@@ -181,15 +181,13 @@ describe('TabsProvider', function() {
       // given
       const tabsProvider = new TabsProvider();
 
-      const latestPlatformVersion = ENGINE_PROFILES.find(
-        p => p.executionPlatform === ENGINES.PLATFORM
-      ).latestStable;
+      const expectedPlatformVersion = getLatestStablePlatformVersion(ENGINES.PLATFORM);
 
       // when
       const { file: { contents } } = tabsProvider.createTab('bpmn');
 
       // then
-      expect(contents).to.include(`modeler:executionPlatformVersion="${ latestPlatformVersion }"`);
+      expect(contents).to.include(`modeler:executionPlatformVersion="${ expectedPlatformVersion }"`);
     });
 
 
@@ -198,15 +196,13 @@ describe('TabsProvider', function() {
       // given
       const tabsProvider = new TabsProvider();
 
-      const latestCloudVersion = ENGINE_PROFILES.find(
-        p => p.executionPlatform === ENGINES.CLOUD
-      ).latestStable;
+      const expectedPlatformVersion = getLatestStablePlatformVersion(ENGINES.CLOUD);
 
       // when
       const { file: { contents } } = tabsProvider.createTab('cloud-bpmn');
 
       // then
-      expect(contents).to.include(`modeler:executionPlatformVersion="${ latestCloudVersion }"`);
+      expect(contents).to.include(`modeler:executionPlatformVersion="${ expectedPlatformVersion }"`);
     });
 
 
@@ -215,15 +211,13 @@ describe('TabsProvider', function() {
       // given
       const tabsProvider = new TabsProvider();
 
-      const latestPlatformVersion = ENGINE_PROFILES.find(
-        p => p.executionPlatform === ENGINES.PLATFORM
-      ).executionPlatformVersions[0];
+      const expectedPlatformVersion = getLatestStablePlatformVersion(ENGINES.PLATFORM);
 
       // when
       const { file: { contents } } = tabsProvider.createTab('dmn');
 
       // then
-      expect(contents).to.include(`modeler:executionPlatformVersion="${ latestPlatformVersion }"`);
+      expect(contents).to.include(`modeler:executionPlatformVersion="${ expectedPlatformVersion }"`);
     });
 
 
@@ -232,15 +226,13 @@ describe('TabsProvider', function() {
       // given
       const tabsProvider = new TabsProvider();
 
-      const latestCloudVersion = ENGINE_PROFILES.find(
-        p => p.executionPlatform === ENGINES.CLOUD
-      ).latestStable;
+      const expectedPlatformVersion = getLatestStablePlatformVersion(ENGINES.CLOUD);
 
       // when
       const { file: { contents } } = tabsProvider.createTab('cloud-dmn');
 
       // then
-      expect(contents).to.include(`modeler:executionPlatformVersion="${ latestCloudVersion }"`);
+      expect(contents).to.include(`modeler:executionPlatformVersion="${ expectedPlatformVersion }"`);
     });
 
 

--- a/client/src/util/Engines.js
+++ b/client/src/util/Engines.js
@@ -16,11 +16,13 @@ export const ENGINES = {
 export const ENGINE_PROFILES = [
   {
     executionPlatform: ENGINES.PLATFORM,
-    executionPlatformVersions: [ '7.18.0', '7.17.0', '7.16.0', '7.15.0' ]
+    executionPlatformVersions: [ '7.19.0', '7.18.0', '7.17.0', '7.16.0', '7.15.0' ],
+    latestStable: '7.18.0'
   },
   {
     executionPlatform: ENGINES.CLOUD,
-    executionPlatformVersions: [ '8.1.0', '8.0.0', '1.3.0', '1.2.0', '1.1.0', '1.0.0' ]
+    executionPlatformVersions: [ '8.2.0', '8.1.0', '8.0.0', '1.3.0', '1.2.0', '1.1.0', '1.0.0' ],
+    latestStable: '8.1.0'
   }
 ];
 

--- a/client/src/util/Engines.js
+++ b/client/src/util/Engines.js
@@ -30,3 +30,15 @@ export const ENGINE_LABELS = {
   [ ENGINES.PLATFORM ]: 'Camunda Platform 7',
   [ ENGINES.CLOUD ]: 'Camunda Platform 8'
 };
+
+export function getLatestStable(platform) {
+  const profile = ENGINE_PROFILES.find(
+    p => p.executionPlatform === platform
+  );
+
+  if (!profile) {
+    throw new Error(`no profile for platform <${platform}>`);
+  }
+
+  return profile.latestStable;
+}

--- a/client/src/util/__tests__/EnginesSpec.js
+++ b/client/src/util/__tests__/EnginesSpec.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  getLatestStable,
+  ENGINES
+} from '../Engines';
+
+
+describe('util/Engines', function() {
+
+  describe('should provide latestStable', function() {
+
+    function verifyLatestStable(platform, expected) {
+
+      return function() {
+
+        // then
+        expect(getLatestStable(platform)).to.eql(expected);
+      };
+    }
+
+    it('Platform', verifyLatestStable(ENGINES.PLATFORM, '7.18.0'));
+
+    it('Cloud', verifyLatestStable(ENGINES.CLOUD, '8.1.0'));
+
+  });
+
+});


### PR DESCRIPTION
I decided to stick with "Camunda 8.2" as target label (instead of "8.2-alpha") to keep the naming consistent with the lint warnings. 

![Recording 2022-11-09 at 10 53 18](https://user-images.githubusercontent.com/21984219/200798952-1d5cf9f8-a18c-4d4f-906c-07e8a88bcbf5.gif)

closes #3284 