### PR TITLE
fix(VersionInfo): missing query params to release notes link

### DIFF
--- a/client/src/plugins/version-info/VersionInfoOverlay.js
+++ b/client/src/plugins/version-info/VersionInfoOverlay.js
@@ -14,7 +14,7 @@ import { Overlay, Section } from '../../shared/ui';
 
 import { ReleaseInfo } from './ReleaseInfo';
 
-const RELEASE_NOTES_LINK = 'https://camunda.com/blog/category/releases/?s=desktop+modeler';
+const RELEASE_NOTES_LINK = 'https://camunda.com/blog/category/releases/?s=desktop+modeler&utm_source=modeler&utm_medium=referral';
 const DOCS_LINK = 'https://docs.camunda.io/docs/components/modeler/desktop-modeler/?utm_source=modeler&utm_medium=referral';
 const CHANGELOG_LINK = 'https://github.com/camunda/camunda-modeler/blob/master/CHANGELOG.md';
 


### PR DESCRIPTION
Follow up from https://github.com/camunda/camunda-modeler/pull/3663#discussion_r1226221916
