### PR TITLE
deps(client): update to camunda-bpmn-js@0.23.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -28,7 +28,7 @@
     "bpmn-js": "^10.2.1",
     "bpmn-js-properties-panel": "^1.11.2",
     "bpmn-moddle": "^8.0.0",
-    "camunda-bpmn-js": "^0.23.0",
+    "camunda-bpmn-js": "^0.23.1",
     "camunda-bpmn-moddle": "^7.0.1",
     "camunda-cmmn-moddle": "^1.0.0",
     "camunda-dmn-js": "^0.7.0",

--- a/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
+++ b/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
@@ -18,10 +18,6 @@ import handToolOnSpaceModule from './features/hand-tool-on-space';
 import propertiesPanelKeyboardBindingsModule from './features/properties-panel-keyboard-bindings';
 import lintingAnnotationsModule from '@camunda/linting/modeler';
 
-import {
-  CamundaPlatformPropertiesProviderModule as platformPropertiesProviderModule
-} from 'bpmn-js-properties-panel';
-
 import Flags, { DISABLE_ADJUST_ORIGIN } from '../../../../util/Flags';
 
 
@@ -52,10 +48,7 @@ const extensionModules = [
   globalClipboardModule,
   handToolOnSpaceModule,
   propertiesPanelKeyboardBindingsModule,
-  lintingAnnotationsModule,
-
-  // TODO(nikku): remove this temporary fix to https://github.com/camunda/camunda-modeler/issues/3303
-  platformPropertiesProviderModule
+  lintingAnnotationsModule
 ];
 
 PlatformBpmnModeler.prototype._modules = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -394,7 +394,7 @@
         "@camunda/execution-platform": "^0.3.2",
         "@camunda/form-linting": "^0.1.2",
         "@camunda/form-playground": "^0.2.0",
-        "@camunda/linting": "^0.7.2",
+        "@camunda/linting": "^0.10.0",
         "@codemirror/commands": "^6.1.0",
         "@codemirror/lang-json": "^6.0.0",
         "@codemirror/lang-xml": "^6.0.0",
@@ -406,7 +406,7 @@
         "bpmn-js": "^10.2.1",
         "bpmn-js-properties-panel": "^1.11.2",
         "bpmn-moddle": "^8.0.0",
-        "camunda-bpmn-js": "^0.21.1",
+        "camunda-bpmn-js": "^0.23.1",
         "camunda-bpmn-moddle": "^7.0.1",
         "camunda-cmmn-moddle": "^1.0.0",
         "camunda-dmn-js": "^0.7.0",
@@ -440,7 +440,7 @@
         "semver-compare": "^1.0.0",
         "sourcemapped-stacktrace": "^1.1.9",
         "ua-parser-js": "^0.7.28",
-        "zeebe-bpmn-moddle": "^0.15.0"
+        "zeebe-bpmn-moddle": "^0.16.0"
       },
       "devDependencies": {
         "@babel/core": "^7.4.3",
@@ -1343,6 +1343,48 @@
         "modeler-moddle": "^0.2.0"
       }
     },
+    "client/node_modules/@camunda/linting": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-0.10.0.tgz",
+      "integrity": "sha512-xWIPMSdALFjH8G1svfmvvj7l8RL9DjNgPyc4bvZKXQtzbJebbyi1KLHf3eTAlnfmalOhQT1Hr6wJZrVMDe37pA==",
+      "dependencies": {
+        "bpmn-moddle": "^7.1.3",
+        "bpmnlint": "^8.0.0",
+        "bpmnlint-plugin-camunda-compat": "^0.15.1",
+        "bpmnlint-utils": "^1.0.2",
+        "min-dash": "^4.0.0",
+        "min-dom": "^4.0.1",
+        "zeebe-bpmn-moddle": "^0.15.0"
+      },
+      "peerDependencies": {
+        "bpmn-js-properties-panel": ">= 1.10.0"
+      },
+      "peerDependenciesMeta": {
+        "bpmn-js-properties-panel": {
+          "optional": true
+        }
+      }
+    },
+    "client/node_modules/@camunda/linting/node_modules/bpmn-moddle": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-7.1.3.tgz",
+      "integrity": "sha512-ZcBfw0NSOdYTSXFKEn7MOXHItz7VfLZTrFYKO8cK6V8ZzGjCcdiLIOiw7Lctw1PJsihhLiZQS8Htj2xKf+NwCg==",
+      "dependencies": {
+        "min-dash": "^3.5.2",
+        "moddle": "^5.0.2",
+        "moddle-xml": "^9.0.6"
+      }
+    },
+    "client/node_modules/@camunda/linting/node_modules/bpmn-moddle/node_modules/min-dash": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
+    },
+    "client/node_modules/@camunda/linting/node_modules/zeebe-bpmn-moddle": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.15.0.tgz",
+      "integrity": "sha512-cgn6bjkjrtOGcRumrgWnT1J93wTKmnFlSGGuwGXjF7pOksPF28ssbKiwKVMU6IXHnBDIVLQdf8fVNZn7JiBtQQ=="
+    },
     "client/node_modules/@codemirror/lang-xml": {
       "version": "6.0.0",
       "license": "MIT",
@@ -1735,13 +1777,13 @@
       "license": "ISC"
     },
     "client/node_modules/bpmn-js": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-10.2.1.tgz",
-      "integrity": "sha512-7ejbrq0CXQXon6oTUH4Dfq+KbNWsD7TXN0GTu1e5PA5V/w9s4bDTd95c+6/1ltJNOyYi6zwBFh5jjuEpAJGbVQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-10.3.0.tgz",
+      "integrity": "sha512-6tO5SHt5YyxgX9lRAAwYNmtSum4ZAekP6S0kdDlmh2ztDRAjUZaq7n1Q1ORzTddpngviRZyf5ssP1ZqjE6CgUQ==",
       "dependencies": {
         "bpmn-moddle": "^8.0.0",
         "css.escape": "^1.5.1",
-        "diagram-js": "^9.1.0",
+        "diagram-js": "^10.0.0",
         "diagram-js-direct-editing": "^2.0.0",
         "ids": "^1.0.0",
         "inherits-browser": "^0.1.0",
@@ -1771,6 +1813,22 @@
         "bpmn-js": ">= 8",
         "camunda-bpmn-js-behaviors": ">= 0.4",
         "diagram-js": ">= 7"
+      }
+    },
+    "client/node_modules/bpmn-js/node_modules/diagram-js": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-10.0.0.tgz",
+      "integrity": "sha512-VtZof5MLwVpHjTznfS7B1rQxYtpJ1Gyzse7Aan22QgMhD8FDpm0nXcIblkB//05vFJUljJfp9etNujJtmU1yvA==",
+      "dependencies": {
+        "css.escape": "^1.5.1",
+        "didi": "^9.0.0",
+        "hammerjs": "^2.0.1",
+        "inherits-browser": "^0.1.0",
+        "min-dash": "^4.0.0",
+        "min-dom": "^4.0.2",
+        "object-refs": "^0.3.0",
+        "path-intersection": "^2.2.1",
+        "tiny-svg": "^3.0.0"
       }
     },
     "client/node_modules/bpmn-js/node_modules/tiny-svg": {
@@ -1806,6 +1864,23 @@
         "saxen": "^8.1.2"
       }
     },
+    "client/node_modules/bpmnlint-plugin-camunda-compat": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.15.2.tgz",
+      "integrity": "sha512-Ah30wOH/NoSKtLF4W+SBRbkCV9qT+Jf2p4JYUcO1K05/3sh4d6j0cO4BMHBt/HTgK94JSstDaopXA4NxeJww5g==",
+      "dependencies": {
+        "@bpmn-io/feel-lint": "^0.1.0",
+        "@bpmn-io/moddle-utils": "^0.1.0",
+        "bpmnlint-utils": "^1.0.2",
+        "min-dash": "^3.8.1",
+        "semver-compare": "^1.0.0"
+      }
+    },
+    "client/node_modules/bpmnlint-plugin-camunda-compat/node_modules/min-dash": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
+    },
     "client/node_modules/braces": {
       "version": "3.0.2",
       "dev": true,
@@ -1818,33 +1893,31 @@
       }
     },
     "client/node_modules/camunda-bpmn-js": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-0.21.1.tgz",
-      "integrity": "sha512-ZB5g+tkdegEW+ax4m4jKG0/n79y1amDyr0+1HFSUb+jGzta6pu+2kc9M2BnJa5Zq5Jm3iNHWdMgoI6+u6KTrPg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-0.23.1.tgz",
+      "integrity": "sha512-aTWc02X+DA04tubC3MzA2PxpmmIoohsaPjoF3TDwNIsonzOZMSxpu6j+ZOnGdW4mKFIIqsLPXMKyM9imeurJuQ==",
       "dependencies": {
         "@bpmn-io/align-to-origin": "^0.7.0",
         "@bpmn-io/element-templates-icons-renderer": "^0.3.0",
-        "bpmn-js": "^10.2.0",
-        "bpmn-js-disable-collapsed-subprocess": "^0.1.7",
+        "bpmn-js": "^10.3.0",
         "bpmn-js-executable-fix": "^0.2.0",
-        "camunda-bpmn-js-behaviors": "^0.3.0",
+        "camunda-bpmn-js-behaviors": "^0.4.0",
         "camunda-bpmn-moddle": "^7.0.1",
-        "diagram-js": "^9.1.0",
+        "diagram-js": "^10.0.0",
         "diagram-js-minimap": "^3.0.0",
         "diagram-js-origin": "^1.3.4",
         "inherits": "^2.0.4",
         "min-dash": "^4.0.0",
-        "zeebe-bpmn-moddle": "^0.15.0"
+        "zeebe-bpmn-moddle": "^0.16.0"
       },
       "peerDependencies": {
-        "bpmn-js-properties-panel": ">= 1.10.0"
+        "bpmn-js-properties-panel": ">= 1.11.1"
       }
     },
     "client/node_modules/camunda-bpmn-js-behaviors": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-0.4.0.tgz",
       "integrity": "sha512-Scyc2n85HLPTdvnTCE8rdU0AwuWkdvsq19JZkXhIuTdT9qeUY+FnuIlpa+H0OIvf4E/R0Vkn4mc4LkePUQPRdg==",
-      "peer": true,
       "dependencies": {
         "ids": "^1.0.0",
         "min-dash": "^4.0.0"
@@ -1855,19 +1928,26 @@
         "zeebe-bpmn-moddle": ">= 0.15"
       }
     },
-    "client/node_modules/camunda-bpmn-js/node_modules/camunda-bpmn-js-behaviors": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-0.3.0.tgz",
-      "integrity": "sha512-isD424Lwgh4+v3IWDnqLkkA/oIQcwFHQ6TmxUYBNuF5WshO25a2u/6SgAtBiWpg2xqjD5x8zi5/0JWr/Yp7WEg==",
+    "client/node_modules/camunda-bpmn-js/node_modules/diagram-js": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-10.0.0.tgz",
+      "integrity": "sha512-VtZof5MLwVpHjTznfS7B1rQxYtpJ1Gyzse7Aan22QgMhD8FDpm0nXcIblkB//05vFJUljJfp9etNujJtmU1yvA==",
       "dependencies": {
-        "ids": "^1.0.0",
-        "min-dash": "^4.0.0"
-      },
-      "peerDependencies": {
-        "bpmn-js": ">= 9",
-        "camunda-bpmn-moddle": ">= 7",
-        "zeebe-bpmn-moddle": ">= 0.15"
+        "css.escape": "^1.5.1",
+        "didi": "^9.0.0",
+        "hammerjs": "^2.0.1",
+        "inherits-browser": "^0.1.0",
+        "min-dash": "^4.0.0",
+        "min-dom": "^4.0.2",
+        "object-refs": "^0.3.0",
+        "path-intersection": "^2.2.1",
+        "tiny-svg": "^3.0.0"
       }
+    },
+    "client/node_modules/camunda-bpmn-js/node_modules/tiny-svg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
+      "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w=="
     },
     "client/node_modules/camunda-cmmn-moddle": {
       "version": "1.0.0",
@@ -2434,11 +2514,6 @@
         "diagram-js": "*"
       }
     },
-    "client/node_modules/diagram-js/node_modules/didi": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
-      "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w=="
-    },
     "client/node_modules/diagram-js/node_modules/path-intersection": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
@@ -2448,6 +2523,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
       "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w=="
+    },
+    "client/node_modules/didi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
+      "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w=="
     },
     "client/node_modules/diff": {
       "version": "5.1.0",
@@ -4193,6 +4273,11 @@
         "node": ">=0.1"
       }
     },
+    "client/node_modules/zeebe-bpmn-moddle": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.16.0.tgz",
+      "integrity": "sha512-Fr6NqtWWl604wMnEKis8CIyyi4DGSPsFaGB4rm4bwjbOY2O3d1UrvFS4LnOAxUi6SH8Q1agdBU1GjUXYz5pAtA=="
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
       "dev": true,
@@ -4544,27 +4629,6 @@
       "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
       "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w=="
     },
-    "node_modules/@bpmn-io/element-templates-validator": {
-      "version": "0.10.0",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@camunda/element-templates-json-schema": "^0.10.1",
-        "@camunda/zeebe-element-templates-json-schema": "^0.6.0",
-        "json-source-map": "^0.6.1",
-        "min-dash": "^3.8.1"
-      }
-    },
-    "node_modules/@bpmn-io/extract-process-variables": {
-      "version": "0.5.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "min-dash": "^3.8.1"
-      }
-    },
     "node_modules/@bpmn-io/feel-editor": {
       "version": "0.3.0",
       "license": "MIT",
@@ -4578,6 +4642,24 @@
         "@codemirror/view": "^6.0.0",
         "@lezer/highlight": "^1.0.0",
         "lezer-feel": "^0.4.0"
+      }
+    },
+    "node_modules/@bpmn-io/feel-lint": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-0.1.0.tgz",
+      "integrity": "sha512-Ryc2EP0kJx1e5gYghqEg60gEoEz/zFRsyISSFRTRC+Fz3MGjbscHSWitPaXs2Hb0BvgRWA4zSx+Jc2oOvV6LSQ==",
+      "dependencies": {
+        "@codemirror/language": "^6.2.1",
+        "lezer-feel": "^0.14.1"
+      }
+    },
+    "node_modules/@bpmn-io/feel-lint/node_modules/lezer-feel": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.14.1.tgz",
+      "integrity": "sha512-sfpzZvAtObFon74XiFp1L8pS1FminnfM8JAm4S2Kxk7Wk8qYe7crjJdhHqju/MKl9dV5s44NHDhbq5tCDWMTlw==",
+      "dependencies": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.2.3"
       }
     },
     "node_modules/@bpmn-io/form-js": {
@@ -4728,84 +4810,6 @@
         "domify": "^1.4.1",
         "min-dash": "^4.0.0"
       }
-    },
-    "node_modules/@camunda/linting": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-0.7.2.tgz",
-      "integrity": "sha512-zzFvcgx0TPf4n0gObU6jXCx8aJAV0MgshTye1eG8NyUOix+kOZTqErfbcGBsIi4zmVTdBLjxshRt4tFGdOge2A==",
-      "dependencies": {
-        "bpmn-moddle": "^7.1.3",
-        "bpmnlint": "^8.0.0",
-        "bpmnlint-plugin-camunda-compat": "^0.13.1",
-        "bpmnlint-utils": "^1.0.2",
-        "min-dash": "^4.0.0",
-        "min-dom": "^4.0.1",
-        "zeebe-bpmn-moddle": "^0.15.0"
-      },
-      "peerDependencies": {
-        "bpmn-js-properties-panel": "^1.3.0"
-      },
-      "peerDependenciesMeta": {
-        "bpmn-js-properties-panel": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@camunda/linting/node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@camunda/linting/node_modules/bpmnlint": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-8.1.0.tgz",
-      "integrity": "sha512-mFt92TQMo5nFjoumngZ8mYCLYQ4fETNjoe4U0X76lnArKSm/CfJj5Y2U3wtQapd5zirbZFa9kuX/cdKzajZzcQ==",
-      "dependencies": {
-        "@bpmn-io/moddle-utils": "^0.1.0",
-        "ansi-colors": "^4.1.3",
-        "bpmn-moddle": "^7.1.3",
-        "bpmnlint-utils": "^1.0.2",
-        "cli-table": "^0.3.11",
-        "color-support": "^1.1.3",
-        "min-dash": "^3.8.1",
-        "mri": "^1.2.0",
-        "pluralize": "^7.0.0",
-        "tiny-glob": "^0.2.9"
-      },
-      "bin": {
-        "bpmnlint": "bin/bpmnlint.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@camunda/linting/node_modules/bpmnlint/node_modules/min-dash": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
-      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
-    },
-    "node_modules/@camunda/linting/node_modules/min-dash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
-      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
-    },
-    "node_modules/@camunda/linting/node_modules/min-dom": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.0.1.tgz",
-      "integrity": "sha512-82fpjdsvbwJ2cqG2I1MMWaRN8fdDZ7e7QM05aYfzXXMhU050JrqEOGATAXrCh+OBs75doTBEKp8diOuu/UfdYA==",
-      "dependencies": {
-        "component-event": "^0.1.4",
-        "domify": "^1.4.1",
-        "min-dash": "^3.8.1"
-      }
-    },
-    "node_modules/@camunda/linting/node_modules/min-dom/node_modules/min-dash": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
-      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
       "version": "0.6.0",
@@ -8104,12 +8108,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@philippfromme/moddle-helpers": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -9582,51 +9580,12 @@
         "tiny-svg": "^2.2.4"
       }
     },
-    "node_modules/bpmn-js-disable-collapsed-subprocess": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/bpmn-js-disable-collapsed-subprocess/-/bpmn-js-disable-collapsed-subprocess-0.1.7.tgz",
-      "integrity": "sha512-Lhaklmi77ulvcWG8wh6w0nLVAIlWvHPkri6hwm7ReP6tw/S2SMSNsFHYa+dfvVEZD30uNLZHGpDztZOdxBGvrw==",
-      "dependencies": {
-        "min-dash": "^4.0.0"
-      },
-      "peerDependencies": {
-        "bpmn-js": ">= 6"
-      }
-    },
-    "node_modules/bpmn-js-disable-collapsed-subprocess/node_modules/min-dash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
-      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
-    },
     "node_modules/bpmn-js-executable-fix": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/bpmn-js-executable-fix/-/bpmn-js-executable-fix-0.2.0.tgz",
       "integrity": "sha512-sIQ+eW4pWUzBPTDIzTPlWpmBZ0uodvWMJqtfc2Mqh6wZm97BC+PXeEFw35cl7dM0HjN3eueKMbKSrXTtk+JZ6Q==",
       "peerDependencies": {
         "bpmn-js": ">= 6"
-      }
-    },
-    "node_modules/bpmn-js-properties-panel": {
-      "version": "1.6.1",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@bpmn-io/element-templates-validator": "^0.10.0",
-        "@bpmn-io/extract-process-variables": "^0.5.0",
-        "array-move": "^3.0.1",
-        "classnames": "^2.3.1",
-        "ids": "^1.0.0",
-        "min-dash": "^3.8.1",
-        "min-dom": "^3.1.3",
-        "preact-markup": "^2.1.1",
-        "semver-compare": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@bpmn-io/properties-panel": "^0.20.1",
-        "bpmn-js": "8.x || 9.x",
-        "camunda-bpmn-js-behaviors": "0.2.x",
-        "diagram-js": "7.x || 8.x"
       }
     },
     "node_modules/bpmn-moddle": {
@@ -9639,18 +9598,17 @@
       }
     },
     "node_modules/bpmnlint": {
-      "version": "7.8.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-8.1.1.tgz",
+      "integrity": "sha512-MN81JGqqHx2+wAF1HVvYq7N5+lKJd82Op8VnLQ19V56HmavwbwUlR+r3L5jv6x/YCthudR1FVhEd/N20xQLHEg==",
       "dependencies": {
-        "@philippfromme/moddle-helpers": "^0.1.0",
-        "ansi-colors": "^4.1.1",
-        "bpmn-moddle": "^7.1.2",
+        "@bpmn-io/moddle-utils": "^0.1.0",
+        "ansi-colors": "^4.1.3",
+        "bpmn-moddle": "^7.1.3",
         "bpmnlint-utils": "^1.0.2",
-        "cli-table": "^0.3.9",
+        "cli-table": "^0.3.11",
         "color-support": "^1.1.3",
-        "min-dash": "^3.8.0",
+        "min-dash": "^3.8.1",
         "mri": "^1.2.0",
         "pluralize": "^7.0.0",
         "tiny-glob": "^0.2.9"
@@ -9659,7 +9617,7 @@
         "bpmnlint": "bin/bpmnlint.js"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12"
       }
     },
     "node_modules/bpmnlint-loader": {
@@ -9671,19 +9629,17 @@
         "bpmnlint": "*"
       }
     },
-    "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.13.1.tgz",
-      "integrity": "sha512-Zp11rMtJXA3GM2u8Vx9eCDN54bBW5BLHtmDUy6++bk8PdKSSqzOh40TGx4pxl+QtxlRB8WcNBCS5QFaJmMgPKw==",
-      "dependencies": {
-        "@bpmn-io/moddle-utils": "^0.1.0",
-        "bpmnlint-utils": "^1.0.2",
-        "min-dash": "^3.8.1"
-      }
-    },
     "node_modules/bpmnlint-utils": {
       "version": "1.0.2",
       "license": "MIT"
+    },
+    "node_modules/bpmnlint/node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -10106,29 +10062,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/camunda-bpmn-js-behaviors": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-0.2.2.tgz",
-      "integrity": "sha512-MsWByIIE4qdUVNAcOAGZBmouadHHxDgHuCmwOfg5rCiUICW5ljmzDJHgp3L00OOv+OuxiHC81h13Lc6/HLfPmQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ids": "^1.0.0",
-        "min-dash": "^4.0.0"
-      },
-      "peerDependencies": {
-        "bpmn-js": ">= 9",
-        "camunda-bpmn-moddle": ">= 7",
-        "zeebe-bpmn-moddle": ">= 0.15"
-      }
-    },
-    "node_modules/camunda-bpmn-js-behaviors/node_modules/min-dash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
-      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/camunda-bpmn-moddle": {
       "version": "7.0.1",
@@ -26149,10 +26082,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/zeebe-bpmn-moddle": {
-      "version": "0.15.0",
-      "license": "MIT"
-    },
     "node_modules/zeebe-node": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.1.0.tgz",
@@ -26461,25 +26390,6 @@
         }
       }
     },
-    "@bpmn-io/element-templates-validator": {
-      "version": "0.10.0",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@camunda/element-templates-json-schema": "^0.10.1",
-        "@camunda/zeebe-element-templates-json-schema": "^0.6.0",
-        "json-source-map": "^0.6.1",
-        "min-dash": "^3.8.1"
-      }
-    },
-    "@bpmn-io/extract-process-variables": {
-      "version": "0.5.1",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "min-dash": "^3.8.1"
-      }
-    },
     "@bpmn-io/feel-editor": {
       "version": "0.3.0",
       "peer": true,
@@ -26492,6 +26402,26 @@
         "@codemirror/view": "^6.0.0",
         "@lezer/highlight": "^1.0.0",
         "lezer-feel": "^0.4.0"
+      }
+    },
+    "@bpmn-io/feel-lint": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-0.1.0.tgz",
+      "integrity": "sha512-Ryc2EP0kJx1e5gYghqEg60gEoEz/zFRsyISSFRTRC+Fz3MGjbscHSWitPaXs2Hb0BvgRWA4zSx+Jc2oOvV6LSQ==",
+      "requires": {
+        "@codemirror/language": "^6.2.1",
+        "lezer-feel": "^0.14.1"
+      },
+      "dependencies": {
+        "lezer-feel": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.14.1.tgz",
+          "integrity": "sha512-sfpzZvAtObFon74XiFp1L8pS1FminnfM8JAm4S2Kxk7Wk8qYe7crjJdhHqju/MKl9dV5s44NHDhbq5tCDWMTlw==",
+          "requires": {
+            "@lezer/highlight": "^1.0.0",
+            "@lezer/lr": "^1.2.3"
+          }
+        }
       }
     },
     "@bpmn-io/form-js": {
@@ -26640,73 +26570,6 @@
             "component-event": "^0.1.4",
             "domify": "^1.4.1",
             "min-dash": "^4.0.0"
-          }
-        }
-      }
-    },
-    "@camunda/linting": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-0.7.2.tgz",
-      "integrity": "sha512-zzFvcgx0TPf4n0gObU6jXCx8aJAV0MgshTye1eG8NyUOix+kOZTqErfbcGBsIi4zmVTdBLjxshRt4tFGdOge2A==",
-      "requires": {
-        "bpmn-moddle": "^7.1.3",
-        "bpmnlint": "^8.0.0",
-        "bpmnlint-plugin-camunda-compat": "^0.13.1",
-        "bpmnlint-utils": "^1.0.2",
-        "min-dash": "^4.0.0",
-        "min-dom": "^4.0.1",
-        "zeebe-bpmn-moddle": "^0.15.0"
-      },
-      "dependencies": {
-        "ansi-colors": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-          "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
-        },
-        "bpmnlint": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-8.1.0.tgz",
-          "integrity": "sha512-mFt92TQMo5nFjoumngZ8mYCLYQ4fETNjoe4U0X76lnArKSm/CfJj5Y2U3wtQapd5zirbZFa9kuX/cdKzajZzcQ==",
-          "requires": {
-            "@bpmn-io/moddle-utils": "^0.1.0",
-            "ansi-colors": "^4.1.3",
-            "bpmn-moddle": "^7.1.3",
-            "bpmnlint-utils": "^1.0.2",
-            "cli-table": "^0.3.11",
-            "color-support": "^1.1.3",
-            "min-dash": "^3.8.1",
-            "mri": "^1.2.0",
-            "pluralize": "^7.0.0",
-            "tiny-glob": "^0.2.9"
-          },
-          "dependencies": {
-            "min-dash": {
-              "version": "3.8.1",
-              "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
-              "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
-            }
-          }
-        },
-        "min-dash": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
-          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
-        },
-        "min-dom": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.0.1.tgz",
-          "integrity": "sha512-82fpjdsvbwJ2cqG2I1MMWaRN8fdDZ7e7QM05aYfzXXMhU050JrqEOGATAXrCh+OBs75doTBEKp8diOuu/UfdYA==",
-          "requires": {
-            "component-event": "^0.1.4",
-            "domify": "^1.4.1",
-            "min-dash": "^3.8.1"
-          },
-          "dependencies": {
-            "min-dash": {
-              "version": "3.8.1",
-              "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
-              "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
-            }
           }
         }
       }
@@ -28961,11 +28824,6 @@
         }
       }
     },
-    "@philippfromme/moddle-helpers": {
-      "version": "0.1.0",
-      "dev": true,
-      "peer": true
-    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -30091,42 +29949,11 @@
         "tiny-svg": "^2.2.4"
       }
     },
-    "bpmn-js-disable-collapsed-subprocess": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/bpmn-js-disable-collapsed-subprocess/-/bpmn-js-disable-collapsed-subprocess-0.1.7.tgz",
-      "integrity": "sha512-Lhaklmi77ulvcWG8wh6w0nLVAIlWvHPkri6hwm7ReP6tw/S2SMSNsFHYa+dfvVEZD30uNLZHGpDztZOdxBGvrw==",
-      "requires": {
-        "min-dash": "^4.0.0"
-      },
-      "dependencies": {
-        "min-dash": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
-          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
-        }
-      }
-    },
     "bpmn-js-executable-fix": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/bpmn-js-executable-fix/-/bpmn-js-executable-fix-0.2.0.tgz",
       "integrity": "sha512-sIQ+eW4pWUzBPTDIzTPlWpmBZ0uodvWMJqtfc2Mqh6wZm97BC+PXeEFw35cl7dM0HjN3eueKMbKSrXTtk+JZ6Q==",
       "requires": {}
-    },
-    "bpmn-js-properties-panel": {
-      "version": "1.6.1",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@bpmn-io/element-templates-validator": "^0.10.0",
-        "@bpmn-io/extract-process-variables": "^0.5.0",
-        "array-move": "^3.0.1",
-        "classnames": "^2.3.1",
-        "ids": "^1.0.0",
-        "min-dash": "^3.8.1",
-        "min-dom": "^3.1.3",
-        "preact-markup": "^2.1.1",
-        "semver-compare": "^1.0.0"
-      }
     },
     "bpmn-moddle": {
       "version": "7.1.3",
@@ -30137,20 +29964,27 @@
       }
     },
     "bpmnlint": {
-      "version": "7.8.0",
-      "dev": true,
-      "peer": true,
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-8.1.1.tgz",
+      "integrity": "sha512-MN81JGqqHx2+wAF1HVvYq7N5+lKJd82Op8VnLQ19V56HmavwbwUlR+r3L5jv6x/YCthudR1FVhEd/N20xQLHEg==",
       "requires": {
-        "@philippfromme/moddle-helpers": "^0.1.0",
-        "ansi-colors": "^4.1.1",
-        "bpmn-moddle": "^7.1.2",
+        "@bpmn-io/moddle-utils": "^0.1.0",
+        "ansi-colors": "^4.1.3",
+        "bpmn-moddle": "^7.1.3",
         "bpmnlint-utils": "^1.0.2",
-        "cli-table": "^0.3.9",
+        "cli-table": "^0.3.11",
         "color-support": "^1.1.3",
-        "min-dash": "^3.8.0",
+        "min-dash": "^3.8.1",
         "mri": "^1.2.0",
         "pluralize": "^7.0.0",
         "tiny-glob": "^0.2.9"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+          "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
+        }
       }
     },
     "bpmnlint-loader": {
@@ -30159,16 +29993,6 @@
       "integrity": "sha512-/XmvV70NT1uTpjtC6C5bTJvWFR6v5RFxLzUCuP0ScKKlTf6me9rYgV0sAXdbW2011vFSFfD8DJHTi+D3gnSUww==",
       "dev": true,
       "requires": {}
-    },
-    "bpmnlint-plugin-camunda-compat": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.13.1.tgz",
-      "integrity": "sha512-Zp11rMtJXA3GM2u8Vx9eCDN54bBW5BLHtmDUy6++bk8PdKSSqzOh40TGx4pxl+QtxlRB8WcNBCS5QFaJmMgPKw==",
-      "requires": {
-        "@bpmn-io/moddle-utils": "^0.1.0",
-        "bpmnlint-utils": "^1.0.2",
-        "min-dash": "^3.8.1"
-      }
     },
     "bpmnlint-utils": {
       "version": "1.0.2"
@@ -30455,26 +30279,6 @@
       "version": "3.1.0",
       "dev": true
     },
