### PR TITLE
chore: exclude tasks from Snyk Code reports

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file
+exclude:
+  code:
+  - "tasks/**/*"


### PR DESCRIPTION
This will remove clutter from Snyk reports as `tasks` is not part of the application.

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
