### PR TITLE
fix: 3623 send empty business key on start process as null

### DIFF
--- a/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
@@ -267,6 +267,8 @@ export default class StartInstanceTool extends PureComponent {
         endpoint
       } = deploymentConfig;
 
+      startConfiguration.businessKey = startConfiguration.businessKey === '' ? null : startConfiguration.businessKey;
+
       const processInstance =
          await this.startWithConfiguration(this.decorateVariables(startConfiguration), processDefinition, endpoint);
 


### PR DESCRIPTION
This closes #3623 by setting the business key to `null` if it is an empty string.