-    "camunda-bpmn-js-behaviors": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-0.2.2.tgz",
-      "integrity": "sha512-MsWByIIE4qdUVNAcOAGZBmouadHHxDgHuCmwOfg5rCiUICW5ljmzDJHgp3L00OOv+OuxiHC81h13Lc6/HLfPmQ==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "ids": "^1.0.0",
-        "min-dash": "^4.0.0"
-      },
-      "dependencies": {
-        "min-dash": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
-          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA==",
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
     "camunda-bpmn-moddle": {
       "version": "7.0.1"
     },
@@ -30716,12 +30520,12 @@
         "@bpmn-io/dmn-migrate": "^0.4.3",
         "@bpmn-io/extract-process-variables": "^0.6.0",
         "@bpmn-io/form-js": "^0.9.9",
-        "@bpmn-io/properties-panel": "^0.24.0",
+        "@bpmn-io/properties-panel": "0.24.0",
         "@bpmn-io/replace-ids": "^0.2.0",
         "@camunda/execution-platform": "^0.3.2",
         "@camunda/form-linting": "^0.1.2",
         "@camunda/form-playground": "^0.2.0",
-        "@camunda/linting": "^0.7.2",
+        "@camunda/linting": "^0.10.0",
         "@codemirror/commands": "^6.1.0",
         "@codemirror/lang-json": "^6.0.0",
         "@codemirror/lang-xml": "^6.0.0",
@@ -30734,10 +30538,10 @@
         "babel-loader": "^8.0.5",
         "babel-plugin-istanbul": "^5.1.3",
         "bpmn-js": "^10.2.1",
-        "bpmn-js-properties-panel": "^1.11.2",
+        "bpmn-js-properties-panel": "1.11.2",
         "bpmn-moddle": "^8.0.0",
         "bpmnlint-loader": "^0.1.6",
-        "camunda-bpmn-js": "^0.21.1",
+        "camunda-bpmn-js": "0.23.1",
         "camunda-bpmn-moddle": "^7.0.1",
         "camunda-cmmn-moddle": "^1.0.0",
         "camunda-dmn-js": "^0.7.0",
@@ -30800,7 +30604,7 @@
         "ua-parser-js": "^0.7.28",
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0",
-        "zeebe-bpmn-moddle": "^0.15.0"
+        "zeebe-bpmn-moddle": "^0.16.0"
       },
       "dependencies": {
         "@babel/helper-annotate-as-pure": {
@@ -31437,6 +31241,44 @@
           "version": "0.3.2",
           "requires": {}
         },
+        "@camunda/linting": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-0.10.0.tgz",
+          "integrity": "sha512-xWIPMSdALFjH8G1svfmvvj7l8RL9DjNgPyc4bvZKXQtzbJebbyi1KLHf3eTAlnfmalOhQT1Hr6wJZrVMDe37pA==",
+          "requires": {
+            "bpmn-moddle": "^7.1.3",
+            "bpmnlint": "^8.0.0",
+            "bpmnlint-plugin-camunda-compat": "^0.15.1",
+            "bpmnlint-utils": "^1.0.2",
+            "min-dash": "^4.0.0",
+            "min-dom": "^4.0.1",
+            "zeebe-bpmn-moddle": "^0.15.0"
+          },
+          "dependencies": {
+            "bpmn-moddle": {
+              "version": "7.1.3",
+              "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-7.1.3.tgz",
+              "integrity": "sha512-ZcBfw0NSOdYTSXFKEn7MOXHItz7VfLZTrFYKO8cK6V8ZzGjCcdiLIOiw7Lctw1PJsihhLiZQS8Htj2xKf+NwCg==",
+              "requires": {
+                "min-dash": "^3.5.2",
+                "moddle": "^5.0.2",
+                "moddle-xml": "^9.0.6"
+              },
+              "dependencies": {
+                "min-dash": {
+                  "version": "3.8.1",
+                  "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+                  "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
+                }
+              }
+            },
+            "zeebe-bpmn-moddle": {
+              "version": "0.15.0",
+              "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.15.0.tgz",
+              "integrity": "sha512-cgn6bjkjrtOGcRumrgWnT1J93wTKmnFlSGGuwGXjF7pOksPF28ssbKiwKVMU6IXHnBDIVLQdf8fVNZn7JiBtQQ=="
+            }
+          }
+        },
         "@codemirror/lang-xml": {
           "version": "6.0.0",
           "requires": {
@@ -31710,13 +31552,13 @@
           "dev": true
         },
         "bpmn-js": {
-          "version": "10.2.1",
-          "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-10.2.1.tgz",
-          "integrity": "sha512-7ejbrq0CXQXon6oTUH4Dfq+KbNWsD7TXN0GTu1e5PA5V/w9s4bDTd95c+6/1ltJNOyYi6zwBFh5jjuEpAJGbVQ==",
+          "version": "10.3.0",
+          "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-10.3.0.tgz",
+          "integrity": "sha512-6tO5SHt5YyxgX9lRAAwYNmtSum4ZAekP6S0kdDlmh2ztDRAjUZaq7n1Q1ORzTddpngviRZyf5ssP1ZqjE6CgUQ==",
           "requires": {
             "bpmn-moddle": "^8.0.0",
             "css.escape": "^1.5.1",
-            "diagram-js": "^9.1.0",
+            "diagram-js": "^10.0.0",
             "diagram-js-direct-editing": "^2.0.0",
             "ids": "^1.0.0",
             "inherits-browser": "^0.1.0",
@@ -31726,6 +31568,22 @@
             "tiny-svg": "^3.0.0"
           },
           "dependencies": {
+            "diagram-js": {
+              "version": "10.0.0",
+              "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-10.0.0.tgz",
+              "integrity": "sha512-VtZof5MLwVpHjTznfS7B1rQxYtpJ1Gyzse7Aan22QgMhD8FDpm0nXcIblkB//05vFJUljJfp9etNujJtmU1yvA==",
+              "requires": {
+                "css.escape": "^1.5.1",
+                "didi": "^9.0.0",
+                "hammerjs": "^2.0.1",
+                "inherits-browser": "^0.1.0",
+                "min-dash": "^4.0.0",
+                "min-dom": "^4.0.2",
+                "object-refs": "^0.3.0",
+                "path-intersection": "^2.2.1",
+                "tiny-svg": "^3.0.0"
+              }
+            },
             "tiny-svg": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
@@ -31779,6 +31637,25 @@
             }
           }
         },
+        "bpmnlint-plugin-camunda-compat": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.15.2.tgz",
+          "integrity": "sha512-Ah30wOH/NoSKtLF4W+SBRbkCV9qT+Jf2p4JYUcO1K05/3sh4d6j0cO4BMHBt/HTgK94JSstDaopXA4NxeJww5g==",
+          "requires": {
+            "@bpmn-io/feel-lint": "^0.1.0",
+            "@bpmn-io/moddle-utils": "^0.1.0",
+            "bpmnlint-utils": "^1.0.2",
+            "min-dash": "^3.8.1",
+            "semver-compare": "^1.0.0"
+          },
+          "dependencies": {
+            "min-dash": {
+              "version": "3.8.1",
+              "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+              "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
+            }
+          }
+        },
         "braces": {
           "version": "3.0.2",
           "dev": true,
@@ -31787,33 +31664,44 @@
           }
         },
         "camunda-bpmn-js": {
-          "version": "0.21.1",
-          "resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-0.21.1.tgz",
-          "integrity": "sha512-ZB5g+tkdegEW+ax4m4jKG0/n79y1amDyr0+1HFSUb+jGzta6pu+2kc9M2BnJa5Zq5Jm3iNHWdMgoI6+u6KTrPg==",
+          "version": "0.23.1",
+          "resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-0.23.1.tgz",
+          "integrity": "sha512-aTWc02X+DA04tubC3MzA2PxpmmIoohsaPjoF3TDwNIsonzOZMSxpu6j+ZOnGdW4mKFIIqsLPXMKyM9imeurJuQ==",
           "requires": {
             "@bpmn-io/align-to-origin": "^0.7.0",
             "@bpmn-io/element-templates-icons-renderer": "^0.3.0",
-            "bpmn-js": "^10.2.0",
-            "bpmn-js-disable-collapsed-subprocess": "^0.1.7",
+            "bpmn-js": "^10.3.0",
             "bpmn-js-executable-fix": "^0.2.0",
-            "camunda-bpmn-js-behaviors": "^0.3.0",
+            "camunda-bpmn-js-behaviors": "^0.4.0",
             "camunda-bpmn-moddle": "^7.0.1",
-            "diagram-js": "^9.1.0",
+            "diagram-js": "^10.0.0",
             "diagram-js-minimap": "^3.0.0",
             "diagram-js-origin": "^1.3.4",
             "inherits": "^2.0.4",
             "min-dash": "^4.0.0",
-            "zeebe-bpmn-moddle": "^0.15.0"
+            "zeebe-bpmn-moddle": "^0.16.0"
           },
           "dependencies": {
-            "camunda-bpmn-js-behaviors": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-0.3.0.tgz",
-              "integrity": "sha512-isD424Lwgh4+v3IWDnqLkkA/oIQcwFHQ6TmxUYBNuF5WshO25a2u/6SgAtBiWpg2xqjD5x8zi5/0JWr/Yp7WEg==",
+            "diagram-js": {
+              "version": "10.0.0",
+              "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-10.0.0.tgz",
+              "integrity": "sha512-VtZof5MLwVpHjTznfS7B1rQxYtpJ1Gyzse7Aan22QgMhD8FDpm0nXcIblkB//05vFJUljJfp9etNujJtmU1yvA==",
               "requires": {
-                "ids": "^1.0.0",
-                "min-dash": "^4.0.0"
+                "css.escape": "^1.5.1",
+                "didi": "^9.0.0",
+                "hammerjs": "^2.0.1",
+                "inherits-browser": "^0.1.0",
+                "min-dash": "^4.0.0",
+                "min-dom": "^4.0.2",
+                "object-refs": "^0.3.0",
+                "path-intersection": "^2.2.1",
+                "tiny-svg": "^3.0.0"
               }
+            },
+            "tiny-svg": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
+              "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w=="
             }
           }
         },
@@ -31821,7 +31709,6 @@
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-0.4.0.tgz",
           "integrity": "sha512-Scyc2n85HLPTdvnTCE8rdU0AwuWkdvsq19JZkXhIuTdT9qeUY+FnuIlpa+H0OIvf4E/R0Vkn4mc4LkePUQPRdg==",
-          "peer": true,
           "requires": {
             "ids": "^1.0.0",
             "min-dash": "^4.0.0"
@@ -32188,11 +32075,6 @@
             "tiny-svg": "^3.0.0"
           },
           "dependencies": {
-            "didi": {
-              "version": "9.0.0",
-              "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
-              "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w=="
-            },
             "path-intersection": {
               "version": "2.2.1",
               "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
@@ -32213,6 +32095,11 @@
             "min-dash": "^4.0.0",
             "min-dom": "^4.0.2"
           }
+        },
+        "didi": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
+          "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w=="
         },
         "diff": {
           "version": "5.1.0",
@@ -33523,6 +33410,11 @@
         },
         "xmldom": {
           "version": "0.1.27"
+        },
+        "zeebe-bpmn-moddle": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.16.0.tgz",
+          "integrity": "sha512-Fr6NqtWWl604wMnEKis8CIyyi4DGSPsFaGB4rm4bwjbOY2O3d1UrvFS4LnOAxUi6SH8Q1agdBU1GjUXYz5pAtA=="
         }
       }
     },
@@ -44318,9 +44210,6 @@
     "yocto-queue": {
       "version": "0.1.0",
       "dev": true
-    },
-    "zeebe-bpmn-moddle": {
-      "version": "0.15.0"
     },
     "zeebe-node": {
       "version": "8.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
     },
     "app": {
       "name": "camunda-modeler",
-      "version": "5.5.0",
+      "version": "5.5.1",
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^6.3.6",
@@ -64,78 +64,6 @@
       "optionalDependencies": {
         "vscode-windows-ca-certs": "^0.3.0"
       }
-    },
-    "app/node_modules/@grpc/grpc-js": {
-      "version": "1.7.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grpc/proto-loader": "^0.7.0",
-        "@types/node": ">=12.12.47"
-      },
-      "engines": {
-        "node": "^8.13.0 || >=10.10.0"
-      }
-    },
-    "app/node_modules/@grpc/proto-loader": {
-      "version": "0.7.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/long": "^4.0.1",
-        "lodash.camelcase": "^4.3.0",
-        "long": "^4.0.0",
-        "protobufjs": "^7.0.0",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "app/node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "app/node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "app/node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "license": "BSD-3-Clause"
-    },
-    "app/node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
-    },
-    "app/node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "app/node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "license": "BSD-3-Clause"
-    },
-    "app/node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
-    },
-    "app/node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "app/node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
-    },
-    "app/node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
     },
     "app/node_modules/@sentry/core": {
       "version": "6.3.6",
@@ -225,31 +153,6 @@
         "node": ">=6"
       }
     },
-    "app/node_modules/@sindresorhus/is": {
-      "version": "0.14.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "app/node_modules/@szmarczak/http-timer": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "defer-to-connect": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "app/node_modules/@types/long": {
-      "version": "4.0.2",
-      "license": "MIT"
-    },
-    "app/node_modules/@types/node": {
-      "version": "18.8.1",
-      "license": "MIT"
-    },
     "app/node_modules/agent-base": {
       "version": "6.0.2",
       "license": "MIT",
@@ -259,27 +162,6 @@
       "engines": {
         "node": ">= 6.0.0"
       }
-    },
-    "app/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "app/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "app/node_modules/asynckit": {
-      "version": "0.4.0",
-      "license": "MIT"
     },
     "app/node_modules/balanced-match": {
       "version": "1.0.0",
@@ -293,166 +175,9 @@
         "concat-map": "0.0.1"
       }
     },
-    "app/node_modules/cacheable-request": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^3.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
-        "responselike": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "app/node_modules/cacheable-request/node_modules/get-stream": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "app/node_modules/cacheable-request/node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "app/node_modules/chalk": {
-      "version": "2.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "app/node_modules/cliui": {
-      "version": "7.0.4",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "app/node_modules/clone-response": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "app/node_modules/color-convert": {
-      "version": "1.9.3",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "app/node_modules/color-name": {
-      "version": "1.1.3",
-      "license": "MIT"
-    },
-    "app/node_modules/combined-stream": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "app/node_modules/concat-map": {
       "version": "0.0.1",
       "license": "MIT"
-    },
-    "app/node_modules/console-stamp": {
-      "version": "3.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "dateformat": "^4.6.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "app/node_modules/console-stamp/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "app/node_modules/console-stamp/node_modules/chalk": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "app/node_modules/console-stamp/node_modules/color-convert": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "app/node_modules/console-stamp/node_modules/color-name": {
-      "version": "1.1.4",
-      "license": "MIT"
-    },
-    "app/node_modules/console-stamp/node_modules/has-flag": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "app/node_modules/console-stamp/node_modules/supports-color": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "app/node_modules/cookie": {
       "version": "0.4.1",
@@ -460,17 +185,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "app/node_modules/dateformat": {
-      "version": "4.6.3",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "app/node_modules/dayjs": {
-      "version": "1.11.5",
-      "license": "MIT"
     },
     "app/node_modules/debug": {
       "version": "4.3.1",
@@ -487,74 +201,6 @@
         }
       }
     },
-    "app/node_modules/decompress-response": {
-      "version": "3.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "app/node_modules/defer-to-connect": {
-      "version": "1.1.3",
-      "license": "MIT"
-    },
-    "app/node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "app/node_modules/duplexer3": {
-      "version": "0.1.5",
-      "license": "BSD-3-Clause"
-    },
-    "app/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "license": "MIT"
-    },
-    "app/node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
-    "app/node_modules/err-code": {
-      "version": "1.1.2",
-      "license": "MIT"
-    },
-    "app/node_modules/escalade": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "app/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "app/node_modules/fast-xml-parser": {
-      "version": "3.21.1",
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^1.0.4"
-      },
-      "bin": {
-        "xml2js": "cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
-      }
-    },
     "app/node_modules/form-data": {
       "version": "2.5.1",
       "license": "MIT",
@@ -567,30 +213,9 @@
         "node": ">= 0.12"
       }
     },
-    "app/node_modules/fp-ts": {
-      "version": "2.12.3",
-      "license": "MIT"
-    },
     "app/node_modules/fs.realpath": {
       "version": "1.0.0",
       "license": "ISC"
-    },
-    "app/node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "app/node_modules/get-stream": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "app/node_modules/glob": {
       "version": "7.1.6",
@@ -609,37 +234,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "app/node_modules/got": {
-      "version": "9.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^0.14.0",
-        "@szmarczak/http-timer": "^1.1.2",
-        "cacheable-request": "^6.0.0",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^4.1.0",
-        "lowercase-keys": "^1.0.1",
-        "mimic-response": "^1.0.1",
-        "p-cancelable": "^1.0.0",
-        "to-readable-stream": "^1.0.0",
-        "url-parse-lax": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "app/node_modules/has-flag": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "app/node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "license": "BSD-2-Clause"
     },
     "app/node_modules/https-proxy-agent": {
       "version": "5.0.0",
@@ -668,39 +262,6 @@
       "version": "2.0.4",
       "license": "ISC"
     },
-    "app/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "app/node_modules/json-buffer": {
-      "version": "3.0.0",
-      "license": "MIT"
-    },
-    "app/node_modules/keyv": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "json-buffer": "3.0.0"
-      }
-    },
-    "app/node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "license": "MIT"
-    },
-    "app/node_modules/long": {
-      "version": "4.0.0",
-      "license": "Apache-2.0"
-    },
-    "app/node_modules/lowercase-keys": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "app/node_modules/lru_map": {
       "version": "0.3.3",
       "license": "MIT"
@@ -722,16 +283,10 @@
         "node": ">= 0.6"
       }
     },
-    "app/node_modules/mimic-response": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "app/node_modules/min-dash": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
     },
     "app/node_modules/minimatch": {
       "version": "3.0.4",
@@ -772,25 +327,11 @@
         }
       }
     },
-    "app/node_modules/normalize-url": {
-      "version": "4.5.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "app/node_modules/once": {
       "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "app/node_modules/p-cancelable": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "app/node_modules/parents": {
@@ -814,129 +355,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "app/node_modules/prepend-http": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "app/node_modules/promise-retry": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^1.0.0",
-        "retry": "^0.10.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "app/node_modules/protobufjs": {
-      "version": "7.1.2",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "app/node_modules/protobufjs/node_modules/long": {
-      "version": "5.2.0",
-      "license": "Apache-2.0"
-    },
-    "app/node_modules/pump": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "app/node_modules/require-directory": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "app/node_modules/responselike": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "lowercase-keys": "^1.0.0"
-      }
-    },
-    "app/node_modules/retry": {
-      "version": "0.10.1",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "app/node_modules/stack-trace": {
-      "version": "0.0.10",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "app/node_modules/string-width": {
-      "version": "4.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "app/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "app/node_modules/strnum": {
-      "version": "1.0.5",
-      "license": "MIT"
-    },
-    "app/node_modules/supports-color": {
-      "version": "5.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "app/node_modules/to-readable-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "app/node_modules/tr46": {
       "version": "0.0.3",
       "license": "MIT"
@@ -944,27 +362,6 @@
     "app/node_modules/tslib": {
       "version": "1.14.1",
       "license": "0BSD"
-    },
-    "app/node_modules/typed-duration": {
-      "version": "1.0.13",
-      "license": "ISC"
-    },
-    "app/node_modules/url-parse-lax": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "prepend-http": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "app/node_modules/uuid": {
-      "version": "3.4.0",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "app/node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -978,111 +375,13 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "app/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "app/node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "app/node_modules/wrap-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "app/node_modules/wrap-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "license": "MIT"
-    },
     "app/node_modules/wrappy": {
       "version": "1.0.2",
       "license": "ISC"
     },
-    "app/node_modules/y18n": {
-      "version": "5.0.8",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "app/node_modules/yargs": {
-      "version": "16.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "app/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "app/node_modules/zeebe-node": {
-      "version": "8.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grpc/grpc-js": "^1.7.0",
-        "@grpc/proto-loader": "^0.7.2",
-        "chalk": "^2.4.2",
-        "console-stamp": "^3.0.2",
-        "dayjs": "^1.8.15",
-        "debug": "^4.2.0",
-        "fast-xml-parser": "^3.12.12",
-        "fp-ts": "^2.5.1",
-        "got": "^9.6.0",
-        "long": "^4.0.0",
-        "promise-retry": "^1.1.1",
-        "stack-trace": "0.0.10",
-        "typed-duration": "^1.0.12",
-        "uuid": "^3.3.2"
-      },
-      "bin": {
-        "zeebe-node": "bin/zeebe-node"
-      },
-      "engines": {
-        "node": ">=16.6.1"
-      }
-    },
     "client": {
       "name": "camunda-modeler-client",
-      "version": "5.5.0",
+      "version": "5.5.1",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/add-exporter": "^0.2.0",
@@ -1095,7 +394,7 @@
         "@camunda/execution-platform": "^0.3.2",
         "@camunda/form-linting": "^0.1.2",
         "@camunda/form-playground": "^0.2.0",
-        "@camunda/linting": "^0.10.0",
+        "@camunda/linting": "^0.7.2",
         "@codemirror/commands": "^6.1.0",
         "@codemirror/lang-json": "^6.0.0",
         "@codemirror/lang-xml": "^6.0.0",
@@ -1105,9 +404,9 @@
         "@ibm/plex": "^6.0.0",
         "@sentry/browser": "^6.3.6",
         "bpmn-js": "^10.2.1",
-        "bpmn-js-properties-panel": "^1.10.0",
+        "bpmn-js-properties-panel": "^1.11.2",
         "bpmn-moddle": "^8.0.0",
-        "camunda-bpmn-js": "^0.23.0",
+        "camunda-bpmn-js": "^0.21.1",
         "camunda-bpmn-moddle": "^7.0.1",
         "camunda-cmmn-moddle": "^1.0.0",
         "camunda-dmn-js": "^0.7.0",
@@ -1141,7 +440,7 @@
         "semver-compare": "^1.0.0",
         "sourcemapped-stacktrace": "^1.1.9",
         "ua-parser-js": "^0.7.28",
-        "zeebe-bpmn-moddle": "^0.16.0"
+        "zeebe-bpmn-moddle": "^0.15.0"
       },
       "devDependencies": {
         "@babel/core": "^7.4.3",
@@ -1983,11 +1282,13 @@
     },
     "client/node_modules/@bpmn-io/dmn-migrate/node_modules/min-dash": {
       "version": "3.8.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
     },
     "client/node_modules/@bpmn-io/element-templates-validator": {
       "version": "0.11.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.11.0.tgz",
+      "integrity": "sha512-4eZCPLuWf1N4lL8jIKZjWgwLJ2IUTgkQ4VDnfbDiSvjGJqHaLA4XBcC5smvb8Q/MqsJFxWZumolJJb1h7gt39Q==",
       "dependencies": {
         "@camunda/element-templates-json-schema": "^0.10.1",
         "@camunda/zeebe-element-templates-json-schema": "^0.6.0",
@@ -1997,14 +1298,16 @@
     },
     "client/node_modules/@bpmn-io/extract-process-variables": {
       "version": "0.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.6.0.tgz",
+      "integrity": "sha512-vq4jwGXDO11jwQgj9lvpVxVxjnRAz4C4TqPnhromcsllH5iRBrUNtBKgK0c/RWxiEGNTBhTYm19sP+LN1UcLWA==",
       "dependencies": {
         "min-dash": "^4.0.0"
       }
     },
     "client/node_modules/@bpmn-io/feel-editor": {
       "version": "0.4.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-0.4.1.tgz",
+      "integrity": "sha512-+UGpofI09xGxs1Rr/1V3NLeNSfeKrIGcWvwDY5M3xb4tP6nOQfwqmQA1761Wni9fl3RuLzf6gOx7vGWeQ7afIA==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.1.1",
         "@codemirror/commands": "^6.0.0",
@@ -2020,7 +1323,8 @@
     },
     "client/node_modules/@bpmn-io/properties-panel": {
       "version": "0.24.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.24.0.tgz",
+      "integrity": "sha512-eOkWrMHQqvzpYiTvSFEitoq6lu1uMvvuayB1Q/OfHgkTPZNCj6bAxxDbnXu2TR/oUxOFQ2200pituVhomJPq7w==",
       "dependencies": {
         "@bpmn-io/feel-editor": "0.4.1",
         "classnames": "^2.3.1",
@@ -2038,48 +1342,6 @@
       "peerDependencies": {
         "modeler-moddle": "^0.2.0"
       }
-    },
-    "client/node_modules/@camunda/linting": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-0.10.0.tgz",
-      "integrity": "sha512-xWIPMSdALFjH8G1svfmvvj7l8RL9DjNgPyc4bvZKXQtzbJebbyi1KLHf3eTAlnfmalOhQT1Hr6wJZrVMDe37pA==",
-      "dependencies": {
-        "bpmn-moddle": "^7.1.3",
-        "bpmnlint": "^8.0.0",
-        "bpmnlint-plugin-camunda-compat": "^0.15.1",
-        "bpmnlint-utils": "^1.0.2",
-        "min-dash": "^4.0.0",
-        "min-dom": "^4.0.1",
-        "zeebe-bpmn-moddle": "^0.15.0"
-      },
-      "peerDependencies": {
-        "bpmn-js-properties-panel": ">= 1.10.0"
-      },
-      "peerDependenciesMeta": {
-        "bpmn-js-properties-panel": {
-          "optional": true
-        }
-      }
-    },
-    "client/node_modules/@camunda/linting/node_modules/bpmn-moddle": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-7.1.3.tgz",
-      "integrity": "sha512-ZcBfw0NSOdYTSXFKEn7MOXHItz7VfLZTrFYKO8cK6V8ZzGjCcdiLIOiw7Lctw1PJsihhLiZQS8Htj2xKf+NwCg==",
-      "dependencies": {
-        "min-dash": "^3.5.2",
-        "moddle": "^5.0.2",
-        "moddle-xml": "^9.0.6"
-      }
-    },
-    "client/node_modules/@camunda/linting/node_modules/bpmn-moddle/node_modules/min-dash": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
-      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
-    },
-    "client/node_modules/@camunda/linting/node_modules/zeebe-bpmn-moddle": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.15.0.tgz",
-      "integrity": "sha512-cgn6bjkjrtOGcRumrgWnT1J93wTKmnFlSGGuwGXjF7pOksPF28ssbKiwKVMU6IXHnBDIVLQdf8fVNZn7JiBtQQ=="
     },
     "client/node_modules/@codemirror/lang-xml": {
       "version": "6.0.0",
@@ -2473,13 +1735,13 @@
       "license": "ISC"
     },
     "client/node_modules/bpmn-js": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-10.3.0.tgz",
-      "integrity": "sha512-6tO5SHt5YyxgX9lRAAwYNmtSum4ZAekP6S0kdDlmh2ztDRAjUZaq7n1Q1ORzTddpngviRZyf5ssP1ZqjE6CgUQ==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-10.2.1.tgz",
+      "integrity": "sha512-7ejbrq0CXQXon6oTUH4Dfq+KbNWsD7TXN0GTu1e5PA5V/w9s4bDTd95c+6/1ltJNOyYi6zwBFh5jjuEpAJGbVQ==",
       "dependencies": {
         "bpmn-moddle": "^8.0.0",
         "css.escape": "^1.5.1",
-        "diagram-js": "^10.0.0",
+        "diagram-js": "^9.1.0",
         "diagram-js-direct-editing": "^2.0.0",
         "ids": "^1.0.0",
         "inherits-browser": "^0.1.0",
@@ -2491,7 +1753,8 @@
     },
     "client/node_modules/bpmn-js-properties-panel": {
       "version": "1.11.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.11.2.tgz",
+      "integrity": "sha512-gaaf+0nzdUVe4TuJHURXSnVQLZgvmwMapIAp3/KlNg8U2b3PBGLdcpgUGhvjhnYZZI5fQSV6u91kRshbJ8rrkA==",
       "dependencies": {
         "@bpmn-io/element-templates-validator": "^0.11.0",
         "@bpmn-io/extract-process-variables": "^0.6.0",
@@ -2510,29 +1773,15 @@
         "diagram-js": ">= 7"
       }
     },
-    "client/node_modules/bpmn-js/node_modules/diagram-js": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-10.0.0.tgz",
-      "integrity": "sha512-VtZof5MLwVpHjTznfS7B1rQxYtpJ1Gyzse7Aan22QgMhD8FDpm0nXcIblkB//05vFJUljJfp9etNujJtmU1yvA==",
-      "dependencies": {
-        "css.escape": "^1.5.1",
-        "didi": "^9.0.0",
-        "hammerjs": "^2.0.1",
-        "inherits-browser": "^0.1.0",
-        "min-dash": "^4.0.0",
-        "min-dom": "^4.0.2",
-        "object-refs": "^0.3.0",
-        "path-intersection": "^2.2.1",
-        "tiny-svg": "^3.0.0"
-      }
-    },
     "client/node_modules/bpmn-js/node_modules/tiny-svg": {
       "version": "3.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
+      "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w=="
     },
     "client/node_modules/bpmn-moddle": {
       "version": "8.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-8.0.0.tgz",
+      "integrity": "sha512-mHmtIVzUyZcPMKKl/REq151gYxEtZxvivKnIEp/RtuRm8SOgxAK58uYBkP+jQQBy6XudwObRTH0pwyeKLALWrA==",
       "dependencies": {
         "min-dash": "^4.0.0",
         "moddle": "^6.0.0",
@@ -2541,36 +1790,21 @@
     },
     "client/node_modules/bpmn-moddle/node_modules/moddle": {
       "version": "6.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/moddle/-/moddle-6.0.0.tgz",
+      "integrity": "sha512-dHYSJpGV0R0X8cJeWWUnE0VqCA0SFP0jZYQtO23EdsBk+MpAgSpdhXadYR6WbHElKroB6XTbifpsWro26UlP6Q==",
       "dependencies": {
         "min-dash": "^4.0.0"
       }
     },
     "client/node_modules/bpmn-moddle/node_modules/moddle-xml": {
       "version": "10.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-10.0.0.tgz",
+      "integrity": "sha512-e5qG0uC9ebHXInLEKW9pZNqcAK7ALCOKmcLw8jmepBPY9BiUZFi+8Th/Cydog3S1rrUXyyo0pqaHaCvc1zt6VA==",
       "dependencies": {
         "min-dash": "^4.0.0",
         "moddle": "^6.0.0",
         "saxen": "^8.1.2"
       }
-    },
-    "client/node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.15.2.tgz",
-      "integrity": "sha512-Ah30wOH/NoSKtLF4W+SBRbkCV9qT+Jf2p4JYUcO1K05/3sh4d6j0cO4BMHBt/HTgK94JSstDaopXA4NxeJww5g==",
-      "dependencies": {
-        "@bpmn-io/feel-lint": "^0.1.0",
-        "@bpmn-io/moddle-utils": "^0.1.0",
-        "bpmnlint-utils": "^1.0.2",
-        "min-dash": "^3.8.1",
-        "semver-compare": "^1.0.0"
-      }
-    },
-    "client/node_modules/bpmnlint-plugin-camunda-compat/node_modules/min-dash": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
-      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
     },
     "client/node_modules/braces": {
       "version": "3.0.2",
@@ -2584,30 +1818,33 @@
       }
     },
     "client/node_modules/camunda-bpmn-js": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-0.23.1.tgz",
-      "integrity": "sha512-aTWc02X+DA04tubC3MzA2PxpmmIoohsaPjoF3TDwNIsonzOZMSxpu6j+ZOnGdW4mKFIIqsLPXMKyM9imeurJuQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-0.21.1.tgz",
+      "integrity": "sha512-ZB5g+tkdegEW+ax4m4jKG0/n79y1amDyr0+1HFSUb+jGzta6pu+2kc9M2BnJa5Zq5Jm3iNHWdMgoI6+u6KTrPg==",
       "dependencies": {
         "@bpmn-io/align-to-origin": "^0.7.0",
         "@bpmn-io/element-templates-icons-renderer": "^0.3.0",
-        "bpmn-js": "^10.3.0",
+        "bpmn-js": "^10.2.0",
+        "bpmn-js-disable-collapsed-subprocess": "^0.1.7",
         "bpmn-js-executable-fix": "^0.2.0",
-        "camunda-bpmn-js-behaviors": "^0.4.0",
+        "camunda-bpmn-js-behaviors": "^0.3.0",
         "camunda-bpmn-moddle": "^7.0.1",
-        "diagram-js": "^10.0.0",
+        "diagram-js": "^9.1.0",
         "diagram-js-minimap": "^3.0.0",
         "diagram-js-origin": "^1.3.4",
         "inherits": "^2.0.4",
         "min-dash": "^4.0.0",
-        "zeebe-bpmn-moddle": "^0.16.0"
+        "zeebe-bpmn-moddle": "^0.15.0"
       },
       "peerDependencies": {
-        "bpmn-js-properties-panel": ">= 1.11.1"
+        "bpmn-js-properties-panel": ">= 1.10.0"
       }
     },
     "client/node_modules/camunda-bpmn-js-behaviors": {
       "version": "0.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-0.4.0.tgz",
+      "integrity": "sha512-Scyc2n85HLPTdvnTCE8rdU0AwuWkdvsq19JZkXhIuTdT9qeUY+FnuIlpa+H0OIvf4E/R0Vkn4mc4LkePUQPRdg==",
+      "peer": true,
       "dependencies": {
         "ids": "^1.0.0",
         "min-dash": "^4.0.0"
@@ -2618,26 +1855,19 @@
         "zeebe-bpmn-moddle": ">= 0.15"
       }
     },
-    "client/node_modules/camunda-bpmn-js/node_modules/diagram-js": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-10.0.0.tgz",
-      "integrity": "sha512-VtZof5MLwVpHjTznfS7B1rQxYtpJ1Gyzse7Aan22QgMhD8FDpm0nXcIblkB//05vFJUljJfp9etNujJtmU1yvA==",
+    "client/node_modules/camunda-bpmn-js/node_modules/camunda-bpmn-js-behaviors": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-0.3.0.tgz",
+      "integrity": "sha512-isD424Lwgh4+v3IWDnqLkkA/oIQcwFHQ6TmxUYBNuF5WshO25a2u/6SgAtBiWpg2xqjD5x8zi5/0JWr/Yp7WEg==",
       "dependencies": {
-        "css.escape": "^1.5.1",
-        "didi": "^9.0.0",
-        "hammerjs": "^2.0.1",
-        "inherits-browser": "^0.1.0",
-        "min-dash": "^4.0.0",
-        "min-dom": "^4.0.2",
-        "object-refs": "^0.3.0",
-        "path-intersection": "^2.2.1",
-        "tiny-svg": "^3.0.0"
+        "ids": "^1.0.0",
+        "min-dash": "^4.0.0"
+      },
+      "peerDependencies": {
+        "bpmn-js": ">= 9",
+        "camunda-bpmn-moddle": ">= 7",
+        "zeebe-bpmn-moddle": ">= 0.15"
       }
