### PR TITLE
Integrate `bpmn-js-tracking`

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
     "bpmn-js": "^13.0.0",
     "bpmn-js-properties-panel": "^1.22.1",
     "bpmn-moddle": "^8.0.1",
+    "bpmn-js-tracking": "0.1.0",
     "camunda-bpmn-js": "^2.3.1",
     "camunda-bpmn-moddle": "^7.0.1",
     "camunda-cmmn-moddle": "^1.0.0",

--- a/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
+++ b/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
@@ -20,6 +20,11 @@ import lintingAnnotationsModule from '@camunda/linting/modeler';
 
 import Flags, { DISABLE_ADJUST_ORIGIN } from '../../../../util/Flags';
 
+import {
+  BpmnJSTracking as bpmnJSTracking,
+  BpmnJSTrackingModules as bpmnJSTrackingModules
+} from 'bpmn-js-tracking';
+
 
 export default class PlatformBpmnModeler extends BpmnModeler {
 
@@ -44,6 +49,8 @@ const defaultModules = BpmnModeler.prototype._modules;
 
 const extensionModules = [
   addExporterModule,
+  bpmnJSTracking,
+  bpmnJSTrackingModules,
   completeDirectEditingModule,
   globalClipboardModule,
   handToolOnSpaceModule,

--- a/client/src/app/tabs/cloud-bpmn/modeler/BpmnModeler.js
+++ b/client/src/app/tabs/cloud-bpmn/modeler/BpmnModeler.js
@@ -18,6 +18,11 @@ import handToolOnSpaceModule from '../../bpmn/modeler/features/hand-tool-on-spac
 import propertiesPanelKeyboardBindingsModule from '../../bpmn/modeler/features/properties-panel-keyboard-bindings';
 import lintingAnnotationsModule from '@camunda/linting/modeler';
 
+import {
+  BpmnJSTracking as bpmnJSTracking,
+  BpmnJSTrackingModules as bpmnJSTrackingModules
+} from 'bpmn-js-tracking';
+
 import Flags, {
   DISABLE_ADJUST_ORIGIN
 } from '../../../../util/Flags';
@@ -45,6 +50,8 @@ const defaultModules = BpmnModeler.prototype._modules;
 CloudBpmnModeler.prototype._modules = [
   ...defaultModules,
   addExporterModule,
+  bpmnJSTracking,
+  bpmnJSTrackingModules,
   completeDirectEditingModule,
   globalClipboardModule,
   handToolOnSpaceModule,

--- a/client/src/plugins/user-journey-statistics/MixpanelHandler.js
+++ b/client/src/plugins/user-journey-statistics/MixpanelHandler.js
@@ -36,8 +36,11 @@ export default class MixpanelHandler {
   }
 
   enable(token, id, stage) {
+    const debug = stage === 'prod' ? false : true;
+
     mixpanel.init(token, {
-      property_blacklist: [ '$current_url' ]
+      property_blacklist: [ '$current_url' ],
+      debug
     });
 
     mixpanel.identify(id);

--- a/client/src/plugins/user-journey-statistics/__tests__/UserJourneyStatisticsSpec.js
+++ b/client/src/plugins/user-journey-statistics/__tests__/UserJourneyStatisticsSpec.js
@@ -326,13 +326,14 @@ describe('<UserJourneyStatistics>', () => {
     const eventHandlers = instance._eventHandlers;
 
     // expect
-    expect(eventHandlers).to.have.length(6);
+    expect(eventHandlers).to.have.length(7);
     expectHandler(eventHandlers[0], 'DeploymentEventHandler');
     expectHandler(eventHandlers[1], 'FormEditorEventHandler');
     expectHandler(eventHandlers[2], 'LinkEventHandler');
     expectHandler(eventHandlers[3], 'OverlayEventHandler');
     expectHandler(eventHandlers[4], 'PingEventHandler');
     expectHandler(eventHandlers[5], 'TabEventHandler');
+    expectHandler(eventHandlers[6], 'ModelingEventHandler');
   });
 
 });

--- a/client/src/plugins/user-journey-statistics/event-handlers/ModelingEventHandler.js
+++ b/client/src/plugins/user-journey-statistics/event-handlers/ModelingEventHandler.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { isModelElement } from 'diagram-js/lib/model';
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+import MixpanelHandler from '../MixpanelHandler';
+
+export default class ModelingEventHandler {
+  constructor(props) {
+
+    const {
+      subscribe,
+      track
+    } = props;
+
+    this.track = track;
+    this.bpmnJSTracking = null;
+
+    this.subscribeToModelingEvents(subscribe);
+
+    subscribe('telemetry.enabled', () => {
+      if (this.bpmnJSTracking) {
+        this.bpmnJSTracking.enable();
+      }
+    });
+
+    subscribe('telemetry.disabled', () => {
+      if (this.bpmnJSTracking) {
+        this.bpmnJSTracking.disable();
+      }
+    });
+  }
+
+  subscribeToModelingEvents = (subscribe) => {
+
+    subscribe('bpmn.modeler.created', async (event) => {
+      const { modeler } = event;
+
+      this.bpmnJSTracking = modeler.get('bpmnJSTracking');
+
+      // if telemetry is enabled already, enable bpmnJSTracking
+      if (MixpanelHandler.getInstance().isEnabled()) {
+        this.bpmnJSTracking.enable();
+      }
+
+      this.bpmnJSTracking.on('tracking.event', (trakingEvent) => {
+        const { name, data } = trakingEvent;
+
+        // format event name to be consistent
+        const eventName = name.replace('.', ':');
+
+        // replace diagram elements with serializable data
+        const serializableData = filterDiagramElements(data);
+
+        this.track(eventName, serializableData);
+      });
+    });
+  };
+
+}
+
+
+// helpers //////////
+
+function replaceDiagramElement(object) {
+  return {
+    id: object.id,
+    type: object.type,
+    templateId: getTemplateIdFromElement(object)
+  };
+}
+
+function filterDiagramElements(data) {
+  const replacer = (key, value) => {
+
+    if (isModelElement(value)) {
+      return replaceDiagramElement(value);
+    }
+
+    if (Array.isArray(value)) {
+      return value.map((item) => {
+        if (isModelElement(item)) {
+          return replaceDiagramElement(item);
+        }
+
+        return item;
+      });
+    }
+
+    return value;
+  };
+
+  return JSON.parse(JSON.stringify(data, replacer));
+}
+
+function getTemplateIdFromElement(element) {
+  const businessObject = getBusinessObject(element);
+
+  return businessObject && businessObject.modelerTemplate;
+}

--- a/client/src/plugins/user-journey-statistics/event-handlers/__tests__/ModelingEventHandlerSpec.js
+++ b/client/src/plugins/user-journey-statistics/event-handlers/__tests__/ModelingEventHandlerSpec.js
@@ -1,0 +1,150 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/* global sinon */
+
+import { create } from 'diagram-js/lib/model';
+import ModelingEventHandler from '../ModelingEventHandler';
+
+describe('<ModelingEventHandler>', () => {
+
+  let subscribe, track;
+
+  beforeEach(() => {
+
+    subscribe = sinon.spy();
+
+    track = sinon.spy();
+
+    new ModelingEventHandler({
+      track,
+      subscribe
+    });
+  });
+
+
+  describe('should subscribe', () => {
+
+    it('should subscribe to bpmn.modeler.created', () => {
+      expect(subscribe.getCall(0).args[0]).to.eql('bpmn.modeler.created');
+    });
+
+
+    it('should subscribe to telemetry.disabled', () => {
+      expect(subscribe.getCall(1).args[0]).to.eql('telemetry.enabled');
+    });
+
+
+    it('should subscribe to telemetry.disabled', () => {
+      expect(subscribe.getCall(2).args[0]).to.eql('telemetry.disabled');
+    });
+
+  });
+
+
+  describe('should track modeling events', () => {
+
+    const { subscribe, callSubscriber } = createSubscribe();
+
+    beforeEach(() => {
+      track = sinon.spy();
+
+      new ModelingEventHandler({
+        track,
+        subscribe
+      });
+
+    });
+
+    it('shoud subscribe to bpmnJSTracking events', () => {
+
+      const onSpy = sinon.spy();
+
+      callSubscriber({ on: onSpy });
+
+      expect(onSpy).to.have.been.calledWith('tracking.event');
+    });
+
+
+    it('shoud track bpmnJSTracking events', () => {
+
+      callSubscriber({
+        on: (_, callback) => {
+          callback({ name: '', data: {} });
+        }
+      });
+
+      expect(track).to.have.been.called;
+    });
+
+
+    it('shoud trasform data', () => {
+
+      callSubscriber({
+        on: (_, callback) => {
+          callback({
+            name: 'some.event',
+            data: {
+              nonAnElement: 'someValue',
+              element: create('shape'),
+              elementArray: [ create('shape') ]
+            }
+          });
+        }
+      });
+
+      expect(track).to.have.been.calledWith('some:event', {
+        nonAnElement: 'someValue',
+        element: {},
+        elementArray: [ {} ]
+      });
+    });
+  });
+});
+
+
+// helpers ///////////////
+function createSubscribe() {
+  let callback = null;
+
+  function subscribe(_event, _callback) {
+    if ('bpmn.modeler.created' === _event) {
+      callback = _callback;
+    }
+
+    return function cancel() {
+      callback = null;
+    };
+  }
+
+  function callSubscriber(args) {
+    if (callback) {
+
+      callback({
+        modeler: {
+          get: () => {
+            return {
+              enable: () => {},
+              disable: () => {},
+              on: () => {},
+              ...args
+            };
+          }
+        }
+      });
+    }
+  }
+
+  return {
+    callSubscriber,
+    subscribe
+  };
+}
+

--- a/client/src/plugins/user-journey-statistics/event-handlers/index.js
+++ b/client/src/plugins/user-journey-statistics/event-handlers/index.js
@@ -14,6 +14,7 @@ import OverlayEventHandler from './OverlayEventHandler';
 import PingEventHandler from './PingEventHandler';
 import TabEventHandler from './TabEventHandler';
 import FormEditorEventHandler from './FormEditorEventHandler';
+import ModelingEventHandler from './ModelingEventHandler';
 
 export default [
   DeploymentEventHandler,
@@ -21,5 +22,6 @@ export default [
   LinkEventHandler,
   OverlayEventHandler,
   PingEventHandler,
-  TabEventHandler
+  TabEventHandler,
+  ModelingEventHandler
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -222,6 +222,7 @@
         "@sentry/browser": "^6.3.6",
         "bpmn-js": "^13.0.0",
         "bpmn-js-properties-panel": "^1.22.1",
+        "bpmn-js-tracking": "0.1.0",
         "bpmn-moddle": "^8.0.1",
         "camunda-bpmn-js": "^2.3.1",
         "camunda-bpmn-moddle": "^7.0.1",
@@ -8848,6 +8849,11 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/bpmn-js-tracking": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-tracking/-/bpmn-js-tracking-0.1.0.tgz",
+      "integrity": "sha512-uW3unLgYA7IfVw2U+ZMcNFH2rKoMk39LchS45meAdyfui+jn7bO8i4VFF3jISLB360lqD8wgtM/++JSKbGwvhQ=="
     },
     "node_modules/bpmn-js/node_modules/bpmn-moddle": {
       "version": "8.0.1",
@@ -32686,6 +32692,11 @@
         }
       }
     },
+    "bpmn-js-tracking": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-tracking/-/bpmn-js-tracking-0.1.0.tgz",
+      "integrity": "sha512-uW3unLgYA7IfVw2U+ZMcNFH2rKoMk39LchS45meAdyfui+jn7bO8i4VFF3jISLB360lqD8wgtM/++JSKbGwvhQ=="
+    },
     "bpmn-moddle": {
       "version": "7.1.3",
       "requires": {
@@ -33233,6 +33244,7 @@
         "babel-plugin-istanbul": "^5.1.3",
         "bpmn-js": "^13.0.0",
         "bpmn-js-properties-panel": "^1.22.1",
+        "bpmn-js-tracking": "0.1.0",
         "bpmn-moddle": "^8.0.1",
         "bpmnlint-loader": "^0.1.6",
         "camunda-bpmn-js": "^2.3.1",


### PR DESCRIPTION
Closes #3572 

This PR integrates `bpmn-js-tracking` by:
 * including modules in platform and cloud modelers
 * adding `ModelingEventHandler` (similar to existing tracking) that handles the `bpmn-js-tracking` events
 * transforming `bpmn-js-tracking` events data. Only send relevant information for elements: currently id, element type, template applied. We can expand this as needed (cc @christian-konrad )
 
While doing this I found these issues with `bpmn-js-tracking`, but we can start with this review and just bump the version when these are implemented:
 * https://github.com/bpmn-io/bpmn-js-tracking/issues/21 
 * https://github.com/bpmn-io/bpmn-js-tracking/issues/22 