### PR TITLE
fix(resizable-container): resizer is behind overlays and modals

### DIFF
--- a/client/src/app/resizable-container/ResizableContainer.less
+++ b/client/src/app/resizable-container/ResizableContainer.less
@@ -14,7 +14,7 @@
     position: absolute;
     background-color: transparent;
     user-select: none;
-    z-index: 100000;
+    z-index: 100;
   }
 
   .resizer .resizer-border {


### PR DESCRIPTION
![electron_WVpMpIocRT](https://github.com/camunda/camunda-modeler/assets/7633572/201d3245-f0e6-4cff-8a77-0d220e26a9e6)

Closes #3650

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
