### PR TITLE
chore: add empty element templates directory

### DIFF
--- a/resources/platform/base/resources/element-templates/README.md
+++ b/resources/platform/base/resources/element-templates/README.md
@@ -1,0 +1,7 @@
+# Element Templates Directory
+
+Place element templates into this directory to use them in the Camunda Modeler.
+
+## Learn More
+
+* [Element Templates Documentation](https://docs.camunda.io/docs/components/modeler/desktop-modeler/element-templates/about-templates/)


### PR DESCRIPTION
Based on feedback from @GeethaParthasarathy I've added an `element-templates` directory to avoid confusion.
