### PR TITLE
chore(distro): fix lerna build warnings

### DIFF
--- a/tasks/distro.js
+++ b/tasks/distro.js
@@ -44,10 +44,10 @@ const version = (onDemand || nightly) && getVersion(pkg, {
 if (version) {
 
   const lernaPublishArgs = [
-    'publish',
-    `--repo-version=${version}`,
-    '--skip-npm',
-    '--skip-git',
+    'version',
+    `${version}`,
+    '--no-git-tag-version',
+    '--no-push',
     '--yes'
   ];
 


### PR DESCRIPTION
closes #3394

- `--repo-version=` --> drop for positional parameter
- `--skip-npm` --> replaced by using `lerna version` instead of `lerna publish`
- `--skip-git` --> replaced by `--no-git-tag-version` + `--no-push`

Output for distro task to show that all deprecation warnings are gone:
```
% node tasks/distro.js --linux --nightly                                                                                                                                                    
PUBLISH: undefined

Bumping camunda-modeler version to 5.8.0-nightly.20230201

---

lerna version 5.8.0-nightly.20230201 --no-git-tag-version --no-push --yes

---

lerna notice cli v5.6.2
lerna info current version 5.7.0
lerna notice FYI git repository validation has been skipped, please ensure your version bumps are correct
lerna info Looking for changed packages since v5.7.0
lerna WARN version Skipping working tree validation, proceed at your own risk

Changes:
 - camunda-modeler: 5.7.0 => 5.8.0-nightly.20230201 (private)
 - camunda-modeler-client: 5.7.0 => 5.8.0-nightly.20230201 (private)

lerna info auto-confirmed 
lerna info execute Skipping git tag/commit
lerna info execute Skipping git push
lerna info execute Skipping releases
lerna success version finished
```

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
