### PR TITLE
fix(app): suppress EPIPE errors for app output

### DIFF
--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -56,6 +56,7 @@ const bootstrapLog = Log('app:main:bootstrap');
 const clientLog = Log('client');
 
 bootstrapLogging();
+bootstrapEPIPESuppression();
 
 const name = app.name = 'Camunda Modeler';
 const version = app.version = require('../package').version;
@@ -563,6 +564,22 @@ function bootstrapLogging() {
     // actual app errors in the client user interface
     // new logTransports.Client(renderer, () => app.clientReady)
   );
+}
+
+function bootstrapEPIPESuppression() {
+
+  let suppressing = false;
+  function logEPIPEErrorOnce() {
+    if (suppressing) {
+      return;
+    }
+
+    suppressing = true;
+    log.error('Detected EPIPE error; suppressing further EPIPE errors');
+  }
+
+  require('epipebomb')(process.stdout, logEPIPEErrorOnce);
+  require('epipebomb')(process.stderr, logEPIPEErrorOnce);
 }
 
 /**

--- a/app/package.json
+++ b/app/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "@sentry/node": "^6.3.6",
+    "epipebomb": "^1.0.0",
     "form-data": "^2.5.1",
     "glob": "^7.1.6",
     "ids": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^6.3.6",
+        "epipebomb": "^1.0.0",
         "form-data": "^2.5.1",
         "glob": "^7.1.6",
         "ids": "^1.0.0",
@@ -14016,6 +14017,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/epipebomb": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/epipebomb/-/epipebomb-1.0.0.tgz",
+      "integrity": "sha512-NGv0bGlgetsi6ad5BuG1Pa9zpLLCeXeIa6wFGc+l0Emhr5rUlW8Rjx96NONlXZl4tMMaEODszyyy1A8ENjFoKA==",
+      "bin": {
+        "epipebomb": "bin/cmd.js"
       }
     },
     "node_modules/err-code": {
@@ -30488,6 +30497,7 @@
       "version": "file:app",
       "requires": {
         "@sentry/node": "^6.3.6",
+        "epipebomb": "*",
         "form-data": "^2.5.1",
         "glob": "^7.1.6",
         "ids": "^1.0.0",
@@ -36236,6 +36246,11 @@
     "envinfo": {
       "version": "7.8.1",
       "dev": true
+    },
+    "epipebomb": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/epipebomb/-/epipebomb-1.0.0.tgz",
+      "integrity": "sha512-NGv0bGlgetsi6ad5BuG1Pa9zpLLCeXeIa6wFGc+l0Emhr5rUlW8Rjx96NONlXZl4tMMaEODszyyy1A8ENjFoKA=="
     },
     "err-code": {
       "version": "2.0.3",


### PR DESCRIPTION
With this in place, the app should be still usable even if the output is piped to a closed stream, e.g. `npm start | head`. Check out linked issue for more details.

Closes #3313

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
