### PR TITLE
Fix "ping" event

### DIFF
--- a/client/src/plugins/user-journey-statistics/UserJourneyStatistics.js
+++ b/client/src/plugins/user-journey-statistics/UserJourneyStatistics.js
@@ -47,8 +47,6 @@ export default class UserJourneyStatistics extends PureComponent {
     this.MIXPANEL_TOKEN = Flags.get(MIXPANEL_TOKEN) || DEFINED_MIXPANEL_TOKEN;
     this.MIXPANEL_STAGE = Flags.get(MIXPANEL_STAGE) || DEFINED_MIXPANEL_STAGE;
 
-    this._isEnabled = false;
-
     this._buttonRef = React.createRef(null);
 
     this.mixpanel = MixpanelHandler.getInstance();
@@ -70,21 +68,20 @@ export default class UserJourneyStatistics extends PureComponent {
   }
 
   isEnabled = () => {
-    return this._isEnabled;
+    return MixpanelHandler.getInstance().isEnabled();
   };
 
   enable = () => {
     log('Enabling');
 
     this.mixpanel.enable(this.MIXPANEL_TOKEN, this._editorID, this.MIXPANEL_STAGE);
-    this._isEnabled = true;
   };
 
   disable = () => {
     log('Disabling.');
 
     this.mixpanel.disable();
-    this._isEnabled = false;
+    this.emit('telemetry:disabled');
   };
 
   async setEditorId() {

--- a/client/src/plugins/user-journey-statistics/UserJourneyStatistics.js
+++ b/client/src/plugins/user-journey-statistics/UserJourneyStatistics.js
@@ -75,13 +75,20 @@ export default class UserJourneyStatistics extends PureComponent {
     log('Enabling');
 
     this.mixpanel.enable(this.MIXPANEL_TOKEN, this._editorID, this.MIXPANEL_STAGE);
+
+    this.emit('telemetry.enabled');
   };
+
+  emit(event, payload) {
+    this.props.triggerAction('emit-event', { type: event, payload });
+  }
 
   disable = () => {
     log('Disabling.');
 
     this.mixpanel.disable();
-    this.emit('telemetry:disabled');
+
+    this.emit('telemetry.disabled');
   };
 
   async setEditorId() {

--- a/client/src/plugins/user-journey-statistics/__tests__/UserJourneyStatisticsSpec.js
+++ b/client/src/plugins/user-journey-statistics/__tests__/UserJourneyStatisticsSpec.js
@@ -176,6 +176,8 @@ describe('<UserJourneyStatistics>', () => {
       }
     });
 
+    const emitSpy = sinon.stub(instance, 'emit');
+
     const mixpanel = instance.mixpanel;
 
     expect(mixpanel.isEnabled()).to.be.false;
@@ -185,6 +187,7 @@ describe('<UserJourneyStatistics>', () => {
 
     // then
     expect(mixpanel.isEnabled()).to.be.true;
+    expect(emitSpy).to.have.been.calledWith('telemetry.enabled');
   });
 
 
@@ -202,6 +205,8 @@ describe('<UserJourneyStatistics>', () => {
       }
     });
 
+    const emitSpy = sinon.stub(instance, 'emit');
+
     const mixpanel = instance.mixpanel;
 
     // when
@@ -211,6 +216,7 @@ describe('<UserJourneyStatistics>', () => {
 
     // then
     expect(mixpanel.isEnabled()).to.eql(false);
+    expect(emitSpy).to.have.been.calledWith('telemetry.disabled');
   });
 
 
@@ -363,7 +369,8 @@ function createJourneyStatistics(props = {}) {
         });
       }
     },
-    _getGlobal: () => ({})
+    _getGlobal: () => ({}),
+    triggerAction: () => {}
   });
 }
 

--- a/client/src/plugins/user-journey-statistics/event-handlers/PingEventHandler.js
+++ b/client/src/plugins/user-journey-statistics/event-handlers/PingEventHandler.js
@@ -16,7 +16,8 @@ export default class PingEventHandler {
   constructor(props) {
 
     const {
-      track
+      track,
+      subscribe
     } = props;
 
     this.track = track;
@@ -25,7 +26,13 @@ export default class PingEventHandler {
     this.sentInitially = false;
     this._intervalID = null;
 
-    this.configurePing();
+    subscribe('telemetry.enabled', () => {
+      this.configurePing();
+    });
+
+    subscribe('telemetry.disabled', () => {
+      clearInterval(this._intervalID);
+    });
   }
 
   getPlugins = () => {


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/3486

**Context:**
The "ping" event was not being sent initially because it was being configured before Mixpanel was enabled. I added `tracking.enabled`/`tracking.disabled` emitted events to manage this.

This didn't happen before because previous events are only triggered via user actions. With "ping", we want to send it specifically after tracking has been enabled.