### PR TITLE
docs(RELEASE_TEMPLATE): clarify publishing steps

### DIFF
--- a/docs/.project/RELEASE_TEMPLATE.md
+++ b/docs/.project/RELEASE_TEMPLATE.md
@@ -57,18 +57,16 @@ _To be done once the release is built._
 
 * [ ] publish release on [Github Releases](https://github.com/camunda/camunda-modeler/releases)
 * [ ] trigger mirroring of release to [Camunda Download Center](https://downloads.camunda.cloud/release/camunda-modeler/) via [Jenkins](https://ci.cambpm.camunda.cloud/job/sideprojects/job/camunda-modeler-desktop-RELEASE/build?delay=0sec)
-* [ ] write blog post for the [Camunda Blog](https://camunda.com/blog/), [see guidelines](https://confluence.camunda.com/display/HAN/Your+Content+on+the+Camunda+Blog)
-   * [ ] use the [blog post template](https://docs.google.com/document/d/18aXWFBdbET97EZ_HO1DEVLVsYP-UQEabumSzQdeRbDw/edit?usp=sharing)
-   * [ ] add your contents to the newly created post
-   * [ ] set yourself as the post author
+* [ ] write blog post for the [Camunda Blog](https://camunda.com/blog/) according to [guidelines](https://confluence.camunda.com/x/Wi_SBg):
+   * [ ] create blog from [release blog post template](https://docs.google.com/document/d/1_QxdkGmeaXL1jOZd_e_Eg0V1fvK322uT-OKT9Saa3cA/edit#)
    * [ ] share the post with your colleagues for review
-   * [ ] send the draft to `Christopher Rogers` to double check it and coordinate publishing
+   * [ ] share the post with [`#top-blog-submission`](https://camunda.slack.com/archives/C03NMMN2R28) for checkup and publishing
 * [ ] update Camunda Modeler screenshots (and potentially text content) in the docs by running [screenshots workflow](https://github.com/camunda/camunda-docs-modeler-screenshots/actions/workflows/createScreenshots.yml). Download artifacts and create PRs for:
    * [ ] [camunda-docs-static](https://github.com/camunda/camunda-docs-static)
    * [ ] [camunda-docs-manual](https://github.com/camunda/camunda-docs-manual)
    * [ ] [camunda-docs-platform](https://github.com/camunda/camunda-platform-docs)
-* [ ] send all information required to compile the [release notice email](https://github.com/bpmn-io/internal-docs/blob/master/releases/modeler/CAMUNDA_MODELER.md#release-notice-email) to the [`@product-release-presentation-dri` role](https://confluence.camunda.com/pages/viewpage.action?spaceKey=HAN&title=Release+Presentation+Process#ReleasePresentationProcess-OrganisingtheReleasePresentation)
-* [ ] request marketing to update the [downloads page](https://camunda.com/download/modeler/) via [request form](https://confluence.camunda.com/display/MAR/Marketing+Request+Form)
+* [ ] provide content to the [release presentation and notice](https://confluence.camunda.com/x/Uq-gBQ#ReleasePresentationProcess-OrganisingtheReleasePresentation)
+* [ ] trigger [downloads page](https://camunda.com/download/modeler/) update via [marketing request form](https://confluence.camunda.com/x/rTGSBg)
 * [ ] add new version to [update server releases](https://github.com/camunda/camunda-modeler-update-server/blob/master/releases.json)
 
 _To be done once release is publicly announced on release day._

--- a/docs/.project/RELEASE_TEMPLATE.md
+++ b/docs/.project/RELEASE_TEMPLATE.md
@@ -61,7 +61,7 @@ _To be done once the release is built._
    * [ ] create blog from [release blog post template](https://docs.google.com/document/d/1_QxdkGmeaXL1jOZd_e_Eg0V1fvK322uT-OKT9Saa3cA/edit#)
    * [ ] share the post with your colleagues for review
    * [ ] share the post with [`#top-blog-submission`](https://camunda.slack.com/archives/C03NMMN2R28) for checkup and publishing
-* [ ] update Camunda Modeler screenshots (and potentially text content) in the docs by running [screenshots workflow](https://github.com/camunda/camunda-docs-modeler-screenshots/actions/workflows/createScreenshots.yml). Download artifacts and create PRs for:
+* [ ] update Camunda Modeler screenshots (and potentially text content) in the docs by running [screenshots workflow](https://github.com/camunda/camunda-docs-modeler-screenshots/actions/workflows/CREATE_SCREENSHOTS.yml). Download artifacts and create PRs for:
    * [ ] [camunda-docs-static](https://github.com/camunda/camunda-docs-static)
    * [ ] [camunda-docs-manual](https://github.com/camunda/camunda-docs-manual)
    * [ ] [camunda-docs-platform](https://github.com/camunda/camunda-platform-docs)


### PR DESCRIPTION
This improves the current publishing steps:

* updates to latest blog publishing flow
* simplifies getting started with the blog by using a tailored template