### PR TITLE
Fix vulnerable deps

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,7 @@
     "camunda-cmmn-moddle": "^1.0.0",
     "camunda-dmn-js": "^0.9.0",
     "camunda-dmn-moddle": "^1.2.0",
-    "canvg-browser": "^1.0.0",
+    "canvg": "^4.0.1",
     "classnames": "^2.2.6",
     "cmmn-js": "^0.20.0",
     "cmmn-js-properties-panel": "^0.9.0",

--- a/client/src/app/util/__tests__/generateImageSpec.js
+++ b/client/src/app/util/__tests__/generateImageSpec.js
@@ -28,17 +28,17 @@ describe('util - generateImage', function() {
 
   keys(expectedImagesByType).forEach(function(type) {
 
-    it('should export <' + type + '>', function() {
+    it('should export <' + type + '>', async function() {
 
-      const image = generateImage(type, svg);
+      const image = await generateImage(type, svg);
 
       expect(image).to.exist;
     });
 
 
-    it('should automatically handle large images <' + type + '>', function() {
+    it('should automatically handle large images <' + type + '>', async function() {
 
-      const image = generateImage(type, outOfBoundsSVG);
+      const image = await generateImage(type, outOfBoundsSVG);
 
       // if image cannot be generated properly it returns a data string with
       // 6 characters. If it is generated, image.length returns the actual size
@@ -47,9 +47,9 @@ describe('util - generateImage', function() {
     }).timeout(10000); // downscaling may exceed the default timeout 2000ms.
 
 
-    it('should generate expected images <' + type + '>', function() {
+    it('should generate expected images <' + type + '>', async function() {
 
-      const image = generateImage(type, svg),
+      const image = await generateImage(type, svg),
             expectedImage = expectedImagesByType[ type ];
 
       expect(image).to.be.eql(expectedImage);

--- a/client/src/app/util/generateImage.js
+++ b/client/src/app/util/generateImage.js
@@ -8,7 +8,7 @@
  * except in compliance with the MIT License.
  */
 
-import canvg from 'canvg-browser';
+import { Canvg } from 'canvg';
 
 // list of defined encodings
 const ENCODINGS = [
@@ -23,7 +23,7 @@ const SCALE_STEP = 1;
 const DATA_URL_REGEX = /^data:((?:\w+\/(?:(?!;).)+)?)((?:;[\w\W]*?[^;])*),(.+)$/;
 
 
-export default function generateImage(type, svg) {
+export default async function generateImage(type, svg) {
   const encoding = 'image/' + type;
 
   if (ENCODINGS.indexOf(encoding) === -1) {
@@ -42,11 +42,12 @@ export default function generateImage(type, svg) {
       return `width="${parseInt(widthStr, 10) * scale}" height="${parseInt(heightStr, 10) * scale}"`;
     });
 
-    canvg(canvas, svg);
+    const context = canvas.getContext('2d');
+
+    const canvg = Canvg.fromString(context, svg);
+    await canvg.render();
 
     // make the background white for every format
-    let context = canvas.getContext('2d');
-
     context.globalCompositeOperation = 'destination-over';
     context.fillStyle = 'white';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16106,8 +16106,9 @@
       "license": "MIT"
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "license": "BSD-2-Clause"
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -41835,7 +41836,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0"
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-errors": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -229,7 +229,7 @@
         "camunda-cmmn-moddle": "^1.0.0",
         "camunda-dmn-js": "^0.9.0",
         "camunda-dmn-moddle": "^1.2.0",
-        "canvg-browser": "^1.0.0",
+        "canvg": "^4.0.1",
         "classnames": "^2.2.6",
         "cmmn-js": "^0.20.0",
         "cmmn-js-properties-panel": "^0.9.0",
@@ -2378,11 +2378,6 @@
         "node": ">=4"
       }
     },
-    "client/node_modules/performance-now": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "client/node_modules/postcss": {
       "version": "8.4.16",
       "dev": true,
@@ -2501,14 +2496,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "client/node_modules/raf": {
-      "version": "3.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
     },
     "client/node_modules/railroad-diagrams": {
       "version": "1.0.0",
@@ -7627,6 +7614,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.0",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
+      "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg=="
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -7655,6 +7647,11 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==",
       "dev": true
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
+      "integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw=="
     },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
@@ -10060,14 +10057,28 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/canvg-browser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/canvg-browser/-/canvg-browser-1.0.0.tgz",
-      "integrity": "sha512-awXQ+9yLsqjcGIoURleQfGuE+7vMHXOshluFBS4+A+o3U+ZoIgcrCOWFUWQxdHJETpWxhAgPHX6g8lQujG9hoQ==",
+    "node_modules/canvg": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-4.0.1.tgz",
+      "integrity": "sha512-5gD/d6SiCCT7baLnVr0hokYe93DfcHW2rSqdKOuOQD84YMlyfttnZ8iQsThTdX6koYam+PROz/FuQTo500zqGw==",
       "dependencies": {
-        "rgbcolor": "0.0.4",
-        "stackblur": "^1.0.0",
-        "xmldom": "^0.1.22"
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/raf": "^3.4.0",
+        "raf": "^3.4.1",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/canvg/node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/ccount": {
@@ -22780,6 +22791,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "license": "ISC"
@@ -23248,6 +23264,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dependencies": {
+        "performance-now": "^2.1.0"
       }
     },
     "node_modules/rambda": {
@@ -26002,14 +26026,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/rgbcolor": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-0.0.4.tgz",
-      "integrity": "sha512-fG8I3S9oe435NsIa3bAcavWhr0ioN+m5qRfjidB1vn5rU2D69Ain0N0aiTtXggZJnsV7Fo/poCI0NnkkhtcRgw==",
-      "engines": {
-        "node": ">= 0.8.15"
-      }
-    },
     "node_modules/rimraf": {
       "version": "2.7.1",
       "dev": true,
@@ -26950,10 +26966,13 @@
         "node": "*"
       }
     },
-    "node_modules/stackblur": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stackblur/-/stackblur-1.0.0.tgz",
-      "integrity": "sha512-K92JX8alrs0pTox5U2arVBqB8tJmak9dh9i4Xausy94TnnGMdLfTn7P2Dp/NOzlmxvEs7lDzeryo8YqOy0BHRQ=="
+    "node_modules/stackblur-canvas": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.5.0.tgz",
+      "integrity": "sha512-EeNzTVfj+1In7aSLPKDD03F/ly4RxEuF/EX0YcOG0cKoPXs+SLZxDawQbexQDBzwROs4VKLWTOaZQlZkGBFEIQ==",
+      "engines": {
+        "node": ">=0.1.14"
+      }
     },
     "node_modules/stat-mode": {
       "version": "1.0.0",
@@ -27308,6 +27327,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/svgo": {
@@ -29561,15 +29588,6 @@
       "dev": true,
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
-      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
-      "engines": {
-        "node": ">=0.1"
       }
     },
     "node_modules/xtend": {
@@ -33496,6 +33514,11 @@
       "version": "2.4.1",
       "dev": true
     },
+    "@types/offscreencanvas": {
+      "version": "2019.7.0",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
+      "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg=="
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -33524,6 +33547,11 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==",
       "dev": true
+    },
+    "@types/raf": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
+      "integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw=="
     },
     "@types/responselike": {
       "version": "1.0.0",
@@ -35527,7 +35555,7 @@
         "camunda-cmmn-moddle": "^1.0.0",
         "camunda-dmn-js": "^0.9.0",
         "camunda-dmn-moddle": "^1.2.0",
-        "canvg-browser": "^1.0.0",
+        "canvg": "^4.0.1",
         "case-sensitive-paths-webpack-plugin": "^2.1.2",
         "chai": "^4.2.0",
         "classnames": "^2.2.6",
@@ -37057,10 +37085,6 @@
           "version": "3.0.0",
           "dev": true
         },
-        "performance-now": {
-          "version": "2.1.0",
-          "dev": true
-        },
         "postcss": {
           "version": "8.4.16",
           "dev": true,
@@ -37127,13 +37151,6 @@
           "version": "1.0.1",
           "dev": true,
           "optional": true
-        },
-        "raf": {
-          "version": "3.4.1",
-          "dev": true,
-          "requires": {
-            "performance-now": "^2.1.0"
-          }
         },
         "railroad-diagrams": {
           "version": "1.0.0",
@@ -37389,14 +37406,24 @@
     "caniuse-lite": {
       "version": "1.0.30001384"
     },
-    "canvg-browser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/canvg-browser/-/canvg-browser-1.0.0.tgz",
-      "integrity": "sha512-awXQ+9yLsqjcGIoURleQfGuE+7vMHXOshluFBS4+A+o3U+ZoIgcrCOWFUWQxdHJETpWxhAgPHX6g8lQujG9hoQ==",
+    "canvg": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-4.0.1.tgz",
+      "integrity": "sha512-5gD/d6SiCCT7baLnVr0hokYe93DfcHW2rSqdKOuOQD84YMlyfttnZ8iQsThTdX6koYam+PROz/FuQTo500zqGw==",
       "requires": {
-        "rgbcolor": "0.0.4",
-        "stackblur": "^1.0.0",
-        "xmldom": "^0.1.22"
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/raf": "^3.4.0",
+        "raf": "^3.4.1",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "dependencies": {
+        "rgbcolor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+          "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw=="
+        }
       }
     },
     "ccount": {
@@ -46436,6 +46463,11 @@
       "version": "1.2.0",
       "dev": true
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+    },
     "picocolors": {
       "version": "1.0.0"
     },
@@ -46738,6 +46770,14 @@
       "resolved": "https://registry.npmjs.org/quotation/-/quotation-2.0.2.tgz",
       "integrity": "sha512-FeUlLe40ROXHVWLZkzmeR2PNYWdkvTXEXhW6FX8axRv1ODt8Gxed3APrE1Qb5i1n70ZzZGRmvs0jY3v/BRcJQQ==",
       "dev": true
+    },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
     },
     "rambda": {
       "version": "7.2.1",
@@ -48851,11 +48891,6 @@
       "version": "1.3.0",
       "dev": true
     },
-    "rgbcolor": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-0.0.4.tgz",
-      "integrity": "sha512-fG8I3S9oe435NsIa3bAcavWhr0ioN+m5qRfjidB1vn5rU2D69Ain0N0aiTtXggZJnsV7Fo/poCI0NnkkhtcRgw=="
-    },
     "rimraf": {
       "version": "2.7.1",
       "dev": true,
@@ -49529,10 +49564,10 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="
     },
-    "stackblur": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stackblur/-/stackblur-1.0.0.tgz",
-      "integrity": "sha512-K92JX8alrs0pTox5U2arVBqB8tJmak9dh9i4Xausy94TnnGMdLfTn7P2Dp/NOzlmxvEs7lDzeryo8YqOy0BHRQ=="
+    "stackblur-canvas": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.5.0.tgz",
+      "integrity": "sha512-EeNzTVfj+1In7aSLPKDD03F/ly4RxEuF/EX0YcOG0cKoPXs+SLZxDawQbexQDBzwROs4VKLWTOaZQlZkGBFEIQ=="
     },
     "stat-mode": {
       "version": "1.0.0",
@@ -49773,6 +49808,11 @@
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "dev": true
+    },
+    "svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw=="
     },
     "svgo": {
       "version": "1.3.2",
@@ -51335,11 +51375,6 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
       "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
       "dev": true
-    },
-    "xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17530,8 +17530,9 @@
       "license": "ISC"
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "license": "MIT",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -23377,9 +23378,9 @@
       }
     },
     "node_modules/react-svg-loader/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -27813,9 +27814,10 @@
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -27911,7 +27913,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.31",
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==",
       "funding": [
         {
           "type": "opencollective",
@@ -27922,7 +27926,6 @@
           "url": "https://paypal.me/faisalman"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -42798,7 +42801,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1"
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonc-parser": {
       "version": "3.2.0",
@@ -46858,9 +46863,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -50154,7 +50159,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
@@ -50218,7 +50225,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.31"
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw=="
     },
     "uglify-js": {
       "version": "3.17.4",


### PR DESCRIPTION
This replaces warnings-triggering `canvg-browser` with `canvg`, and upgrades some deps via npm audit fix.

Note that this touches PNG/JPG export facility. It works on my Mac though.

----

Closes https://github.com/camunda/camunda-modeler/issues/3434