### PR TITLE
fix(client): import color picker styles

### DIFF
--- a/client/src/styles/_modeling.less
+++ b/client/src/styles/_modeling.less
@@ -8,6 +8,7 @@
 @import '~camunda-bpmn-js/dist/assets/diagram-js-minimap.css';
 @import '~camunda-bpmn-js/dist/assets/properties-panel.css';
 @import '~camunda-bpmn-js/dist/assets/element-templates.css';
+@import '~camunda-bpmn-js/dist/assets/color-picker.css';
 @import '~camunda-dmn-js/dist/assets/dmn-font/css/dmn-embedded.css';
 @import '~camunda-dmn-js/dist/assets/dmn-js-decision-table-controls.css';
 @import '~camunda-dmn-js/dist/assets/dmn-js-decision-table.css';


### PR DESCRIPTION
I missed the color picker styles import here when I bumped the `camunda-bpmn-js` version, which was causing the color picker to look like this:

![image](https://user-images.githubusercontent.com/25825387/210444999-d0a235cc-46a2-49e1-a7e4-991c2a6dc624.png)


When it should look like:
<img width="270" alt="Screenshot 2023-01-03 at 22 33 45" src="https://user-images.githubusercontent.com/25825387/210444963-661c1121-b261-41de-894a-2c14879f5420.png">

NOTE: I targeted develop because the latest `camunda-bpmn-js` version is still not on master
