### PR TITLE
fix: use custom SSL certificate for oAuth connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+### General
+
+* `FIX`: use custom SSL certificate for oAuth connection
+
 ## 5.10.0
 
 ### General
 
-* `FEAT`: remove ET telemetry and migrate "ping" event to Mixpanel ([#3519](https://github.com/camunda/camunda-modeler/pull/3519), [#3521](https://github.com/camunda/camunda-modeler/pull/3521)) 
+* `FEAT`: remove ET telemetry and migrate "ping" event to Mixpanel ([#3519](https://github.com/camunda/camunda-modeler/pull/3519), [#3521](https://github.com/camunda/camunda-modeler/pull/3521))
 * `FEAT`: add latest execution platform versions ([#3522](https://github.com/camunda/camunda-modeler/pull/3522))
 * `DEPS`: update to `zeebe-node@8.1.6`
 

--- a/app/lib/zeebe-api/zeebe-api.js
+++ b/app/lib/zeebe-api/zeebe-api.js
@@ -333,11 +333,25 @@ class ZeebeAPI {
       return { ...options, ...tlsOptions };
     }
 
+    const rootCertsBuffer = Buffer.from(rootCerts.join('\n'));
+
+    // (3) add custom SSL certificate to oAuth options
+    let oAuthOptions = {};
+    if (options.oAuth) {
+      oAuthOptions = {
+        oAuth: {
+          ...options.oAuth,
+          customRootCert: rootCertsBuffer
+        }
+      };
+    }
+
     return {
       ...options,
       ...tlsOptions,
+      ...oAuthOptions,
       customSSL: {
-        rootCerts: Buffer.from(rootCerts.join('\n'))
+        rootCerts: rootCertsBuffer
       }
     };
   }

--- a/app/test/spec/zeebe-api/zeebe-api-spec.js
+++ b/app/test/spec/zeebe-api/zeebe-api-spec.js
@@ -1647,6 +1647,35 @@ describe('ZeebeAPI', function() {
       });
 
 
+      it('should pass root certificate in oAuth config too', async () => {
+
+        // given
+        const cert = readFile('./root-self-signed.pem');
+        const {
+          configSpy,
+          zeebeAPI
+        } = setup(cert);
+
+        const parameters = {
+          filePath: '/path/to/file.bpmn',
+          endpoint: {
+            type: 'oauth',
+            url: 'https://camunda.com'
+          }
+        };
+
+        // when
+        await zeebeAPI.deploy(parameters);
+
+        // then
+        const { oAuth } = configSpy.args[0][1];
+        expect(oAuth).to.exist;
+
+        const { customRootCert } = oAuth;
+        expect(Buffer.from(cert).equals(customRootCert)).to.be.true;
+      });
+
+
       it('should pass certificate to zeebe even if appears non-root', async () => {
 
         // given


### PR DESCRIPTION
Before this fix, we did not pass certificates to the oauth config
which is separated from customSSL.

Related to https://github.com/camunda-community-hub/zeebe-client-node-js#oauth

This popped up via [SUPPORT-15807](https://jira.camunda.com/browse/SUPPORT-15807)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
