### PR TITLE
fix(app): allow to send event via keyboard shortcuts

### DIFF
--- a/client/src/app/AppParent.js
+++ b/client/src/app/AppParent.js
@@ -49,18 +49,18 @@ export default class AppParent extends PureComponent {
     this.appRef = React.createRef();
   }
 
-  triggerAction = (event, action, options) => {
+  triggerAction = (action, context) => {
 
     // fail-safe trigger given action
     const exec = async () => {
 
-      log('trigger action %s, %o', action, options);
+      log('trigger action %s, %o', action, context);
 
       const {
         backend
       } = this.props.globals;
 
-      const result = await this.getApp().triggerAction(action, options);
+      const result = await this.getApp().triggerAction(action, context);
 
       if (action === 'quit') {
 
@@ -243,11 +243,11 @@ export default class AppParent extends PureComponent {
     this.getBackend().sendReady();
   };
 
-  handleResize = () => this.triggerAction(null, 'resize');
+  handleResize = () => this.triggerAction('resize');
 
-  handleFocus = (event) => {
-    this.triggerAction(event, 'check-file-changed');
-    this.triggerAction(event, 'notify-focus-change');
+  handleFocus = () => {
+    this.triggerAction('check-file-changed');
+    this.triggerAction('notify-focus-change');
   };
 
   handleStarted = async () => {
@@ -316,7 +316,7 @@ export default class AppParent extends PureComponent {
    * @param {string} entry.action
    */
   logToClient(entry) {
-    this.triggerAction(null, 'log', entry);
+    this.triggerAction('log', entry);
   }
 
   /**
@@ -338,7 +338,7 @@ export default class AppParent extends PureComponent {
     backend.once('client:started', this.handleStarted);
 
     this.subscriptions = [
-      backend.on('menu:action', this.triggerAction),
+      backend.on('menu:action', (_, action, options) => this.triggerAction(action, options)),
       backend.on('client:open-files', this.handleOpenFiles),
       backend.on('client:window-focused', this.handleFocus),
       backend.on('backend:error', this.handleBackendError)

--- a/client/src/app/KeyboardBindings.js
+++ b/client/src/app/KeyboardBindings.js
@@ -148,7 +148,7 @@ export default class KeyboardBindings {
     }
 
     if (action && onAction) {
-      onAction(null, action);
+      onAction(action, event);
 
       event.preventDefault();
     }
@@ -167,7 +167,7 @@ export default class KeyboardBindings {
     var { key } = event;
 
     if (action && onAction && !this.pressedKeys[ key ]) {
-      onAction(null, action);
+      onAction(action, event);
 
       this.pressedKeys[ key ] = true;
 
@@ -186,7 +186,7 @@ export default class KeyboardBindings {
     }
 
     if (action && onAction) {
-      onAction(null, action);
+      onAction(action, event);
 
       event.preventDefault();
     }

--- a/client/src/app/__tests__/AppParentSpec.js
+++ b/client/src/app/__tests__/AppParentSpec.js
@@ -247,7 +247,7 @@ describe('<AppParent>', function() {
       const quitAllowedSpy = spy(backend, 'sendQuitAllowed');
 
       // when
-      await appParent.triggerAction({}, 'quit');
+      await appParent.triggerAction('quit');
 
       // then
       expect(closeAllTabsSpy).to.be.calledWith('close-all-tabs');
@@ -271,7 +271,7 @@ describe('<AppParent>', function() {
       const quitAbortedSpy = spy(backend, 'sendQuitAborted');
 
       // when
-      await appParent.triggerAction({}, 'quit');
+      await appParent.triggerAction('quit');
 
       // then
       expect(closeTabsStub).to.be.calledOnce;

--- a/client/src/app/__tests__/KeyboardBindingsSpec.js
+++ b/client/src/app/__tests__/KeyboardBindingsSpec.js
@@ -61,7 +61,7 @@ describe('KeyboardBindings', function() {
       // then
       expect(actionSpy).to.have.been.calledTwice;
 
-      expect(actionSpy.alwaysCalledWith(null, 'foo')).to.be.true;
+      expect(actionSpy.alwaysCalledWith('foo', event)).to.be.true;
     });
 
 
@@ -89,7 +89,7 @@ describe('KeyboardBindings', function() {
       // then
       expect(actionSpy).to.have.been.calledTwice;
 
-      expect(actionSpy.alwaysCalledWith(null, 'foo')).to.be.true;
+      expect(actionSpy.alwaysCalledWith('foo', event)).to.be.true;
     });
 
 
@@ -113,7 +113,7 @@ describe('KeyboardBindings', function() {
       // then
       expect(actionSpy).to.have.been.calledTwice;
 
-      expect(actionSpy.alwaysCalledWith(null, 'foo')).to.be.true;
+      expect(actionSpy.alwaysCalledWith('foo', event)).to.be.true;
     });
 
   });
@@ -133,7 +133,7 @@ describe('KeyboardBindings', function() {
     keyboardBindings._keyDownHandler(event);
 
     // then
-    expect(actionSpy).to.have.been.calledWith(null, 'copy');
+    expect(actionSpy).to.have.been.calledWith('copy', event);
   });
 
 
@@ -151,7 +151,7 @@ describe('KeyboardBindings', function() {
     keyboardBindings._keyDownHandler(event);
 
     // then
-    expect(actionSpy).to.have.been.calledWith(null, 'cut');
+    expect(actionSpy).to.have.been.calledWith('cut', event);
   });
 
 
@@ -169,7 +169,7 @@ describe('KeyboardBindings', function() {
     keyboardBindings._keyDownHandler(event);
 
     // then
-    expect(actionSpy).to.have.been.calledWith(null, 'paste');
+    expect(actionSpy).to.have.been.calledWith('paste', event);
   });
 
 
@@ -187,7 +187,7 @@ describe('KeyboardBindings', function() {
     keyboardBindings._keyDownHandler(event);
 
     // then
-    expect(actionSpy).to.have.been.calledWith(null, 'undo');
+    expect(actionSpy).to.have.been.calledWith('undo', event);
   });
 
 
@@ -207,7 +207,7 @@ describe('KeyboardBindings', function() {
       keyboardBindings._keyDownHandler(event);
 
       // then
-      expect(actionSpy).to.have.been.calledWith(null, 'redo');
+      expect(actionSpy).to.have.been.calledWith('redo', event);
     });
 
 
@@ -225,7 +225,7 @@ describe('KeyboardBindings', function() {
       keyboardBindings._keyDownHandler(event);
 
       // then
-      expect(actionSpy).to.have.been.calledWith(null, 'redo');
+      expect(actionSpy).to.have.been.calledWith('redo', event);
     });
 
   });
@@ -245,7 +245,7 @@ describe('KeyboardBindings', function() {
     keyboardBindings._keyDownHandler(event);
 
     // then
-    expect(actionSpy).to.have.been.calledWith(null, 'selectAll');
+    expect(actionSpy).to.have.been.calledWith('selectAll', event);
   });
 
 
@@ -315,7 +315,7 @@ describe('KeyboardBindings', function() {
       keyboardBindings._keyDownHandler(event);
 
       // then
-      expect(actionSpy).to.have.been.calledWith(null, 'removeSelection');
+      expect(actionSpy).to.have.been.calledWith('removeSelection', event);
     });
 
 
@@ -338,7 +338,7 @@ describe('KeyboardBindings', function() {
       keyboardBindings._keyDownHandler(event);
 
       // then
-      expect(actionSpy).to.have.been.calledWith(null, 'removeSelection');
+      expect(actionSpy).to.have.been.calledWith('removeSelection', event);
     });
   });
 
@@ -359,7 +359,7 @@ describe('KeyboardBindings', function() {
       keyboardBindings._keyDownHandler(event);
 
       // then
-      expect(actionSpy).to.have.been.calledWith(null, 'replaceElement');
+      expect(actionSpy).to.have.been.calledWith('replaceElement', event);
 
     });
 
@@ -404,7 +404,7 @@ describe('KeyboardBindings', function() {
     keyboardBindings._keyDownHandler(event);
 
     expect(actionSpy).not.to.have.been.called;
-    expect(newActionSpy).to.have.been.calledWith(null, 'selectAll');
+    expect(newActionSpy).to.have.been.calledWith('selectAll', event);
   });
 
 


### PR DESCRIPTION
**Context**
I was trying to open create the create menu on the position of the keyboard shortcut event that triggered it  

**Issue**
Currently there isn’t really a way to trigger an editor action via keyboard bindings and send the event as an argument. I discovered that we actually allow for a `event` param [here](https://github.com/camunda/camunda-modeler/blob/develop/client/src/app/AppParent.js#L52) but we don’t use it. Also, we have the `event` in KeyboardBindings but we [choose to pass it as `null`](https://github.com/camunda/camunda-modeler/blob/develop/client/src/app/KeyboardBindings.js#L150). 

Me and Martin discussed this and figured that there is no reason not to send the event, and this is probably an oversight (because it hasn’t been needed yet).

**Suggestion**
Use the second param of `AppParent#triggerAction` as general `context`, and send the event through there (we use `context` in the Editors for example - https://github.com/camunda/camunda-modeler/blob/develop/client/src/app/tabs/bpmn/BpmnEditor.js#L651)
