### PR TITLE
feat: 3444 Add MacOS specific switch tabs keyboard shortcuts

### DIFF
--- a/app/lib/menu/mac-os/mac-menu-builder.js
+++ b/app/lib/menu/mac-os/mac-menu-builder.js
@@ -12,6 +12,7 @@
 
 const {
   app,
+  Menu,
   MenuItem
 } = require('electron');
 
@@ -93,6 +94,47 @@ class MacMenuBuilder extends MenuBuilder {
     return submenuTemplate;
   }
 
+  /**
+   * Add Mac-specific Cmd+Shift+[/] shortcuts
+   */
+  appendSwitchTab(submenu) {
+    this.menu.append(new MenuItem({
+      label: 'Switch Tab...',
+      submenu: submenu || Menu.buildFromTemplate([ {
+        label: 'Select Next Tab',
+        enabled: canSwitchTab(this.options.state),
+        accelerator: 'Control+TAB',
+        click: () => app.emit('menu:action', 'select-tab', 'next')
+      },
+      {
+        label: 'Select Previous Tab',
+        enabled: canSwitchTab(this.options.state),
+        accelerator: 'Control+SHIFT+TAB',
+        click: () => app.emit('menu:action', 'select-tab', 'previous')
+      },
+      {
+        label: 'Select Next Tab',
+        enabled: canSwitchTab(this.options.state),
+        accelerator: 'Command+SHIFT+]',
+        visible: false,
+        acceleratorWorksWhenHidden: true,
+        click: () => app.emit('menu:action', 'select-tab', 'next')
+      },
+      {
+        label: 'Select Previous Tab',
+        enabled: canSwitchTab(this.options.state),
+        accelerator: 'Command+SHIFT+[',
+        visible: false,
+        acceleratorWorksWhenHidden: true,
+        click: () => app.emit('menu:action', 'select-tab', 'previous')
+      } ])
+    }));
+
+    this.appendSeparator();
+
+    return this;
+  }
+
   build() {
     this.appendAppMenu();
 
@@ -103,3 +145,7 @@ class MacMenuBuilder extends MenuBuilder {
 }
 
 module.exports = MacMenuBuilder;
+
+function canSwitchTab(state) {
+  return state.tabsCount > 1;
+}

--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -302,7 +302,7 @@ class MenuBuilder {
 
   appendSwitchTab(submenu) {
     this.menu.append(new MenuItem({
-      label: 'Switch Tab..',
+      label: 'Switch Tab...',
       submenu: submenu || Menu.buildFromTemplate([ {
         label: 'Select Next Tab',
         enabled: canSwitchTab(this.options.state),
@@ -313,6 +313,22 @@ class MenuBuilder {
         label: 'Select Previous Tab',
         enabled: canSwitchTab(this.options.state),
         accelerator: 'Control+SHIFT+TAB',
+        click: () => app.emit('menu:action', 'select-tab', 'previous')
+      },
+      {
+        label: 'Select Next Tab',
+        enabled: canSwitchTab(this.options.state),
+        accelerator: 'CommandOrControl+SHIFT+]',
+        visible: false,
+        acceleratorWorksWhenHidden: true,
+        click: () => app.emit('menu:action', 'select-tab', 'next')
+      },
+      {
+        label: 'Select Previous Tab',
+        enabled: canSwitchTab(this.options.state),
+        accelerator: 'CommandOrControl+SHIFT+[',
+        visible: false,
+        acceleratorWorksWhenHidden: true,
         click: () => app.emit('menu:action', 'select-tab', 'previous')
       } ])
     }));

--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -314,23 +314,8 @@ class MenuBuilder {
         enabled: canSwitchTab(this.options.state),
         accelerator: 'Control+SHIFT+TAB',
         click: () => app.emit('menu:action', 'select-tab', 'previous')
-      },
-      {
-        label: 'Select Next Tab',
-        enabled: canSwitchTab(this.options.state),
-        accelerator: 'CommandOrControl+SHIFT+]',
-        visible: false,
-        acceleratorWorksWhenHidden: true,
-        click: () => app.emit('menu:action', 'select-tab', 'next')
-      },
-      {
-        label: 'Select Previous Tab',
-        enabled: canSwitchTab(this.options.state),
-        accelerator: 'CommandOrControl+SHIFT+[',
-        visible: false,
-        acceleratorWorksWhenHidden: true,
-        click: () => app.emit('menu:action', 'select-tab', 'previous')
-      } ])
+      }
+      ])
     }));
 
     this.appendSeparator();


### PR DESCRIPTION
Closes #3444 

MacOS shortcuts for switching tabs next and previous is now `Cmd+SHIFT+[`  and `Cmd+SHIFT+]` respectively. Window shortcut remain `Control+TAB` and `Control+SHIFT+TAB` respectively. 