### PR TITLE
Update check release note container rework

### DIFF
--- a/client/src/plugins/update-checks/NewVersionInfoView.js
+++ b/client/src/plugins/update-checks/NewVersionInfoView.js
@@ -42,7 +42,7 @@ class NewVersionInfoView extends PureComponent {
         <div
           className="htmlSnippetItem"
           key={ version }>
-          <div><b>{ version }</b></div>
+          <h4>{ version }</h4>
           <div dangerouslySetInnerHTML={ { __html: releaseNoteHTML } } />
         </div>
       );
@@ -72,13 +72,14 @@ class NewVersionInfoView extends PureComponent {
         <Modal.Title>{ MODAL_TITLE }</Modal.Title>
 
         <Modal.Body>
-          <div className="newVersionInfoText">
+          <p>
             { infoTextProcessed }
-          </div>
-          <br />
-          { INFO_TEXT2 }
+          </p>
+          <p>
+            { INFO_TEXT2 }
+          </p>
           <div className="releaseNotesContainer">
-            <b className="releaseNotesTitle"> { RELEASE_NOTES_TITLE } </b>
+            <h4>{ RELEASE_NOTES_TITLE }</h4>
             <div className="htmlSnippet">
               { this.renderHtmlSnippets(releases) }
             </div>

--- a/client/src/plugins/update-checks/NewVersionInfoView.less
+++ b/client/src/plugins/update-checks/NewVersionInfoView.less
@@ -16,8 +16,17 @@
     margin-top: 10px;
   }
 
-  .releaseNotesContainer {
-    margin-top: 20px;
+  .htmlSnippet * {
+    user-select: text;
+  }
+
+  .releaseNotesContainer h4 {
+    margin-bottom: .25rem;
+    margin-top: .5rem;
+  }
+
+  .releaseNotesContainer p {
+    margin: 0.25rem 0 1rem;
   }
 
   .doNotShowContainer {
@@ -32,11 +41,11 @@
     height: 200px;
     overflow-y: auto;
     border: 1px solid gray;
-    margin-top: 10px;
-    padding: 5px;
+    margin: .5rem 0;
+    padding: 0 .5rem;
   }
 
-  .htmlSnippetItem {
-    margin-bottom: 25px;
+  .htmlSnippetItem + .htmlSnippetItem {
+    margin-top: 2rem;
   }
 }

--- a/client/src/plugins/update-checks/PrivacyPreferencesLink.js
+++ b/client/src/plugins/update-checks/PrivacyPreferencesLink.js
@@ -22,13 +22,10 @@ export default class PrivacyPreferencesLink extends PureComponent {
       !updateChecksEnabled && (
         <div>
           <p>
-            Periodic checks for new updates are currently <b>disabled</b>.
-          </p>
-          <p>
+            Periodic update checks are currently <b>disabled</b>. Enable them in the {' '}
             <a href="#" onClick={ onOpenPrivacyPreferences }>
-              Open the Privacy Preferences
-            </a>
-            {' '} to enable them.
+              Privacy Preferences
+            </a>.
           </p>
         </div>
       )

--- a/client/src/plugins/update-checks/__tests__/NewVersionInfoViewSpec.js
+++ b/client/src/plugins/update-checks/__tests__/NewVersionInfoViewSpec.js
@@ -17,8 +17,6 @@ import {
 
 import {
   MODAL_TITLE,
-  INFO_TEXT,
-  RELEASE_NOTES_TITLE,
   BUTTON_NEGATIVE,
   BUTTON_POSITIVE
 } from '../constants';
@@ -61,48 +59,71 @@ describe('<NewVersionInfoView>', () => {
   });
 
 
-  it('should render info text', () => {
-
-    const expectedText = INFO_TEXT.replace('@@1', 'v3.7.0').replace('@@2', 'v3.4.0');
-
-    const infoText = wrapper.find('.newVersionInfoText');
-
-    expect(infoText.text()).to.be.eql(expectedText);
-  });
-
-
-  it('should render release notes title', () => {
-
-    const releaseNotesTitle = wrapper.find('.releaseNotesTitle');
-
-    expect(releaseNotesTitle.text().trim()).to.be.eql(RELEASE_NOTES_TITLE);
-  });
-
-
-  it('should render positive button', () => {
-
-    const positiveButton = wrapper.find('.btn-primary');
-
-    expect(positiveButton.text().trim()).to.be.eql(BUTTON_POSITIVE);
-  });
-
-
-  it('should auto focus primary button', () => {
+  it('should render body', () => {
 
     // given
-    const positiveButton = wrapper.find('.btn-primary');
+    const expectedText = `
+      Camunda Modeler v3.7.0 is available. Your version is v3.4.0.
+
+      Would you like to download it now?
+
+      Release notes
+
+      v3.5.0
+      HTML 1
+
+      v3.6.0
+      HTML 2
+
+      Periodic update checks are currently disabled. Enable them in the  Privacy Preferences.
+    `;
+
+    const expectedFragments = expectedText.split('\n').map(l => l.trim()).filter(l => l);
+
+    // when
+    const body = wrapper.find('.modal-body');
+
+    const text = body.text();
 
     // then
-    expect(positiveButton.instance()).to.be.eql(document.activeElement);
+    for (const expectedText of expectedFragments) {
+      expect(text, 'body text').to.include(expectedText);
+    }
   });
 
 
-  it('should render negative button', () => {
+  describe('footer', () => {
 
-    const negativeButton = wrapper.find('.btn-secondary');
+    it('should render <Download> button', () => {
 
-    expect(negativeButton.text().trim()).to.be.eql(BUTTON_NEGATIVE);
+      // given
+      const footer = wrapper.find('.modal-footer');
+
+      // when
+      const downloadButton = footer.find('.btn-primary');
+
+      // then
+      expect(downloadButton.text().trim()).to.be.eql(BUTTON_POSITIVE);
+
+      // and auto-focussed
+      expect(downloadButton.instance()).to.eql(document.activeElement);
+    });
+
+
+    it('should render <Skip> button', () => {
+
+      // given
+      const footer = wrapper.find('.modal-footer');
+
+      // when
+      const skipButton = footer.find('.btn-secondary');
+
+      // then
+      expect(skipButton.text().trim()).to.be.eql(BUTTON_NEGATIVE);
+    });
+
   });
+
 
 
   it('should close', () => {

--- a/client/src/plugins/update-checks/__tests__/NewVersionInfoViewSpec.js
+++ b/client/src/plugins/update-checks/__tests__/NewVersionInfoViewSpec.js
@@ -125,7 +125,6 @@ describe('<NewVersionInfoView>', () => {
   });
 
 
-
   it('should close', () => {
 
     const onCloseSpy = spy();

--- a/client/src/plugins/update-checks/constants.js
+++ b/client/src/plugins/update-checks/constants.js
@@ -14,7 +14,7 @@ export const BUTTON_NEGATIVE = 'Skip this version';
 
 export const BUTTON_POSITIVE = 'Go to download page';
 
-export const RELEASE_NOTES_TITLE = 'Release notes:';
+export const RELEASE_NOTES_TITLE = 'Release notes';
 
 export const INFO_TEXT = 'Camunda Modeler @@1 is available. Your version is @@2.';
 


### PR DESCRIPTION
This PR proposes a sensible improvement to our existing release note container:

![screenshot xQv7xY](https://user-images.githubusercontent.com/58601/218884095-b186dd43-0f29-4b18-82a1-6c98e777d610.png)