### PR TITLE
feat: link directly to deployed process definition

### DIFF
--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
@@ -39,8 +39,9 @@ import { ENGINES } from '../../../util/Engines';
 import css from './DeploymentPlugin.less';
 
 import {
-  getCloudLink,
-  getProcessId
+  getClusterUrl,
+  getProcessId,
+  getProcessVersion
 } from '../shared/util';
 
 const DEPLOYMENT_CONFIG_KEY = 'zeebe-deployment-tool';
@@ -623,11 +624,12 @@ function CloudLink(props) {
     return null;
   }
 
-  const cloudUrl = getCloudLink(endpoint, response);
-  cloudUrl.searchParams.set('process', processId);
-  cloudUrl.searchParams.set('version', 'all');
-  cloudUrl.searchParams.set('active', 'true');
-  cloudUrl.searchParams.set('incidents', 'true');
+  const clusterUrl = getClusterUrl(endpoint, response);
+  const processesUrl = new URL(`${clusterUrl}/processes`);
+  processesUrl.searchParams.set('process', processId);
+  processesUrl.searchParams.set('version', getProcessVersion(response) || 'all');
+  processesUrl.searchParams.set('active', 'true');
+  processesUrl.searchParams.set('incidents', 'true');
 
   return (
     <div className={ css.CloudLink }>
@@ -635,7 +637,7 @@ function CloudLink(props) {
         Process Definition ID:
         <code>{processId}</code>
       </div>
-      <a href={ cloudUrl.toString() }>
+      <a href={ processesUrl.toString() }>
         Open in Camunda Operate
       </a>
     </div>

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
@@ -628,7 +628,7 @@ describe('<DeploymentPlugin> (Zeebe)', () => {
     const notificationHTML = shallow(notification.content).html().replace(/&amp;/g, '&');
 
     expect(notificationHTML).to.include(
-      'https://region.operate.camunda.io/CLUSTER_ID/instances?process=test&version=all&active=true&incidents=true'
+      'https://region.operate.camunda.io/CLUSTER_ID/processes?process=test&version=1&active=true&incidents=true'
     );
   });
 
@@ -1509,7 +1509,7 @@ function MockZeebeAPI(options = {}) {
     }
 
     const result = deploymentResult ||
-      { success: true, response: { processes: [ { bpmnProcessId: 'test' } ] } };
+      { success: true, response: { processes: [ { bpmnProcessId: 'test', version: 1 } ] } };
 
     return Promise.resolve(result);
   };

--- a/client/src/plugins/zeebe-plugin/shared/__tests__/utilSpec.js
+++ b/client/src/plugins/zeebe-plugin/shared/__tests__/utilSpec.js
@@ -9,14 +9,16 @@
  */
 
 import {
-  getCloudLink
+  getClusterUrl,
+  getProcessId,
+  getProcessVersion
 } from '../util';
 
 describe('util', () => {
 
-  describe('getCloudLink', () => {
+  describe('getClusterUrl', () => {
 
-    it('should return cloud link', () => {
+    it('should return cluster url', () => {
 
       // given
       const endpoint = {
@@ -25,10 +27,112 @@ describe('util', () => {
       };
 
       // when
-      const url = getCloudLink(endpoint);
+      const url = getClusterUrl(endpoint);
 
       // then
-      expect(url.toString()).to.eql('https://camundacloudclusterregion.operate.camunda.io/camundaCloudClusterId/instances');
+      expect(url.toString()).to.eql('https://camundacloudclusterregion.operate.camunda.io/camundaCloudClusterId');
     });
+  });
+
+
+  describe('getProcessId', () => {
+
+    it('should return process id', () => {
+
+      // given
+      const response = {
+        processes: [
+          {
+            bpmnProcessId: 'processId'
+          }
+        ]
+      };
+
+      // when
+      const processId = getProcessId(response);
+
+      // then
+      expect(processId).to.eql('processId');
+    });
+
+
+    it('should return null for empty response', () => {
+
+      // given
+      const response = {};
+
+      // when
+      const processId = getProcessId(response);
+
+      // then
+      expect(processId).to.be.null;
+    });
+
+
+    it('should return null if process missing', () => {
+
+      // given
+      const response = {
+        processes: []
+      };
+
+      // when
+      const processId = getProcessId(response);
+
+      // then
+      expect(processId).to.be.null;
+    });
+  });
+
+
+  describe('getProcessVersion', () => {
+
+    it('should return version', () => {
+
+      // given
+      const response = {
+        processes: [
+          {
+            bpmnProcessId: 'processId',
+            version: 2
+          }
+        ]
+      };
+
+      // when
+      const version = getProcessVersion(response);
+
+      // then
+      expect(version).to.eql(2);
+    });
+
+
+    it('should return null for empty response', () => {
+
+      // given
+      const response = {};
+
+      // when
+      const version = getProcessVersion(response);
+
+      // then
+      expect(version).to.be.null;
+    });
+
+
+    it('should return null if process missing', () => {
+
+      // given
+      const response = {
+        processes: []
+      };
+
+      // when
+      const version = getProcessVersion(response);
+
+      // then
+      expect(version).to.be.null;
+    });
+
   });
 });

--- a/client/src/plugins/zeebe-plugin/shared/util.js
+++ b/client/src/plugins/zeebe-plugin/shared/util.js
@@ -9,21 +9,29 @@
  */
 
 /**
- * Get a link to instances in Operate.
+ * Get a link to cluster in Operate.
  *
  * @param {Endpoint} endpoint
  */
-export function getCloudLink(endpoint) {
+export function getClusterUrl(endpoint) {
   const {
     camundaCloudClusterId,
     camundaCloudClusterRegion
   } = endpoint;
 
-  const url = new URL(`https://${camundaCloudClusterRegion}.operate.camunda.io/${camundaCloudClusterId}/instances`);
+  const url = new URL(`https://${camundaCloudClusterRegion}.operate.camunda.io/${camundaCloudClusterId}`);
 
   return url;
 }
 
+function getProcess(apiResponse) {
+  return apiResponse?.processes?.[0] || null;
+}
+
 export function getProcessId(response) {
-  return response.processes && response.processes[0] && response.processes[0].bpmnProcessId || null;
+  return getProcess(response)?.bpmnProcessId || null;
+}
+
+export function getProcessVersion(response) {
+  return getProcess(response)?.version || null;
 }

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
@@ -20,7 +20,7 @@ import pDefer from 'p-defer';
 import classNames from 'classnames';
 import { CAMUNDA_CLOUD } from '../shared/ZeebeTargetTypes';
 import StartInstanceConfigOverlay from './StartInstanceConfigOverlay';
-import { getCloudLink } from '../shared/util';
+import { getClusterUrl } from '../shared/util';
 
 const DEFAULT_CONFIGURATION = { variables: '' };
 
@@ -342,8 +342,8 @@ function CloudLink(props) {
     processInstanceKey
   } = response;
 
-  const cloudUrl = getCloudLink(endpoint);
-  const url = cloudUrl.toString() + `/${processInstanceKey}`;
+  const clusterUrl = getClusterUrl(endpoint);
+  const url = `${clusterUrl}/instances/${processInstanceKey}`;
 
   return (
     <div className={ css.CloudLink }>


### PR DESCRIPTION
Closes #3605

Apart from version change, this includes also `instances -> processes` endpoint change, as without it the link worked only for second and next deployments of the same version.

Before:

https://github.com/camunda/camunda-modeler/assets/28307541/2ec48eae-6c21-44cc-8c00-ad00af286d9e

After:

https://github.com/camunda/camunda-modeler/assets/28307541/753a756f-8aa6-4725-a779-b9af1866cdff
