### PR TITLE
docs: remove manually adding release appointments

### DIFF
--- a/docs/.project/RELEASE_TEMPLATE.md
+++ b/docs/.project/RELEASE_TEMPLATE.md
@@ -18,8 +18,6 @@ labels:
 
 _To be done immediately after creating this issue._
 
-* [ ] put up code freeze appointment in calendar (include `modeling`, `qa`, `infra`, and `Team-Support`)
-* [ ] put up release appointment in calendar (include `modeling`, `DevRel` and Marketing [ `Christopher Rogers` ])
 * [ ] add Slack role to release manager (`@modeling-release-manager`)
 * [ ] (optional) update [release presentation](https://confluence.camunda.com/display/HAN/Release+Presentation+Process) page
 


### PR DESCRIPTION
Releases are reoccurring events now

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
