### PR TITLE
deps: bump `zeebe-node`

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -20,7 +20,7 @@
     "mri": "^1.1.6",
     "node-fetch": "^2.6.1",
     "parents": "^1.0.1",
-    "zeebe-node": "^8.1.6"
+    "zeebe-node": "^8.2.0"
   },
   "homepage": "https://github.com/camunda/camunda-modeler",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "mri": "^1.1.6",
         "node-fetch": "^2.6.1",
         "parents": "^1.0.1",
-        "zeebe-node": "^8.1.6"
+        "zeebe-node": "^8.2.0"
       },
       "optionalDependencies": {
         "vscode-windows-ca-certs": "^0.3.0"
@@ -29934,9 +29934,9 @@
       "integrity": "sha512-stIyK/bVCRpEQgvRigfzPrAnEhM3NmrxE9cGxge8mbk6T+/40k2FNxsKxpCRIwWza5F5Ve1pk8aL3l49PbFyjQ=="
     },
     "node_modules/zeebe-node": {
-      "version": "8.1.6",
-      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.1.6.tgz",
-      "integrity": "sha512-GZ7vnGyKmLq4uBmt4uwWzw6cpCCCJJu4ASIJOqVd5V6Z7v/l8oVoA1QHA05FdbN9nvKvDl6G38zzZ5qcomac7Q==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.2.0.tgz",
+      "integrity": "sha512-LUNxDqf6yRc/PMxEjNsAR66jLzB7Y1ah1WUiECaaQzYkKtcnACTIdaJlXF7GA82OCynE+FSP6PYaMJ6Vli7oLg==",
       "dependencies": {
         "@grpc/grpc-js": "1.8.7",
         "@grpc/proto-loader": "0.7.4",
@@ -51896,9 +51896,9 @@
       "integrity": "sha512-stIyK/bVCRpEQgvRigfzPrAnEhM3NmrxE9cGxge8mbk6T+/40k2FNxsKxpCRIwWza5F5Ve1pk8aL3l49PbFyjQ=="
     },
     "zeebe-node": {
-      "version": "8.1.6",
-      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.1.6.tgz",
-      "integrity": "sha512-GZ7vnGyKmLq4uBmt4uwWzw6cpCCCJJu4ASIJOqVd5V6Z7v/l8oVoA1QHA05FdbN9nvKvDl6G38zzZ5qcomac7Q==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.2.0.tgz",
+      "integrity": "sha512-LUNxDqf6yRc/PMxEjNsAR66jLzB7Y1ah1WUiECaaQzYkKtcnACTIdaJlXF7GA82OCynE+FSP6PYaMJ6Vli7oLg==",
       "requires": {
         "@grpc/grpc-js": "1.8.7",
         "@grpc/proto-loader": "0.7.4",


### PR DESCRIPTION
Update to `8.2` version.

I integration tested this against self-managed using [zeebe-connection-test](https://github.com/camunda/zeebe-connection-test).