### PR TITLE
fix(client): correctly apply default templates in BPMN editor

### DIFF
--- a/client/src/app/tabs/bpmn-shared/modeler/features/apply-default-templates/__tests__/applyDefaultTemplatesSpec.js
+++ b/client/src/app/tabs/bpmn-shared/modeler/features/apply-default-templates/__tests__/applyDefaultTemplatesSpec.js
@@ -27,6 +27,13 @@ describe('applyDefaultTemplates', function() {
   });
 
 
+  it('should depend on <config.changeTemplateCommand>', function() {
+    expect(
+      applyDefaultTemplates.$inject
+    ).to.include('config.changeTemplateCommand');
+  });
+
+
   it('should not throw errors for empty diagram', function() {
 
     // given
@@ -151,7 +158,8 @@ describe('applyDefaultTemplates', function() {
 
 
 
-// helpers //////
+// helpers ///////////
+
 function getDependencies(mockModules = {}) {
   const modeler = new Modeler({
     modules: {

--- a/client/src/app/tabs/bpmn-shared/modeler/features/apply-default-templates/applyDefaultTemplates.js
+++ b/client/src/app/tabs/bpmn-shared/modeler/features/apply-default-templates/applyDefaultTemplates.js
@@ -9,6 +9,11 @@
  */
 
 export default function applyDefaultTemplates(elementRegistry, elementTemplates, commandStack, changeTemplateCommand) {
+
+  if (!changeTemplateCommand) {
+    throw new Error('<config.changeTemplateCommand> not provided');
+  }
+
   const elements = elementRegistry.getAll();
 
   const commands = elements.reduce((currentCommands, element) => {
@@ -35,7 +40,8 @@ export default function applyDefaultTemplates(elementRegistry, elementTemplates,
 applyDefaultTemplates.$inject = [
   'elementRegistry',
   'elementTemplates',
-  'commandStack'
+  'commandStack',
+  'config.changeTemplateCommand'
 ];
 
 


### PR DESCRIPTION
Missing injection meant that we did not provide the command used to apply the template.

Closes https://github.com/camunda/camunda-modeler/issues/3687