### PR TITLE
feat(mixpanel): add templates tracking module

### DIFF
--- a/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
+++ b/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
@@ -23,6 +23,7 @@ import Flags, { DISABLE_ADJUST_ORIGIN } from '../../../../util/Flags';
 import { BpmnJSTracking as bpmnJSTracking } from 'bpmn-js-tracking';
 
 import contextPadTracking from 'bpmn-js-tracking/lib/features/context-pad';
+import elementTemplatesTracking from 'bpmn-js-tracking/lib/features/element-templates';
 import modelingTracking from 'bpmn-js-tracking/lib/features/modeling';
 import popupMenuTracking from 'bpmn-js-tracking/lib/features/popup-menu';
 import paletteTracking from 'bpmn-js-tracking/lib/features/palette';
@@ -58,6 +59,7 @@ const extensionModules = [
   lintingAnnotationsModule,
   bpmnJSTracking,
   contextPadTracking,
+  elementTemplatesTracking,
   modelingTracking,
   popupMenuTracking,
   paletteTracking

--- a/client/src/app/tabs/cloud-bpmn/modeler/BpmnModeler.js
+++ b/client/src/app/tabs/cloud-bpmn/modeler/BpmnModeler.js
@@ -21,6 +21,7 @@ import lintingAnnotationsModule from '@camunda/linting/modeler';
 import { BpmnJSTracking as bpmnJSTracking } from 'bpmn-js-tracking';
 
 import contextPadTracking from 'bpmn-js-tracking/lib/features/context-pad';
+import elementTemplates from 'bpmn-js-tracking/lib/features/element-templates';
 import modelingTracking from 'bpmn-js-tracking/lib/features/modeling';
 import popupMenuTracking from 'bpmn-js-tracking/lib/features/popup-menu';
 import paletteTracking from 'bpmn-js-tracking/lib/features/palette';
@@ -59,6 +60,7 @@ CloudBpmnModeler.prototype._modules = [
   lintingAnnotationsModule,
   bpmnJSTracking,
   contextPadTracking,
+  elementTemplates,
   modelingTracking,
   popupMenuTracking,
   paletteTracking


### PR DESCRIPTION
_Fixing a oopsie I made._

When updating the `bpmn-js-tracking` last time, I forgot to add the newest tracking module, seeing as we add each one explicitly.
 
