### PR TITLE
Handle post import errors

### DIFF
--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -365,10 +365,22 @@ export class BpmnEditor extends CachedComponent {
 
     let engineProfile = null;
 
-    try {
-      engineProfile = this.engineProfile.get(true);
-    } catch (err) {
-      error = err;
+    if (!error) {
+      try {
+        engineProfile = this.engineProfile.get(true);
+      } catch (err) {
+        error = err;
+      }
+    }
+
+    if (!error && isNew && !defaultTemplatesApplied) {
+      try {
+        modeler.invoke(applyDefaultTemplates);
+
+        defaultTemplatesApplied = true;
+      } catch (err) {
+        error = err;
+      }
     }
 
     if (error) {
@@ -378,20 +390,20 @@ export class BpmnEditor extends CachedComponent {
         lastXML: null
       });
     } else {
-      if (isNew && !defaultTemplatesApplied) {
-        modeler.invoke(applyDefaultTemplates);
-
-        defaultTemplatesApplied = true;
-      }
-
       this.setCached({
         defaultTemplatesApplied,
         engineProfile,
         lastXML: xml,
         stackIdx
       });
+    }
 
-      this.handleLinting();
+    if (!error) {
+      try {
+        this.handleLinting();
+      } catch (err) {
+        error = err;
+      }
     }
 
     this.setState({

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -325,10 +325,22 @@ export class BpmnEditor extends CachedComponent {
 
     let engineProfile = null;
 
-    try {
-      engineProfile = this.engineProfile.get(true);
-    } catch (err) {
-      error = err;
+    if (!error) {
+      try {
+        engineProfile = this.engineProfile.get(true);
+      } catch (err) {
+        error = err;
+      }
+    }
+
+    if (!error && isNew && !defaultTemplatesApplied) {
+      try {
+        modeler.invoke(applyDefaultTemplates);
+
+        defaultTemplatesApplied = true;
+      } catch (err) {
+        error = err;
+      }
     }
 
     if (error) {
@@ -338,20 +350,20 @@ export class BpmnEditor extends CachedComponent {
         lastXML: null
       });
     } else {
-      if (isNew && !defaultTemplatesApplied) {
-        modeler.invoke(applyDefaultTemplates);
-
-        defaultTemplatesApplied = true;
-      }
-
       this.setCached({
         defaultTemplatesApplied,
         engineProfile,
         lastXML: xml,
         stackIdx
       });
+    }
 
-      this.handleLinting();
+    if (!error) {
+      try {
+        this.handleLinting();
+      } catch (err) {
+        error = err;
+      }
     }
 
     this.setState({

--- a/client/src/app/tabs/cloud-dmn/DmnEditor.js
+++ b/client/src/app/tabs/cloud-dmn/DmnEditor.js
@@ -237,10 +237,13 @@ export class DmnEditor extends CachedComponent {
     const stackIdx = modeler.getStackIdx();
 
     let engineProfile = null;
-    try {
-      engineProfile = this.engineProfile.get();
-    } catch (err) {
-      error = err;
+
+    if (!error) {
+      try {
+        engineProfile = this.engineProfile.get();
+      } catch (err) {
+        error = err;
+      }
     }
 
     onImport(error, warnings);

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -237,10 +237,13 @@ export class DmnEditor extends CachedComponent {
     const stackIdx = modeler.getStackIdx();
 
     let engineProfile = null;
-    try {
-      engineProfile = this.engineProfile.get();
-    } catch (err) {
-      error = err;
+
+    if (!error) {
+      try {
+        engineProfile = this.engineProfile.get();
+      } catch (err) {
+        error = err;
+      }
     }
 
     onImport(error, warnings);


### PR DESCRIPTION
As found in https://github.com/camunda/camunda-modeler/issues/3687 post import errors in the BPMN editors were not appropriately handled.

Reviewing the existing code it was clear that it 

(1) swallowed existing exceptions
(2) did not catch exceptions in all cases, i.e. https://github.com/camunda/camunda-modeler/issues/3687.

This PR should clean up the matter.