-    },
-    "client/node_modules/camunda-bpmn-js/node_modules/tiny-svg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
-      "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w=="
     },
     "client/node_modules/camunda-cmmn-moddle": {
       "version": "1.0.0",
@@ -2645,7 +1875,8 @@
     },
     "client/node_modules/camunda-dmn-js": {
       "version": "0.7.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/camunda-dmn-js/-/camunda-dmn-js-0.7.0.tgz",
+      "integrity": "sha512-FR6CT+nDrmmEmmJYtPzTd72S8FBNl5JIH2o7A2zFRXStQqTPrCekO7JaMcSUPpYaCEAPxVnFIf1ONx10Sv2TRg==",
       "dependencies": {
         "@bpmn-io/align-to-origin": "^0.7.0",
         "camunda-dmn-moddle": "^1.1.0",
@@ -2910,8 +2141,9 @@
     },
     "client/node_modules/commander": {
       "version": "2.20.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "client/node_modules/copy-anything": {
       "version": "2.0.6",
@@ -3176,7 +2408,8 @@
     },
     "client/node_modules/diagram-js": {
       "version": "9.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-9.1.0.tgz",
+      "integrity": "sha512-Kh74c7iKczxrDmnnRn3Fay8+1AnOIEm22A7yxPP/1jyfGiGM1Thxp08niKru60HSpFyOguhYu4jgqOSM9fJzdw==",
       "dependencies": {
         "css.escape": "^1.5.1",
         "didi": "^9.0.0",
@@ -3191,7 +2424,8 @@
     },
     "client/node_modules/diagram-js-direct-editing": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-2.0.0.tgz",
+      "integrity": "sha512-/12OWL0B0RMCfaT1w3723c729MD42r5fay4wtm2DvxNFNBMdPaEvOHCTA/khLKjFzOzMVKxSzbAp7IEwBGonVw==",
       "dependencies": {
         "min-dash": "^4.0.0",
         "min-dom": "^4.0.2"
@@ -3200,18 +2434,20 @@
         "diagram-js": "*"
       }
     },
-    "client/node_modules/diagram-js/node_modules/path-intersection": {
-      "version": "2.2.1",
-      "license": "MIT"
-    },
-    "client/node_modules/diagram-js/node_modules/tiny-svg": {
-      "version": "3.0.0",
-      "license": "MIT"
-    },
-    "client/node_modules/didi": {
+    "client/node_modules/diagram-js/node_modules/didi": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
       "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w=="
+    },
+    "client/node_modules/diagram-js/node_modules/path-intersection": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
+      "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA=="
+    },
+    "client/node_modules/diagram-js/node_modules/tiny-svg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
+      "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w=="
     },
     "client/node_modules/diff": {
       "version": "5.1.0",
@@ -3228,7 +2464,8 @@
     },
     "client/node_modules/dmn-js": {
       "version": "13.0.0",
-      "license": "SEE LICENSE IN LICENSE",
+      "resolved": "https://registry.npmjs.org/dmn-js/-/dmn-js-13.0.0.tgz",
+      "integrity": "sha512-NEzFJhmAu3zF2V0zJ713fLrEjkRz24DdafWA9sdyVjkura8G5Ct97pmSX5g/JRbL4UjAkzwpmbUlfuXbqHLTig==",
       "dependencies": {
         "dmn-js-decision-table": "^13.0.0",
         "dmn-js-drd": "^13.0.0",
@@ -3238,7 +2475,8 @@
     },
     "client/node_modules/dmn-js-decision-table": {
       "version": "13.0.0",
-      "license": "SEE LICENSE IN LICENSE",
+      "resolved": "https://registry.npmjs.org/dmn-js-decision-table/-/dmn-js-decision-table-13.0.0.tgz",
+      "integrity": "sha512-pLhD7+hYG3++Ce8xmYNY18lvUmW8aljNiKMLa0Dsl0lKoO2Sg4dPeqrUOR2oY8ESZEIOYCtIEj3w7c3dJWwGvg==",
       "dependencies": {
         "css.escape": "^1.5.1",
         "diagram-js": "^8.8.0",
@@ -3253,7 +2491,8 @@
     },
     "client/node_modules/dmn-js-decision-table/node_modules/diagram-js": {
       "version": "8.9.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.9.0.tgz",
+      "integrity": "sha512-577bUEbkwZ7id4SCXcD2qrlKoRPXry2SDSPt5T6tEOjwKrTllKr5d1HZoJzGws4VMQq5fmY51Gce1iFT9S4Dlw==",
       "dependencies": {
         "css.escape": "^1.5.1",
         "didi": "^8.0.1",
@@ -3268,19 +2507,23 @@
     },
     "client/node_modules/dmn-js-decision-table/node_modules/didi": {
       "version": "8.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.2.tgz",
+      "integrity": "sha512-Wpq46GzfER5kVkqFCJtHTXsdlqh6SRPA60jTrKECQ1cl84/ALpQJrqAFlEXpue+Lxi7/6xzFIxC5V3UsS/x9aA=="
     },
     "client/node_modules/dmn-js-decision-table/node_modules/inherits-browser": {
       "version": "0.0.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.0.1.tgz",
+      "integrity": "sha512-kaDA3DkCdCpvrKIo/1T/3yVn+qpFUHLjYtSHmTYewb+QfjfaQy6FGQ7LwBu7st0tG9UvYad/XAlqQmdIh6CICw=="
     },
     "client/node_modules/dmn-js-decision-table/node_modules/min-dash": {
       "version": "3.8.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
     },
     "client/node_modules/dmn-js-decision-table/node_modules/min-dom": {
       "version": "3.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
+      "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
       "dependencies": {
         "component-event": "^0.1.4",
         "domify": "^1.3.1",
@@ -3291,11 +2534,13 @@
     },
     "client/node_modules/dmn-js-decision-table/node_modules/path-intersection": {
       "version": "2.2.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
+      "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA=="
     },
     "client/node_modules/dmn-js-drd": {
       "version": "13.0.0",
-      "license": "SEE LICENSE IN LICENSE",
+      "resolved": "https://registry.npmjs.org/dmn-js-drd/-/dmn-js-drd-13.0.0.tgz",
+      "integrity": "sha512-wg59lKe0O64J0vEIancPNLAg9SDti+Z2uNZL7JXIIq/CCox+hFAhp7YzXB/pJnIiv1+roP79RF3Ln4V5Gl+CHg==",
       "dependencies": {
         "diagram-js": "^8.8.0",
         "diagram-js-direct-editing": "^1.6.3",
@@ -3309,7 +2554,8 @@
     },
     "client/node_modules/dmn-js-drd/node_modules/diagram-js": {
       "version": "8.9.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.9.0.tgz",
+      "integrity": "sha512-577bUEbkwZ7id4SCXcD2qrlKoRPXry2SDSPt5T6tEOjwKrTllKr5d1HZoJzGws4VMQq5fmY51Gce1iFT9S4Dlw==",
       "dependencies": {
         "css.escape": "^1.5.1",
         "didi": "^8.0.1",
@@ -3324,7 +2570,8 @@
     },
     "client/node_modules/dmn-js-drd/node_modules/diagram-js-direct-editing": {
       "version": "1.8.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-1.8.0.tgz",
+      "integrity": "sha512-B4Xj+PJfgBjbPEzT3uZQEkZI5xHFB0Izc+7BhDFuHidzrEMzQKZrFGdA3PqfWhReHf3dp+iB6Tt11G9eGNjKMw==",
       "dependencies": {
         "min-dash": "^3.5.2",
         "min-dom": "^3.1.3"
@@ -3335,19 +2582,23 @@
     },
     "client/node_modules/dmn-js-drd/node_modules/diagram-js/node_modules/inherits-browser": {
       "version": "0.0.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.0.1.tgz",
+      "integrity": "sha512-kaDA3DkCdCpvrKIo/1T/3yVn+qpFUHLjYtSHmTYewb+QfjfaQy6FGQ7LwBu7st0tG9UvYad/XAlqQmdIh6CICw=="
     },
     "client/node_modules/dmn-js-drd/node_modules/didi": {
       "version": "8.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.2.tgz",
+      "integrity": "sha512-Wpq46GzfER5kVkqFCJtHTXsdlqh6SRPA60jTrKECQ1cl84/ALpQJrqAFlEXpue+Lxi7/6xzFIxC5V3UsS/x9aA=="
     },
     "client/node_modules/dmn-js-drd/node_modules/min-dash": {
       "version": "3.8.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
     },
     "client/node_modules/dmn-js-drd/node_modules/min-dom": {
       "version": "3.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
+      "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
       "dependencies": {
         "component-event": "^0.1.4",
         "domify": "^1.3.1",
@@ -3358,11 +2609,13 @@
     },
     "client/node_modules/dmn-js-drd/node_modules/path-intersection": {
       "version": "2.2.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
+      "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA=="
     },
     "client/node_modules/dmn-js-literal-expression": {
       "version": "13.0.0",
-      "license": "SEE LICENSE IN LICENSE",
+      "resolved": "https://registry.npmjs.org/dmn-js-literal-expression/-/dmn-js-literal-expression-13.0.0.tgz",
+      "integrity": "sha512-WxUQ52ZQCh1mGjInBKBAEKZ4e4d1yp3iZ9aH32Ncv4Sjw9x3CEZsNX1JTmrZx6Fi+va6nxwRjnNkLePJu4NkXw==",
       "dependencies": {
         "diagram-js": "^8.8.0",
         "dmn-js-shared": "^13.0.0",
@@ -3375,7 +2628,8 @@
     },
     "client/node_modules/dmn-js-literal-expression/node_modules/diagram-js": {
       "version": "8.9.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.9.0.tgz",
+      "integrity": "sha512-577bUEbkwZ7id4SCXcD2qrlKoRPXry2SDSPt5T6tEOjwKrTllKr5d1HZoJzGws4VMQq5fmY51Gce1iFT9S4Dlw==",
       "dependencies": {
         "css.escape": "^1.5.1",
         "didi": "^8.0.1",
@@ -3390,19 +2644,23 @@
     },
     "client/node_modules/dmn-js-literal-expression/node_modules/didi": {
       "version": "8.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.2.tgz",
+      "integrity": "sha512-Wpq46GzfER5kVkqFCJtHTXsdlqh6SRPA60jTrKECQ1cl84/ALpQJrqAFlEXpue+Lxi7/6xzFIxC5V3UsS/x9aA=="
     },
     "client/node_modules/dmn-js-literal-expression/node_modules/inherits-browser": {
       "version": "0.0.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.0.1.tgz",
+      "integrity": "sha512-kaDA3DkCdCpvrKIo/1T/3yVn+qpFUHLjYtSHmTYewb+QfjfaQy6FGQ7LwBu7st0tG9UvYad/XAlqQmdIh6CICw=="
     },
     "client/node_modules/dmn-js-literal-expression/node_modules/min-dash": {
       "version": "3.8.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
     },
     "client/node_modules/dmn-js-literal-expression/node_modules/min-dom": {
       "version": "3.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
+      "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
       "dependencies": {
         "component-event": "^0.1.4",
         "domify": "^1.3.1",
@@ -3413,11 +2671,13 @@
     },
     "client/node_modules/dmn-js-literal-expression/node_modules/path-intersection": {
       "version": "2.2.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
+      "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA=="
     },
     "client/node_modules/dmn-js-shared": {
       "version": "13.0.0",
-      "license": "SEE LICENSE IN LICENSE",
+      "resolved": "https://registry.npmjs.org/dmn-js-shared/-/dmn-js-shared-13.0.0.tgz",
+      "integrity": "sha512-Li3nobue4IzHPY/phZfCgRtg4vr3OYIYPTBYJIcgjz33XyclvVzGFPbUziEHGC35pIM3YjaUNbwXCgaAKR2cvw==",
       "dependencies": {
         "diagram-js": "^8.8.0",
         "didi": "^8.0.1",
@@ -3433,7 +2693,8 @@
     },
     "client/node_modules/dmn-js-shared/node_modules/diagram-js": {
       "version": "8.9.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.9.0.tgz",
+      "integrity": "sha512-577bUEbkwZ7id4SCXcD2qrlKoRPXry2SDSPt5T6tEOjwKrTllKr5d1HZoJzGws4VMQq5fmY51Gce1iFT9S4Dlw==",
       "dependencies": {
         "css.escape": "^1.5.1",
         "didi": "^8.0.1",
@@ -3448,11 +2709,13 @@
     },
     "client/node_modules/dmn-js-shared/node_modules/didi": {
       "version": "8.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.2.tgz",
+      "integrity": "sha512-Wpq46GzfER5kVkqFCJtHTXsdlqh6SRPA60jTrKECQ1cl84/ALpQJrqAFlEXpue+Lxi7/6xzFIxC5V3UsS/x9aA=="
     },
     "client/node_modules/dmn-js-shared/node_modules/dmn-moddle": {
       "version": "10.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/dmn-moddle/-/dmn-moddle-10.0.0.tgz",
+      "integrity": "sha512-JD08qH2VqA7O54qCQFrGruwGyVovow+9g2O5/ww0KpC/n0mvuua117dz2CONiUWexJxq/dOAaMjrQwkWnK+oEA==",
       "dependencies": {
         "min-dash": "^3.0.0",
         "moddle": "^5.0.1",
@@ -3461,22 +2724,26 @@
     },
     "client/node_modules/dmn-js-shared/node_modules/ids": {
       "version": "0.2.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ids/-/ids-0.2.2.tgz",
+      "integrity": "sha512-icIO8S7A7Hat9x/59VYjS5uwfBU1xRTDxeFC4t9wNceLxZFm2JbPhO4lC/xhFqFNVaxw2idwpLgUfkVQrjsxIw==",
       "dependencies": {
         "hat": "^0.0.3"
       }
     },
     "client/node_modules/dmn-js-shared/node_modules/inherits-browser": {
       "version": "0.0.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.0.1.tgz",
+      "integrity": "sha512-kaDA3DkCdCpvrKIo/1T/3yVn+qpFUHLjYtSHmTYewb+QfjfaQy6FGQ7LwBu7st0tG9UvYad/XAlqQmdIh6CICw=="
     },
     "client/node_modules/dmn-js-shared/node_modules/min-dash": {
       "version": "3.8.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
     },
     "client/node_modules/dmn-js-shared/node_modules/min-dom": {
       "version": "3.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
+      "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
       "dependencies": {
         "component-event": "^0.1.4",
         "domify": "^1.3.1",
@@ -3487,14 +2754,16 @@
     },
     "client/node_modules/dmn-js-shared/node_modules/moddle": {
       "version": "5.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/moddle/-/moddle-5.0.4.tgz",
+      "integrity": "sha512-Kjb+hjuzO+YlojNGxEUXvdhLYTHTtAABDlDcJTtTcn5MbJF9Zkv4I1Fyvp3Ypmfgg1EfHDZ3PsCQTuML9JD6wg==",
       "dependencies": {
         "min-dash": "^3.0.0"
       }
     },
     "client/node_modules/dmn-js-shared/node_modules/moddle-xml": {
       "version": "9.0.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-9.0.6.tgz",
+      "integrity": "sha512-tl0reHpsY/aKlLGhXeFlQWlYAQHFxTkFqC8tq8jXRYpQSnLVw13T6swMaourLd7EXqHdWsc+5ggsB+fEep6xZQ==",
       "dependencies": {
         "min-dash": "^3.5.2",
         "moddle": "^5.0.2",
@@ -3503,7 +2772,8 @@
     },
     "client/node_modules/dmn-js-shared/node_modules/path-intersection": {
       "version": "2.2.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
+      "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA=="
     },
     "client/node_modules/dmn-moddle": {
       "version": "8.0.4",
@@ -3516,7 +2786,8 @@
     },
     "client/node_modules/dmn-moddle/node_modules/min-dash": {
       "version": "3.8.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
     },
     "client/node_modules/dmn-moddle/node_modules/moddle": {
       "version": "5.0.1",
@@ -3559,11 +2830,13 @@
     },
     "client/node_modules/drag-tabs/node_modules/min-dash": {
       "version": "3.8.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
     },
     "client/node_modules/drag-tabs/node_modules/min-dom": {
       "version": "3.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
+      "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
       "dependencies": {
         "component-event": "^0.1.4",
         "domify": "^1.3.1",
@@ -4032,7 +3305,8 @@
     },
     "client/node_modules/lezer-feel": {
       "version": "0.14.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.14.1.tgz",
+      "integrity": "sha512-sfpzZvAtObFon74XiFp1L8pS1FminnfM8JAm4S2Kxk7Wk8qYe7crjJdhHqju/MKl9dV5s44NHDhbq5tCDWMTlw==",
       "dependencies": {
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.2.3"
@@ -4109,11 +3383,13 @@
     },
     "client/node_modules/min-dash": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
     },
     "client/node_modules/min-dom": {
       "version": "4.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.0.3.tgz",
+      "integrity": "sha512-5zQyCMe8rtGiDIRjfGeqnF2YPJ7OAPFdJQeC7MakHais3dh4VG4PV2a0FacziKTzJjYK5qnPKm2sq1wSXB1wTQ==",
       "dependencies": {
         "component-event": "^0.1.4",
         "domify": "^1.4.1",
@@ -4917,11 +4193,6 @@
         "node": ">=0.1"
       }
     },
-    "client/node_modules/zeebe-bpmn-moddle": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.16.0.tgz",
-      "integrity": "sha512-Fr6NqtWWl604wMnEKis8CIyyi4DGSPsFaGB4rm4bwjbOY2O3d1UrvFS4LnOAxUi6SH8Q1agdBU1GjUXYz5pAtA=="
-    },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
       "dev": true,
@@ -5257,7 +4528,8 @@
     },
     "node_modules/@bpmn-io/element-templates-icons-renderer": {
       "version": "0.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-icons-renderer/-/element-templates-icons-renderer-0.3.0.tgz",
+      "integrity": "sha512-F6UWtjqkd1CmMoiGk+cl4m3JjGzR37e+8lO7OsW9NncMpY3Xxcafn6kPaLBfJDhiwAlFzK6jMd9/cSs5YRXusQ==",
       "dependencies": {
         "inherits": "^2.0.4",
         "tiny-svg": "^3.0.0"
@@ -5269,7 +4541,29 @@
     },
     "node_modules/@bpmn-io/element-templates-icons-renderer/node_modules/tiny-svg": {
       "version": "3.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
+      "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w=="
+    },
+    "node_modules/@bpmn-io/element-templates-validator": {
+      "version": "0.10.0",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@camunda/element-templates-json-schema": "^0.10.1",
+        "@camunda/zeebe-element-templates-json-schema": "^0.6.0",
+        "json-source-map": "^0.6.1",
+        "min-dash": "^3.8.1"
+      }
+    },
+    "node_modules/@bpmn-io/extract-process-variables": {
+      "version": "0.5.1",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "min-dash": "^3.8.1"
+      }
     },
     "node_modules/@bpmn-io/feel-editor": {
       "version": "0.3.0",
@@ -5286,27 +4580,10 @@
         "lezer-feel": "^0.4.0"
       }
     },
-    "node_modules/@bpmn-io/feel-lint": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-0.1.0.tgz",
-      "integrity": "sha512-Ryc2EP0kJx1e5gYghqEg60gEoEz/zFRsyISSFRTRC+Fz3MGjbscHSWitPaXs2Hb0BvgRWA4zSx+Jc2oOvV6LSQ==",
-      "dependencies": {
-        "@codemirror/language": "^6.2.1",
-        "lezer-feel": "^0.14.1"
-      }
-    },
-    "node_modules/@bpmn-io/feel-lint/node_modules/lezer-feel": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.14.1.tgz",
-      "integrity": "sha512-sfpzZvAtObFon74XiFp1L8pS1FminnfM8JAm4S2Kxk7Wk8qYe7crjJdhHqju/MKl9dV5s44NHDhbq5tCDWMTlw==",
-      "dependencies": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.2.3"
-      }
-    },
     "node_modules/@bpmn-io/form-js": {
       "version": "0.9.9",
-      "license": "SEE LICENSE IN LICENSE",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js/-/form-js-0.9.9.tgz",
+      "integrity": "sha512-r428u/eWDV7J2kwJTNaHnUig60ZvAEfqG8At5uYP1/ReHNdnJttrff6g2RktYV6K5F6+au1RR139ej4ahfudZA==",
       "dependencies": {
         "@bpmn-io/form-js-editor": "^0.9.9",
         "@bpmn-io/form-js-playground": "^0.9.9",
@@ -5315,7 +4592,8 @@
     },
     "node_modules/@bpmn-io/form-js-editor": {
       "version": "0.9.9",
-      "license": "SEE LICENSE IN LICENSE",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-editor/-/form-js-editor-0.9.9.tgz",
+      "integrity": "sha512-ek1ySA354QgAoN4ZnaTTbg2TNTf+ZPy4BVix2pbdh7Neg3dGki6KPX1ANqd1TAAHAplkuHdXGEZEI815PxA1+w==",
       "dependencies": {
         "@bpmn-io/form-js-viewer": "^0.9.9",
         "array-move": "^3.0.1",
@@ -5328,11 +4606,13 @@
     },
     "node_modules/@bpmn-io/form-js-editor/node_modules/min-dash": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
     },
     "node_modules/@bpmn-io/form-js-editor/node_modules/min-dom": {
       "version": "4.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.0.3.tgz",
+      "integrity": "sha512-5zQyCMe8rtGiDIRjfGeqnF2YPJ7OAPFdJQeC7MakHais3dh4VG4PV2a0FacziKTzJjYK5qnPKm2sq1wSXB1wTQ==",
       "dependencies": {
         "component-event": "^0.1.4",
         "domify": "^1.4.1",
@@ -5341,7 +4621,8 @@
     },
     "node_modules/@bpmn-io/form-js-playground": {
       "version": "0.9.9",
-      "license": "SEE LICENSE IN LICENSE",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-playground/-/form-js-playground-0.9.9.tgz",
+      "integrity": "sha512-XmdPFUpMjlnCRymEOwsFyjLNCm0VnHXWkxk4SEAGMJ6xj4uMSWoU3OYYDRQjEzoO67EpE5NmL8MhPE23n/CDoA==",
       "dependencies": {
         "@bpmn-io/form-js-editor": "^0.9.9",
         "@bpmn-io/form-js-viewer": "^0.9.9",
@@ -5358,7 +4639,8 @@
     },
     "node_modules/@bpmn-io/form-js-viewer": {
       "version": "0.9.9",
-      "license": "SEE LICENSE IN LICENSE",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-viewer/-/form-js-viewer-0.9.9.tgz",
+      "integrity": "sha512-8V7iW1t2JrqK8E7AFb1c002Q7nx0OWVUvEiMZ1aznAk1hGgCzTg6JFltSdm77ARkVeH7kg8bHYWqrNkbWOswUw==",
       "dependencies": {
         "@bpmn-io/snarkdown": "^2.1.0",
         "classnames": "^2.3.1",
@@ -5371,15 +4653,18 @@
     },
     "node_modules/@bpmn-io/form-js-viewer/node_modules/didi": {
       "version": "9.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
+      "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w=="
     },
     "node_modules/@bpmn-io/form-js-viewer/node_modules/min-dash": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
     },
     "node_modules/@bpmn-io/moddle-utils": {
       "version": "0.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/moddle-utils/-/moddle-utils-0.1.0.tgz",
+      "integrity": "sha512-2hon5+Lv1MCRz/O6j3xaayTltQXjIu+JEqCIwgRJco5l9eqY3liHOR2eih0bDRjnVmGXC9nS/r2s46FiULxwNw==",
       "dependencies": {
         "min-dash": "^3.8.1"
       }
@@ -5398,7 +4683,8 @@
     },
     "node_modules/@bpmn-io/snarkdown": {
       "version": "2.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@bpmn-io/snarkdown/-/snarkdown-2.1.0.tgz",
+      "integrity": "sha512-OWe9YQx3Vtnopz0trJCJVI3y7k2EfeR4QkKHfRhukcB7yxG4PD1FGaB5LAxc1wxp66V1S3LU4bqUpJdVhQhIww=="
     },
     "node_modules/@camunda/element-templates-json-schema": {
       "version": "0.10.1",
@@ -5406,17 +4692,16 @@
     },
     "node_modules/@camunda/form-linting": {
       "version": "0.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@camunda/form-linting/-/form-linting-0.1.2.tgz",
+      "integrity": "sha512-U2DQcea0xPeE7xoTqcydYfbNRDvzeWbnV7111dXll3UsbS7dq7QeaM/fxjEGmEsEe79/5IuQOfLmNpyE6dblGw==",
       "dependencies": {
         "semver-compare": "^1.0.0"
       }
     },
     "node_modules/@camunda/form-playground": {
       "version": "0.2.0",
-      "license": "MIT",
-      "workspaces": [
-        "example"
-      ],
+      "resolved": "https://registry.npmjs.org/@camunda/form-playground/-/form-playground-0.2.0.tgz",
+      "integrity": "sha512-aqGD0+ps0q74jVDlpH2GFHjIovS4fT3qHyViAAGGYYgPZQZbAb9w6wVRA3x/As+9Yq7UfzHJoTeDxv/QO63TBQ==",
       "dependencies": {
         "classnames": "^2.3.1",
         "htm": "^3.1.1",
@@ -5431,16 +4716,96 @@
     },
     "node_modules/@camunda/form-playground/node_modules/min-dash": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
     },
     "node_modules/@camunda/form-playground/node_modules/min-dom": {
       "version": "4.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.0.3.tgz",
+      "integrity": "sha512-5zQyCMe8rtGiDIRjfGeqnF2YPJ7OAPFdJQeC7MakHais3dh4VG4PV2a0FacziKTzJjYK5qnPKm2sq1wSXB1wTQ==",
       "dependencies": {
         "component-event": "^0.1.4",
         "domify": "^1.4.1",
         "min-dash": "^4.0.0"
       }
+    },
+    "node_modules/@camunda/linting": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-0.7.2.tgz",
+      "integrity": "sha512-zzFvcgx0TPf4n0gObU6jXCx8aJAV0MgshTye1eG8NyUOix+kOZTqErfbcGBsIi4zmVTdBLjxshRt4tFGdOge2A==",
+      "dependencies": {
+        "bpmn-moddle": "^7.1.3",
+        "bpmnlint": "^8.0.0",
+        "bpmnlint-plugin-camunda-compat": "^0.13.1",
+        "bpmnlint-utils": "^1.0.2",
+        "min-dash": "^4.0.0",
+        "min-dom": "^4.0.1",
+        "zeebe-bpmn-moddle": "^0.15.0"
+      },
+      "peerDependencies": {
+        "bpmn-js-properties-panel": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "bpmn-js-properties-panel": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@camunda/linting/node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@camunda/linting/node_modules/bpmnlint": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-8.1.0.tgz",
+      "integrity": "sha512-mFt92TQMo5nFjoumngZ8mYCLYQ4fETNjoe4U0X76lnArKSm/CfJj5Y2U3wtQapd5zirbZFa9kuX/cdKzajZzcQ==",
+      "dependencies": {
+        "@bpmn-io/moddle-utils": "^0.1.0",
+        "ansi-colors": "^4.1.3",
+        "bpmn-moddle": "^7.1.3",
+        "bpmnlint-utils": "^1.0.2",
+        "cli-table": "^0.3.11",
+        "color-support": "^1.1.3",
+        "min-dash": "^3.8.1",
+        "mri": "^1.2.0",
+        "pluralize": "^7.0.0",
+        "tiny-glob": "^0.2.9"
+      },
+      "bin": {
+        "bpmnlint": "bin/bpmnlint.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@camunda/linting/node_modules/bpmnlint/node_modules/min-dash": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
+    },
+    "node_modules/@camunda/linting/node_modules/min-dash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
+    },
+    "node_modules/@camunda/linting/node_modules/min-dom": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.0.1.tgz",
+      "integrity": "sha512-82fpjdsvbwJ2cqG2I1MMWaRN8fdDZ7e7QM05aYfzXXMhU050JrqEOGATAXrCh+OBs75doTBEKp8diOuu/UfdYA==",
+      "dependencies": {
+        "component-event": "^0.1.4",
+        "domify": "^1.4.1",
+        "min-dash": "^3.8.1"
+      }
+    },
+    "node_modules/@camunda/linting/node_modules/min-dom/node_modules/min-dash": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+      "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
       "version": "0.6.0",
@@ -5448,7 +4813,8 @@
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.3.0.tgz",
+      "integrity": "sha512-4jEvh3AjJZTDKazd10J6ZsCIqaYxDMCeua5ouQxY8hlFIml+nr7le0SgBhT3SIytFBmdzPK3AUhXGuW3T79nVg==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -5503,7 +4869,8 @@
     },
     "node_modules/@codemirror/search": {
       "version": "6.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.2.1.tgz",
+      "integrity": "sha512-Q1JgUSBjQZRPIddlXzad/AVDigdhriLxQNFyP0gfrDTq6LDHNhr95U/tW3bpVssGenkaLzujtu/7XoK4kyvL3g==",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -5533,8 +4900,9 @@
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+      "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.0",
         "ajv-keywords": "^3.4.1"
@@ -5549,8 +4917,9 @@
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -5607,8 +4976,9 @@
     },
     "node_modules/@electron/universal": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.2.1.tgz",
+      "integrity": "sha512-7323HyMh7KBAl/nPDppdLsC87G6RwRU02dy5FPeGB1eS7rUePh55+WNWiDPLhFQqqVPHzh77M69uhmoT8XnwMQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@malept/cross-spawn-promise": "^1.1.0",
         "asar": "^3.1.0",
@@ -5624,8 +4994,9 @@
     },
     "node_modules/@electron/universal/node_modules/fs-extra": {
       "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -5638,8 +5009,9 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
+      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -5663,10 +5035,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.0.tgz",
+      "integrity": "sha512-wvKxal+40Xx11DXO2q5PfY3UiE25iwTb8SOz6A9IJII/V7d19x2ex0he+GJfVW0JZCaBjCPSjUB0yU9Ecm4WCw==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.0",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.3.tgz",
+      "integrity": "sha512-5dAvoZwna2Py3Ef96Ux9jIkp3iZ62TUsV00p3wVBPNX5K178UbNi8Q7gQVqwXT1Yq9RejIGG9G2IPEo93T6RcA==",
+      "dependencies": {
+        "@types/long": "^4.0.1",
+        "lodash.camelcase": "^4.3.0",
+        "long": "^4.0.0",
+        "protobufjs": "^7.0.0",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
+      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
@@ -5678,8 +5081,9 @@
     },
     "node_modules/@humanwhocodes/gitignore-to-minimatch": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
+      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
       "dev": true,
-      "license": "Apache-2.0",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
@@ -5687,8 +5091,9 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
       },
@@ -5699,8 +5104,9 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
     },
     "node_modules/@hutson/parse-repository-url": {
       "version": "3.0.2",
@@ -5858,8 +5264,9 @@
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -7991,6 +7398,8 @@
     },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
       "dev": true,
       "funding": [
         {
@@ -8002,7 +7411,6 @@
           "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
         }
       ],
-      "license": "Apache-2.0",
       "dependencies": {
         "cross-spawn": "^7.0.1"
       },
@@ -8012,8 +7420,9 @@
     },
     "node_modules/@malept/flatpak-bundler": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+      "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
         "fs-extra": "^9.0.0",
@@ -8026,8 +7435,9 @@
     },
     "node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
       "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -8689,9 +8099,73 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/watcher/node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@philippfromme/moddle-helpers": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8735,7 +8209,6 @@
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^1.0.1"
@@ -8772,8 +8245,9 @@
     },
     "node_modules/@types/eslint": {
       "version": "8.4.6",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
+      "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -8781,8 +8255,9 @@
     },
     "node_modules/@types/eslint-scope": {
       "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+      "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -8790,8 +8265,9 @@
     },
     "node_modules/@types/estree": {
       "version": "0.0.51",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "dev": true
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
@@ -8803,8 +8279,9 @@
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/minimatch": "*",
@@ -8813,18 +8290,25 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true,
-      "license": "MIT",
       "optional": true
     },
     "node_modules/@types/minimist": {
@@ -8839,7 +8323,6 @@
     },
     "node_modules/@types/node": {
       "version": "18.7.13",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
@@ -8851,6 +8334,24 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/plist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.2.tgz",
+      "integrity": "sha512-ULqvZNGMv0zRFvqn8/4LSPtnmN4MfhlPNtJCTpKuIIxGVGZ2rYWzFXrvEBoh9CVyqSE7D6YFRJ1hydLHI6kbWw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*",
+        "xmlbuilder": ">=11.0.1"
+      }
+    },
+    "node_modules/@types/verror": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.6.tgz",
+      "integrity": "sha512-NNm+gdePAX1VGvPcGZCDKQZKYSiAWigKhKaz5KF94hG6f2s8de9Ow5+7AbXoeKxL8gavZfk4UquSAygOF2duEQ==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.11",
@@ -8867,8 +8368,9 @@
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -8881,8 +8383,9 @@
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+      "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.11.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -8890,23 +8393,27 @@
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.11.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+      "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+      "dev": true
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.11.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+      "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+      "dev": true
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.11.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+      "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+      "dev": true
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+      "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.11.1",
         "@webassemblyjs/helper-api-error": "1.11.1",
@@ -8915,13 +8422,15 @@
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.11.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+      "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+      "dev": true
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+      "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -8931,29 +8440,33 @@
     },
     "node_modules/@webassemblyjs/ieee754": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+      "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "node_modules/@webassemblyjs/leb128": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+      "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.11.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+      "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+      "dev": true
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+      "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -8967,8 +8480,9 @@
     },
     "node_modules/@webassemblyjs/wasm-gen": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+      "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -8979,8 +8493,9 @@
     },
     "node_modules/@webassemblyjs/wasm-opt": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+      "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -8990,8 +8505,9 @@
     },
     "node_modules/@webassemblyjs/wasm-parser": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+      "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-api-error": "1.11.1",
@@ -9003,8 +8519,9 @@
     },
     "node_modules/@webassemblyjs/wast-printer": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+      "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
