### PR TITLE
chore: tag development build with `minorInc-dev`

### DIFF
--- a/app/util/get-version.js
+++ b/app/util/get-version.js
@@ -18,6 +18,7 @@ var semver = require('semver');
  * @param {Object} pkg
  * @param {Object} options
  * @param {boolean} [options.nightly]
+ * @param {boolean} [options.increment]
  * @param {string} [options.buildName]
  *
  * @return {string} actual app version
@@ -28,11 +29,16 @@ module.exports = function getVersion(pkg, options) {
 
   var {
     buildName,
-    nightly
+    nightly,
+    increment = nightly,
   } = options;
 
+  if (increment) {
+    appVersion = semver.inc(appVersion, 'minor');
+  }
+
   if (nightly) {
-    appVersion = `${semver.inc(appVersion, 'minor')}-nightly.${today()}`;
+    appVersion = `${appVersion}-nightly.${today()}`;
   } else if (buildName) {
     appVersion = `${appVersion}-${buildName}`;
   }

--- a/dev.js
+++ b/dev.js
@@ -18,10 +18,11 @@ const getAppVersion = require('./app/util/get-version');
 process.env.NODE_ENV = 'development';
 
 // monkey-patch package version to indicate DEV mode in application
-const pkg = require('./package');
+const pkg = require('./app/package');
 
 pkg.version = getAppVersion(pkg, {
-  nightly: 'dev'
+  buildName: 'dev',
+  increment: true
 });
 
 // monkey-patch cli args to not open this file in application


### PR DESCRIPTION
Ensures the `dev` version of the modeler has a `minorInc-dev` tag rather than showing the currently released version:

![image](https://user-images.githubusercontent.com/58601/214678676-7a419ed9-3700-4bb3-8920-19c0a1debcdf.png)
