### PR TITLE
Hide `Check for Updates` on MacOS menu when disable-remote-interaction is set

### DIFF
--- a/app/lib/menu/mac-os/mac-menu-builder.js
+++ b/app/lib/menu/mac-os/mac-menu-builder.js
@@ -28,10 +28,14 @@ class MacMenuBuilder extends MenuBuilder {
       template: [ {
         label: 'About ' + this.options.appName,
         role: 'about'
-      }, {
-        label: 'Check for Updates',
-        click: () => app.emit('menu:action', 'emit-event', { type: 'updateChecks.execute' })
-      },{
+      },
+      ... (app.flags && !app.flags.get('disable-remote-interaction')) ? [
+        {
+          label: 'Check for Updates',
+          click: () => app.emit('menu:action', 'emit-event', { type: 'updateChecks.execute' })
+        }
+      ] : [],
+      {
         type: 'separator'
       }, {
         label: 'Services',

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
@@ -613,8 +613,8 @@ function CloudLink(props) {
   } = props;
 
   const {
-    camundaCloudClusterUrl,
-    camundaCloudClusterRegion
+    camundaCloudClusterRegion,
+    camundaCloudClusterId
   } = endpoint;
 
   const processId = getProcessId(response);
@@ -624,8 +624,7 @@ function CloudLink(props) {
   }
 
   const query = `?process=${processId}&version=all&active=true&incidents=true`;
-  const cluster = camundaCloudClusterUrl.substring(0, camundaCloudClusterUrl.indexOf('.'));
-  const cloudUrl = `https://${camundaCloudClusterRegion}.operate.camunda.io/${cluster}/instances/${query}`;
+  const cloudUrl = `https://${camundaCloudClusterRegion}.operate.camunda.io/${camundaCloudClusterId}/instances/${query}`;
 
   return (
     <div className={ css.CloudLink }>

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
@@ -596,8 +596,8 @@ describe('<DeploymentPlugin> (Zeebe)', () => {
       displayNotification,
       endpoint: {
         targetType: CAMUNDA_CLOUD,
-        camundaCloudClusterUrl: 'clusterId.region.zeebe.camunda.io',
-        camundaCloudClusterRegion:'region'
+        camundaCloudClusterRegion: 'REGION',
+        camundaCloudClusterId: 'CLUSTER_ID'
       }
     });
 
@@ -614,7 +614,8 @@ describe('<DeploymentPlugin> (Zeebe)', () => {
         type: notification.type,
         title: notification.title,
         duration: notification.duration
-      }).to.eql(
+      }
+    ).to.eql(
       {
         type: 'success',
         title: 'Process definition deployed',
@@ -622,8 +623,13 @@ describe('<DeploymentPlugin> (Zeebe)', () => {
       }
     );
 
-    expect(notification.content).to.not.be.null;
+    expect(notification.content).to.exist;
 
+    const notificationHTML = shallow(notification.content).html().replace(/&amp;/g, '&');
+
+    expect(notificationHTML).to.include(
+      'https://REGION.operate.camunda.io/CLUSTER_ID/instances/?process=test&version=all&active=true&incidents=true'
+    );
   });
 
 

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
@@ -338,7 +338,7 @@ function CloudLink(props) {
   } = props;
 
   const {
-    camundaCloudClusterUrl,
+    camundaCloudClusterId,
     camundaCloudClusterRegion
   } = endpoint;
 
@@ -346,8 +346,7 @@ function CloudLink(props) {
     processInstanceKey
   } = response;
 
-  const cluster = camundaCloudClusterUrl.substring(0, camundaCloudClusterUrl.indexOf('.'));
-  const cloudUrl = `https://${camundaCloudClusterRegion}.operate.camunda.io/${cluster}/instances/${processInstanceKey}`;
+  const cloudUrl = `https://${camundaCloudClusterRegion}.operate.camunda.io/${camundaCloudClusterId}/instances/${processInstanceKey}`;
 
   return (
     <div className={ css.CloudLink }>

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginSpec.js
@@ -376,10 +376,10 @@ describe('<StartInstancePlugin> (Zeebe)', () => {
       const displayNotification = sinon.spy();
       const { instance } = createStartInstancePlugin({
         displayNotification,
-        deploymentEndpoint : {
+        deploymentEndpoint: {
           targetType: CAMUNDA_CLOUD,
-          camundaCloudClusterUrl: 'clusterId.region.zeebe.camunda.io',
-          camundaCloudClusterRegion:'region'
+          camundaCloudClusterRegion: 'REGION',
+          camundaCloudClusterId: 'CLUSTER_ID'
         },
       });
 
@@ -395,7 +395,8 @@ describe('<StartInstancePlugin> (Zeebe)', () => {
           type: notification.type,
           title: notification.title,
           duration: notification.duration
-        }).to.eql(
+        }
+      ).to.eql(
         {
           type: 'success',
           title: 'Process instance started',
@@ -403,8 +404,13 @@ describe('<StartInstancePlugin> (Zeebe)', () => {
         }
       );
 
-      expect(notification.content).to.not.be.null;
+      expect(notification.content).to.exist;
 
+      const notificationHTML = shallow(notification.content).html().replace(/&amp;/g, '&');
+
+      expect(notificationHTML).to.include(
+        'https://REGION.operate.camunda.io/CLUSTER_ID/instances/undefined'
+      );
     });
 
   });


### PR DESCRIPTION
Closes #3457 

bug: 3457 hide "Check for Updates" on MacOS menu when disable-remote-interaction flag is true.

<img width="314" alt="Screenshot 2023-02-11 at 8 22 28 PM" src="https://user-images.githubusercontent.com/8097956/218291267-0ddba478-488a-4dae-8913-ab470bed8fbd.png">