@@ -9012,8 +8529,9 @@
     },
     "node_modules/@webpack-cli/configtest": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+      "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "webpack": "4.x.x || 5.x.x",
         "webpack-cli": "4.x.x"
@@ -9021,8 +8539,9 @@
     },
     "node_modules/@webpack-cli/info": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
+      "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "envinfo": "^7.7.3"
       },
@@ -9032,8 +8551,9 @@
     },
     "node_modules/@webpack-cli/serve": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
+      "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "webpack-cli": "4.x.x"
       },
@@ -9045,13 +8565,15 @@
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "dev": true
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
-      "dev": true,
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true
     },
     "node_modules/7zip-bin": {
       "version": "5.1.1",
@@ -9077,8 +8599,9 @@
     },
     "node_modules/acorn": {
       "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9088,8 +8611,9 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -9201,7 +8725,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9209,7 +8732,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -9240,8 +8762,9 @@
     },
     "node_modules/app-builder-lib": {
       "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.6.0.tgz",
+      "integrity": "sha512-dQYDuqm/rmy8GSCE6Xl/3ShJg6Ab4bZJMT8KaTKGzT436gl1DN4REP3FCWfXoh75qGTJ+u+WsdnnpO9Jl8nyMA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@develar/schema-utils": "~2.6.5",
         "@electron/universal": "1.2.1",
@@ -9276,8 +8799,9 @@
     },
     "node_modules/app-builder-lib/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -9290,13 +8814,15 @@
     },
     "node_modules/app-builder-lib/node_modules/app-builder-bin": {
       "version": "4.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
+      "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
+      "dev": true
     },
     "node_modules/app-builder-lib/node_modules/builder-util": {
       "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.6.0.tgz",
+      "integrity": "sha512-QiQHweYsh8o+U/KNCZFSvISRnvRctb8m/2rB2I1JdByzvNKxPeFLlHFRPQRXab6aYeXc18j9LpsDLJ3sGQmWTQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.1.6",
         "@types/fs-extra": "^9.0.11",
@@ -9319,8 +8845,9 @@
     },
     "node_modules/app-builder-lib/node_modules/builder-util-runtime": {
       "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.1.1.tgz",
+      "integrity": "sha512-azRhYLEoDvRDR8Dhis4JatELC/jUvYjm4cVSj7n9dauGTOM2eeNn9KS0z6YA6oDsjI1xphjNbY6PZZeHPzzqaw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
         "sax": "^1.2.4"
@@ -9331,8 +8858,9 @@
     },
     "node_modules/app-builder-lib/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -9346,8 +8874,9 @@
     },
     "node_modules/app-builder-lib/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -9357,21 +8886,24 @@
     },
     "node_modules/app-builder-lib/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/app-builder-lib/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/app-builder-lib/node_modules/semver": {
       "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -9384,8 +8916,9 @@
     },
     "node_modules/app-builder-lib/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -9647,8 +9180,9 @@
     },
     "node_modules/asar": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/asar/-/asar-3.2.0.tgz",
+      "integrity": "sha512-COdw2ZQvKdFGFxXwX3oYh2/sOsJWJegrdJCGxnN4MZ7IULgRBp9P6665aqj9z1v9VwP4oP1hRBojRDQ//IGgAg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chromium-pickle-js": "^0.2.0",
         "commander": "^5.0.0",
@@ -9665,6 +9199,16 @@
         "@types/glob": "^7.1.1"
       }
     },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "dev": true,
@@ -9679,6 +9223,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/async": {
@@ -9704,8 +9258,8 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -9717,7 +9271,8 @@
     },
     "node_modules/atoa": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/atoa/-/atoa-1.0.0.tgz",
+      "integrity": "sha512-VVE1H6cc4ai+ZXo/CRWoJiHXrA1qfA31DPnx6D20+kSI547hQN5Greh51LQ1baMRMfxO5K5M4ImMtZbZt2DODQ=="
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -9917,6 +9472,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "dev": true,
@@ -10018,11 +9582,51 @@
         "tiny-svg": "^2.2.4"
       }
     },
-    "node_modules/bpmn-js-executable-fix": {
-      "version": "0.2.0",
-      "license": "MIT",
+    "node_modules/bpmn-js-disable-collapsed-subprocess": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/bpmn-js-disable-collapsed-subprocess/-/bpmn-js-disable-collapsed-subprocess-0.1.7.tgz",
+      "integrity": "sha512-Lhaklmi77ulvcWG8wh6w0nLVAIlWvHPkri6hwm7ReP6tw/S2SMSNsFHYa+dfvVEZD30uNLZHGpDztZOdxBGvrw==",
+      "dependencies": {
+        "min-dash": "^4.0.0"
+      },
       "peerDependencies": {
         "bpmn-js": ">= 6"
+      }
+    },
+    "node_modules/bpmn-js-disable-collapsed-subprocess/node_modules/min-dash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
+    },
+    "node_modules/bpmn-js-executable-fix": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-executable-fix/-/bpmn-js-executable-fix-0.2.0.tgz",
+      "integrity": "sha512-sIQ+eW4pWUzBPTDIzTPlWpmBZ0uodvWMJqtfc2Mqh6wZm97BC+PXeEFw35cl7dM0HjN3eueKMbKSrXTtk+JZ6Q==",
+      "peerDependencies": {
+        "bpmn-js": ">= 6"
+      }
+    },
+    "node_modules/bpmn-js-properties-panel": {
+      "version": "1.6.1",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@bpmn-io/element-templates-validator": "^0.10.0",
+        "@bpmn-io/extract-process-variables": "^0.5.0",
+        "array-move": "^3.0.1",
+        "classnames": "^2.3.1",
+        "ids": "^1.0.0",
+        "min-dash": "^3.8.1",
+        "min-dom": "^3.1.3",
+        "preact-markup": "^2.1.1",
+        "semver-compare": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@bpmn-io/properties-panel": "^0.20.1",
+        "bpmn-js": "8.x || 9.x",
+        "camunda-bpmn-js-behaviors": "0.2.x",
+        "diagram-js": "7.x || 8.x"
       }
     },
     "node_modules/bpmn-moddle": {
@@ -10035,17 +9639,18 @@
       }
     },
     "node_modules/bpmnlint": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-8.1.1.tgz",
-      "integrity": "sha512-MN81JGqqHx2+wAF1HVvYq7N5+lKJd82Op8VnLQ19V56HmavwbwUlR+r3L5jv6x/YCthudR1FVhEd/N20xQLHEg==",
+      "version": "7.8.0",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@bpmn-io/moddle-utils": "^0.1.0",
-        "ansi-colors": "^4.1.3",
-        "bpmn-moddle": "^7.1.3",
+        "@philippfromme/moddle-helpers": "^0.1.0",
+        "ansi-colors": "^4.1.1",
+        "bpmn-moddle": "^7.1.2",
         "bpmnlint-utils": "^1.0.2",
-        "cli-table": "^0.3.11",
+        "cli-table": "^0.3.9",
         "color-support": "^1.1.3",
-        "min-dash": "^3.8.1",
+        "min-dash": "^3.8.0",
         "mri": "^1.2.0",
         "pluralize": "^7.0.0",
         "tiny-glob": "^0.2.9"
@@ -10054,28 +9659,31 @@
         "bpmnlint": "bin/bpmnlint.js"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 10"
       }
     },
     "node_modules/bpmnlint-loader": {
       "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bpmnlint-loader/-/bpmnlint-loader-0.1.6.tgz",
+      "integrity": "sha512-/XmvV70NT1uTpjtC6C5bTJvWFR6v5RFxLzUCuP0ScKKlTf6me9rYgV0sAXdbW2011vFSFfD8DJHTi+D3gnSUww==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "bpmnlint": "*"
+      }
+    },
+    "node_modules/bpmnlint-plugin-camunda-compat": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.13.1.tgz",
+      "integrity": "sha512-Zp11rMtJXA3GM2u8Vx9eCDN54bBW5BLHtmDUy6++bk8PdKSSqzOh40TGx4pxl+QtxlRB8WcNBCS5QFaJmMgPKw==",
+      "dependencies": {
+        "@bpmn-io/moddle-utils": "^0.1.0",
+        "bpmnlint-utils": "^1.0.2",
+        "min-dash": "^3.8.1"
       }
     },
     "node_modules/bpmnlint-utils": {
       "version": "1.0.2",
       "license": "MIT"
-    },
-    "node_modules/bpmnlint/node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -10156,8 +9764,9 @@
     },
     "node_modules/buffer-alloc": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -10165,8 +9774,9 @@
     },
     "node_modules/buffer-alloc-unsafe": {
       "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "dev": true
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
@@ -10178,16 +9788,18 @@
     },
     "node_modules/buffer-equal": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+      "integrity": "sha512-tcBWO2Dl4e7Asr9hTGcpVrCe+F7DubpmqWCTbj4FHLmjqO2hIaC383acQubWtRJhdceqs5uBHs6Es+Sk//RKiQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/buffer-fill": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+      "dev": true
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -10412,7 +10024,6 @@
     },
     "node_modules/cacheable-request": {
       "version": "6.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
@@ -10429,7 +10040,6 @@
     },
     "node_modules/cacheable-request/node_modules/get-stream": {
       "version": "5.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -10440,7 +10050,6 @@
     },
     "node_modules/cacheable-request/node_modules/lowercase-keys": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10448,7 +10057,6 @@
     },
     "node_modules/cacheable-request/node_modules/normalize-url": {
       "version": "4.5.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10498,6 +10106,29 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/camunda-bpmn-js-behaviors": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-0.2.2.tgz",
+      "integrity": "sha512-MsWByIIE4qdUVNAcOAGZBmouadHHxDgHuCmwOfg5rCiUICW5ljmzDJHgp3L00OOv+OuxiHC81h13Lc6/HLfPmQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "ids": "^1.0.0",
+        "min-dash": "^4.0.0"
+      },
+      "peerDependencies": {
+        "bpmn-js": ">= 9",
+        "camunda-bpmn-moddle": ">= 7",
+        "zeebe-bpmn-moddle": ">= 0.15"
+      }
+    },
+    "node_modules/camunda-bpmn-js-behaviors/node_modules/min-dash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/camunda-bpmn-moddle": {
       "version": "7.0.1",
@@ -10552,7 +10183,6 @@
     },
     "node_modules/chalk": {
       "version": "2.4.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -10604,16 +10234,18 @@
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+      "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.0"
       }
     },
     "node_modules/chromium-pickle-js": {
       "version": "0.2.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
+      "dev": true
     },
     "node_modules/ci-info": {
       "version": "3.3.2",
@@ -10761,6 +10393,23 @@
         "node": ">= 0.2.0"
       }
     },
+    "node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-width": {
       "version": "3.0.0",
       "dev": true,
@@ -10771,7 +10420,6 @@
     },
     "node_modules/cliui": {
       "version": "7.0.4",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -10821,7 +10469,6 @@
     },
     "node_modules/clone-response": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
@@ -10840,11 +10487,13 @@
     },
     "node_modules/cmmn-font": {
       "version": "0.5.0",
-      "license": "SIL"
+      "resolved": "https://registry.npmjs.org/cmmn-font/-/cmmn-font-0.5.0.tgz",
+      "integrity": "sha512-6AghADr1eKdQLRVbTyPREGvjdh4AfZlRbVsDzoN704hfKWjChp6FodneoUP+EgkQ6g3/1XRWbcyAePUovtwU2g=="
     },
     "node_modules/cmmn-js": {
       "version": "0.20.0",
-      "license": "SEE LICENSE IN LICENSE",
+      "resolved": "https://registry.npmjs.org/cmmn-js/-/cmmn-js-0.20.0.tgz",
+      "integrity": "sha512-iiIqCmrkSRpdDzMjFhTkK56poQNdZgWviQlrCEWtuFCeBTWq5BcNdycXsMaxMDKA400LbVkDMTBl5ZI/WWacPQ==",
       "dependencies": {
         "cmmn-font": "^0.5.0",
         "cmmn-moddle": "^5.0.0",
@@ -10861,7 +10510,8 @@
     },
     "node_modules/cmmn-js-properties-panel": {
       "version": "0.9.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cmmn-js-properties-panel/-/cmmn-js-properties-panel-0.9.0.tgz",
+      "integrity": "sha512-MMBR3gaXlNuEJy5HSW6ypyI/w9e2PIsKvD/7r2kqkcwsKFWB7Jw/Gusy9OXijaZkCGulJt5L56BxF5qbj9C3Uw==",
       "dependencies": {
         "ids": "^0.2.0",
         "inherits": "^2.0.1",
@@ -10876,14 +10526,16 @@
     },
     "node_modules/cmmn-js-properties-panel/node_modules/ids": {
       "version": "0.2.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ids/-/ids-0.2.2.tgz",
+      "integrity": "sha512-icIO8S7A7Hat9x/59VYjS5uwfBU1xRTDxeFC4t9wNceLxZFm2JbPhO4lC/xhFqFNVaxw2idwpLgUfkVQrjsxIw==",
       "dependencies": {
         "hat": "^0.0.3"
       }
     },
     "node_modules/cmmn-js/node_modules/diagram-js": {
       "version": "4.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-4.0.3.tgz",
+      "integrity": "sha512-BzcWUEnRfO2tpdc8XHvG/wsX+GrE/7qGRDf1khn5b0UrzrqqLhj1yiguvpgb0rQSTPeBtkot6PUA4wB2QAQutA==",
       "dependencies": {
         "css.escape": "^1.5.1",
         "didi": "^4.0.0",
@@ -10898,22 +10550,26 @@
     },
     "node_modules/cmmn-js/node_modules/didi": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/didi/-/didi-4.0.0.tgz",
+      "integrity": "sha512-AzMElh8mCHOPWPCWfGjoJRla31fMXUT6+287W5ef3IPmtuBcyG9+MkFS7uPP6v3t2Cl086KwWfRB9mESa0OsHQ=="
     },
     "node_modules/cmmn-js/node_modules/ids": {
       "version": "0.2.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ids/-/ids-0.2.2.tgz",
+      "integrity": "sha512-icIO8S7A7Hat9x/59VYjS5uwfBU1xRTDxeFC4t9wNceLxZFm2JbPhO4lC/xhFqFNVaxw2idwpLgUfkVQrjsxIw==",
       "dependencies": {
         "hat": "^0.0.3"
       }
     },
     "node_modules/cmmn-js/node_modules/path-intersection": {
       "version": "1.1.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-1.1.1.tgz",
+      "integrity": "sha512-EdeUuXCm0+tb/2gv8PmRhd9fYYOtbDeTYkwCnzkBuAEjevEZi2mWUi1DVFF5nqSObYsxKcchvKUhnRULWOFreQ=="
     },
     "node_modules/cmmn-moddle": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cmmn-moddle/-/cmmn-moddle-5.0.0.tgz",
+      "integrity": "sha512-mmHG+Ey/Zc+ZgTAlGF4aTGdEYZuloZ0L+eRlVYeGCpMEgIrIwJWsRlshaTB4yNts9p929Emmd+Gcl5xGHGhMmA==",
       "dependencies": {
         "min-dash": "^3.0.0",
         "moddle": "^4.1.0",
@@ -10922,14 +10578,16 @@
     },
     "node_modules/cmmn-moddle/node_modules/moddle": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/moddle/-/moddle-4.1.0.tgz",
+      "integrity": "sha512-asBaDLTTNpv4oC8iFdwonfMf/noPVvaBDXoSL7AsXZUDqwokgy8Lsf5eXwdnjXiDqm0olYi/S3Do544uVJSQDg==",
       "dependencies": {
         "min-dash": "^3.0.0"
       }
     },
     "node_modules/cmmn-moddle/node_modules/moddle-xml": {
       "version": "7.5.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-7.5.0.tgz",
+      "integrity": "sha512-wPm3TD9910Iblp4lg1okHDRilY9gTvNBdo7ZHBmBzH4OioF5R2hvG3SMyn7cAUjOUg0kYUfChHgcUEO+qUc77Q==",
       "dependencies": {
         "min-dash": "^3.0.0",
         "moddle": "^4.1.0",
@@ -10938,7 +10596,8 @@
     },
     "node_modules/codemirror": {
       "version": "6.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
+      "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -10963,7 +10622,6 @@
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -10971,7 +10629,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-support": {
@@ -10983,8 +10640,9 @@
     },
     "node_modules/colorette": {
       "version": "2.0.19",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
+      "dev": true
     },
     "node_modules/colors": {
       "version": "1.0.3",
@@ -11007,8 +10665,8 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -11018,8 +10676,9 @@
     },
     "node_modules/commander": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -11056,8 +10715,9 @@
     },
     "node_modules/compare-version": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+      "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11164,6 +10824,90 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/console-stamp": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/console-stamp/-/console-stamp-3.0.6.tgz",
+      "integrity": "sha512-j4tP+1shVIUjSnvrtv5nJ5uVzLeNOTweVHkcEXB2ej4NJdlRp14w0hOzQiF+iQvOTjz4jafmdhd1CdYSwNzM8Q==",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "dateformat": "^4.6.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/console-stamp/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/console-stamp/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/console-stamp/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/console-stamp/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/console-stamp/node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/console-stamp/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/console-stamp/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/content-type": {
       "version": "1.0.4",
       "dev": true,
@@ -11174,7 +10918,8 @@
     },
     "node_modules/contra": {
       "version": "1.9.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/contra/-/contra-1.9.4.tgz",
+      "integrity": "sha512-N9ArHAqwR/lhPq4OdIAwH4e1btn6EIZMAz4TazjnzCiVECcWUPTma+dRAM38ERImEJBh8NiCCpjoQruSZ+agYg==",
       "dependencies": {
         "atoa": "1.0.0",
         "ticky": "1.0.1"
@@ -12107,8 +11852,9 @@
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "node-fetch": "2.6.7"
       }
@@ -12142,7 +11888,8 @@
     },
     "node_modules/crossvent": {
       "version": "1.5.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/crossvent/-/crossvent-1.5.5.tgz",
+      "integrity": "sha512-MY4xhBYEnVi+pmTpHCOCsCLYczc0PVtGdPBz6NXNXxikLaUZo4HdAeUb1UqAo3t3yXAloSelTmfxJ+/oUqkW5w==",
       "dependencies": {
         "custom-event": "^1.0.0"
       }
@@ -12189,6 +11936,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
+      "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -12247,7 +11999,6 @@
     },
     "node_modules/decompress-response": {
       "version": "3.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
@@ -12298,7 +12049,6 @@
     },
     "node_modules/defer-to-connect": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/define-lazy-prop": {
@@ -12789,8 +12539,8 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -12838,8 +12588,9 @@
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.1036444",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1036444.tgz",
+      "integrity": "sha512-0y4f/T8H9lsESV9kKP1HDUXgHxCdniFeJh6Erq+FbdOEvp/Ydp9t8kcAAM5gOd17pMrTDlFWntoHtzzeTUWKNw==",
+      "dev": true
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -12883,7 +12634,8 @@
     },
     "node_modules/diagram-js-minimap": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/diagram-js-minimap/-/diagram-js-minimap-3.0.0.tgz",
+      "integrity": "sha512-ntjlGZpfnlkBS8YpMD8mwUETtA4NijVP8Wxh+4/FLEVhqYZw1fO8SpoSEOLjievCfkJwmN49FME0wa/fqz5qzA==",
       "dependencies": {
         "css.escape": "^1.5.1",
         "min-dash": "^4.0.0",
@@ -12893,11 +12645,13 @@
     },
     "node_modules/diagram-js-minimap/node_modules/min-dash": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
     },
     "node_modules/diagram-js-minimap/node_modules/min-dom": {
       "version": "4.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.0.3.tgz",
+      "integrity": "sha512-5zQyCMe8rtGiDIRjfGeqnF2YPJ7OAPFdJQeC7MakHais3dh4VG4PV2a0FacziKTzJjYK5qnPKm2sq1wSXB1wTQ==",
       "dependencies": {
         "component-event": "^0.1.4",
         "domify": "^1.4.1",
@@ -12906,11 +12660,13 @@
     },
     "node_modules/diagram-js-minimap/node_modules/tiny-svg": {
       "version": "3.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
+      "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w=="
     },
     "node_modules/diagram-js-origin": {
       "version": "1.3.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/diagram-js-origin/-/diagram-js-origin-1.3.4.tgz",
+      "integrity": "sha512-0cSuf8iHG9IUC+rJpI2cGba0HEW17W5dv0JQWuGbFAG6Y12YUCDzFkMB44VhD+X/cvSmNRgyaDVxGw3U1LSpIQ==",
       "dependencies": {
         "tiny-svg": "^2.0.0"
       },
@@ -12955,8 +12711,9 @@
     },
     "node_modules/dir-compare": {
       "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-2.4.0.tgz",
+      "integrity": "sha512-l9hmu8x/rjVC9Z2zmGzkhOEowZvW7pmYws5CWHutg8u1JgvsKWMx7Q/UODeu4djLZ4FgW5besw5yvMQnBHzuCA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "buffer-equal": "1.0.0",
         "colors": "1.0.3",
@@ -12969,8 +12726,9 @@
     },
     "node_modules/dir-compare/node_modules/commander": {
       "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-readlink": ">= 1.0.0"
       },
@@ -12980,8 +12738,9 @@
     },
     "node_modules/dir-compare/node_modules/minimatch": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -13002,8 +12761,9 @@
     },
     "node_modules/dmg-builder": {
       "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.6.0.tgz",
+      "integrity": "sha512-jFZvY1JohyHarIAlTbfQOk+HnceGjjAdFjVn3n8xlDWKsYNqbO4muca6qXEZTfGXeQMG7TYim6CeS5XKSfSsGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "app-builder-lib": "23.6.0",
         "builder-util": "23.6.0",
@@ -13018,8 +12778,9 @@
     },
     "node_modules/dmg-builder/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -13032,13 +12793,15 @@
     },
     "node_modules/dmg-builder/node_modules/app-builder-bin": {
       "version": "4.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
+      "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
+      "dev": true
     },
     "node_modules/dmg-builder/node_modules/builder-util": {
       "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.6.0.tgz",
+      "integrity": "sha512-QiQHweYsh8o+U/KNCZFSvISRnvRctb8m/2rB2I1JdByzvNKxPeFLlHFRPQRXab6aYeXc18j9LpsDLJ3sGQmWTQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.1.6",
         "@types/fs-extra": "^9.0.11",
@@ -13061,8 +12824,9 @@
     },
     "node_modules/dmg-builder/node_modules/builder-util-runtime": {
       "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.1.1.tgz",
+      "integrity": "sha512-azRhYLEoDvRDR8Dhis4JatELC/jUvYjm4cVSj7n9dauGTOM2eeNn9KS0z6YA6oDsjI1xphjNbY6PZZeHPzzqaw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
         "sax": "^1.2.4"
@@ -13073,8 +12837,9 @@
     },
     "node_modules/dmg-builder/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -13088,8 +12853,9 @@
     },
     "node_modules/dmg-builder/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -13099,23 +12865,52 @@
     },
     "node_modules/dmg-builder/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/dmg-builder/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/dmg-builder/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dmg-license": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
+      "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "@types/plist": "^3.0.1",
+        "@types/verror": "^1.10.3",
+        "ajv": "^6.10.0",
+        "crc": "^3.8.0",
+        "iconv-corefoundation": "^1.1.7",
+        "plist": "^3.0.4",
+        "smart-buffer": "^4.0.2",
+        "verror": "^1.10.0"
+      },
+      "bin": {
+        "dmg-license": "bin/dmg-license.js"
       },
       "engines": {
         "node": ">=8"
@@ -13184,7 +12979,8 @@
     },
     "node_modules/dmn-js-properties-panel": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/dmn-js-properties-panel/-/dmn-js-properties-panel-1.2.1.tgz",
+      "integrity": "sha512-bHWH8z5v7KpjrJ/PJ/ZU/RDlZhEiFnxAOYSkjmmXDbpZ6FKmtTxcC/UenWmqFQhMoACxDHrmajt/owRHt8t3uw==",
       "dependencies": {
         "diagram-js": "^8.9.0",
         "min-dash": "^3.8.1",
@@ -13288,16 +13084,19 @@
     },
     "node_modules/dotenv-expand": {
       "version": "5.1.0",
-      "dev": true,
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+      "dev": true
     },
     "node_modules/downloadjs": {
       "version": "1.4.7",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
+      "integrity": "sha512-LN1gO7+u9xjU5oEScGFKvXhYf7Y/empUIIEAGBs1LzUq/rg5duiDrkuH5A2lQGd5jfMOb9X9usDa2oVXwJ0U/Q=="
     },
     "node_modules/dragula": {
       "version": "3.7.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/dragula/-/dragula-3.7.3.tgz",
+      "integrity": "sha512-/rRg4zRhcpf81TyDhaHLtXt6sEywdfpv1cRUMeFFy7DuypH2U0WUL0GTdyAQvXegviT4PJK4KuMmOaIDpICseQ==",
       "dependencies": {
         "contra": "1.9.4",
         "crossvent": "1.5.5"
@@ -13310,7 +13109,6 @@
     },
     "node_modules/duplexer3": {
       "version": "0.1.4",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/ee-first": {
@@ -13320,8 +13118,9 @@
     },
     "node_modules/ejs": {
       "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
+      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "jake": "^10.8.5"
       },
@@ -13334,9 +13133,10 @@
     },
     "node_modules/electron": {
       "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-21.1.0.tgz",
+      "integrity": "sha512-CM5VZpZPtAoPgTPcmEbRaZWXlxGuD5a5DTeAwm0F0F6/k6R3HZAi8vZnE77gwuHK/Qqcinw4/MAbiCwAKh2W+g==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@electron/get": "^1.14.1",
         "@types/node": "^16.11.26",
@@ -13351,8 +13151,9 @@
     },
     "node_modules/electron-builder": {
       "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.6.0.tgz",
+      "integrity": "sha512-y8D4zO+HXGCNxFBV/JlyhFnoQ0Y0K7/sFH+XwIbj47pqaW8S6PGYQbjoObolKBR1ddQFPt4rwp4CnwMJrW3HAw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/yargs": "^17.0.1",
         "app-builder-lib": "23.6.0",
@@ -13377,8 +13178,9 @@
     },
     "node_modules/electron-builder/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -13391,13 +13193,15 @@
     },
     "node_modules/electron-builder/node_modules/app-builder-bin": {
       "version": "4.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
+      "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
+      "dev": true
     },
     "node_modules/electron-builder/node_modules/builder-util": {
       "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.6.0.tgz",
+      "integrity": "sha512-QiQHweYsh8o+U/KNCZFSvISRnvRctb8m/2rB2I1JdByzvNKxPeFLlHFRPQRXab6aYeXc18j9LpsDLJ3sGQmWTQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.1.6",
         "@types/fs-extra": "^9.0.11",
@@ -13420,8 +13224,9 @@
     },
     "node_modules/electron-builder/node_modules/builder-util-runtime": {
       "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.1.1.tgz",
+      "integrity": "sha512-azRhYLEoDvRDR8Dhis4JatELC/jUvYjm4cVSj7n9dauGTOM2eeNn9KS0z6YA6oDsjI1xphjNbY6PZZeHPzzqaw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
         "sax": "^1.2.4"
@@ -13432,8 +13237,9 @@
     },
     "node_modules/electron-builder/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -13447,8 +13253,9 @@
     },
     "node_modules/electron-builder/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -13458,21 +13265,24 @@
     },
     "node_modules/electron-builder/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/electron-builder/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/electron-builder/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -13577,8 +13387,10 @@
     },
     "node_modules/electron-osx-sign": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.6.0.tgz",
+      "integrity": "sha512-+hiIEb2Xxk6eDKJ2FFlpofCnemCbjbT5jz+BKGpVBrRNT3kWTGs4DfNX6IzGwgi33hUcXF+kFs9JW+r6Wc1LRg==",
+      "deprecated": "Please use @electron/osx-sign moving forward. Be aware the API is slightly different",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "bluebird": "^3.5.0",
         "compare-version": "^0.1.2",
@@ -13597,16 +13409,18 @@
     },
     "node_modules/electron-osx-sign/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/electron-osx-sign/node_modules/isbinaryfile": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
+      "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "buffer-alloc": "^1.2.0"
       },
@@ -13616,13 +13430,15 @@
     },
     "node_modules/electron-osx-sign/node_modules/ms": {
       "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
     },
     "node_modules/electron-publish": {
       "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.6.0.tgz",
+      "integrity": "sha512-jPj3y+eIZQJF/+t5SLvsI5eS4mazCbNYqatv5JihbqOstIM13k0d1Z3vAWntvtt13Itl61SO6seicWdioOU5dg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
         "builder-util": "23.6.0",
@@ -13635,8 +13451,9 @@
     },
     "node_modules/electron-publish/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -13649,13 +13466,15 @@
     },
     "node_modules/electron-publish/node_modules/app-builder-bin": {
       "version": "4.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
+      "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
+      "dev": true
     },
     "node_modules/electron-publish/node_modules/builder-util": {
       "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.6.0.tgz",
+      "integrity": "sha512-QiQHweYsh8o+U/KNCZFSvISRnvRctb8m/2rB2I1JdByzvNKxPeFLlHFRPQRXab6aYeXc18j9LpsDLJ3sGQmWTQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.1.6",
         "@types/fs-extra": "^9.0.11",
@@ -13678,8 +13497,9 @@
     },
     "node_modules/electron-publish/node_modules/builder-util-runtime": {
       "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.1.1.tgz",
+      "integrity": "sha512-azRhYLEoDvRDR8Dhis4JatELC/jUvYjm4cVSj7n9dauGTOM2eeNn9KS0z6YA6oDsjI1xphjNbY6PZZeHPzzqaw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
         "sax": "^1.2.4"
@@ -13690,8 +13510,9 @@
     },
     "node_modules/electron-publish/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -13705,8 +13526,9 @@
     },
     "node_modules/electron-publish/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -13716,21 +13538,24 @@
     },
     "node_modules/electron-publish/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/electron-publish/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/electron-publish/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -14000,6 +13825,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/electron-reloader/node_modules/fsevents": {
+      "version": "2.3.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/electron-reloader/node_modules/glob-parent": {
       "version": "5.1.2",
       "dev": true,
@@ -14078,8 +13915,9 @@
     },
     "node_modules/electron/node_modules/@types/node": {
       "version": "16.11.62",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.62.tgz",
+      "integrity": "sha512-K/ggecSdwAAy2NUW4WKmF4Rc03GKbsfP+k326UWgckoS+Rzd2PaWbjk76dSmqdLQvLTJAO9axiTUJ6488mFsYQ==",
+      "dev": true
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -14099,7 +13937,6 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -14135,8 +13972,9 @@
     },
     "node_modules/enhanced-resolve": {
       "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
+      "integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -14231,8 +14069,9 @@
     },
     "node_modules/es-module-lexer": {
       "version": "0.9.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+      "dev": true
     },
     "node_modules/es-shim-unscopables": {
       "version": "1.0.0",
@@ -14265,7 +14104,6 @@
     },
     "node_modules/escalade": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14277,7 +14115,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -14285,8 +14122,9 @@
     },
     "node_modules/eslint": {
       "version": "8.23.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
+      "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint/eslintrc": "^1.3.2",
         "@humanwhocodes/config-array": "^0.10.4",
@@ -14381,8 +14219,9 @@
     },
     "node_modules/eslint-plugin-bpmn-io": {
       "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-bpmn-io/-/eslint-plugin-bpmn-io-0.16.0.tgz",
+      "integrity": "sha512-33lxw01ombcLWX5gEGpnqKh7DXbTdBh6CWlmkfCwTGFqklndvrP7qemZczO8Sg0mMlQiF7Eu17Zlv7etwX2BIg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-plugin-mocha": "^10.1.0",
         "eslint-plugin-react": "^7.30.1"
@@ -14393,8 +14232,9 @@
     },
     "node_modules/eslint-plugin-camunda-licensed": {
       "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-camunda-licensed/-/eslint-plugin-camunda-licensed-0.4.6.tgz",
+      "integrity": "sha512-cdt0dPcEKKurUKeX8zxQhyXD/cloVRIzsAJWXE57bqzeV/Q2edDQGOHxQDSoAd07MHCHJyizZBMb/5y8gN3PTg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-plugin-license-header": "^0.2.0"
       },
