### PR TITLE
feat: add bpmnlint recommended rules built-in

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -33,6 +33,7 @@
     "camunda-cmmn-moddle": "^1.0.0",
     "camunda-dmn-js": "^0.8.1",
     "camunda-dmn-moddle": "^1.2.0",
+    "camunda-modeler-plugin-helpers": "^5.1.0",
     "canvg-browser": "^1.0.0",
     "classnames": "^2.2.6",
     "cmmn-js": "^0.20.0",

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -10,6 +10,8 @@
 
 import './styles/style.less';
 
+import './plugins/linting/bpmnlint-recommended-rules';
+
 import {
   backend,
   config,

--- a/client/src/plugins/linting/bpmnlint-recommended-rules/.bpmnlintrc
+++ b/client/src/plugins/linting/bpmnlint-recommended-rules/.bpmnlintrc
@@ -1,0 +1,22 @@
+{
+  "extends": "bpmnlint:recommended",
+  "rules": {
+    "conditional-flows": "warn",
+    "end-event-required": "warn",
+    "event-sub-process-typed-start-event": "warn",
+    "fake-join": "warn",
+    "label-required": "warn",
+    "no-bpmndi": "warn",
+    "no-complex-gateway": "warn",
+    "no-disconnected": "warn",
+    "no-duplicate-sequence-flows": "warn",
+    "no-gateway-join-fork": "warn",
+    "no-implicit-split": "warn",
+    "no-inclusive-gateway": "warn",
+    "single-blank-start-event": "warn",
+    "single-event-definition": "warn",
+    "start-event-required": "warn",
+    "sub-process-blank-start-event": "warn",
+    "superfluous-gateway": "warn"
+  }
+}

--- a/client/src/plugins/linting/bpmnlint-recommended-rules/index.js
+++ b/client/src/plugins/linting/bpmnlint-recommended-rules/index.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  registerClientPlugin
+} from 'camunda-modeler-plugin-helpers';
+
+import recommendedRules from './.bpmnlintrc';
+
+registerClientPlugin(recommendedRules, 'lintRules.bpmn');
+registerClientPlugin(recommendedRules, 'lintRules.cloud-bpmn');

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -66,6 +66,10 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /\.bpmnlintrc$/i,
+        use: 'bpmnlint-loader',
+      },
+      {
         test: /\.js$/,
         exclude: /node_modules/,
         use: 'babel-loader'

--- a/package-lock.json
+++ b/package-lock.json
@@ -227,6 +227,7 @@
         "camunda-cmmn-moddle": "^1.0.0",
         "camunda-dmn-js": "^0.8.1",
         "camunda-dmn-moddle": "^1.2.0",
+        "camunda-modeler-plugin-helpers": "^5.1.0",
         "canvg-browser": "^1.0.0",
         "classnames": "^2.2.6",
         "cmmn-js": "^0.20.0",
@@ -10047,6 +10048,11 @@
     "node_modules/camunda-modeler-client": {
       "resolved": "client",
       "link": true
+    },
+    "node_modules/camunda-modeler-plugin-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/camunda-modeler-plugin-helpers/-/camunda-modeler-plugin-helpers-5.1.0.tgz",
+      "integrity": "sha512-QwUMNUBWDQlWtOY76sFEsG26IpVt9Xo+Vyg/NiFi22/5KfiKgxqS93LeJ/BsM2cq00setWM3QSzILyQieyNyTQ=="
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001384",
@@ -35519,6 +35525,7 @@
         "camunda-cmmn-moddle": "^1.0.0",
         "camunda-dmn-js": "^0.8.1",
         "camunda-dmn-moddle": "^1.2.0",
+        "camunda-modeler-plugin-helpers": "^5.1.0",
         "canvg-browser": "^1.0.0",
         "case-sensitive-paths-webpack-plugin": "^2.1.2",
         "chai": "^4.2.0",
@@ -37377,6 +37384,11 @@
           }
         }
       }
+    },
+    "camunda-modeler-plugin-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/camunda-modeler-plugin-helpers/-/camunda-modeler-plugin-helpers-5.1.0.tgz",
+      "integrity": "sha512-QwUMNUBWDQlWtOY76sFEsG26IpVt9Xo+Vyg/NiFi22/5KfiKgxqS93LeJ/BsM2cq00setWM3QSzILyQieyNyTQ=="
     },
     "caniuse-lite": {
       "version": "1.0.30001384"


### PR DESCRIPTION
Adds bpmnlint recommended rules as part of the modeler core:

![capture I7FXLd_optimized](https://user-images.githubusercontent.com/58601/200845323-f37652fb-8883-41a6-8d9b-b7edbf089063.gif)

----

Can be tried out via the following artifacts:

* https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/recommended-lint-rules/camunda-modeler-recommended-lint-rules-linux-x64.tar.gz
* https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/recommended-lint-rules/camunda-modeler-recommended-lint-rules-mac.dmg
* https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/recommended-lint-rules/camunda-modeler-recommended-lint-rules-mac.zip
* https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/recommended-lint-rules/camunda-modeler-recommended-lint-rules-win-ia32.zip
* https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/recommended-lint-rules/camunda-modeler-recommended-lint-rules-win-x64.zip

----

Child of https://github.com/bpmn-io/internal-docs/issues/657.