### PR TITLE
Possible work around for issue #3593

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ plugins/**
 coverage
 .nyc_output
 .linked-dependencies
+.idea/

--- a/app/lib/zeebe-api/zeebe-api.js
+++ b/app/lib/zeebe-api/zeebe-api.js
@@ -350,9 +350,9 @@ class ZeebeAPI {
       ...options,
       ...tlsOptions,
       ...oAuthOptions,
-      customSSL: {
+      /*customSSL: {
         rootCerts: rootCertsBuffer
-      }
+      }*/
     };
   }
 

--- a/app/test/smtls.js
+++ b/app/test/smtls.js
@@ -1,0 +1,97 @@
+const ZeebeAPI = require("../lib/zeebe-api");
+const {readFile} = require("../lib/file-system");
+const ZeebeNode = require("zeebe-node");
+const Flags = require("../lib/flags")
+
+const customClusterEndpoint = "gke.upgradingdave.com:443";
+const customOauthUrl = "https://gke.upgradingdave.com/auth/realms/camunda-platform/protocol/openid-connect/token";
+const customAudience = "oauth2";
+const customClientId = "zeebe";
+const customClientSecret = "xxx";
+
+/**
+ * Test using the zeebe-node library directly
+ * with Oauth Handshake
+ */
+async function smOauthTest() {
+
+  const zbc = new ZeebeNode.ZBClient(customClusterEndpoint, {
+    oAuth: {
+      url: customOauthUrl,
+      audience: customAudience,
+      clientId: customClientId,
+      clientSecret: customClientSecret,
+      //customRootCert: fs.readFileSync('./my_CA.pem'),
+      cacheOnDisk: false
+    }, useTLS: true
+  });
+
+  //console.log(zbc);
+
+  try {
+    let result = await zbc.topology();
+    console.log("success!");
+    //console.log(result);
+  } catch (err) {
+    console.log(err);
+  }
+}
+
+/**
+ * Test using the zeebe-node library directly
+ * no Oauth Handshake
+ */
+async function smTls() {
+
+  const zbc = new ZeebeNode.ZBClient(customClusterEndpoint, {
+    useTLS: true
+  });
+
+  //console.log(zbc);
+
+  try {
+    let result = await zbc.topology();
+    console.log("success!");
+    //console.log(result);
+  } catch (err) {
+    console.log(err);
+  }
+}
+
+async function smModelerOauthTest() {
+
+  const parameters = {
+    endpoint: {
+      type: 'oauth',
+      url: customClusterEndpoint,
+      oauthURL: customOauthUrl,
+      audience: customAudience,
+      clientId: customClientId,
+      clientSecret: customClientSecret
+    }
+  };
+
+  const flags = new Flags({});
+  const zeebeAPI = new ZeebeAPI({ readFile }, ZeebeNode, flags);
+  const result = await zeebeAPI.checkConnection(parameters);
+  console.log(result);
+}
+
+async function smModelerTls() {
+
+  const parameters = {
+    endpoint: {
+      type: 'selfHosted',
+      url: 'https://' + customClusterEndpoint,
+    }
+  };
+
+  const flags = new Flags({});
+  const zeebeAPI = new ZeebeAPI({ readFile }, ZeebeNode, flags);
+  const result = await zeebeAPI.checkConnection(parameters);
+  console.log(result);
+}
+
+smTls();
+smModelerTls();
+


### PR DESCRIPTION
This is some hacky, quick and dirty testing to troubleshoot #3593 . 

There seems to be some issue related to line 336 in `zeebe-api.js`: 

```
const rootCertsBuffer = Buffer.from(rootCerts.join('\n'));
```

Maybe this call is not really getting all root certs from the operating system? Or perhaps some other bug?

If the `customSSL` option is commented out so that the `rootCertsBuffer` is not passed thru to the node ZeebeClient, then I was able to connect via Desktop Modeler to my self managed environments over tls configured with letsencrypt certificates. 

I also created a very hacky test file named `smtls.js`. The `smTls` function attempts to connect using `ZeebeClient` directly. The `smModelerTls` function attempts to connect using the `ZeebeApi` implemented in Modeler. 

Hope this helps to investigate this issue, please let me know if you have any questions. 

Thanks!