@@ -14481,8 +14321,9 @@
     },
     "node_modules/eslint-plugin-mocha": {
       "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.1.0.tgz",
+      "integrity": "sha512-xLqqWUF17llsogVOC+8C6/jvQ+4IoOREbN7ZCHuOHuD6cT5cDD4h7f2LgsZuzMAiwswWE21tO7ExaknHVDrSkw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-utils": "^3.0.0",
         "rambda": "^7.1.0"
@@ -14570,8 +14411,9 @@
     },
     "node_modules/eslint-utils": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^2.0.0"
       },
@@ -14587,16 +14429,18 @@
     },
     "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -14617,16 +14461,18 @@
     },
     "node_modules/eslint/node_modules/array-union": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/eslint/node_modules/braces": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -14678,8 +14524,9 @@
     },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -14690,8 +14537,9 @@
     },
     "node_modules/eslint/node_modules/fast-glob": {
       "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -14705,8 +14553,9 @@
     },
     "node_modules/eslint/node_modules/fast-glob/node_modules/glob-parent": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -14716,8 +14565,9 @@
     },
     "node_modules/eslint/node_modules/fill-range": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -14727,8 +14577,9 @@
     },
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -14738,8 +14589,9 @@
     },
     "node_modules/eslint/node_modules/globby": {
       "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -14765,16 +14617,18 @@
     },
     "node_modules/eslint/node_modules/is-extglob": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/eslint/node_modules/is-glob": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -14784,8 +14638,9 @@
     },
     "node_modules/eslint/node_modules/micromatch": {
       "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -14807,8 +14662,9 @@
     },
     "node_modules/espree": {
       "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
+      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
@@ -15057,8 +14913,9 @@
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -15076,8 +14933,9 @@
     },
     "node_modules/extract-zip/node_modules/get-stream": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -15087,6 +14945,16 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/extsprintf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "optional": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -15182,6 +15050,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
+      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
+      "dependencies": {
+        "strnum": "^1.0.4"
+      },
+      "bin": {
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "dev": true,
@@ -15214,7 +15097,8 @@
     },
     "node_modules/file-drops": {
       "version": "0.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/file-drops/-/file-drops-0.4.0.tgz",
+      "integrity": "sha512-dPLRxrQ/sWHyU1DMf72doyyFuqeR/T8hJ97coJHXmdeHvqMTdOMJ/PLsHKjQzDHC8TBQO0rDUinDEXz3WGTnQA==",
       "dependencies": {
         "min-dom": "^3.1.1"
       }
@@ -15230,26 +15114,35 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/filelist": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -15468,8 +15361,9 @@
     },
     "node_modules/form-data": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -15478,6 +15372,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fp-ts": {
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.3.tgz",
+      "integrity": "sha512-8m0XvW8kZbfnJOA4NvSVXu95mLbPf4LQGwQyqVukIYS4KzSNJiyKSmuZUmbVHteUi6MGkAJGPb0goPZqI+Tsqg=="
     },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
@@ -15581,6 +15480,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "1.2.13",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "dev": true,
@@ -15647,7 +15563,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -15748,7 +15663,6 @@
     },
     "node_modules/get-stream": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -16353,8 +16267,9 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "dev": true,
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true
     },
     "node_modules/glob2base": {
       "version": "0.0.12",
@@ -16415,8 +16330,9 @@
     },
     "node_modules/globals": {
       "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -16475,7 +16391,6 @@
     },
     "node_modules/got": {
       "version": "9.6.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^0.14.0",
@@ -16501,13 +16416,15 @@
     },
     "node_modules/graceful-readlink": {
       "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
+      "dev": true
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
     },
     "node_modules/hammerjs": {
       "version": "2.0.8",
@@ -16565,7 +16482,6 @@
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -16765,7 +16681,8 @@
     },
     "node_modules/htm": {
       "version": "3.1.1",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -16774,7 +16691,6 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.1.0",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
@@ -16862,6 +16778,23 @@
         "ms": "^2.0.0"
       }
     },
+    "node_modules/iconv-corefoundation": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
+      "integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "node-addon-api": "^1.6.3"
+      },
+      "engines": {
+        "node": "^8.11.2 || >=10"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "devOptional": true,
@@ -16898,8 +16831,9 @@
     },
     "node_modules/ignore": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -17196,8 +17130,9 @@
     },
     "node_modules/interpret": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -17402,7 +17337,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -17889,8 +17823,9 @@
     },
     "node_modules/jake": {
       "version": "10.8.5",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "async": "^3.2.3",
         "chalk": "^4.0.2",
@@ -17906,8 +17841,9 @@
     },
     "node_modules/jake/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -17920,13 +17856,15 @@
     },
     "node_modules/jake/node_modules/async": {
       "version": "3.2.4",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+      "dev": true
     },
     "node_modules/jake/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -17940,8 +17878,9 @@
     },
     "node_modules/jake/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -17951,21 +17890,24 @@
     },
     "node_modules/jake/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/jake/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/jake/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -17975,8 +17917,9 @@
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -17988,6 +17931,8 @@
     },
     "node_modules/jest-worker/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17996,6 +17941,8 @@
     },
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18018,8 +17965,9 @@
     },
     "node_modules/js-sdsl": {
       "version": "4.1.4",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
+      "integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==",
+      "dev": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -18049,7 +17997,6 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-better-errors": {
@@ -18282,8 +18229,9 @@
     },
     "node_modules/karma-env-preprocessor": {
       "version": "0.1.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/karma-env-preprocessor/-/karma-env-preprocessor-0.1.1.tgz",
+      "integrity": "sha512-3FAuA0B1lS4DXNyOpD1Y+BjteVmnfX0WXUpsZ19aYykTk/GPz0kqnjzdApDiEe4sapreVeVSme2qTALnbHJb/A==",
+      "dev": true
     },
     "node_modules/karma-mocha": {
       "version": "2.0.1",
@@ -18295,8 +18243,9 @@
     },
     "node_modules/karma-sinon-chai": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/karma-sinon-chai/-/karma-sinon-chai-2.0.2.tgz",
+      "integrity": "sha512-SDgh6V0CUd+7ruL1d3yG6lFzmJNGRNQuEuCYXLaorruNP9nwQfA7hpsp4clx4CbOo5Gsajh3qUOT7CrVStUKMw==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "chai": ">=3.5.0",
         "sinon": ">=2.1.0",
@@ -18305,8 +18254,9 @@
     },
     "node_modules/karma-webpack": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-5.0.0.tgz",
+      "integrity": "sha512-+54i/cd3/piZuP3dr54+NcFeKOPnys5QeM1IY+0SPASwrtHsliXUiCL50iW+K9WWA7RvamC4macvvQ86l3KtaA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "glob": "^7.1.3",
         "minimatch": "^3.0.4",
@@ -18385,6 +18335,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/karma/node_modules/fsevents": {
+      "version": "2.3.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/karma/node_modules/glob-parent": {
@@ -18466,7 +18428,6 @@
     },
     "node_modules/keyv": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.0"
@@ -18482,7 +18443,8 @@
     },
     "node_modules/lang-feel": {
       "version": "0.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/lang-feel/-/lang-feel-0.0.3.tgz",
+      "integrity": "sha512-YEs49jXQfLetXUr4Sj+pq9kcwHyNFcEYiXvm/bRvQyUwVfUEAHQdeFneqw+5zGeDuKDgIGxawXVs7uysXaLrjQ==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.0.0",
@@ -18494,7 +18456,8 @@
     },
     "node_modules/lang-feel/node_modules/lezer-feel": {
       "version": "0.14.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.14.1.tgz",
+      "integrity": "sha512-sfpzZvAtObFon74XiFp1L8pS1FminnfM8JAm4S2Kxk7Wk8qYe7crjJdhHqju/MKl9dV5s44NHDhbq5tCDWMTlw==",
       "dependencies": {
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.2.3"
@@ -18830,8 +18793,9 @@
     },
     "node_modules/loader-runner": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
       }
@@ -18853,6 +18817,11 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
@@ -18993,6 +18962,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "license": "MIT",
@@ -19013,7 +18987,6 @@
     },
     "node_modules/lowercase-keys": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -19256,7 +19229,6 @@
     },
     "node_modules/mimic-response": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -19424,7 +19396,8 @@
     },
     "node_modules/mitt": {
       "version": "3.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
@@ -19481,8 +19454,9 @@
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
     },
     "node_modules/mkdirp-infer-owner": {
       "version": "2.0.0",
@@ -19633,6 +19607,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/mocha/node_modules/fsevents": {
+      "version": "2.3.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/mocha/node_modules/glob": {
@@ -19839,6 +19825,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/nan": {
+      "version": "2.16.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.3",
       "dev": true,
@@ -19923,10 +19915,11 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
-      "devOptional": true
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -20718,6 +20711,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/nx/node_modules/fsevents": {
+      "version": "2.3.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/nx/node_modules/glob": {
       "version": "7.1.4",
       "dev": true,
@@ -21353,7 +21358,6 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -21525,7 +21529,6 @@
     },
     "node_modules/p-cancelable": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -22051,8 +22054,9 @@
     },
     "node_modules/plist": {
       "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.6.tgz",
+      "integrity": "sha512-WiIVYyrp8TD4w8yCvyeIr+lkmrGRd5u0VbRnU+tP/aRLxP/YadJUYOMZJ/6hIa3oUyVCsycXvtNRgd5XBJIbiA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
@@ -22101,7 +22105,6 @@
     },
     "node_modules/prepend-http": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -22202,6 +22205,34 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/protobufjs": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
+      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+    },
     "node_modules/protocols": {
       "version": "2.0.1",
       "dev": true,
@@ -22209,8 +22240,9 @@
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/proxyquire": {
       "version": "2.1.3",
@@ -22224,7 +22256,6 @@
     },
     "node_modules/pump": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -22241,9 +22272,10 @@
     },
     "node_modules/puppeteer": {
       "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.0.5.tgz",
+      "integrity": "sha512-s4erjxU0VtKojPvF+KvLKG6OHUPw7gO2YV1dtOsoryyCbhrs444fXb4QZqGWuTv3V/rgSCUzeixxu34g0ZkSMA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -22263,8 +22295,9 @@
     },
     "node_modules/puppeteer/node_modules/rimraf": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -22277,8 +22310,9 @@
     },
     "node_modules/puppeteer/node_modules/ws": {
       "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -22362,8 +22396,9 @@
     },
     "node_modules/rambda": {
       "version": "7.2.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.2.1.tgz",
+      "integrity": "sha512-Wswj8ZvzdI3VhaGPkZAxaCTwuMmGtgWt7Zxsgyo4P+iTmVnkojvyWaOep5q3ZjMIecW0wtQa66GWxaKkZ24RAA==",
+      "dev": true
     },
     "node_modules/randomatic": {
       "version": "3.1.1",
@@ -22452,8 +22487,9 @@
     },
     "node_modules/read-config-file": {
       "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-6.2.0.tgz",
+      "integrity": "sha512-gx7Pgr5I56JtYz+WuqEbQHj/xWo+5Vwua2jhb1VwM4Wid5PqYmZ4i00ZB0YEGIfkVBsCv9UrjgyqCiQfS/Oosg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "dotenv": "^9.0.2",
         "dotenv-expand": "^5.1.0",
@@ -22467,8 +22503,9 @@
     },
     "node_modules/read-config-file/node_modules/dotenv": {
       "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
+      "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=10"
       }
@@ -23157,6 +23194,8 @@
     },
     "node_modules/rechoir": {
       "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23255,7 +23294,6 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23337,7 +23375,6 @@
     },
     "node_modules/responselike": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^1.0.0"
@@ -23485,8 +23522,9 @@
     },
     "node_modules/sanitize-filename": {
       "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
       "dev": true,
-      "license": "WTFPL OR ISC",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
       }
@@ -23502,8 +23540,9 @@
     },
     "node_modules/schema-utils": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -23519,7 +23558,8 @@
     },
     "node_modules/scroll-tabs": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/scroll-tabs/-/scroll-tabs-1.0.1.tgz",
+      "integrity": "sha512-W4xjEwNS4QAyQnaJ450vQTcKpbnalBAfsTDV926WrxEMOqjyj2To8uv2d0Cp0oxMdk5TkygtzXmctPNc2zgBcg==",
       "dependencies": {
         "min-dash": "^3.1.0",
         "min-dom": "^3.1.0",
@@ -23528,7 +23568,8 @@
     },
     "node_modules/scroll-tabs/node_modules/mitt": {
       "version": "1.2.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
+      "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw=="
     },
     "node_modules/selection-ranges": {
       "version": "3.0.3",
@@ -23702,8 +23743,9 @@
     },
     "node_modules/simple-update-notifier": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.0.7.tgz",
+      "integrity": "sha512-BBKgR84BJQJm6WjWFMHgLVuo61FBDSj1z/xSFUIozqO6wO7ii0JxCqlIud7Enr/+LhlbNI0whErq96P2qHNWew==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "semver": "~7.0.0"
       },
@@ -23713,8 +23755,9 @@
     },
     "node_modules/simple-update-notifier/node_modules/semver": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -23771,6 +23814,57 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/slide": {
       "version": "1.1.6",
@@ -24220,6 +24314,14 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "dev": true,
@@ -24376,7 +24478,6 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -24389,7 +24490,6 @@
     },
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string.prototype.matchall": {
@@ -24454,7 +24554,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -24498,6 +24597,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
     "node_modules/strong-log-transformer": {
       "version": "2.1.0",
       "dev": true,
@@ -24539,7 +24643,6 @@
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -24576,8 +24679,9 @@
     },
     "node_modules/tapable": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -24600,8 +24704,9 @@
     },
     "node_modules/tar-fs": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -24611,8 +24716,9 @@
     },
     "node_modules/tar-fs/node_modules/chownr": {
       "version": "1.1.4",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
@@ -24659,8 +24765,10 @@
     },
     "node_modules/terser": {
       "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -24676,6 +24784,8 @@
     },
     "node_modules/terser-webpack-plugin": {
       "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -24709,8 +24819,9 @@
     },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -24753,7 +24864,8 @@
     },
     "node_modules/ticky": {
       "version": "1.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ticky/-/ticky-1.0.1.tgz",
+      "integrity": "sha512-RX35iq/D+lrsqhcPWIazM9ELkjOe30MSeoBHQHSsRwd1YuhJO5ui1K1/R0r7N3mFvbLBs33idw+eR6j+w6i/DA=="
     },
     "node_modules/time-zone": {
       "version": "1.0.0",
@@ -24788,16 +24900,18 @@
     },
     "node_modules/tmp-promise": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tmp": "^0.2.0"
       }
     },
     "node_modules/tmp-promise/node_modules/rimraf": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -24810,8 +24924,9 @@
     },
     "node_modules/tmp-promise/node_modules/tmp": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "rimraf": "^3.0.0"
       },
@@ -24851,7 +24966,6 @@
     },
     "node_modules/to-readable-stream": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -24927,8 +25041,9 @@
     },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
       "dev": true,
-      "license": "WTFPL",
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
@@ -25019,6 +25134,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-duration": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/typed-duration/-/typed-duration-1.0.13.tgz",
+      "integrity": "sha512-HLwA+hNq/2eXe03isJSfa7YJt6NikplBGdNKvlhyuR6WL5iZi2uXJIZv1SSOMEIukCZbeQ8QwIcQ801S0/Qulw=="
+    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "dev": true,
@@ -25077,8 +25197,9 @@
     },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -25261,7 +25382,6 @@
     },
     "node_modules/url-parse-lax": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prepend-http": "^2.0.0"
@@ -25285,8 +25405,9 @@
     },
     "node_modules/utf8-byte-length": {
       "version": "1.0.4",
-      "dev": true,
-      "license": "WTFPL"
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==",
+      "dev": true
     },
     "node_modules/util": {
       "version": "0.12.4",
@@ -25317,6 +25438,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -25352,6 +25482,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/verror": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/void-elements": {
       "version": "2.0.1",
       "dev": true,
@@ -25373,6 +25518,12 @@
         "node-addon-api": "^3.0.2"
       }
     },
+    "node_modules/vscode-windows-ca-certs/node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "optional": true
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.6",
       "license": "MIT"
@@ -25384,8 +25535,9 @@
     },
     "node_modules/watchpack": {
       "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -25412,8 +25564,9 @@
     },
     "node_modules/webpack": {
       "version": "5.74.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
+      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -25458,8 +25611,9 @@
     },
     "node_modules/webpack-cli": {
       "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
+      "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",
@@ -25504,16 +25658,18 @@
     },
     "node_modules/webpack-cli/node_modules/commander": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/webpack-cli/node_modules/webpack-merge": {
       "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+      "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "clone-deep": "^4.0.1",
         "wildcard": "^2.0.0"
@@ -25524,32 +25680,36 @@
     },
     "node_modules/webpack-merge": {
       "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.15"
       }
     },
     "node_modules/webpack-sources": {
       "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
       }
     },
     "node_modules/webpack/node_modules/acorn-import-assertions": {
       "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
       }
     },
     "node_modules/webpack/node_modules/events": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
       }
@@ -25619,8 +25779,9 @@
     },
     "node_modules/wildcard": {
       "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
+      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+      "dev": true
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -25642,7 +25803,6 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -25658,7 +25818,6 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -25672,7 +25831,6 @@
     },
     "node_modules/wrap-ansi/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -25683,12 +25841,10 @@
     },
     "node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -25874,8 +26030,9 @@
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8.0"
       }
@@ -25890,7 +26047,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -25916,7 +26072,6 @@
     },
     "node_modules/yargs": {
       "version": "16.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^7.0.2",
@@ -25933,7 +26088,6 @@
     },
     "node_modules/yargs-parser": {
       "version": "20.2.4",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -25993,6 +26147,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zeebe-bpmn-moddle": {
+      "version": "0.15.0",
+      "license": "MIT"
+    },
+    "node_modules/zeebe-node": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.1.0.tgz",
+      "integrity": "sha512-2sCn5FF4bZ4uSFx2uS2t/11tg1qbyHO2KA2stQ77YgiFP+yeJy/WtWhrC1GpOkWHmu/8TNCmiLpEGocbOX++jw==",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.0",
+        "@grpc/proto-loader": "^0.7.2",
+        "chalk": "^2.4.2",
+        "console-stamp": "^3.0.2",
+        "dayjs": "^1.8.15",
+        "debug": "^4.2.0",
+        "fast-xml-parser": "^3.12.12",
+        "fp-ts": "^2.5.1",
+        "got": "^9.6.0",
+        "long": "^4.0.0",
+        "promise-retry": "^1.1.1",
+        "stack-trace": "0.0.10",
+        "typed-duration": "^1.0.12",
+        "uuid": "^3.3.2"
+      },
+      "bin": {
+        "zeebe-node": "bin/zeebe-node"
+      },
+      "engines": {
+        "node": ">=16.6.1"
+      }
+    },
+    "node_modules/zeebe-node/node_modules/err-code": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "integrity": "sha512-CJAN+O0/yA1CKfRn9SXOGctSpEM7DCon/r/5r2eXFMY2zCCJBasFhcM5I+1kh3Ap11FsQCX+vGHceNPvpWKhoA=="
+    },
+    "node_modules/zeebe-node/node_modules/promise-retry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+      "integrity": "sha512-StEy2osPr28o17bIW776GtwO6+Q+M9zPiZkYfosciUUMYqjhU/ffwRAH0zN2+uvGyUsn8/YICIHRzLbPacpZGw==",
+      "dependencies": {
+        "err-code": "^1.0.0",
+        "retry": "^0.10.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/zeebe-node/node_modules/retry": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha512-ZXUSQYTHdl3uS7IuCehYfMzKyIDBNoAuUblvy5oGO5UJSUTmStUUVPXbA9Qxd173Bgre53yCQczQuHgRWAdvJQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/zip-stream": {
@@ -26237,14 +26447,37 @@
     },
     "@bpmn-io/element-templates-icons-renderer": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-icons-renderer/-/element-templates-icons-renderer-0.3.0.tgz",
+      "integrity": "sha512-F6UWtjqkd1CmMoiGk+cl4m3JjGzR37e+8lO7OsW9NncMpY3Xxcafn6kPaLBfJDhiwAlFzK6jMd9/cSs5YRXusQ==",
       "requires": {
         "inherits": "^2.0.4",
         "tiny-svg": "^3.0.0"
       },
       "dependencies": {
         "tiny-svg": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
+          "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w=="
         }
+      }
+    },
+    "@bpmn-io/element-templates-validator": {
+      "version": "0.10.0",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@camunda/element-templates-json-schema": "^0.10.1",
+        "@camunda/zeebe-element-templates-json-schema": "^0.6.0",
+        "json-source-map": "^0.6.1",
+        "min-dash": "^3.8.1"
+      }
+    },
+    "@bpmn-io/extract-process-variables": {
+      "version": "0.5.1",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "min-dash": "^3.8.1"
       }
     },
     "@bpmn-io/feel-editor": {
@@ -26261,28 +26494,10 @@
         "lezer-feel": "^0.4.0"
       }
     },
-    "@bpmn-io/feel-lint": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-0.1.0.tgz",
-      "integrity": "sha512-Ryc2EP0kJx1e5gYghqEg60gEoEz/zFRsyISSFRTRC+Fz3MGjbscHSWitPaXs2Hb0BvgRWA4zSx+Jc2oOvV6LSQ==",
-      "requires": {
-        "@codemirror/language": "^6.2.1",
-        "lezer-feel": "^0.14.1"
-      },
-      "dependencies": {
-        "lezer-feel": {
-          "version": "0.14.1",
-          "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.14.1.tgz",
-          "integrity": "sha512-sfpzZvAtObFon74XiFp1L8pS1FminnfM8JAm4S2Kxk7Wk8qYe7crjJdhHqju/MKl9dV5s44NHDhbq5tCDWMTlw==",
-          "requires": {
-            "@lezer/highlight": "^1.0.0",
-            "@lezer/lr": "^1.2.3"
-          }
-        }
-      }
-    },
     "@bpmn-io/form-js": {
       "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js/-/form-js-0.9.9.tgz",
+      "integrity": "sha512-r428u/eWDV7J2kwJTNaHnUig60ZvAEfqG8At5uYP1/ReHNdnJttrff6g2RktYV6K5F6+au1RR139ej4ahfudZA==",
       "requires": {
         "@bpmn-io/form-js-editor": "^0.9.9",
         "@bpmn-io/form-js-playground": "^0.9.9",
@@ -26291,6 +26506,8 @@
     },
     "@bpmn-io/form-js-editor": {
       "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-editor/-/form-js-editor-0.9.9.tgz",
+      "integrity": "sha512-ek1ySA354QgAoN4ZnaTTbg2TNTf+ZPy4BVix2pbdh7Neg3dGki6KPX1ANqd1TAAHAplkuHdXGEZEI815PxA1+w==",
       "requires": {
         "@bpmn-io/form-js-viewer": "^0.9.9",
         "array-move": "^3.0.1",
@@ -26302,10 +26519,14 @@
       },
       "dependencies": {
         "min-dash": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
         },
         "min-dom": {
           "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.0.3.tgz",
+          "integrity": "sha512-5zQyCMe8rtGiDIRjfGeqnF2YPJ7OAPFdJQeC7MakHais3dh4VG4PV2a0FacziKTzJjYK5qnPKm2sq1wSXB1wTQ==",
           "requires": {
             "component-event": "^0.1.4",
             "domify": "^1.4.1",
@@ -26316,6 +26537,8 @@
     },
     "@bpmn-io/form-js-playground": {
       "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-playground/-/form-js-playground-0.9.9.tgz",
+      "integrity": "sha512-XmdPFUpMjlnCRymEOwsFyjLNCm0VnHXWkxk4SEAGMJ6xj4uMSWoU3OYYDRQjEzoO67EpE5NmL8MhPE23n/CDoA==",
       "requires": {
         "@bpmn-io/form-js-editor": "^0.9.9",
         "@bpmn-io/form-js-viewer": "^0.9.9",
@@ -26332,6 +26555,8 @@
     },
     "@bpmn-io/form-js-viewer": {
       "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/form-js-viewer/-/form-js-viewer-0.9.9.tgz",
+      "integrity": "sha512-8V7iW1t2JrqK8E7AFb1c002Q7nx0OWVUvEiMZ1aznAk1hGgCzTg6JFltSdm77ARkVeH7kg8bHYWqrNkbWOswUw==",
       "requires": {
         "@bpmn-io/snarkdown": "^2.1.0",
         "classnames": "^2.3.1",
@@ -26343,15 +26568,21 @@
       },
       "dependencies": {
         "didi": {
-          "version": "9.0.0"
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
+          "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w=="
         },
         "min-dash": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
         }
       }
     },
     "@bpmn-io/moddle-utils": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/moddle-utils/-/moddle-utils-0.1.0.tgz",
+      "integrity": "sha512-2hon5+Lv1MCRz/O6j3xaayTltQXjIu+JEqCIwgRJco5l9eqY3liHOR2eih0bDRjnVmGXC9nS/r2s46FiULxwNw==",
       "requires": {
         "min-dash": "^3.8.1"
       }
@@ -26368,19 +26599,25 @@
       }
     },
     "@bpmn-io/snarkdown": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/snarkdown/-/snarkdown-2.1.0.tgz",
+      "integrity": "sha512-OWe9YQx3Vtnopz0trJCJVI3y7k2EfeR4QkKHfRhukcB7yxG4PD1FGaB5LAxc1wxp66V1S3LU4bqUpJdVhQhIww=="
     },
     "@camunda/element-templates-json-schema": {
       "version": "0.10.1"
     },
     "@camunda/form-linting": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@camunda/form-linting/-/form-linting-0.1.2.tgz",
+      "integrity": "sha512-U2DQcea0xPeE7xoTqcydYfbNRDvzeWbnV7111dXll3UsbS7dq7QeaM/fxjEGmEsEe79/5IuQOfLmNpyE6dblGw==",
       "requires": {
         "semver-compare": "^1.0.0"
       }
     },
     "@camunda/form-playground": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@camunda/form-playground/-/form-playground-0.2.0.tgz",
+      "integrity": "sha512-aqGD0+ps0q74jVDlpH2GFHjIovS4fT3qHyViAAGGYYgPZQZbAb9w6wVRA3x/As+9Yq7UfzHJoTeDxv/QO63TBQ==",
       "requires": {
         "classnames": "^2.3.1",
         "htm": "^3.1.1",
@@ -26391,14 +26628,85 @@
       },
       "dependencies": {
         "min-dash": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
         },
         "min-dom": {
           "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.0.3.tgz",
+          "integrity": "sha512-5zQyCMe8rtGiDIRjfGeqnF2YPJ7OAPFdJQeC7MakHais3dh4VG4PV2a0FacziKTzJjYK5qnPKm2sq1wSXB1wTQ==",
           "requires": {
             "component-event": "^0.1.4",
             "domify": "^1.4.1",
             "min-dash": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@camunda/linting": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-0.7.2.tgz",
+      "integrity": "sha512-zzFvcgx0TPf4n0gObU6jXCx8aJAV0MgshTye1eG8NyUOix+kOZTqErfbcGBsIi4zmVTdBLjxshRt4tFGdOge2A==",
+      "requires": {
+        "bpmn-moddle": "^7.1.3",
+        "bpmnlint": "^8.0.0",
+        "bpmnlint-plugin-camunda-compat": "^0.13.1",
+        "bpmnlint-utils": "^1.0.2",
+        "min-dash": "^4.0.0",
+        "min-dom": "^4.0.1",
+        "zeebe-bpmn-moddle": "^0.15.0"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+          "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
+        },
+        "bpmnlint": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-8.1.0.tgz",
+          "integrity": "sha512-mFt92TQMo5nFjoumngZ8mYCLYQ4fETNjoe4U0X76lnArKSm/CfJj5Y2U3wtQapd5zirbZFa9kuX/cdKzajZzcQ==",
+          "requires": {
+            "@bpmn-io/moddle-utils": "^0.1.0",
+            "ansi-colors": "^4.1.3",
+            "bpmn-moddle": "^7.1.3",
+            "bpmnlint-utils": "^1.0.2",
+            "cli-table": "^0.3.11",
+            "color-support": "^1.1.3",
+            "min-dash": "^3.8.1",
+            "mri": "^1.2.0",
+            "pluralize": "^7.0.0",
+            "tiny-glob": "^0.2.9"
+          },
+          "dependencies": {
+            "min-dash": {
+              "version": "3.8.1",
+              "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+              "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
+            }
+          }
+        },
+        "min-dash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
+        },
+        "min-dom": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.0.1.tgz",
+          "integrity": "sha512-82fpjdsvbwJ2cqG2I1MMWaRN8fdDZ7e7QM05aYfzXXMhU050JrqEOGATAXrCh+OBs75doTBEKp8diOuu/UfdYA==",
+          "requires": {
+            "component-event": "^0.1.4",
+            "domify": "^1.4.1",
+            "min-dash": "^3.8.1"
+          },
+          "dependencies": {
+            "min-dash": {
+              "version": "3.8.1",
+              "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+              "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
+            }
           }
         }
       }
@@ -26408,6 +26716,8 @@
     },
     "@codemirror/autocomplete": {
       "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.3.0.tgz",
+      "integrity": "sha512-4jEvh3AjJZTDKazd10J6ZsCIqaYxDMCeua5ouQxY8hlFIml+nr7le0SgBhT3SIytFBmdzPK3AUhXGuW3T79nVg==",
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -26452,6 +26762,8 @@
     },
     "@codemirror/search": {
       "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.2.1.tgz",
+      "integrity": "sha512-Q1JgUSBjQZRPIddlXzad/AVDigdhriLxQNFyP0gfrDTq6LDHNhr95U/tW3bpVssGenkaLzujtu/7XoK4kyvL3g==",
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -26475,6 +26787,8 @@
     },
     "@develar/schema-utils": {
       "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+      "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.0",
@@ -26483,6 +26797,8 @@
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true
     },
     "@electron/get": {
@@ -26524,6 +26840,8 @@
     },
     "@electron/universal": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.2.1.tgz",
+      "integrity": "sha512-7323HyMh7KBAl/nPDppdLsC87G6RwRU02dy5FPeGB1eS7rUePh55+WNWiDPLhFQqqVPHzh77M69uhmoT8XnwMQ==",
       "dev": true,
       "requires": {
         "@malept/cross-spawn-promise": "^1.1.0",
@@ -26537,6 +26855,8 @@
       "dependencies": {
         "fs-extra": {
           "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
@@ -26549,6 +26869,8 @@
     },
     "@eslint/eslintrc": {
       "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
+      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -26566,8 +26888,31 @@
       "version": "1.1.3",
       "dev": true
     },
+    "@grpc/grpc-js": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.0.tgz",
+      "integrity": "sha512-wvKxal+40Xx11DXO2q5PfY3UiE25iwTb8SOz6A9IJII/V7d19x2ex0he+GJfVW0JZCaBjCPSjUB0yU9Ecm4WCw==",
+      "requires": {
+        "@grpc/proto-loader": "^0.7.0",
+        "@types/node": ">=12.12.47"
+      }
+    },
+    "@grpc/proto-loader": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.3.tgz",
+      "integrity": "sha512-5dAvoZwna2Py3Ef96Ux9jIkp3iZ62TUsV00p3wVBPNX5K178UbNi8Q7gQVqwXT1Yq9RejIGG9G2IPEo93T6RcA==",
+      "requires": {
+        "@types/long": "^4.0.1",
+        "lodash.camelcase": "^4.3.0",
+        "long": "^4.0.0",
+        "protobufjs": "^7.0.0",
+        "yargs": "^16.2.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
+      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -26577,14 +26922,20 @@
     },
     "@humanwhocodes/gitignore-to-minimatch": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
+      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
       "dev": true
     },
     "@humanwhocodes/module-importer": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
     "@hutson/parse-repository-url": {
@@ -26687,6 +27038,8 @@
     },
     "@jridgewell/source-map": {
       "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
       "dev": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
@@ -28141,6 +28494,8 @@
     },
     "@malept/cross-spawn-promise": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.1"
