### PR TITLE
fix: remove non-existing linting module usage in forms

### DIFF
--- a/client/src/app/tabs/form/FormEditor.js
+++ b/client/src/app/tabs/form/FormEditor.js
@@ -147,16 +147,6 @@ export class FormEditor extends CachedComponent {
     if (isCacheStateChanged(prevProps, this.props)) {
       this.handleChanged();
     }
-
-    const { layout = {} } = this.props;
-
-    const { panel = {} } = layout;
-
-    if (panel.open && panel.tab === 'linting') {
-      this.getForm().get('linting').activate();
-    } else if (!panel.open || panel.tab !== 'linting') {
-      this.getForm().get('linting').deactivate();
-    }
   }
 
   checkImport(prevProps) {

--- a/client/src/app/tabs/form/__tests__/FormEditorSpec.js
+++ b/client/src/app/tabs/form/__tests__/FormEditorSpec.js
@@ -815,6 +815,29 @@ describe('<FormEditor>', function() {
         expect(calls).to.have.lengthOf(1);
       });
 
+
+      it('should NOT break application with linting tab open', async function() {
+
+        // given
+        const props = {
+          layout: {
+            panel: {
+              open: true,
+              tab: 'linting'
+            }
+          }
+        };
+
+        // when
+        try {
+          await renderEditor(schema, props);
+        } catch (error) {
+
+          // then
+          expect(true, 'should not reach error block').to.be.false;
+        }
+      });
+
     });
 
   });
@@ -1293,7 +1316,6 @@ async function renderEditor(schema, options = {}) {
     getConfig = noop,
     id = 'editor',
     layout = {},
-    linting = [],
     onAction = noop,
     onChanged = noop,
     onContentUpdated = noop,
@@ -1324,7 +1346,6 @@ async function renderEditor(schema, options = {}) {
           getConfig={ getConfig }
           id={ id }
           layout={ layout }
-          linting={ linting }
           onAction={ onAction }
           onChanged={ onChanged }
           onContentUpdated={ onContentUpdated }

--- a/client/test/mocks/form-js/index.js
+++ b/client/test/mocks/form-js/index.js
@@ -31,7 +31,6 @@ export class FormEditor {
         fire() {}
       },
       commandStack: new CommandStack(),
-      linting: new Linting(),
       selection: {
         get() {
           return [];
@@ -207,26 +206,4 @@ export class FormPlayground {
       }
     });
   }
-}
-
-class Linting {
-  constructor(options = {}) {
-    this._isActive = options.active;
-  }
-
-  activate() {
-    this._isActive = true;
-  }
-
-  deactivate() {
-    this._isActive = false;
-  }
-
-  isActive() {
-    return this._isActive;
-  }
-
-  setErrors() {}
-
-  showError() {}
 }


### PR DESCRIPTION
Closes #3640

The issue went under the radar because in tests we mock Forms Editor even to an extent where we mock non-existing module 🤡 
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
