### PR TITLE
deps: update to zeebe-node@8.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: infer default port when connecting to Zeebe instances ([#3412](https://github.com/camunda/camunda-modeler/issues/3412))
 * `FEAT`: point to troubleshooting guide on connection problems ([#3618](https://github.com/camunda/camunda-modeler/pull/3618))
 * `FIX`: default empty business key to null in starting process instance ([#3644](https://github.com/camunda/camunda-modeler/pull/3644))
+* `FIX`: account for custom SSL certificates when connecting to C8 SaaS 
+* `DEPS`: update to `zeebe-node@8.2.4`
 
 ### BPMN
 

--- a/app/package.json
+++ b/app/package.json
@@ -20,7 +20,7 @@
     "mri": "^1.1.6",
     "node-fetch": "^2.6.1",
     "parents": "^1.0.1",
-    "zeebe-node": "^8.2.0"
+    "zeebe-node": "^8.2.4"
   },
   "homepage": "https://github.com/camunda/camunda-modeler",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "mri": "^1.1.6",
         "node-fetch": "^2.6.1",
         "parents": "^1.0.1",
-        "zeebe-node": "^8.2.0"
+        "zeebe-node": "^8.2.4"
       },
       "optionalDependencies": {
         "vscode-windows-ca-certs": "^0.3.0"
@@ -27668,10 +27668,11 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "license": "MIT",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/uvu": {
@@ -28531,8 +28532,9 @@
       "license": "MIT"
     },
     "node_modules/zeebe-node": {
-      "version": "8.2.0",
-      "license": "Apache-2.0",
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.2.4.tgz",
+      "integrity": "sha512-AFrmPhlp7uYhnCW5Yo6kTaJOkU8Pa26XvtxnRxbg1HcSeKlnIoO0R117aYbSgSKcjHog7zWgSiYnARJMREkyPQ==",
       "dependencies": {
         "@grpc/grpc-js": "1.8.7",
         "@grpc/proto-loader": "0.7.4",
@@ -28547,7 +28549,7 @@
         "promise-retry": "^1.1.1",
         "stack-trace": "0.0.10",
         "typed-duration": "^1.0.12",
-        "uuid": "^3.3.2"
+        "uuid": "^7.0.3"
       },
       "bin": {
         "zeebe-node": "bin/zeebe-node"
@@ -33298,7 +33300,7 @@
         "node-fetch": "^2.6.1",
         "parents": "^1.0.1",
         "vscode-windows-ca-certs": "^0.3.0",
-        "zeebe-node": "^8.2.0"
+        "zeebe-node": "^8.2.4"
       },
       "dependencies": {
         "@sentry/core": {
@@ -47201,7 +47203,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0"
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
     },
     "uvu": {
       "version": "0.5.6",
@@ -47735,7 +47739,9 @@
       "version": "0.19.0"
     },
     "zeebe-node": {
-      "version": "8.2.0",
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.2.4.tgz",
+      "integrity": "sha512-AFrmPhlp7uYhnCW5Yo6kTaJOkU8Pa26XvtxnRxbg1HcSeKlnIoO0R117aYbSgSKcjHog7zWgSiYnARJMREkyPQ==",
       "requires": {
         "@grpc/grpc-js": "1.8.7",
         "@grpc/proto-loader": "0.7.4",
@@ -47750,7 +47756,7 @@
         "promise-retry": "^1.1.1",
         "stack-trace": "0.0.10",
         "typed-duration": "^1.0.12",
-        "uuid": "^3.3.2"
+        "uuid": "^7.0.3"
       },
       "dependencies": {
         "err-code": {


### PR DESCRIPTION
Accounts for `customSSL.rootCerts` when connecting to Camunda 8 SaaS.

Related to upstream bug https://github.com/camunda-community-hub/zeebe-client-node-js/issues/319.


-----

Related to SUPPORT-16844