@@ -28148,6 +28503,8 @@
     },
     "@malept/flatpak-bundler": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+      "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -28158,6 +28515,8 @@
       "dependencies": {
         "fs-extra": {
           "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
@@ -28594,11 +28953,75 @@
       "requires": {
         "node-addon-api": "^3.2.1",
         "node-gyp-build": "^4.3.0"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "3.2.1",
+          "dev": true
+        }
       }
     },
+    "@philippfromme/moddle-helpers": {
+      "version": "0.1.0",
+      "dev": true,
+      "peer": true
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "@sindresorhus/is": {
-      "version": "0.14.0",
-      "dev": true
+      "version": "0.14.0"
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -28633,7 +29056,6 @@
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
-      "dev": true,
       "requires": {
         "defer-to-connect": "^1.0.1"
       }
@@ -28659,6 +29081,8 @@
     },
     "@types/eslint": {
       "version": "8.4.6",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
+      "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
@@ -28667,6 +29091,8 @@
     },
     "@types/eslint-scope": {
       "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+      "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
       "dev": true,
       "requires": {
         "@types/eslint": "*",
@@ -28675,6 +29101,8 @@
     },
     "@types/estree": {
       "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
     },
     "@types/fs-extra": {
@@ -28686,6 +29114,8 @@
     },
     "@types/glob": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -28695,14 +29125,23 @@
     },
     "@types/json-schema": {
       "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
     "@types/json5": {
       "version": "0.0.29",
       "dev": true
     },
+    "@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
     "@types/minimatch": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true,
       "optional": true
     },
@@ -28715,8 +29154,7 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.7.13",
-      "dev": true
+      "version": "18.7.13"
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -28725,6 +29163,24 @@
     "@types/parse-json": {
       "version": "4.0.0",
       "dev": true
+    },
+    "@types/plist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.2.tgz",
+      "integrity": "sha512-ULqvZNGMv0zRFvqn8/4LSPtnmN4MfhlPNtJCTpKuIIxGVGZ2rYWzFXrvEBoh9CVyqSE7D6YFRJ1hydLHI6kbWw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*",
+        "xmlbuilder": ">=11.0.1"
+      }
+    },
+    "@types/verror": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.6.tgz",
+      "integrity": "sha512-NNm+gdePAX1VGvPcGZCDKQZKYSiAWigKhKaz5KF94hG6f2s8de9Ow5+7AbXoeKxL8gavZfk4UquSAygOF2duEQ==",
+      "dev": true,
+      "optional": true
     },
     "@types/yargs": {
       "version": "17.0.11",
@@ -28739,6 +29195,8 @@
     },
     "@types/yauzl": {
       "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -28751,6 +29209,8 @@
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+      "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
       "dev": true,
       "requires": {
         "@webassemblyjs/helper-numbers": "1.11.1",
@@ -28759,18 +29219,26 @@
     },
     "@webassemblyjs/floating-point-hex-parser": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+      "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+      "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+      "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
       "dev": true
     },
     "@webassemblyjs/helper-numbers": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+      "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
       "dev": true,
       "requires": {
         "@webassemblyjs/floating-point-hex-parser": "1.11.1",
@@ -28780,10 +29248,14 @@
     },
     "@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+      "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+      "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
@@ -28794,6 +29266,8 @@
     },
     "@webassemblyjs/ieee754": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+      "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
       "dev": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
@@ -28801,6 +29275,8 @@
     },
     "@webassemblyjs/leb128": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+      "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
       "dev": true,
       "requires": {
         "@xtuc/long": "4.2.2"
@@ -28808,10 +29284,14 @@
     },
     "@webassemblyjs/utf8": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+      "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+      "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
@@ -28826,6 +29306,8 @@
     },
     "@webassemblyjs/wasm-gen": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+      "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
@@ -28837,6 +29319,8 @@
     },
     "@webassemblyjs/wasm-opt": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+      "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
@@ -28847,6 +29331,8 @@
     },
     "@webassemblyjs/wasm-parser": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+      "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
@@ -28859,6 +29345,8 @@
     },
     "@webassemblyjs/wast-printer": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+      "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
@@ -28867,11 +29355,15 @@
     },
     "@webpack-cli/configtest": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+      "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
       "dev": true,
       "requires": {}
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
+      "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
       "dev": true,
       "requires": {
         "envinfo": "^7.7.3"
@@ -28879,15 +29371,21 @@
     },
     "@webpack-cli/serve": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
+      "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
       "dev": true,
       "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
       "dev": true
     },
     "@xtuc/long": {
       "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
     "7zip-bin": {
@@ -28908,10 +29406,14 @@
     },
     "acorn": {
       "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
     },
@@ -28982,12 +29484,10 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.1",
-      "dev": true
+      "version": "5.0.1"
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -29011,6 +29511,8 @@
     },
     "app-builder-lib": {
       "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.6.0.tgz",
+      "integrity": "sha512-dQYDuqm/rmy8GSCE6Xl/3ShJg6Ab4bZJMT8KaTKGzT436gl1DN4REP3FCWfXoh75qGTJ+u+WsdnnpO9Jl8nyMA==",
       "dev": true,
       "requires": {
         "@develar/schema-utils": "~2.6.5",
@@ -29043,6 +29545,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
@@ -29050,10 +29554,14 @@
         },
         "app-builder-bin": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
+          "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
           "dev": true
         },
         "builder-util": {
           "version": "23.6.0",
+          "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.6.0.tgz",
+          "integrity": "sha512-QiQHweYsh8o+U/KNCZFSvISRnvRctb8m/2rB2I1JdByzvNKxPeFLlHFRPQRXab6aYeXc18j9LpsDLJ3sGQmWTQ==",
           "dev": true,
           "requires": {
             "@types/debug": "^4.1.6",
@@ -29077,6 +29585,8 @@
         },
         "builder-util-runtime": {
           "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.1.1.tgz",
+          "integrity": "sha512-azRhYLEoDvRDR8Dhis4JatELC/jUvYjm4cVSj7n9dauGTOM2eeNn9KS0z6YA6oDsjI1xphjNbY6PZZeHPzzqaw==",
           "dev": true,
           "requires": {
             "debug": "^4.3.4",
@@ -29085,6 +29595,8 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -29093,6 +29605,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -29100,14 +29614,20 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "semver": {
           "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -29115,6 +29635,8 @@
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -29290,6 +29812,8 @@
     },
     "asar": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/asar/-/asar-3.2.0.tgz",
+      "integrity": "sha512-COdw2ZQvKdFGFxXwX3oYh2/sOsJWJegrdJCGxnN4MZ7IULgRBp9P6665aqj9z1v9VwP4oP1hRBojRDQ//IGgAg==",
       "dev": true,
       "requires": {
         "@types/glob": "^7.1.1",
@@ -29299,6 +29823,13 @@
         "minimatch": "^3.0.4"
       }
     },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true,
+      "optional": true
+    },
     "assertion-error": {
       "version": "1.1.0",
       "dev": true
@@ -29306,6 +29837,13 @@
     "assign-symbols": {
       "version": "1.0.0",
       "dev": true
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "optional": true
     },
     "async": {
       "version": "2.6.4",
@@ -29324,14 +29862,17 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "at-least-node": {
       "version": "1.0.0",
       "dev": true
     },
     "atoa": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atoa/-/atoa-1.0.0.tgz",
+      "integrity": "sha512-VVE1H6cc4ai+ZXo/CRWoJiHXrA1qfA31DPnx6D20+kSI547hQN5Greh51LQ1baMRMfxO5K5M4ImMtZbZt2DODQ=="
     },
     "atob": {
       "version": "2.1.2",
@@ -29459,6 +30000,14 @@
       "version": "1.13.1",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.1.0",
       "dev": true,
@@ -29542,9 +30091,42 @@
         "tiny-svg": "^2.2.4"
       }
     },
+    "bpmn-js-disable-collapsed-subprocess": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/bpmn-js-disable-collapsed-subprocess/-/bpmn-js-disable-collapsed-subprocess-0.1.7.tgz",
+      "integrity": "sha512-Lhaklmi77ulvcWG8wh6w0nLVAIlWvHPkri6hwm7ReP6tw/S2SMSNsFHYa+dfvVEZD30uNLZHGpDztZOdxBGvrw==",
+      "requires": {
+        "min-dash": "^4.0.0"
+      },
+      "dependencies": {
+        "min-dash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
+        }
+      }
+    },
     "bpmn-js-executable-fix": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-executable-fix/-/bpmn-js-executable-fix-0.2.0.tgz",
+      "integrity": "sha512-sIQ+eW4pWUzBPTDIzTPlWpmBZ0uodvWMJqtfc2Mqh6wZm97BC+PXeEFw35cl7dM0HjN3eueKMbKSrXTtk+JZ6Q==",
       "requires": {}
+    },
+    "bpmn-js-properties-panel": {
+      "version": "1.6.1",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@bpmn-io/element-templates-validator": "^0.10.0",
+        "@bpmn-io/extract-process-variables": "^0.5.0",
+        "array-move": "^3.0.1",
+        "classnames": "^2.3.1",
+        "ids": "^1.0.0",
+        "min-dash": "^3.8.1",
+        "min-dom": "^3.1.3",
+        "preact-markup": "^2.1.1",
+        "semver-compare": "^1.0.0"
+      }
     },
     "bpmn-moddle": {
       "version": "7.1.3",
@@ -29555,33 +30137,38 @@
       }
     },
     "bpmnlint": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-8.1.1.tgz",
-      "integrity": "sha512-MN81JGqqHx2+wAF1HVvYq7N5+lKJd82Op8VnLQ19V56HmavwbwUlR+r3L5jv6x/YCthudR1FVhEd/N20xQLHEg==",
+      "version": "7.8.0",
+      "dev": true,
+      "peer": true,
       "requires": {
-        "@bpmn-io/moddle-utils": "^0.1.0",
-        "ansi-colors": "^4.1.3",
-        "bpmn-moddle": "^7.1.3",
+        "@philippfromme/moddle-helpers": "^0.1.0",
+        "ansi-colors": "^4.1.1",
+        "bpmn-moddle": "^7.1.2",
         "bpmnlint-utils": "^1.0.2",
-        "cli-table": "^0.3.11",
+        "cli-table": "^0.3.9",
         "color-support": "^1.1.3",
-        "min-dash": "^3.8.1",
+        "min-dash": "^3.8.0",
         "mri": "^1.2.0",
         "pluralize": "^7.0.0",
         "tiny-glob": "^0.2.9"
-      },
-      "dependencies": {
-        "ansi-colors": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-          "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="
-        }
       }
     },
     "bpmnlint-loader": {
       "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bpmnlint-loader/-/bpmnlint-loader-0.1.6.tgz",
+      "integrity": "sha512-/XmvV70NT1uTpjtC6C5bTJvWFR6v5RFxLzUCuP0ScKKlTf6me9rYgV0sAXdbW2011vFSFfD8DJHTi+D3gnSUww==",
       "dev": true,
       "requires": {}
+    },
+    "bpmnlint-plugin-camunda-compat": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.13.1.tgz",
+      "integrity": "sha512-Zp11rMtJXA3GM2u8Vx9eCDN54bBW5BLHtmDUy6++bk8PdKSSqzOh40TGx4pxl+QtxlRB8WcNBCS5QFaJmMgPKw==",
+      "requires": {
+        "@bpmn-io/moddle-utils": "^0.1.0",
+        "bpmnlint-utils": "^1.0.2",
+        "min-dash": "^3.8.1"
+      }
     },
     "bpmnlint-utils": {
       "version": "1.0.2"
@@ -29627,6 +30214,8 @@
     },
     "buffer-alloc": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,
       "requires": {
         "buffer-alloc-unsafe": "^1.1.0",
@@ -29635,6 +30224,8 @@
     },
     "buffer-alloc-unsafe": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
       "dev": true
     },
     "buffer-crc32": {
@@ -29643,10 +30234,14 @@
     },
     "buffer-equal": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+      "integrity": "sha512-tcBWO2Dl4e7Asr9hTGcpVrCe+F7DubpmqWCTbj4FHLmjqO2hIaC383acQubWtRJhdceqs5uBHs6Es+Sk//RKiQ==",
       "dev": true
     },
     "buffer-fill": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
       "dev": true
     },
     "buffer-from": {
@@ -29802,7 +30397,6 @@
     },
     "cacheable-request": {
       "version": "6.1.0",
-      "dev": true,
       "requires": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -29815,18 +30409,15 @@
       "dependencies": {
         "get-stream": {
           "version": "5.1.0",
-          "dev": true,
           "requires": {
             "pump": "^3.0.0"
           }
         },
         "lowercase-keys": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "normalize-url": {
-          "version": "4.5.1",
-          "dev": true
+          "version": "4.5.1"
         }
       }
     },
@@ -29864,6 +30455,26 @@
       "version": "3.1.0",
       "dev": true
     },
+    "camunda-bpmn-js-behaviors": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-0.2.2.tgz",
+      "integrity": "sha512-MsWByIIE4qdUVNAcOAGZBmouadHHxDgHuCmwOfg5rCiUICW5ljmzDJHgp3L00OOv+OuxiHC81h13Lc6/HLfPmQ==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "ids": "^1.0.0",
+        "min-dash": "^4.0.0"
+      },
+      "dependencies": {
+        "min-dash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA==",
+          "optional": true,
+          "peer": true
+        }
+      }
+    },
     "camunda-bpmn-moddle": {
       "version": "7.0.1"
     },
@@ -29888,57 +30499,6 @@
         "zeebe-node": "^8.1.0"
       },
       "dependencies": {
-        "@grpc/grpc-js": {
-          "version": "1.7.1",
-          "requires": {
-            "@grpc/proto-loader": "^0.7.0",
-            "@types/node": ">=12.12.47"
-          }
-        },
-        "@grpc/proto-loader": {
-          "version": "0.7.3",
-          "requires": {
-            "@types/long": "^4.0.1",
-            "lodash.camelcase": "^4.3.0",
-            "long": "^4.0.0",
-            "protobufjs": "^7.0.0",
-            "yargs": "^16.2.0"
-          }
-        },
-        "@protobufjs/aspromise": {
-          "version": "1.1.2"
-        },
-        "@protobufjs/base64": {
-          "version": "1.1.2"
-        },
-        "@protobufjs/codegen": {
-          "version": "2.0.4"
-        },
-        "@protobufjs/eventemitter": {
-          "version": "1.1.0"
-        },
-        "@protobufjs/fetch": {
-          "version": "1.1.0",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.1",
-            "@protobufjs/inquire": "^1.1.0"
-          }
-        },
-        "@protobufjs/float": {
-          "version": "1.0.2"
-        },
-        "@protobufjs/inquire": {
-          "version": "1.1.0"
-        },
-        "@protobufjs/path": {
-          "version": "1.1.2"
-        },
-        "@protobufjs/pool": {
-          "version": "1.1.0"
-        },
-        "@protobufjs/utf8": {
-          "version": "1.1.0"
-        },
         "@sentry/core": {
           "version": "6.3.6",
           "requires": {
@@ -29999,38 +30559,11 @@
             "tslib": "^1.9.3"
           }
         },
-        "@sindresorhus/is": {
-          "version": "0.14.0"
-        },
-        "@szmarczak/http-timer": {
-          "version": "1.1.2",
-          "requires": {
-            "defer-to-connect": "^1.0.1"
-          }
-        },
-        "@types/long": {
-          "version": "4.0.2"
-        },
-        "@types/node": {
-          "version": "18.8.1"
-        },
         "agent-base": {
           "version": "6.0.2",
           "requires": {
             "debug": "4"
           }
-        },
-        "ansi-regex": {
-          "version": "5.0.1"
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "asynckit": {
-          "version": "0.4.0"
         },
         "balanced-match": {
           "version": "1.0.0"
@@ -30042,161 +30575,16 @@
             "concat-map": "0.0.1"
           }
         },
-        "cacheable-request": {
-          "version": "6.1.0",
-          "requires": {
-            "clone-response": "^1.0.2",
-            "get-stream": "^5.1.0",
-            "http-cache-semantics": "^4.0.0",
-            "keyv": "^3.0.0",
-            "lowercase-keys": "^2.0.0",
-            "normalize-url": "^4.1.0",
-            "responselike": "^1.0.2"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "5.2.0",
-              "requires": {
-                "pump": "^3.0.0"
-              }
-            },
-            "lowercase-keys": {
-              "version": "2.0.0"
-            }
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "cliui": {
-          "version": "7.0.4",
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "clone-response": {
-          "version": "1.0.3",
-          "requires": {
-            "mimic-response": "^1.0.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3"
-        },
-        "combined-stream": {
-          "version": "1.0.8",
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        },
         "concat-map": {
           "version": "0.0.1"
         },
-        "console-stamp": {
-          "version": "3.0.6",
-          "requires": {
-            "chalk": "^4.1.2",
-            "dateformat": "^4.6.3"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "4.3.0",
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            },
-            "chalk": {
-              "version": "4.1.2",
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            },
-            "color-convert": {
-              "version": "2.0.1",
-              "requires": {
-                "color-name": "~1.1.4"
-              }
-            },
-            "color-name": {
-              "version": "1.1.4"
-            },
-            "has-flag": {
-              "version": "4.0.0"
-            },
-            "supports-color": {
-              "version": "7.2.0",
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            }
-          }
-        },
         "cookie": {
           "version": "0.4.1"
-        },
-        "dateformat": {
-          "version": "4.6.3"
-        },
-        "dayjs": {
-          "version": "1.11.5"
         },
         "debug": {
           "version": "4.3.1",
           "requires": {
             "ms": "2.1.2"
-          }
-        },
-        "decompress-response": {
-          "version": "3.3.0",
-          "requires": {
-            "mimic-response": "^1.0.0"
-          }
-        },
-        "defer-to-connect": {
-          "version": "1.1.3"
-        },
-        "delayed-stream": {
-          "version": "1.0.0"
-        },
-        "duplexer3": {
-          "version": "0.1.5"
-        },
-        "emoji-regex": {
-          "version": "8.0.0"
-        },
-        "end-of-stream": {
-          "version": "1.4.4",
-          "requires": {
-            "once": "^1.4.0"
-          }
-        },
-        "err-code": {
-          "version": "1.1.2"
-        },
-        "escalade": {
-          "version": "3.1.1"
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5"
-        },
-        "fast-xml-parser": {
-          "version": "3.21.1",
-          "requires": {
-            "strnum": "^1.0.4"
           }
         },
         "form-data": {
@@ -30207,20 +30595,8 @@
             "mime-types": "^2.1.12"
           }
         },
-        "fp-ts": {
-          "version": "2.12.3"
-        },
         "fs.realpath": {
           "version": "1.0.0"
-        },
-        "get-caller-file": {
-          "version": "2.0.5"
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "requires": {
-            "pump": "^3.0.0"
-          }
         },
         "glob": {
           "version": "7.1.6",
@@ -30232,28 +30608,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "got": {
-          "version": "9.6.0",
-          "requires": {
-            "@sindresorhus/is": "^0.14.0",
-            "@szmarczak/http-timer": "^1.1.2",
-            "cacheable-request": "^6.0.0",
-            "decompress-response": "^3.3.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^4.1.0",
-            "lowercase-keys": "^1.0.1",
-            "mimic-response": "^1.0.1",
-            "p-cancelable": "^1.0.0",
-            "to-readable-stream": "^1.0.0",
-            "url-parse-lax": "^3.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0"
-        },
-        "http-cache-semantics": {
-          "version": "4.1.0"
         },
         "https-proxy-agent": {
           "version": "5.0.0",
@@ -30275,27 +30629,6 @@
         "inherits": {
           "version": "2.0.4"
         },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0"
-        },
-        "json-buffer": {
-          "version": "3.0.0"
-        },
-        "keyv": {
-          "version": "3.1.0",
-          "requires": {
-            "json-buffer": "3.0.0"
-          }
-        },
-        "lodash.camelcase": {
-          "version": "4.3.0"
-        },
-        "long": {
-          "version": "4.0.0"
-        },
-        "lowercase-keys": {
-          "version": "1.0.1"
-        },
         "lru_map": {
           "version": "0.3.3"
         },
@@ -30308,11 +30641,10 @@
             "mime-db": "1.45.0"
           }
         },
-        "mimic-response": {
-          "version": "1.0.1"
-        },
         "min-dash": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
         },
         "minimatch": {
           "version": "3.0.4",
@@ -30332,17 +30664,11 @@
             "whatwg-url": "^5.0.0"
           }
         },
-        "normalize-url": {
-          "version": "4.5.1"
-        },
         "once": {
           "version": "1.4.0",
           "requires": {
             "wrappy": "1"
           }
-        },
-        "p-cancelable": {
-          "version": "1.1.0"
         },
         "parents": {
           "version": "1.0.1",
@@ -30356,103 +30682,11 @@
         "path-platform": {
           "version": "0.11.15"
         },
-        "prepend-http": {
-          "version": "2.0.0"
-        },
-        "promise-retry": {
-          "version": "1.1.1",
-          "requires": {
-            "err-code": "^1.0.0",
-            "retry": "^0.10.0"
-          }
-        },
-        "protobufjs": {
-          "version": "7.1.2",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
-          },
-          "dependencies": {
-            "long": {
-              "version": "5.2.0"
-            }
-          }
-        },
-        "pump": {
-          "version": "3.0.0",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "require-directory": {
-          "version": "2.1.1"
-        },
-        "responselike": {
-          "version": "1.0.2",
-          "requires": {
-            "lowercase-keys": "^1.0.0"
-          }
-        },
-        "retry": {
-          "version": "0.10.1"
-        },
-        "stack-trace": {
-          "version": "0.0.10"
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
-        "strnum": {
-          "version": "1.0.5"
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "to-readable-stream": {
-          "version": "1.0.0"
-        },
         "tr46": {
           "version": "0.0.3"
         },
         "tslib": {
           "version": "1.14.1"
-        },
-        "typed-duration": {
-          "version": "1.0.13"
-        },
-        "url-parse-lax": {
-          "version": "3.0.0",
-          "requires": {
-            "prepend-http": "^2.0.0"
-          }
-        },
-        "uuid": {
-          "version": "3.4.0"
         },
         "webidl-conversions": {
           "version": "3.0.1"
@@ -30464,70 +30698,8 @@
             "webidl-conversions": "^3.0.0"
           }
         },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "4.3.0",
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            },
-            "color-convert": {
-              "version": "2.0.1",
-              "requires": {
-                "color-name": "~1.1.4"
-              }
-            },
-            "color-name": {
-              "version": "1.1.4"
-            }
-          }
-        },
         "wrappy": {
           "version": "1.0.2"
-        },
-        "y18n": {
-          "version": "5.0.8"
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.9"
-        },
-        "zeebe-node": {
-          "version": "8.1.0",
-          "requires": {
-            "@grpc/grpc-js": "^1.7.0",
-            "@grpc/proto-loader": "^0.7.2",
-            "chalk": "^2.4.2",
-            "console-stamp": "^3.0.2",
-            "dayjs": "^1.8.15",
-            "debug": "^4.2.0",
-            "fast-xml-parser": "^3.12.12",
-            "fp-ts": "^2.5.1",
-            "got": "^9.6.0",
-            "long": "^4.0.0",
-            "promise-retry": "^1.1.1",
-            "stack-trace": "0.0.10",
-            "typed-duration": "^1.0.12",
-            "uuid": "^3.3.2"
-          }
         }
       }
     },
@@ -30549,7 +30721,7 @@
         "@camunda/execution-platform": "^0.3.2",
         "@camunda/form-linting": "^0.1.2",
         "@camunda/form-playground": "^0.2.0",
-        "@camunda/linting": "^0.10.0",
+        "@camunda/linting": "^0.7.2",
         "@codemirror/commands": "^6.1.0",
         "@codemirror/lang-json": "^6.0.0",
         "@codemirror/lang-xml": "^6.0.0",
@@ -30562,10 +30734,10 @@
         "babel-loader": "^8.0.5",
         "babel-plugin-istanbul": "^5.1.3",
         "bpmn-js": "^10.2.1",
-        "bpmn-js-properties-panel": "^1.10.0",
+        "bpmn-js-properties-panel": "^1.11.2",
         "bpmn-moddle": "^8.0.0",
         "bpmnlint-loader": "^0.1.6",
-        "camunda-bpmn-js": "^0.23.0",
+        "camunda-bpmn-js": "^0.21.1",
         "camunda-bpmn-moddle": "^7.0.1",
         "camunda-cmmn-moddle": "^1.0.0",
         "camunda-dmn-js": "^0.7.0",
