### PR TITLE
flags for default execution version

### DIFF
--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -73,6 +73,7 @@ import {
 } from '../../../util/Engines';
 
 import { getPlatformTemplates } from '../../../util/elementTemplates';
+import Flags, { DEFAULT_C7_EXECUTION_ENGINE_VERSION } from '../../../util/Flags';
 
 const NAMESPACE_URL_ACTIVITI = 'http://activiti.org/bpmn';
 
@@ -84,8 +85,19 @@ const NAMESPACE_CAMUNDA = {
 const EXPORT_AS = [ 'png', 'jpeg', 'svg' ];
 
 export const DEFAULT_ENGINE_PROFILE = {
-  executionPlatform: ENGINES.PLATFORM
+  executionPlatform: ENGINES.PLATFORM,
+  executionPlatformVersion: getDefaultEnginePlatformVersion()
 };
+
+function getDefaultEnginePlatformVersion() {
+  console.log('getDefaultEnginePlatformVersion');
+  if (Flags.get(DEFAULT_C7_EXECUTION_ENGINE_VERSION)) {
+    console.log(`DEFAULT_C7_EXECUTION_ENGINE_VERSION flag set to ${Flags.get(DEFAULT_C7_EXECUTION_ENGINE_VERSION)}`);
+    return Flags.get(DEFAULT_C7_EXECUTION_ENGINE_VERSION);
+  }
+  console.log('DEFAULT_C7_EXECUTION_ENGINE_VERSION flag not set');
+  return undefined;
+}
 
 const LOW_PRIORITY = 500;
 

--- a/client/src/util/Flags.js
+++ b/client/src/util/Flags.js
@@ -46,3 +46,5 @@ export const SENTRY_DSN = 'sentry-dsn';
 export const MIXPANEL_TOKEN = 'mixpanel-token';
 export const MIXPANEL_STAGE = 'mixpanel-stage';
 export const DISPLAY_VERSION = 'display-version';
+export const DEFAULT_C7_EXECUTION_ENGINE_VERSION = 'default-c7-execution-engine-version';
+


### PR DESCRIPTION
Addresses #3515 

This is in a draft state with discussions continuing from that issue here. 

@nikku  as you mentioned in the issue 
> @codygulley Your contribution looks promising. However flags are initialized late (during modeler initialization, not source loading), hence they cannot be retrieved eagerly. 

Can you provide some guidance on how I can implement this with that "lazy loading" in mind. 
 