@@ -30628,7 +30800,7 @@
         "ua-parser-js": "^0.7.28",
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0",
-        "zeebe-bpmn-moddle": "^0.16.0"
+        "zeebe-bpmn-moddle": "^0.15.0"
       },
       "dependencies": {
         "@babel/helper-annotate-as-pure": {
@@ -31205,12 +31377,16 @@
           },
           "dependencies": {
             "min-dash": {
-              "version": "3.8.1"
+              "version": "3.8.1",
+              "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+              "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
             }
           }
         },
         "@bpmn-io/element-templates-validator": {
           "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-0.11.0.tgz",
+          "integrity": "sha512-4eZCPLuWf1N4lL8jIKZjWgwLJ2IUTgkQ4VDnfbDiSvjGJqHaLA4XBcC5smvb8Q/MqsJFxWZumolJJb1h7gt39Q==",
           "requires": {
             "@camunda/element-templates-json-schema": "^0.10.1",
             "@camunda/zeebe-element-templates-json-schema": "^0.6.0",
@@ -31220,12 +31396,16 @@
         },
         "@bpmn-io/extract-process-variables": {
           "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.6.0.tgz",
+          "integrity": "sha512-vq4jwGXDO11jwQgj9lvpVxVxjnRAz4C4TqPnhromcsllH5iRBrUNtBKgK0c/RWxiEGNTBhTYm19sP+LN1UcLWA==",
           "requires": {
             "min-dash": "^4.0.0"
           }
         },
         "@bpmn-io/feel-editor": {
           "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-0.4.1.tgz",
+          "integrity": "sha512-+UGpofI09xGxs1Rr/1V3NLeNSfeKrIGcWvwDY5M3xb4tP6nOQfwqmQA1761Wni9fl3RuLzf6gOx7vGWeQ7afIA==",
           "requires": {
             "@codemirror/autocomplete": "^6.1.1",
             "@codemirror/commands": "^6.0.0",
@@ -31241,6 +31421,8 @@
         },
         "@bpmn-io/properties-panel": {
           "version": "0.24.0",
+          "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.24.0.tgz",
+          "integrity": "sha512-eOkWrMHQqvzpYiTvSFEitoq6lu1uMvvuayB1Q/OfHgkTPZNCj6bAxxDbnXu2TR/oUxOFQ2200pituVhomJPq7w==",
           "requires": {
             "@bpmn-io/feel-editor": "0.4.1",
             "classnames": "^2.3.1",
@@ -31254,44 +31436,6 @@
         "@camunda/execution-platform": {
           "version": "0.3.2",
           "requires": {}
-        },
-        "@camunda/linting": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-0.10.0.tgz",
-          "integrity": "sha512-xWIPMSdALFjH8G1svfmvvj7l8RL9DjNgPyc4bvZKXQtzbJebbyi1KLHf3eTAlnfmalOhQT1Hr6wJZrVMDe37pA==",
-          "requires": {
-            "bpmn-moddle": "^7.1.3",
-            "bpmnlint": "^8.0.0",
-            "bpmnlint-plugin-camunda-compat": "^0.15.1",
-            "bpmnlint-utils": "^1.0.2",
-            "min-dash": "^4.0.0",
-            "min-dom": "^4.0.1",
-            "zeebe-bpmn-moddle": "^0.15.0"
-          },
-          "dependencies": {
-            "bpmn-moddle": {
-              "version": "7.1.3",
-              "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-7.1.3.tgz",
-              "integrity": "sha512-ZcBfw0NSOdYTSXFKEn7MOXHItz7VfLZTrFYKO8cK6V8ZzGjCcdiLIOiw7Lctw1PJsihhLiZQS8Htj2xKf+NwCg==",
-              "requires": {
-                "min-dash": "^3.5.2",
-                "moddle": "^5.0.2",
-                "moddle-xml": "^9.0.6"
-              },
-              "dependencies": {
-                "min-dash": {
-                  "version": "3.8.1",
-                  "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
-                  "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
-                }
-              }
-            },
-            "zeebe-bpmn-moddle": {
-              "version": "0.15.0",
-              "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.15.0.tgz",
-              "integrity": "sha512-cgn6bjkjrtOGcRumrgWnT1J93wTKmnFlSGGuwGXjF7pOksPF28ssbKiwKVMU6IXHnBDIVLQdf8fVNZn7JiBtQQ=="
-            }
-          }
         },
         "@codemirror/lang-xml": {
           "version": "6.0.0",
@@ -31566,13 +31710,13 @@
           "dev": true
         },
         "bpmn-js": {
-          "version": "10.3.0",
-          "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-10.3.0.tgz",
-          "integrity": "sha512-6tO5SHt5YyxgX9lRAAwYNmtSum4ZAekP6S0kdDlmh2ztDRAjUZaq7n1Q1ORzTddpngviRZyf5ssP1ZqjE6CgUQ==",
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-10.2.1.tgz",
+          "integrity": "sha512-7ejbrq0CXQXon6oTUH4Dfq+KbNWsD7TXN0GTu1e5PA5V/w9s4bDTd95c+6/1ltJNOyYi6zwBFh5jjuEpAJGbVQ==",
           "requires": {
             "bpmn-moddle": "^8.0.0",
             "css.escape": "^1.5.1",
-            "diagram-js": "^10.0.0",
+            "diagram-js": "^9.1.0",
             "diagram-js-direct-editing": "^2.0.0",
             "ids": "^1.0.0",
             "inherits-browser": "^0.1.0",
@@ -31582,29 +31726,17 @@
             "tiny-svg": "^3.0.0"
           },
           "dependencies": {
-            "diagram-js": {
-              "version": "10.0.0",
-              "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-10.0.0.tgz",
-              "integrity": "sha512-VtZof5MLwVpHjTznfS7B1rQxYtpJ1Gyzse7Aan22QgMhD8FDpm0nXcIblkB//05vFJUljJfp9etNujJtmU1yvA==",
-              "requires": {
-                "css.escape": "^1.5.1",
-                "didi": "^9.0.0",
-                "hammerjs": "^2.0.1",
-                "inherits-browser": "^0.1.0",
-                "min-dash": "^4.0.0",
-                "min-dom": "^4.0.2",
-                "object-refs": "^0.3.0",
-                "path-intersection": "^2.2.1",
-                "tiny-svg": "^3.0.0"
-              }
-            },
             "tiny-svg": {
-              "version": "3.0.0"
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
+              "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w=="
             }
           }
         },
         "bpmn-js-properties-panel": {
           "version": "1.11.2",
+          "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-1.11.2.tgz",
+          "integrity": "sha512-gaaf+0nzdUVe4TuJHURXSnVQLZgvmwMapIAp3/KlNg8U2b3PBGLdcpgUGhvjhnYZZI5fQSV6u91kRshbJ8rrkA==",
           "requires": {
             "@bpmn-io/element-templates-validator": "^0.11.0",
             "@bpmn-io/extract-process-variables": "^0.6.0",
@@ -31619,6 +31751,8 @@
         },
         "bpmn-moddle": {
           "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-8.0.0.tgz",
+          "integrity": "sha512-mHmtIVzUyZcPMKKl/REq151gYxEtZxvivKnIEp/RtuRm8SOgxAK58uYBkP+jQQBy6XudwObRTH0pwyeKLALWrA==",
           "requires": {
             "min-dash": "^4.0.0",
             "moddle": "^6.0.0",
@@ -31627,36 +31761,21 @@
           "dependencies": {
             "moddle": {
               "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/moddle/-/moddle-6.0.0.tgz",
+              "integrity": "sha512-dHYSJpGV0R0X8cJeWWUnE0VqCA0SFP0jZYQtO23EdsBk+MpAgSpdhXadYR6WbHElKroB6XTbifpsWro26UlP6Q==",
               "requires": {
                 "min-dash": "^4.0.0"
               }
             },
             "moddle-xml": {
               "version": "10.0.0",
+              "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-10.0.0.tgz",
+              "integrity": "sha512-e5qG0uC9ebHXInLEKW9pZNqcAK7ALCOKmcLw8jmepBPY9BiUZFi+8Th/Cydog3S1rrUXyyo0pqaHaCvc1zt6VA==",
               "requires": {
                 "min-dash": "^4.0.0",
                 "moddle": "^6.0.0",
                 "saxen": "^8.1.2"
               }
-            }
-          }
-        },
-        "bpmnlint-plugin-camunda-compat": {
-          "version": "0.15.2",
-          "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-0.15.2.tgz",
-          "integrity": "sha512-Ah30wOH/NoSKtLF4W+SBRbkCV9qT+Jf2p4JYUcO1K05/3sh4d6j0cO4BMHBt/HTgK94JSstDaopXA4NxeJww5g==",
-          "requires": {
-            "@bpmn-io/feel-lint": "^0.1.0",
-            "@bpmn-io/moddle-utils": "^0.1.0",
-            "bpmnlint-utils": "^1.0.2",
-            "min-dash": "^3.8.1",
-            "semver-compare": "^1.0.0"
-          },
-          "dependencies": {
-            "min-dash": {
-              "version": "3.8.1",
-              "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
-              "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
             }
           }
         },
@@ -31668,49 +31787,41 @@
           }
         },
         "camunda-bpmn-js": {
-          "version": "0.23.1",
-          "resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-0.23.1.tgz",
-          "integrity": "sha512-aTWc02X+DA04tubC3MzA2PxpmmIoohsaPjoF3TDwNIsonzOZMSxpu6j+ZOnGdW4mKFIIqsLPXMKyM9imeurJuQ==",
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-0.21.1.tgz",
+          "integrity": "sha512-ZB5g+tkdegEW+ax4m4jKG0/n79y1amDyr0+1HFSUb+jGzta6pu+2kc9M2BnJa5Zq5Jm3iNHWdMgoI6+u6KTrPg==",
           "requires": {
             "@bpmn-io/align-to-origin": "^0.7.0",
             "@bpmn-io/element-templates-icons-renderer": "^0.3.0",
-            "bpmn-js": "^10.3.0",
+            "bpmn-js": "^10.2.0",
+            "bpmn-js-disable-collapsed-subprocess": "^0.1.7",
             "bpmn-js-executable-fix": "^0.2.0",
-            "camunda-bpmn-js-behaviors": "^0.4.0",
+            "camunda-bpmn-js-behaviors": "^0.3.0",
             "camunda-bpmn-moddle": "^7.0.1",
-            "diagram-js": "^10.0.0",
+            "diagram-js": "^9.1.0",
             "diagram-js-minimap": "^3.0.0",
             "diagram-js-origin": "^1.3.4",
             "inherits": "^2.0.4",
             "min-dash": "^4.0.0",
-            "zeebe-bpmn-moddle": "^0.16.0"
+            "zeebe-bpmn-moddle": "^0.15.0"
           },
           "dependencies": {
-            "diagram-js": {
-              "version": "10.0.0",
-              "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-10.0.0.tgz",
-              "integrity": "sha512-VtZof5MLwVpHjTznfS7B1rQxYtpJ1Gyzse7Aan22QgMhD8FDpm0nXcIblkB//05vFJUljJfp9etNujJtmU1yvA==",
+            "camunda-bpmn-js-behaviors": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-0.3.0.tgz",
+              "integrity": "sha512-isD424Lwgh4+v3IWDnqLkkA/oIQcwFHQ6TmxUYBNuF5WshO25a2u/6SgAtBiWpg2xqjD5x8zi5/0JWr/Yp7WEg==",
               "requires": {
-                "css.escape": "^1.5.1",
-                "didi": "^9.0.0",
-                "hammerjs": "^2.0.1",
-                "inherits-browser": "^0.1.0",
-                "min-dash": "^4.0.0",
-                "min-dom": "^4.0.2",
-                "object-refs": "^0.3.0",
-                "path-intersection": "^2.2.1",
-                "tiny-svg": "^3.0.0"
+                "ids": "^1.0.0",
+                "min-dash": "^4.0.0"
               }
-            },
-            "tiny-svg": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
-              "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w=="
             }
           }
         },
         "camunda-bpmn-js-behaviors": {
           "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-0.4.0.tgz",
+          "integrity": "sha512-Scyc2n85HLPTdvnTCE8rdU0AwuWkdvsq19JZkXhIuTdT9qeUY+FnuIlpa+H0OIvf4E/R0Vkn4mc4LkePUQPRdg==",
+          "peer": true,
           "requires": {
             "ids": "^1.0.0",
             "min-dash": "^4.0.0"
@@ -31721,6 +31832,8 @@
         },
         "camunda-dmn-js": {
           "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/camunda-dmn-js/-/camunda-dmn-js-0.7.0.tgz",
+          "integrity": "sha512-FR6CT+nDrmmEmmJYtPzTd72S8FBNl5JIH2o7A2zFRXStQqTPrCekO7JaMcSUPpYaCEAPxVnFIf1ONx10Sv2TRg==",
           "requires": {
             "@bpmn-io/align-to-origin": "^0.7.0",
             "camunda-dmn-moddle": "^1.1.0",
@@ -31887,6 +32000,8 @@
         },
         "commander": {
           "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
         },
         "copy-anything": {
@@ -32059,6 +32174,8 @@
         },
         "diagram-js": {
           "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-9.1.0.tgz",
+          "integrity": "sha512-Kh74c7iKczxrDmnnRn3Fay8+1AnOIEm22A7yxPP/1jyfGiGM1Thxp08niKru60HSpFyOguhYu4jgqOSM9fJzdw==",
           "requires": {
             "css.escape": "^1.5.1",
             "didi": "^9.0.0",
@@ -32071,25 +32188,31 @@
             "tiny-svg": "^3.0.0"
           },
           "dependencies": {
+            "didi": {
+              "version": "9.0.0",
+              "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
+              "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w=="
+            },
             "path-intersection": {
-              "version": "2.2.1"
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
+              "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA=="
             },
             "tiny-svg": {
-              "version": "3.0.0"
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
+              "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w=="
             }
           }
         },
         "diagram-js-direct-editing": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-2.0.0.tgz",
+          "integrity": "sha512-/12OWL0B0RMCfaT1w3723c729MD42r5fay4wtm2DvxNFNBMdPaEvOHCTA/khLKjFzOzMVKxSzbAp7IEwBGonVw==",
           "requires": {
             "min-dash": "^4.0.0",
             "min-dom": "^4.0.2"
           }
-        },
-        "didi": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
-          "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w=="
         },
         "diff": {
           "version": "5.1.0",
@@ -32101,6 +32224,8 @@
         },
         "dmn-js": {
           "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/dmn-js/-/dmn-js-13.0.0.tgz",
+          "integrity": "sha512-NEzFJhmAu3zF2V0zJ713fLrEjkRz24DdafWA9sdyVjkura8G5Ct97pmSX5g/JRbL4UjAkzwpmbUlfuXbqHLTig==",
           "requires": {
             "dmn-js-decision-table": "^13.0.0",
             "dmn-js-drd": "^13.0.0",
@@ -32110,6 +32235,8 @@
         },
         "dmn-js-decision-table": {
           "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/dmn-js-decision-table/-/dmn-js-decision-table-13.0.0.tgz",
+          "integrity": "sha512-pLhD7+hYG3++Ce8xmYNY18lvUmW8aljNiKMLa0Dsl0lKoO2Sg4dPeqrUOR2oY8ESZEIOYCtIEj3w7c3dJWwGvg==",
           "requires": {
             "css.escape": "^1.5.1",
             "diagram-js": "^8.8.0",
@@ -32124,6 +32251,8 @@
           "dependencies": {
             "diagram-js": {
               "version": "8.9.0",
+              "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.9.0.tgz",
+              "integrity": "sha512-577bUEbkwZ7id4SCXcD2qrlKoRPXry2SDSPt5T6tEOjwKrTllKr5d1HZoJzGws4VMQq5fmY51Gce1iFT9S4Dlw==",
               "requires": {
                 "css.escape": "^1.5.1",
                 "didi": "^8.0.1",
@@ -32137,16 +32266,24 @@
               }
             },
             "didi": {
-              "version": "8.0.2"
+              "version": "8.0.2",
+              "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.2.tgz",
+              "integrity": "sha512-Wpq46GzfER5kVkqFCJtHTXsdlqh6SRPA60jTrKECQ1cl84/ALpQJrqAFlEXpue+Lxi7/6xzFIxC5V3UsS/x9aA=="
             },
             "inherits-browser": {
-              "version": "0.0.1"
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.0.1.tgz",
+              "integrity": "sha512-kaDA3DkCdCpvrKIo/1T/3yVn+qpFUHLjYtSHmTYewb+QfjfaQy6FGQ7LwBu7st0tG9UvYad/XAlqQmdIh6CICw=="
             },
             "min-dash": {
-              "version": "3.8.1"
+              "version": "3.8.1",
+              "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+              "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
             },
             "min-dom": {
               "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
+              "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
               "requires": {
                 "component-event": "^0.1.4",
                 "domify": "^1.3.1",
@@ -32156,12 +32293,16 @@
               }
             },
             "path-intersection": {
-              "version": "2.2.1"
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
+              "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA=="
             }
           }
         },
         "dmn-js-drd": {
           "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/dmn-js-drd/-/dmn-js-drd-13.0.0.tgz",
+          "integrity": "sha512-wg59lKe0O64J0vEIancPNLAg9SDti+Z2uNZL7JXIIq/CCox+hFAhp7YzXB/pJnIiv1+roP79RF3Ln4V5Gl+CHg==",
           "requires": {
             "diagram-js": "^8.8.0",
             "diagram-js-direct-editing": "^1.6.3",
@@ -32175,6 +32316,8 @@
           "dependencies": {
             "diagram-js": {
               "version": "8.9.0",
+              "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.9.0.tgz",
+              "integrity": "sha512-577bUEbkwZ7id4SCXcD2qrlKoRPXry2SDSPt5T6tEOjwKrTllKr5d1HZoJzGws4VMQq5fmY51Gce1iFT9S4Dlw==",
               "requires": {
                 "css.escape": "^1.5.1",
                 "didi": "^8.0.1",
@@ -32188,25 +32331,35 @@
               },
               "dependencies": {
                 "inherits-browser": {
-                  "version": "0.0.1"
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.0.1.tgz",
+                  "integrity": "sha512-kaDA3DkCdCpvrKIo/1T/3yVn+qpFUHLjYtSHmTYewb+QfjfaQy6FGQ7LwBu7st0tG9UvYad/XAlqQmdIh6CICw=="
                 }
               }
             },
             "diagram-js-direct-editing": {
               "version": "1.8.0",
+              "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-1.8.0.tgz",
+              "integrity": "sha512-B4Xj+PJfgBjbPEzT3uZQEkZI5xHFB0Izc+7BhDFuHidzrEMzQKZrFGdA3PqfWhReHf3dp+iB6Tt11G9eGNjKMw==",
               "requires": {
                 "min-dash": "^3.5.2",
                 "min-dom": "^3.1.3"
               }
             },
             "didi": {
-              "version": "8.0.2"
+              "version": "8.0.2",
+              "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.2.tgz",
+              "integrity": "sha512-Wpq46GzfER5kVkqFCJtHTXsdlqh6SRPA60jTrKECQ1cl84/ALpQJrqAFlEXpue+Lxi7/6xzFIxC5V3UsS/x9aA=="
             },
             "min-dash": {
-              "version": "3.8.1"
+              "version": "3.8.1",
+              "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+              "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
             },
             "min-dom": {
               "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
+              "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
               "requires": {
                 "component-event": "^0.1.4",
                 "domify": "^1.3.1",
@@ -32216,12 +32369,16 @@
               }
             },
             "path-intersection": {
-              "version": "2.2.1"
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
+              "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA=="
             }
           }
         },
         "dmn-js-literal-expression": {
           "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/dmn-js-literal-expression/-/dmn-js-literal-expression-13.0.0.tgz",
+          "integrity": "sha512-WxUQ52ZQCh1mGjInBKBAEKZ4e4d1yp3iZ9aH32Ncv4Sjw9x3CEZsNX1JTmrZx6Fi+va6nxwRjnNkLePJu4NkXw==",
           "requires": {
             "diagram-js": "^8.8.0",
             "dmn-js-shared": "^13.0.0",
@@ -32234,6 +32391,8 @@
           "dependencies": {
             "diagram-js": {
               "version": "8.9.0",
+              "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.9.0.tgz",
+              "integrity": "sha512-577bUEbkwZ7id4SCXcD2qrlKoRPXry2SDSPt5T6tEOjwKrTllKr5d1HZoJzGws4VMQq5fmY51Gce1iFT9S4Dlw==",
               "requires": {
                 "css.escape": "^1.5.1",
                 "didi": "^8.0.1",
@@ -32247,16 +32406,24 @@
               }
             },
             "didi": {
-              "version": "8.0.2"
+              "version": "8.0.2",
+              "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.2.tgz",
+              "integrity": "sha512-Wpq46GzfER5kVkqFCJtHTXsdlqh6SRPA60jTrKECQ1cl84/ALpQJrqAFlEXpue+Lxi7/6xzFIxC5V3UsS/x9aA=="
             },
             "inherits-browser": {
-              "version": "0.0.1"
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.0.1.tgz",
+              "integrity": "sha512-kaDA3DkCdCpvrKIo/1T/3yVn+qpFUHLjYtSHmTYewb+QfjfaQy6FGQ7LwBu7st0tG9UvYad/XAlqQmdIh6CICw=="
             },
             "min-dash": {
-              "version": "3.8.1"
+              "version": "3.8.1",
+              "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+              "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
             },
             "min-dom": {
               "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
+              "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
               "requires": {
                 "component-event": "^0.1.4",
                 "domify": "^1.3.1",
@@ -32266,12 +32433,16 @@
               }
             },
             "path-intersection": {
-              "version": "2.2.1"
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
+              "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA=="
             }
           }
         },
         "dmn-js-shared": {
           "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/dmn-js-shared/-/dmn-js-shared-13.0.0.tgz",
+          "integrity": "sha512-Li3nobue4IzHPY/phZfCgRtg4vr3OYIYPTBYJIcgjz33XyclvVzGFPbUziEHGC35pIM3YjaUNbwXCgaAKR2cvw==",
           "requires": {
             "diagram-js": "^8.8.0",
             "didi": "^8.0.1",
@@ -32287,6 +32458,8 @@
           "dependencies": {
             "diagram-js": {
               "version": "8.9.0",
+              "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.9.0.tgz",
+              "integrity": "sha512-577bUEbkwZ7id4SCXcD2qrlKoRPXry2SDSPt5T6tEOjwKrTllKr5d1HZoJzGws4VMQq5fmY51Gce1iFT9S4Dlw==",
               "requires": {
                 "css.escape": "^1.5.1",
                 "didi": "^8.0.1",
@@ -32300,10 +32473,14 @@
               }
             },
             "didi": {
-              "version": "8.0.2"
+              "version": "8.0.2",
+              "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.2.tgz",
+              "integrity": "sha512-Wpq46GzfER5kVkqFCJtHTXsdlqh6SRPA60jTrKECQ1cl84/ALpQJrqAFlEXpue+Lxi7/6xzFIxC5V3UsS/x9aA=="
             },
             "dmn-moddle": {
               "version": "10.0.0",
+              "resolved": "https://registry.npmjs.org/dmn-moddle/-/dmn-moddle-10.0.0.tgz",
+              "integrity": "sha512-JD08qH2VqA7O54qCQFrGruwGyVovow+9g2O5/ww0KpC/n0mvuua117dz2CONiUWexJxq/dOAaMjrQwkWnK+oEA==",
               "requires": {
                 "min-dash": "^3.0.0",
                 "moddle": "^5.0.1",
@@ -32312,18 +32489,26 @@
             },
             "ids": {
               "version": "0.2.2",
+              "resolved": "https://registry.npmjs.org/ids/-/ids-0.2.2.tgz",
+              "integrity": "sha512-icIO8S7A7Hat9x/59VYjS5uwfBU1xRTDxeFC4t9wNceLxZFm2JbPhO4lC/xhFqFNVaxw2idwpLgUfkVQrjsxIw==",
               "requires": {
                 "hat": "^0.0.3"
               }
             },
             "inherits-browser": {
-              "version": "0.0.1"
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.0.1.tgz",
+              "integrity": "sha512-kaDA3DkCdCpvrKIo/1T/3yVn+qpFUHLjYtSHmTYewb+QfjfaQy6FGQ7LwBu7st0tG9UvYad/XAlqQmdIh6CICw=="
             },
             "min-dash": {
-              "version": "3.8.1"
+              "version": "3.8.1",
+              "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+              "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
             },
             "min-dom": {
               "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
+              "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
               "requires": {
                 "component-event": "^0.1.4",
                 "domify": "^1.3.1",
@@ -32334,12 +32519,16 @@
             },
             "moddle": {
               "version": "5.0.4",
+              "resolved": "https://registry.npmjs.org/moddle/-/moddle-5.0.4.tgz",
+              "integrity": "sha512-Kjb+hjuzO+YlojNGxEUXvdhLYTHTtAABDlDcJTtTcn5MbJF9Zkv4I1Fyvp3Ypmfgg1EfHDZ3PsCQTuML9JD6wg==",
               "requires": {
                 "min-dash": "^3.0.0"
               }
             },
             "moddle-xml": {
               "version": "9.0.6",
+              "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-9.0.6.tgz",
+              "integrity": "sha512-tl0reHpsY/aKlLGhXeFlQWlYAQHFxTkFqC8tq8jXRYpQSnLVw13T6swMaourLd7EXqHdWsc+5ggsB+fEep6xZQ==",
               "requires": {
                 "min-dash": "^3.5.2",
                 "moddle": "^5.0.2",
@@ -32347,7 +32536,9 @@
               }
             },
             "path-intersection": {
-              "version": "2.2.1"
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-2.2.1.tgz",
+              "integrity": "sha512-9u8xvMcSfuOiStv9bPdnRJQhGQXLKurew94n4GPQCdH1nj9QKC9ObbNoIpiRq8skiOBxKkt277PgOoFgAt3/rA=="
             }
           }
         },
@@ -32360,7 +32551,9 @@
           },
           "dependencies": {
             "min-dash": {
-              "version": "3.8.1"
+              "version": "3.8.1",
+              "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+              "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
             },
             "moddle": {
               "version": "5.0.1",
@@ -32399,10 +32592,14 @@
           },
           "dependencies": {
             "min-dash": {
-              "version": "3.8.1"
+              "version": "3.8.1",
+              "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.1.tgz",
+              "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
             },
             "min-dom": {
               "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-3.2.1.tgz",
+              "integrity": "sha512-v6YCmnDzxk4rRJntWTUiwggLupPw/8ZSRqUq0PDaBwVZEO/wYzCH4SKVBV+KkEvf3u0XaWHly5JEosPtqRATZA==",
               "requires": {
                 "component-event": "^0.1.4",
                 "domify": "^1.3.1",
@@ -32722,6 +32919,8 @@
         },
         "lezer-feel": {
           "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.14.1.tgz",
+          "integrity": "sha512-sfpzZvAtObFon74XiFp1L8pS1FminnfM8JAm4S2Kxk7Wk8qYe7crjJdhHqju/MKl9dV5s44NHDhbq5tCDWMTlw==",
           "requires": {
             "@lezer/highlight": "^1.0.0",
             "@lezer/lr": "^1.2.3"
@@ -32781,10 +32980,14 @@
           }
         },
         "min-dash": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
         },
         "min-dom": {
           "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.0.3.tgz",
+          "integrity": "sha512-5zQyCMe8rtGiDIRjfGeqnF2YPJ7OAPFdJQeC7MakHais3dh4VG4PV2a0FacziKTzJjYK5qnPKm2sq1wSXB1wTQ==",
           "requires": {
             "component-event": "^0.1.4",
             "domify": "^1.4.1",
@@ -33320,11 +33523,6 @@
         },
         "xmldom": {
           "version": "0.1.27"
-        },
-        "zeebe-bpmn-moddle": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.16.0.tgz",
-          "integrity": "sha512-Fr6NqtWWl604wMnEKis8CIyyi4DGSPsFaGB4rm4bwjbOY2O3d1UrvFS4LnOAxUi6SH8Q1agdBU1GjUXYz5pAtA=="
         }
       }
     },
@@ -33347,7 +33545,6 @@
     },
     "chalk": {
       "version": "2.4.2",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -33383,10 +33580,14 @@
     },
     "chrome-trace-event": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+      "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
       "dev": true
     },
     "chromium-pickle-js": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
       "dev": true
     },
     "ci-info": {
@@ -33485,13 +33686,23 @@
         "colors": "1.0.3"
       }
     },
+    "cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      }
+    },
     "cli-width": {
       "version": "3.0.0",
       "dev": true
     },
     "cliui": {
       "version": "7.0.4",
-      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -33526,7 +33737,6 @@
     },
     "clone-response": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -33539,10 +33749,14 @@
       }
     },
     "cmmn-font": {
-      "version": "0.5.0"
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cmmn-font/-/cmmn-font-0.5.0.tgz",
+      "integrity": "sha512-6AghADr1eKdQLRVbTyPREGvjdh4AfZlRbVsDzoN704hfKWjChp6FodneoUP+EgkQ6g3/1XRWbcyAePUovtwU2g=="
     },
     "cmmn-js": {
       "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/cmmn-js/-/cmmn-js-0.20.0.tgz",
+      "integrity": "sha512-iiIqCmrkSRpdDzMjFhTkK56poQNdZgWviQlrCEWtuFCeBTWq5BcNdycXsMaxMDKA400LbVkDMTBl5ZI/WWacPQ==",
       "requires": {
         "cmmn-font": "^0.5.0",
         "cmmn-moddle": "^5.0.0",
@@ -33559,6 +33773,8 @@
       "dependencies": {
         "diagram-js": {
           "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-4.0.3.tgz",
+          "integrity": "sha512-BzcWUEnRfO2tpdc8XHvG/wsX+GrE/7qGRDf1khn5b0UrzrqqLhj1yiguvpgb0rQSTPeBtkot6PUA4wB2QAQutA==",
           "requires": {
             "css.escape": "^1.5.1",
             "didi": "^4.0.0",
@@ -33572,21 +33788,29 @@
           }
         },
         "didi": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/didi/-/didi-4.0.0.tgz",
+          "integrity": "sha512-AzMElh8mCHOPWPCWfGjoJRla31fMXUT6+287W5ef3IPmtuBcyG9+MkFS7uPP6v3t2Cl086KwWfRB9mESa0OsHQ=="
         },
         "ids": {
           "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/ids/-/ids-0.2.2.tgz",
+          "integrity": "sha512-icIO8S7A7Hat9x/59VYjS5uwfBU1xRTDxeFC4t9wNceLxZFm2JbPhO4lC/xhFqFNVaxw2idwpLgUfkVQrjsxIw==",
           "requires": {
             "hat": "^0.0.3"
           }
         },
         "path-intersection": {
-          "version": "1.1.1"
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-1.1.1.tgz",
+          "integrity": "sha512-EdeUuXCm0+tb/2gv8PmRhd9fYYOtbDeTYkwCnzkBuAEjevEZi2mWUi1DVFF5nqSObYsxKcchvKUhnRULWOFreQ=="
         }
       }
     },
     "cmmn-js-properties-panel": {
       "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/cmmn-js-properties-panel/-/cmmn-js-properties-panel-0.9.0.tgz",
+      "integrity": "sha512-MMBR3gaXlNuEJy5HSW6ypyI/w9e2PIsKvD/7r2kqkcwsKFWB7Jw/Gusy9OXijaZkCGulJt5L56BxF5qbj9C3Uw==",
       "requires": {
         "ids": "^0.2.0",
         "inherits": "^2.0.1",
@@ -33598,6 +33822,8 @@
       "dependencies": {
         "ids": {
           "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/ids/-/ids-0.2.2.tgz",
+          "integrity": "sha512-icIO8S7A7Hat9x/59VYjS5uwfBU1xRTDxeFC4t9wNceLxZFm2JbPhO4lC/xhFqFNVaxw2idwpLgUfkVQrjsxIw==",
           "requires": {
             "hat": "^0.0.3"
           }
@@ -33606,6 +33832,8 @@
     },
     "cmmn-moddle": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cmmn-moddle/-/cmmn-moddle-5.0.0.tgz",
+      "integrity": "sha512-mmHG+Ey/Zc+ZgTAlGF4aTGdEYZuloZ0L+eRlVYeGCpMEgIrIwJWsRlshaTB4yNts9p929Emmd+Gcl5xGHGhMmA==",
       "requires": {
         "min-dash": "^3.0.0",
         "moddle": "^4.1.0",
@@ -33614,12 +33842,16 @@
       "dependencies": {
         "moddle": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/moddle/-/moddle-4.1.0.tgz",
+          "integrity": "sha512-asBaDLTTNpv4oC8iFdwonfMf/noPVvaBDXoSL7AsXZUDqwokgy8Lsf5eXwdnjXiDqm0olYi/S3Do544uVJSQDg==",
           "requires": {
             "min-dash": "^3.0.0"
           }
         },
         "moddle-xml": {
           "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-7.5.0.tgz",
+          "integrity": "sha512-wPm3TD9910Iblp4lg1okHDRilY9gTvNBdo7ZHBmBzH4OioF5R2hvG3SMyn7cAUjOUg0kYUfChHgcUEO+qUc77Q==",
           "requires": {
             "min-dash": "^3.0.0",
             "moddle": "^4.1.0",
@@ -33630,6 +33862,8 @@
     },
     "codemirror": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
+      "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
       "requires": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -33650,20 +33884,20 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "dev": true
+      "version": "1.1.3"
     },
     "color-support": {
       "version": "1.1.3"
     },
     "colorette": {
       "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "dev": true
     },
     "colors": {
@@ -33679,13 +33913,16 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "dev": true
     },
     "common-ancestor-path": {
@@ -33715,6 +33952,8 @@
     },
     "compare-version": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+      "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
       "dev": true
     },
     "component-emitter": {
@@ -33805,12 +34044,73 @@
       "version": "1.1.0",
       "dev": true
     },
+    "console-stamp": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/console-stamp/-/console-stamp-3.0.6.tgz",
+      "integrity": "sha512-j4tP+1shVIUjSnvrtv5nJ5uVzLeNOTweVHkcEXB2ej4NJdlRp14w0hOzQiF+iQvOTjz4jafmdhd1CdYSwNzM8Q==",
+      "requires": {
+        "chalk": "^4.1.2",
+        "dateformat": "^4.6.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "dateformat": {
+          "version": "4.6.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+          "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "content-type": {
       "version": "1.0.4",
       "dev": true
     },
     "contra": {
       "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/contra/-/contra-1.9.4.tgz",
+      "integrity": "sha512-N9ArHAqwR/lhPq4OdIAwH4e1btn6EIZMAz4TazjnzCiVECcWUPTma+dRAM38ERImEJBh8NiCCpjoQruSZ+agYg==",
       "requires": {
         "atoa": "1.0.0",
         "ticky": "1.0.1"
@@ -34415,6 +34715,8 @@
     },
     "cross-fetch": {
       "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "dev": true,
       "requires": {
         "node-fetch": "2.6.7"
@@ -34440,6 +34742,8 @@
     },
     "crossvent": {
       "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/crossvent/-/crossvent-1.5.5.tgz",
+      "integrity": "sha512-MY4xhBYEnVi+pmTpHCOCsCLYczc0PVtGdPBz6NXNXxikLaUZo4HdAeUb1UqAo3t3yXAloSelTmfxJ+/oUqkW5w==",
       "requires": {
         "custom-event": "^1.0.0"
       }
@@ -34468,6 +34772,11 @@
     "dateformat": {
       "version": "3.0.3",
       "dev": true
+    },
+    "dayjs": {
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
+      "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA=="
     },
     "debug": {
       "version": "4.3.4",
@@ -34502,7 +34811,6 @@
     },
     "decompress-response": {
       "version": "3.3.0",
-      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -34537,8 +34845,7 @@
       }
     },
     "defer-to-connect": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "define-lazy-prop": {
       "version": "2.0.0",
@@ -34805,7 +35112,8 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -34834,6 +35142,8 @@
     },
     "devtools-protocol": {
       "version": "0.0.1036444",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1036444.tgz",
+      "integrity": "sha512-0y4f/T8H9lsESV9kKP1HDUXgHxCdniFeJh6Erq+FbdOEvp/Ydp9t8kcAAM5gOd17pMrTDlFWntoHtzzeTUWKNw==",
       "dev": true
     },
     "dezalgo": {
@@ -34871,6 +35181,8 @@
     },
     "diagram-js-minimap": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/diagram-js-minimap/-/diagram-js-minimap-3.0.0.tgz",
+      "integrity": "sha512-ntjlGZpfnlkBS8YpMD8mwUETtA4NijVP8Wxh+4/FLEVhqYZw1fO8SpoSEOLjievCfkJwmN49FME0wa/fqz5qzA==",
       "requires": {
         "css.escape": "^1.5.1",
         "min-dash": "^4.0.0",
@@ -34879,10 +35191,14 @@
       },
       "dependencies": {
         "min-dash": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA=="
         },
         "min-dom": {
           "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.0.3.tgz",
+          "integrity": "sha512-5zQyCMe8rtGiDIRjfGeqnF2YPJ7OAPFdJQeC7MakHais3dh4VG4PV2a0FacziKTzJjYK5qnPKm2sq1wSXB1wTQ==",
           "requires": {
             "component-event": "^0.1.4",
             "domify": "^1.4.1",
@@ -34890,12 +35206,16 @@
           }
         },
         "tiny-svg": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
+          "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w=="
         }
       }
     },
     "diagram-js-origin": {
       "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/diagram-js-origin/-/diagram-js-origin-1.3.4.tgz",
+      "integrity": "sha512-0cSuf8iHG9IUC+rJpI2cGba0HEW17W5dv0JQWuGbFAG6Y12YUCDzFkMB44VhD+X/cvSmNRgyaDVxGw3U1LSpIQ==",
       "requires": {
         "tiny-svg": "^2.0.0"
       }
@@ -34924,6 +35244,8 @@
     },
     "dir-compare": {
       "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-2.4.0.tgz",
+      "integrity": "sha512-l9hmu8x/rjVC9Z2zmGzkhOEowZvW7pmYws5CWHutg8u1JgvsKWMx7Q/UODeu4djLZ4FgW5besw5yvMQnBHzuCA==",
       "dev": true,
       "requires": {
         "buffer-equal": "1.0.0",
@@ -34934,6 +35256,8 @@
       "dependencies": {
         "commander": {
           "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
           "dev": true,
           "requires": {
             "graceful-readlink": ">= 1.0.0"
@@ -34941,6 +35265,8 @@
         },
         "minimatch": {
           "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -34957,6 +35283,8 @@
     },
     "dmg-builder": {
       "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.6.0.tgz",
+      "integrity": "sha512-jFZvY1JohyHarIAlTbfQOk+HnceGjjAdFjVn3n8xlDWKsYNqbO4muca6qXEZTfGXeQMG7TYim6CeS5XKSfSsGA==",
       "dev": true,
       "requires": {
         "app-builder-lib": "23.6.0",
@@ -34970,6 +35298,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
@@ -34977,10 +35307,14 @@
         },
         "app-builder-bin": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
+          "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
           "dev": true
         },
         "builder-util": {
           "version": "23.6.0",
+          "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.6.0.tgz",
+          "integrity": "sha512-QiQHweYsh8o+U/KNCZFSvISRnvRctb8m/2rB2I1JdByzvNKxPeFLlHFRPQRXab6aYeXc18j9LpsDLJ3sGQmWTQ==",
           "dev": true,
           "requires": {
             "@types/debug": "^4.1.6",
@@ -35004,6 +35338,8 @@
         },
         "builder-util-runtime": {
           "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.1.1.tgz",
+          "integrity": "sha512-azRhYLEoDvRDR8Dhis4JatELC/jUvYjm4cVSj7n9dauGTOM2eeNn9KS0z6YA6oDsjI1xphjNbY6PZZeHPzzqaw==",
           "dev": true,
           "requires": {
             "debug": "^4.3.4",
@@ -35012,6 +35348,8 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -35020,6 +35358,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -35027,19 +35367,42 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "dmg-license": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
+      "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/plist": "^3.0.1",
+        "@types/verror": "^1.10.3",
+        "ajv": "^6.10.0",
+        "crc": "^3.8.0",
+        "iconv-corefoundation": "^1.1.7",
+        "plist": "^3.0.4",
+        "smart-buffer": "^4.0.2",
+        "verror": "^1.10.0"
       }
     },
     "dmn-js": {
@@ -35102,6 +35465,8 @@
     },
     "dmn-js-properties-panel": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/dmn-js-properties-panel/-/dmn-js-properties-panel-1.2.1.tgz",
+      "integrity": "sha512-bHWH8z5v7KpjrJ/PJ/ZU/RDlZhEiFnxAOYSkjmmXDbpZ6FKmtTxcC/UenWmqFQhMoACxDHrmajt/owRHt8t3uw==",
       "requires": {
         "diagram-js": "^8.9.0",
         "min-dash": "^3.8.1",
@@ -35182,13 +35547,19 @@
     },
     "dotenv-expand": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
     },
     "downloadjs": {
-      "version": "1.4.7"
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
+      "integrity": "sha512-LN1gO7+u9xjU5oEScGFKvXhYf7Y/empUIIEAGBs1LzUq/rg5duiDrkuH5A2lQGd5jfMOb9X9usDa2oVXwJ0U/Q=="
     },
     "dragula": {
       "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/dragula/-/dragula-3.7.3.tgz",
+      "integrity": "sha512-/rRg4zRhcpf81TyDhaHLtXt6sEywdfpv1cRUMeFFy7DuypH2U0WUL0GTdyAQvXegviT4PJK4KuMmOaIDpICseQ==",
       "requires": {
         "contra": "1.9.4",
         "crossvent": "1.5.5"
@@ -35199,8 +35570,7 @@
       "dev": true
     },
     "duplexer3": {
-      "version": "0.1.4",
-      "dev": true
+      "version": "0.1.4"
     },
     "ee-first": {
       "version": "1.1.1",
@@ -35208,6 +35578,8 @@
     },
     "ejs": {
       "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
+      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
       "dev": true,
       "requires": {
         "jake": "^10.8.5"
@@ -35215,6 +35587,8 @@
     },
     "electron": {
       "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-21.1.0.tgz",
+      "integrity": "sha512-CM5VZpZPtAoPgTPcmEbRaZWXlxGuD5a5DTeAwm0F0F6/k6R3HZAi8vZnE77gwuHK/Qqcinw4/MAbiCwAKh2W+g==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.14.1",
@@ -35224,12 +35598,16 @@
       "dependencies": {
         "@types/node": {
           "version": "16.11.62",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.62.tgz",
+          "integrity": "sha512-K/ggecSdwAAy2NUW4WKmF4Rc03GKbsfP+k326UWgckoS+Rzd2PaWbjk76dSmqdLQvLTJAO9axiTUJ6488mFsYQ==",
           "dev": true
         }
       }
     },
     "electron-builder": {
       "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.6.0.tgz",
+      "integrity": "sha512-y8D4zO+HXGCNxFBV/JlyhFnoQ0Y0K7/sFH+XwIbj47pqaW8S6PGYQbjoObolKBR1ddQFPt4rwp4CnwMJrW3HAw==",
       "dev": true,
       "requires": {
         "@types/yargs": "^17.0.1",
@@ -35248,6 +35626,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
@@ -35255,10 +35635,14 @@
         },
         "app-builder-bin": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
+          "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
           "dev": true
         },
         "builder-util": {
           "version": "23.6.0",
+          "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.6.0.tgz",
+          "integrity": "sha512-QiQHweYsh8o+U/KNCZFSvISRnvRctb8m/2rB2I1JdByzvNKxPeFLlHFRPQRXab6aYeXc18j9LpsDLJ3sGQmWTQ==",
           "dev": true,
           "requires": {
             "@types/debug": "^4.1.6",
@@ -35282,6 +35666,8 @@
         },
         "builder-util-runtime": {
           "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.1.1.tgz",
+          "integrity": "sha512-azRhYLEoDvRDR8Dhis4JatELC/jUvYjm4cVSj7n9dauGTOM2eeNn9KS0z6YA6oDsjI1xphjNbY6PZZeHPzzqaw==",
           "dev": true,
           "requires": {
             "debug": "^4.3.4",
@@ -35290,6 +35676,8 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -35298,6 +35686,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -35305,14 +35695,20 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -35389,6 +35785,8 @@
     },
     "electron-osx-sign": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.6.0.tgz",
+      "integrity": "sha512-+hiIEb2Xxk6eDKJ2FFlpofCnemCbjbT5jz+BKGpVBrRNT3kWTGs4DfNX6IzGwgi33hUcXF+kFs9JW+r6Wc1LRg==",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.0",
@@ -35401,6 +35799,8 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -35408,6 +35808,8 @@
         },
         "isbinaryfile": {
           "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
+          "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
           "dev": true,
           "requires": {
             "buffer-alloc": "^1.2.0"
@@ -35415,12 +35817,16 @@
         },
         "ms": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
       }
     },
     "electron-publish": {
       "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.6.0.tgz",
+      "integrity": "sha512-jPj3y+eIZQJF/+t5SLvsI5eS4mazCbNYqatv5JihbqOstIM13k0d1Z3vAWntvtt13Itl61SO6seicWdioOU5dg==",
       "dev": true,
       "requires": {
         "@types/fs-extra": "^9.0.11",
@@ -35434,6 +35840,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
@@ -35441,10 +35849,14 @@
         },
         "app-builder-bin": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
+          "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
           "dev": true
         },
         "builder-util": {
           "version": "23.6.0",
+          "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.6.0.tgz",
+          "integrity": "sha512-QiQHweYsh8o+U/KNCZFSvISRnvRctb8m/2rB2I1JdByzvNKxPeFLlHFRPQRXab6aYeXc18j9LpsDLJ3sGQmWTQ==",
           "dev": true,
           "requires": {
             "@types/debug": "^4.1.6",
@@ -35468,6 +35880,8 @@
         },
         "builder-util-runtime": {
           "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.1.1.tgz",
+          "integrity": "sha512-azRhYLEoDvRDR8Dhis4JatELC/jUvYjm4cVSj7n9dauGTOM2eeNn9KS0z6YA6oDsjI1xphjNbY6PZZeHPzzqaw==",
           "dev": true,
           "requires": {
             "debug": "^4.3.4",
@@ -35476,6 +35890,8 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -35484,6 +35900,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -35491,14 +35909,20 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -35693,6 +36117,11 @@
             "to-regex-range": "^5.0.1"
           }
         },
+        "fsevents": {
+          "version": "2.3.2",
+          "dev": true,
+          "optional": true
+        },
         "glob-parent": {
           "version": "5.1.2",
           "dev": true,
@@ -35755,7 +36184,6 @@
     },
     "end-of-stream": {
       "version": "1.4.1",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -35782,6 +36210,8 @@
     },
     "enhanced-resolve": {
       "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
+      "integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.4",
@@ -35849,6 +36279,8 @@
     },
     "es-module-lexer": {
       "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
       "dev": true
     },
     "es-shim-unscopables": {
@@ -35872,18 +36304,18 @@
       "dev": true
     },
     "escalade": {
-      "version": "3.1.1",
-      "dev": true
+      "version": "3.1.1"
     },
     "escape-html": {
       "version": "1.0.3"
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "dev": true
+      "version": "1.0.5"
     },
     "eslint": {
       "version": "8.23.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
+      "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.2",
@@ -35936,10 +36368,14 @@
         },
         "array-union": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
           "dev": true
         },
         "braces": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "dev": true,
           "requires": {
             "fill-range": "^7.0.1"
@@ -35970,6 +36406,8 @@
         },
         "eslint-scope": {
           "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+          "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
           "dev": true,
           "requires": {
             "esrecurse": "^4.3.0",
@@ -35978,6 +36416,8 @@
         },
         "fast-glob": {
           "version": "3.2.12",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+          "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
@@ -35989,6 +36429,8 @@
           "dependencies": {
             "glob-parent": {
               "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+              "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
               "dev": true,
               "requires": {
                 "is-glob": "^4.0.1"
@@ -35998,6 +36440,8 @@
         },
         "fill-range": {
           "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
           "requires": {
             "to-regex-range": "^5.0.1"
@@ -36005,6 +36449,8 @@
         },
         "glob-parent": {
           "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
           "dev": true,
           "requires": {
             "is-glob": "^4.0.3"
@@ -36012,6 +36458,8 @@
         },
         "globby": {
           "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
           "dev": true,
           "requires": {
             "array-union": "^2.1.0",
@@ -36028,10 +36476,14 @@
         },
         "is-extglob": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
           "dev": true
         },
         "is-glob": {
           "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
           "dev": true,
           "requires": {
             "is-extglob": "^2.1.1"
@@ -36039,6 +36491,8 @@
         },
         "micromatch": {
           "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
           "dev": true,
           "requires": {
             "braces": "^3.0.2",
@@ -36089,6 +36543,8 @@
     },
     "eslint-plugin-bpmn-io": {
       "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-bpmn-io/-/eslint-plugin-bpmn-io-0.16.0.tgz",
+      "integrity": "sha512-33lxw01ombcLWX5gEGpnqKh7DXbTdBh6CWlmkfCwTGFqklndvrP7qemZczO8Sg0mMlQiF7Eu17Zlv7etwX2BIg==",
       "dev": true,
       "requires": {
         "eslint-plugin-mocha": "^10.1.0",
@@ -36097,6 +36553,8 @@
     },
     "eslint-plugin-camunda-licensed": {
       "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-camunda-licensed/-/eslint-plugin-camunda-licensed-0.4.6.tgz",
+      "integrity": "sha512-cdt0dPcEKKurUKeX8zxQhyXD/cloVRIzsAJWXE57bqzeV/Q2edDQGOHxQDSoAd07MHCHJyizZBMb/5y8gN3PTg==",
       "dev": true,
       "requires": {
         "eslint-plugin-license-header": "^0.2.0"
@@ -36161,6 +36619,8 @@
     },
     "eslint-plugin-mocha": {
       "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.1.0.tgz",
+      "integrity": "sha512-xLqqWUF17llsogVOC+8C6/jvQ+4IoOREbN7ZCHuOHuD6cT5cDD4h7f2LgsZuzMAiwswWE21tO7ExaknHVDrSkw==",
       "dev": true,
       "requires": {
         "eslint-utils": "^3.0.0",
@@ -36221,6 +36681,8 @@
     },
     "eslint-utils": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^2.0.0"
@@ -36228,16 +36690,22 @@
       "dependencies": {
         "eslint-visitor-keys": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
           "dev": true
         }
       }
     },
     "eslint-visitor-keys": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true
     },
     "espree": {
       "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
+      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.0",
@@ -36397,6 +36865,8 @@
     },
     "extract-zip": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "requires": {
         "@types/yauzl": "^2.9.1",
@@ -36407,12 +36877,21 @@
       "dependencies": {
         "get-stream": {
           "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
           }
         }
       }
+    },
+    "extsprintf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+      "dev": true,
+      "optional": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -36479,6 +36958,14 @@
       "version": "2.0.6",
       "dev": true
     },
+    "fast-xml-parser": {
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
+      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
+      "requires": {
+        "strnum": "^1.0.4"
+      }
+    },
     "fastq": {
       "version": "1.13.0",
       "dev": true,
@@ -36502,6 +36989,8 @@
     },
     "file-drops": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/file-drops/-/file-drops-0.4.0.tgz",
+      "integrity": "sha512-dPLRxrQ/sWHyU1DMf72doyyFuqeR/T8hJ97coJHXmdeHvqMTdOMJ/PLsHKjQzDHC8TBQO0rDUinDEXz3WGTnQA==",
       "requires": {
         "min-dom": "^3.1.1"
       }
@@ -36513,8 +37002,15 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "dev": true,
+      "optional": true
+    },
     "filelist": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
       "dev": true,
       "requires": {
         "minimatch": "^5.0.1"
@@ -36522,6 +37018,8 @@
       "dependencies": {
         "brace-expansion": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
@@ -36529,6 +37027,8 @@
         },
         "minimatch": {
           "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -36670,12 +37170,19 @@
     },
     "form-data": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
+    },
+    "fp-ts": {
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.3.tgz",
+      "integrity": "sha512-8m0XvW8kZbfnJOA4NvSVXu95mLbPf4LQGwQyqVukIYS4KzSNJiyKSmuZUmbVHteUi6MGkAJGPb0goPZqI+Tsqg=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -36742,6 +37249,15 @@
       "version": "1.0.0",
       "dev": true
     },
+    "fsevents": {
+      "version": "1.2.13",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "dev": true
@@ -36788,8 +37304,7 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "2.0.5",
-      "dev": true
+      "version": "2.0.5"
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -36858,7 +37373,6 @@
     },
     "get-stream": {
       "version": "4.1.0",
-      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
@@ -37241,6 +37755,8 @@
     },
     "glob-to-regexp": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
     "glob2base": {
@@ -37286,6 +37802,8 @@
     },
     "globals": {
       "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -37324,7 +37842,6 @@
     },
     "got": {
       "version": "9.6.0",
-      "dev": true,
       "requires": {
         "@sindresorhus/is": "^0.14.0",
         "@szmarczak/http-timer": "^1.1.2",
@@ -37345,10 +37862,14 @@
     },
     "graceful-readlink": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
       "dev": true
     },
     "grapheme-splitter": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
     "hammerjs": {
@@ -37381,8 +37902,7 @@
       "dev": true
     },
     "has-flag": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "has-property-descriptors": {
       "version": "1.0.0",
@@ -37506,15 +38026,16 @@
       }
     },
     "htm": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
     },
     "html-escaper": {
       "version": "2.0.2",
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "dev": true
+      "version": "4.1.0"
     },
     "http-errors": {
       "version": "2.0.0",
@@ -37574,6 +38095,17 @@
         "ms": "^2.0.0"
       }
     },
+    "iconv-corefoundation": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
+      "integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "cli-truncate": "^2.1.0",
+        "node-addon-api": "^1.6.3"
+      }
+    },
     "iconv-lite": {
       "version": "0.6.3",
       "devOptional": true,
@@ -37590,6 +38122,8 @@
     },
     "ignore": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
     "ignore-walk": {
@@ -37794,6 +38328,8 @@
     },
     "interpret": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "dev": true
     },
     "ip": {
@@ -37910,8 +38446,7 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "is-generator-function": {
       "version": "1.0.10",
@@ -38201,6 +38736,8 @@
     },
     "jake": {
       "version": "10.8.5",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
       "dev": true,
       "requires": {
         "async": "^3.2.3",
@@ -38211,6 +38748,8 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
@@ -38218,10 +38757,14 @@
         },
         "async": {
           "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+          "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
           "dev": true
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -38230,6 +38773,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -38237,14 +38782,20 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -38254,6 +38805,8 @@
     },
     "jest-worker": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -38263,10 +38816,14 @@
       "dependencies": {
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
           "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -38280,6 +38837,8 @@
     },
     "js-sdsl": {
       "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
+      "integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==",
       "dev": true
     },
     "js-tokens": {
@@ -38297,8 +38856,7 @@
       "dev": true
     },
     "json-buffer": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -38481,6 +39039,11 @@
             "to-regex-range": "^5.0.1"
           }
         },
+        "fsevents": {
+          "version": "2.3.2",
+          "dev": true,
+          "optional": true
+        },
         "glob-parent": {
           "version": "5.1.2",
           "dev": true,
@@ -38563,6 +39126,8 @@
     },
     "karma-env-preprocessor": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/karma-env-preprocessor/-/karma-env-preprocessor-0.1.1.tgz",
+      "integrity": "sha512-3FAuA0B1lS4DXNyOpD1Y+BjteVmnfX0WXUpsZ19aYykTk/GPz0kqnjzdApDiEe4sapreVeVSme2qTALnbHJb/A==",
       "dev": true
     },
     "karma-mocha": {
@@ -38574,11 +39139,15 @@
     },
     "karma-sinon-chai": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/karma-sinon-chai/-/karma-sinon-chai-2.0.2.tgz",
+      "integrity": "sha512-SDgh6V0CUd+7ruL1d3yG6lFzmJNGRNQuEuCYXLaorruNP9nwQfA7hpsp4clx4CbOo5Gsajh3qUOT7CrVStUKMw==",
       "dev": true,
       "requires": {}
     },
     "karma-webpack": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-5.0.0.tgz",
+      "integrity": "sha512-+54i/cd3/piZuP3dr54+NcFeKOPnys5QeM1IY+0SPASwrtHsliXUiCL50iW+K9WWA7RvamC4macvvQ86l3KtaA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3",
@@ -38588,7 +39157,6 @@
     },
     "keyv": {
       "version": "3.1.0",
-      "dev": true,
       "requires": {
         "json-buffer": "3.0.0"
       }
@@ -38599,6 +39167,8 @@
     },
     "lang-feel": {
       "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/lang-feel/-/lang-feel-0.0.3.tgz",
+      "integrity": "sha512-YEs49jXQfLetXUr4Sj+pq9kcwHyNFcEYiXvm/bRvQyUwVfUEAHQdeFneqw+5zGeDuKDgIGxawXVs7uysXaLrjQ==",
       "requires": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.0.0",
@@ -38610,6 +39180,8 @@
       "dependencies": {
         "lezer-feel": {
           "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.14.1.tgz",
+          "integrity": "sha512-sfpzZvAtObFon74XiFp1L8pS1FminnfM8JAm4S2Kxk7Wk8qYe7crjJdhHqju/MKl9dV5s44NHDhbq5tCDWMTlw==",
           "requires": {
             "@lezer/highlight": "^1.0.0",
             "@lezer/lr": "^1.2.3"
@@ -38868,6 +39440,8 @@
     },
     "loader-runner": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
       "dev": true
     },
     "locate-path": {
@@ -38879,6 +39453,11 @@
     },
     "lodash": {
       "version": "4.17.21"
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -38974,6 +39553,11 @@
         "streamroller": "^3.1.2"
       }
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "requires": {
@@ -38988,8 +39572,7 @@
       }
     },
     "lowercase-keys": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -39145,8 +39728,7 @@
       "dev": true
     },
     "mimic-response": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "min-dash": {
       "version": "3.8.1"
@@ -39257,7 +39839,9 @@
       }
     },
     "mitt": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -39296,6 +39880,8 @@
     },
     "mkdirp-classic": {
       "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
     "mkdirp-infer-owner": {
@@ -39388,6 +39974,11 @@
           "requires": {
             "to-regex-range": "^5.0.1"
           }
+        },
+        "fsevents": {
+          "version": "2.3.2",
+          "dev": true,
+          "optional": true
         },
         "glob": {
           "version": "7.2.0",
@@ -39528,6 +40119,11 @@
       "version": "0.0.8",
       "dev": true
     },
+    "nan": {
+      "version": "2.16.0",
+      "dev": true,
+      "optional": true
+    },
     "nanoid": {
       "version": "3.3.3",
       "dev": true
@@ -39587,10 +40183,11 @@
       }
     },
     "node-addon-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
-      "devOptional": true
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+      "dev": true,
+      "optional": true
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -40099,6 +40696,11 @@
             "to-regex-range": "^5.0.1"
           }
         },
+        "fsevents": {
+          "version": "2.3.2",
+          "dev": true,
+          "optional": true
+        },
         "glob": {
           "version": "7.1.4",
           "dev": true,
@@ -40515,7 +41117,6 @@
     },
     "once": {
       "version": "1.4.0",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -40622,8 +41223,7 @@
       }
     },
     "p-cancelable": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
     },
     "p-finally": {
       "version": "1.0.0",
@@ -40944,6 +41544,8 @@
     },
     "plist": {
       "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.6.tgz",
+      "integrity": "sha512-WiIVYyrp8TD4w8yCvyeIr+lkmrGRd5u0VbRnU+tP/aRLxP/YadJUYOMZJ/6hIa3oUyVCsycXvtNRgd5XBJIbiA==",
       "dev": true,
       "requires": {
         "base64-js": "^1.5.1",
@@ -40969,8 +41571,7 @@
       "dev": true
     },
     "prepend-http": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "preserve": {
       "version": "0.2.0",
@@ -41034,12 +41635,40 @@
       "version": "1.2.4",
       "dev": true
     },
+    "protobufjs": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
+      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "dependencies": {
+        "long": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+          "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+        }
+      }
+    },
     "protocols": {
       "version": "2.0.1",
       "dev": true
     },
     "proxy-from-env": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
     },
     "proxyquire": {
@@ -41053,7 +41682,6 @@
     },
     "pump": {
       "version": "3.0.0",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -41065,6 +41693,8 @@
     },
     "puppeteer": {
       "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.0.5.tgz",
+      "integrity": "sha512-s4erjxU0VtKojPvF+KvLKG6OHUPw7gO2YV1dtOsoryyCbhrs444fXb4QZqGWuTv3V/rgSCUzeixxu34g0ZkSMA==",
       "dev": true,
       "requires": {
         "cross-fetch": "3.1.5",
@@ -41082,6 +41712,8 @@
       "dependencies": {
         "rimraf": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -41089,6 +41721,8 @@
         },
         "ws": {
           "version": "8.8.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+          "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
           "dev": true,
           "requires": {}
         }
@@ -41123,6 +41757,8 @@
     },
     "rambda": {
       "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.2.1.tgz",
+      "integrity": "sha512-Wswj8ZvzdI3VhaGPkZAxaCTwuMmGtgWt7Zxsgyo4P+iTmVnkojvyWaOep5q3ZjMIecW0wtQa66GWxaKkZ24RAA==",
       "dev": true
     },
     "randomatic": {
@@ -41186,6 +41822,8 @@
     },
     "read-config-file": {
       "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-6.2.0.tgz",
+      "integrity": "sha512-gx7Pgr5I56JtYz+WuqEbQHj/xWo+5Vwua2jhb1VwM4Wid5PqYmZ4i00ZB0YEGIfkVBsCv9UrjgyqCiQfS/Oosg==",
       "dev": true,
       "requires": {
         "dotenv": "^9.0.2",
@@ -41197,6 +41835,8 @@
       "dependencies": {
         "dotenv": {
           "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
+          "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
           "dev": true
         }
       }
@@ -41698,6 +42338,8 @@
     },
     "rechoir": {
       "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
       "dev": true,
       "requires": {
         "resolve": "^1.9.0"
@@ -41755,8 +42397,7 @@
       "dev": true
     },
     "require-directory": {
-      "version": "2.1.1",
-      "dev": true
+      "version": "2.1.1"
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -41806,7 +42447,6 @@
     },
     "responselike": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "lowercase-keys": "^1.0.0"
       }
@@ -41890,6 +42530,8 @@
     },
     "sanitize-filename": {
       "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
       "dev": true,
       "requires": {
         "truncate-utf8-bytes": "^1.0.0"
@@ -41904,6 +42546,8 @@
     },
     "schema-utils": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.8",
@@ -41913,6 +42557,8 @@
     },
     "scroll-tabs": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/scroll-tabs/-/scroll-tabs-1.0.1.tgz",
+      "integrity": "sha512-W4xjEwNS4QAyQnaJ450vQTcKpbnalBAfsTDV926WrxEMOqjyj2To8uv2d0Cp0oxMdk5TkygtzXmctPNc2zgBcg==",
       "requires": {
         "min-dash": "^3.1.0",
         "min-dom": "^3.1.0",
@@ -41920,7 +42566,9 @@
       },
       "dependencies": {
         "mitt": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
+          "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw=="
         }
       }
     },
@@ -42041,6 +42689,8 @@
     },
     "simple-update-notifier": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.0.7.tgz",
+      "integrity": "sha512-BBKgR84BJQJm6WjWFMHgLVuo61FBDSj1z/xSFUIozqO6wO7ii0JxCqlIud7Enr/+LhlbNI0whErq96P2qHNWew==",
       "dev": true,
       "requires": {
         "semver": "~7.0.0"
@@ -42048,6 +42698,8 @@
       "dependencies": {
         "semver": {
           "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
           "dev": true
         }
       }
@@ -42085,6 +42737,47 @@
     "slash": {
       "version": "3.0.0",
       "dev": true
+    },
+    "slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "slide": {
       "version": "1.1.6",
@@ -42404,6 +43097,11 @@
         "minipass": "^3.1.1"
       }
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="
+    },
     "stat-mode": {
       "version": "1.0.0",
       "dev": true
@@ -42514,7 +43212,6 @@
     },
     "string-width": {
       "version": "4.2.3",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -42522,8 +43219,7 @@
       },
       "dependencies": {
         "emoji-regex": {
-          "version": "8.0.0",
-          "dev": true
+          "version": "8.0.0"
         }
       }
     },
@@ -42570,7 +43266,6 @@
     },
     "strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -42590,6 +43285,11 @@
     "strip-json-comments": {
       "version": "3.1.1",
       "dev": true
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "strong-log-transformer": {
       "version": "2.1.0",
@@ -42619,7 +43319,6 @@
     },
     "supports-color": {
       "version": "5.5.0",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -42640,6 +43339,8 @@
     },
     "tapable": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "dev": true
     },
     "tar": {
@@ -42662,6 +43363,8 @@
     },
     "tar-fs": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "dev": true,
       "requires": {
         "chownr": "^1.1.1",
@@ -42672,6 +43375,8 @@
       "dependencies": {
         "chownr": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "dev": true
         }
       }
@@ -42701,6 +43406,8 @@
     },
     "terser": {
       "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
@@ -42711,12 +43418,16 @@
       "dependencies": {
         "commander": {
           "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
         }
       }
     },
     "terser-webpack-plugin": {
       "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.14",
@@ -42755,7 +43466,9 @@
       }
     },
     "ticky": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ticky/-/ticky-1.0.1.tgz",
+      "integrity": "sha512-RX35iq/D+lrsqhcPWIazM9ELkjOe30MSeoBHQHSsRwd1YuhJO5ui1K1/R0r7N3mFvbLBs33idw+eR6j+w6i/DA=="
     },
     "time-zone": {
       "version": "1.0.0",
@@ -42780,6 +43493,8 @@
     },
     "tmp-promise": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
       "dev": true,
       "requires": {
         "tmp": "^0.2.0"
@@ -42787,6 +43502,8 @@
       "dependencies": {
         "rimraf": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -42794,6 +43511,8 @@
         },
         "tmp": {
           "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
           "dev": true,
           "requires": {
             "rimraf": "^3.0.0"
@@ -42822,8 +43541,7 @@
       }
     },
     "to-readable-stream": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "to-regex": {
       "version": "3.0.2",
@@ -42869,6 +43587,8 @@
     },
     "truncate-utf8-bytes": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
       "dev": true,
       "requires": {
         "utf8-byte-length": "^1.0.1"
@@ -42929,6 +43649,11 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typed-duration": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/typed-duration/-/typed-duration-1.0.13.tgz",
+      "integrity": "sha512-HLwA+hNq/2eXe03isJSfa7YJt6NikplBGdNKvlhyuR6WL5iZi2uXJIZv1SSOMEIukCZbeQ8QwIcQ801S0/Qulw=="
+    },
     "typedarray": {
       "version": "0.0.6",
       "dev": true
@@ -42960,6 +43685,8 @@
     },
     "unbzip2-stream": {
       "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "dev": true,
       "requires": {
         "buffer": "^5.2.1",
@@ -43086,7 +43813,6 @@
     },
     "url-parse-lax": {
       "version": "3.0.0",
-      "dev": true,
       "requires": {
         "prepend-http": "^2.0.0"
       }
@@ -43097,6 +43823,8 @@
     },
     "utf8-byte-length": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==",
       "dev": true
     },
     "util": {
@@ -43123,6 +43851,11 @@
       "version": "1.0.1",
       "dev": true
     },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
     "v8-compile-cache": {
       "version": "2.3.0",
       "dev": true
@@ -43146,6 +43879,18 @@
       "version": "1.1.2",
       "dev": true
     },
+    "verror": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
     "void-elements": {
       "version": "2.0.1",
       "dev": true
@@ -43157,6 +43902,14 @@
       "optional": true,
       "requires": {
         "node-addon-api": "^3.0.2"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+          "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+          "optional": true
+        }
       }
     },
     "w3c-keyname": {
@@ -43168,6 +43921,8 @@
     },
     "watchpack": {
       "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
       "dev": true,
       "requires": {
         "glob-to-regexp": "^0.4.1",
@@ -43187,6 +43942,8 @@
     },
     "webpack": {
       "version": "5.74.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
+      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
@@ -43217,17 +43974,23 @@
       "dependencies": {
         "acorn-import-assertions": {
           "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+          "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
           "dev": true,
           "requires": {}
         },
         "events": {
           "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
           "dev": true
         }
       }
     },
     "webpack-cli": {
       "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
+      "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
       "requires": {
         "@discoveryjs/json-ext": "^0.5.0",
@@ -43246,10 +44009,14 @@
       "dependencies": {
         "commander": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
           "dev": true
         },
         "webpack-merge": {
           "version": "5.8.0",
+          "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+          "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
           "dev": true,
           "requires": {
             "clone-deep": "^4.0.1",
@@ -43260,6 +44027,8 @@
     },
     "webpack-merge": {
       "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.15"
@@ -43267,6 +44036,8 @@
     },
     "webpack-sources": {
       "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
       "dev": true
     },
     "whatwg-url": {
@@ -43314,6 +44085,8 @@
     },
     "wildcard": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
+      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
     },
     "word-wrap": {
@@ -43330,7 +44103,6 @@
     },
     "wrap-ansi": {
       "version": "7.0.0",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -43339,27 +44111,23 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "color-convert": {
           "version": "2.0.1",
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.4",
-          "dev": true
+          "version": "1.1.4"
         }
       }
     },
     "wrappy": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "write-file-atomic": {
       "version": "4.0.2",
@@ -43481,6 +44249,8 @@
     },
     "xmlbuilder": {
       "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
       "dev": true
     },
     "xtend": {
@@ -43488,8 +44258,7 @@
       "dev": true
     },
     "y18n": {
-      "version": "5.0.8",
-      "dev": true
+      "version": "5.0.8"
     },
     "yaku": {
       "version": "0.16.7",
@@ -43505,7 +44274,6 @@
     },
     "yargs": {
       "version": "16.2.0",
-      "dev": true,
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -43517,8 +44285,7 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.4",
-      "dev": true
+      "version": "20.2.4"
     },
     "yargs-unparser": {
       "version": "2.0.0",
@@ -43551,6 +44318,51 @@
     "yocto-queue": {
       "version": "0.1.0",
       "dev": true
+    },
+    "zeebe-bpmn-moddle": {
+      "version": "0.15.0"
+    },
+    "zeebe-node": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.1.0.tgz",
+      "integrity": "sha512-2sCn5FF4bZ4uSFx2uS2t/11tg1qbyHO2KA2stQ77YgiFP+yeJy/WtWhrC1GpOkWHmu/8TNCmiLpEGocbOX++jw==",
+      "requires": {
+        "@grpc/grpc-js": "^1.7.0",
+        "@grpc/proto-loader": "^0.7.2",
+        "chalk": "^2.4.2",
+        "console-stamp": "^3.0.2",
+        "dayjs": "^1.8.15",
+        "debug": "^4.2.0",
+        "fast-xml-parser": "^3.12.12",
+        "fp-ts": "^2.5.1",
+        "got": "^9.6.0",
+        "long": "^4.0.0",
+        "promise-retry": "^1.1.1",
+        "stack-trace": "0.0.10",
+        "typed-duration": "^1.0.12",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "err-code": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+          "integrity": "sha512-CJAN+O0/yA1CKfRn9SXOGctSpEM7DCon/r/5r2eXFMY2zCCJBasFhcM5I+1kh3Ap11FsQCX+vGHceNPvpWKhoA=="
+        },
+        "promise-retry": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+          "integrity": "sha512-StEy2osPr28o17bIW776GtwO6+Q+M9zPiZkYfosciUUMYqjhU/ffwRAH0zN2+uvGyUsn8/YICIHRzLbPacpZGw==",
+          "requires": {
+            "err-code": "^1.0.0",
+            "retry": "^0.10.0"
+          }
+        },
+        "retry": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+          "integrity": "sha512-ZXUSQYTHdl3uS7IuCehYfMzKyIDBNoAuUblvy5oGO5UJSUTmStUUVPXbA9Qxd173Bgre53yCQczQuHgRWAdvJQ=="
+        }
+      }
     },
     "zip-stream": {
       "version": "2.1.3",


### PR DESCRIPTION
Remove workaround necessary for 5.5.1 release.

----

Closes https://github.com/camunda/camunda-modeler/issues/1753
Closes https://github.com/camunda/camunda-modeler/issues/3276
Closes https://github.com/camunda/camunda-modeler/issues/1371
Closes https://github.com/camunda/camunda-modeler/issues/1705
Closes https://github.com/camunda/camunda-modeler/issues/1750