### PR TITLE
feat: add flags for default execution version

### DIFF
--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -48,7 +48,15 @@ import {
   generateId
 } from '../util';
 
-import Flags, { DISABLE_DMN, DISABLE_FORM, DISABLE_ZEEBE, DISABLE_PLATFORM, DISABLE_CMMN } from '../util/Flags';
+import Flags, {
+  DISABLE_DMN,
+  DISABLE_FORM,
+  DISABLE_ZEEBE,
+  DISABLE_PLATFORM,
+  DISABLE_CMMN,
+  PLATFORM_ENGINE_VERSION,
+  CLOUD_ENGINE_VERSION
+} from '../util/Flags';
 
 import BPMNIcon from '../../resources/icons/file-types/BPMN-16x16.svg';
 import DMNIcon from '../../resources/icons/file-types/DMN-16x16.svg';
@@ -692,13 +700,13 @@ function sortByPriority(providers) {
 
 function replaceVersions(contents) {
 
-  const latestPlatformVersion = getLatestStablePlatformVersion(ENGINES.PLATFORM);
-  const latestCloudVersion = getLatestStablePlatformVersion(ENGINES.CLOUD);
+  const platformVersion = Flags.get(PLATFORM_ENGINE_VERSION, getLatestStablePlatformVersion(ENGINES.PLATFORM));
+  const cloudVersion = Flags.get(CLOUD_ENGINE_VERSION, getLatestStablePlatformVersion(ENGINES.CLOUD));
 
   return (
     contents
-      .replace('{{ CAMUNDA_PLATFORM_VERSION }}', latestPlatformVersion)
-      .replace('{{ CAMUNDA_CLOUD_VERSION }}', latestCloudVersion)
+      .replace('{{ CAMUNDA_PLATFORM_VERSION }}', platformVersion)
+      .replace('{{ CAMUNDA_CLOUD_VERSION }}', cloudVersion)
   );
 }
 

--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -28,8 +28,7 @@ import form from './tabs/form/initial.form';
 import cloudForm from './tabs/form/initial-cloud.form';
 
 import {
-  ENGINES,
-  getLatestStable as getLatestStablePlatformVersion
+  ENGINES
 } from '../util/Engines';
 
 import EmptyTab from './EmptyTab';
@@ -53,14 +52,13 @@ import Flags, {
   DISABLE_FORM,
   DISABLE_ZEEBE,
   DISABLE_PLATFORM,
-  DISABLE_CMMN,
-  PLATFORM_ENGINE_VERSION,
-  CLOUD_ENGINE_VERSION
+  DISABLE_CMMN
 } from '../util/Flags';
 
 import BPMNIcon from '../../resources/icons/file-types/BPMN-16x16.svg';
 import DMNIcon from '../../resources/icons/file-types/DMN-16x16.svg';
 import FormIcon from '../../resources/icons/file-types/Form-16x16.svg';
+import { getDefaultVersion } from './tabs/EngineProfile';
 
 const BPMN_HELP_MENU = [
   {
@@ -700,8 +698,8 @@ function sortByPriority(providers) {
 
 function replaceVersions(contents) {
 
-  const platformVersion = Flags.get(PLATFORM_ENGINE_VERSION, getLatestStablePlatformVersion(ENGINES.PLATFORM));
-  const cloudVersion = Flags.get(CLOUD_ENGINE_VERSION, getLatestStablePlatformVersion(ENGINES.CLOUD));
+  const platformVersion = getDefaultVersion(ENGINES.PLATFORM);
+  const cloudVersion = getDefaultVersion(ENGINES.CLOUD);
 
   return (
     contents

--- a/client/src/app/__tests__/TabsProviderSpec.js
+++ b/client/src/app/__tests__/TabsProviderSpec.js
@@ -10,7 +10,14 @@
 
 import TabsProvider from '../TabsProvider';
 
-import Flags, { DISABLE_DMN, DISABLE_ZEEBE, DISABLE_PLATFORM, DISABLE_CMMN } from '../../util/Flags';
+import Flags, {
+  DISABLE_DMN,
+  DISABLE_ZEEBE,
+  DISABLE_PLATFORM,
+  DISABLE_CMMN,
+  CLOUD_ENGINE_VERSION,
+  PLATFORM_ENGINE_VERSION
+} from '../../util/Flags';
 
 import {
   getLatestStable as getLatestStablePlatformVersion,
@@ -233,6 +240,147 @@ describe('TabsProvider', function() {
 
       // then
       expect(contents).to.include(`modeler:executionPlatformVersion="${ expectedPlatformVersion }"`);
+    });
+
+
+    describe('engine version flag support', function() {
+
+      afterEach(Flags.reset);
+
+
+      it('should replace version placeholder with version from flag (BPMN)', function() {
+
+        // given
+        Flags.init({
+          [PLATFORM_ENGINE_VERSION]: '7.18.0'
+        });
+        const tabsProvider = new TabsProvider();
+
+        // when
+        const { file: { contents } } = tabsProvider.createTab('bpmn');
+
+        // then
+        expect(contents).to.include('modeler:executionPlatformVersion="7.18.0"');
+      });
+
+
+      it('should replace version placeholder with version from flag (Cloud BPMN)', function() {
+
+        // given
+        Flags.init({
+          [CLOUD_ENGINE_VERSION]: '8.0.0'
+        });
+        const tabsProvider = new TabsProvider();
+
+        // when
+        const { file: { contents } } = tabsProvider.createTab('cloud-bpmn');
+
+        // then
+        expect(contents).to.include('modeler:executionPlatformVersion="8.0.0"');
+      });
+
+
+      it('should replace version placeholder with version from flag (DMN)', function() {
+
+        // given
+        Flags.init({
+          [PLATFORM_ENGINE_VERSION]: '7.18.0'
+        });
+        const tabsProvider = new TabsProvider();
+
+        // when
+        const { file: { contents } } = tabsProvider.createTab('dmn');
+
+        // then
+        expect(contents).to.include('modeler:executionPlatformVersion="7.18.0"');
+      });
+
+
+      it('should replace version placeholder with version from flag (Cloud DMN)', function() {
+
+        // given
+        Flags.init({
+          [CLOUD_ENGINE_VERSION]: '8.0.0'
+        });
+        const tabsProvider = new TabsProvider();
+
+        // when
+        const { file: { contents } } = tabsProvider.createTab('cloud-dmn');
+
+        // then
+        expect(contents).to.include('modeler:executionPlatformVersion="8.0.0"');
+      });
+
+
+      describe('invalid flag', function() {
+
+        beforeEach(function() {
+          Flags.init({
+            [PLATFORM_ENGINE_VERSION]: 'abc',
+            [CLOUD_ENGINE_VERSION]: 'cde'
+          });
+        });
+
+
+        it('should replace version placeholder with actual latest version (BPMN)', function() {
+
+          // given
+          const tabsProvider = new TabsProvider();
+
+          const expectedPlatformVersion = getLatestStablePlatformVersion(ENGINES.PLATFORM);
+
+          // when
+          const { file: { contents } } = tabsProvider.createTab('bpmn');
+
+          // then
+          expect(contents).to.include(`modeler:executionPlatformVersion="${ expectedPlatformVersion }"`);
+        });
+
+
+        it('should replace version placeholder with actual latest version (Cloud BPMN)', function() {
+
+          // given
+          const tabsProvider = new TabsProvider();
+
+          const expectedPlatformVersion = getLatestStablePlatformVersion(ENGINES.CLOUD);
+
+          // when
+          const { file: { contents } } = tabsProvider.createTab('cloud-bpmn');
+
+          // then
+          expect(contents).to.include(`modeler:executionPlatformVersion="${ expectedPlatformVersion }"`);
+        });
+
+
+        it('should replace version placeholder with actual latest version (DMN)', function() {
+
+          // given
+          const tabsProvider = new TabsProvider();
+
+          const expectedPlatformVersion = getLatestStablePlatformVersion(ENGINES.PLATFORM);
+
+          // when
+          const { file: { contents } } = tabsProvider.createTab('dmn');
+
+          // then
+          expect(contents).to.include(`modeler:executionPlatformVersion="${ expectedPlatformVersion }"`);
+        });
+
+
+        it('should replace version placeholder with actual latest version (Cloud DMN)', function() {
+
+          // given
+          const tabsProvider = new TabsProvider();
+
+          const expectedPlatformVersion = getLatestStablePlatformVersion(ENGINES.CLOUD);
+
+          // when
+          const { file: { contents } } = tabsProvider.createTab('cloud-dmn');
+
+          // then
+          expect(contents).to.include(`modeler:executionPlatformVersion="${ expectedPlatformVersion }"`);
+        });
+      });
     });
 
 

--- a/client/src/app/tabs/EngineProfile.js
+++ b/client/src/app/tabs/EngineProfile.js
@@ -14,6 +14,12 @@ import classnames from 'classnames';
 
 import semverCompare from 'semver-compare';
 
+
+import Flags, {
+  PLATFORM_ENGINE_VERSION,
+  CLOUD_ENGINE_VERSION
+} from '../../util/Flags';
+
 import {
   Overlay,
   Section
@@ -266,6 +272,29 @@ export function getAnnotatedVersion(version, platform) {
   }
 
   return version;
+}
+
+export function getDefaultVersion(engine) {
+  const flagVersion = getFlagVersion(engine);
+
+  const versions = getVersions(engine);
+  if (isKnownVersion(versions, flagVersion)) {
+    return flagVersion;
+  }
+
+  return getLatestStable(engine);
+}
+
+function getFlagVersion(engine) {
+  if (engine === ENGINES.PLATFORM) {
+    return Flags.get(PLATFORM_ENGINE_VERSION);
+  } else if (engine === ENGINES.CLOUD) {
+    return Flags.get(CLOUD_ENGINE_VERSION);
+  }
+}
+
+function getVersions(engine) {
+  return ENGINE_PROFILES.find(profile => profile.executionPlatform === engine).executionPlatformVersions;
 }
 
 export function engineProfilesEqual(a, b) {

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -66,6 +66,8 @@ import {
 
 import { getPlatformTemplates } from '../../../util/elementTemplates';
 
+import Flags, { PLATFORM_ENGINE_VERSION } from '../../../util/Flags';
+
 const NAMESPACE_URL_ACTIVITI = 'http://activiti.org/bpmn';
 
 const NAMESPACE_CAMUNDA = {
@@ -76,7 +78,8 @@ const NAMESPACE_CAMUNDA = {
 const EXPORT_AS = [ 'png', 'jpeg', 'svg' ];
 
 export const DEFAULT_ENGINE_PROFILE = {
-  executionPlatform: ENGINES.PLATFORM
+  executionPlatform: ENGINES.PLATFORM,
+  executionPlatformVersion: undefined
 };
 
 const LOW_PRIORITY = 500;
@@ -98,7 +101,10 @@ export class BpmnEditor extends CachedComponent {
 
         const definitions = modeler.getDefinitions();
 
-        return getEngineProfileFromBpmn(definitions, DEFAULT_ENGINE_PROFILE);
+        return getEngineProfileFromBpmn(definitions, {
+          executionPlatform: DEFAULT_ENGINE_PROFILE.executionPlatform,
+          executionPlatformVersion: Flags.get(PLATFORM_ENGINE_VERSION, DEFAULT_ENGINE_PROFILE.executionPlatformVersion)
+        });
       },
       set: (engineProfile) => {
         const modeler = this.getModeler();

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -54,6 +54,8 @@ import {
 
 import { SlotFillRoot } from '../../../slot-fill';
 
+import Flags, { PLATFORM_ENGINE_VERSION } from '../../../../util/Flags';
+
 const { spy } = sinon;
 
 
@@ -2029,6 +2031,21 @@ describe('<BpmnEditor>', function() {
       executionPlatform: 'Camunda Platform',
       executionPlatformVersion: '7.16.1'
     }));
+
+
+    it('should respect flags', async function() {
+
+      // given
+      Flags.init({
+        [PLATFORM_ENGINE_VERSION]: '7.19.0'
+      });
+
+      // then
+      expectEngineProfile(engineProfileXML, {
+        executionPlatform: 'Camunda Platform',
+        executionPlatformVersion: '7.19.0'
+      });
+    });
 
 
     it('should not open form if unknown execution profile', async function() {

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -2002,6 +2002,10 @@ describe('<BpmnEditor>', function() {
       };
     }
 
+    afterEach(() => {
+      Flags.reset();
+    });
+
 
     it('should show engine profile (no engine profile)', expectEngineProfile(noEngineProfileXML, {
       executionPlatform: 'Camunda Platform',

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -61,10 +61,13 @@ import {
 
 import { getCloudTemplates } from '../../../util/elementTemplates';
 
+import Flags, { CLOUD_ENGINE_VERSION } from '../../../util/Flags';
+
 const EXPORT_AS = [ 'png', 'jpeg', 'svg' ];
 
 export const DEFAULT_ENGINE_PROFILE = {
-  executionPlatform: ENGINES.CLOUD
+  executionPlatform: ENGINES.CLOUD,
+  executionPlatformVersion: undefined
 };
 
 const LOW_PRIORITY = 500;
@@ -86,7 +89,10 @@ export class BpmnEditor extends CachedComponent {
 
         const definitions = modeler.getDefinitions();
 
-        return getEngineProfileFromBpmn(definitions, DEFAULT_ENGINE_PROFILE);
+        return getEngineProfileFromBpmn(definitions, {
+          executionPlatform: DEFAULT_ENGINE_PROFILE.executionPlatform,
+          executionPlatformVersion: Flags.get(CLOUD_ENGINE_VERSION, DEFAULT_ENGINE_PROFILE.executionPlatformVersion)
+        });
       },
       set: (engineProfile) => {
         const modeler = this.getModeler();

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -1923,6 +1923,10 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
       };
     }
 
+    afterEach(() => {
+      Flags.reset();
+    });
+
 
     it('should show engine profile (no engine profile)', expectEngineProfile(noEngineProfileXML, {
       executionPlatform: 'Camunda Cloud',

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -52,6 +52,8 @@ import {
 
 import { SlotFillRoot } from '../../../slot-fill';
 
+import Flags, { CLOUD_ENGINE_VERSION } from '../../../../util/Flags';
+
 const { spy } = sinon;
 
 
@@ -1950,6 +1952,21 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
       executionPlatform: 'Camunda Cloud',
       executionPlatformVersion: '1.1.1'
     }));
+
+
+    it('should respect flags', async function() {
+
+      // given
+      Flags.init({
+        [CLOUD_ENGINE_VERSION]: '8.2.0'
+      });
+
+      // then
+      expectEngineProfile(engineProfileXML, {
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '8.2.0'
+      });
+    });
 
 
     it('should not open form if unknown execution profile', async function() {

--- a/client/src/app/tabs/cloud-dmn/DmnEditor.js
+++ b/client/src/app/tabs/cloud-dmn/DmnEditor.js
@@ -67,6 +67,8 @@ import EngineProfileHelper from '../EngineProfileHelper';
 
 import { ENGINES } from '../../../util/Engines';
 
+import Flags, { CLOUD_ENGINE_VERSION } from '../../../util/Flags';
+
 const EXPORT_AS = [ 'png', 'jpeg', 'svg' ];
 
 const NAMESPACE_URL_DMN11 = 'http://www.omg.org/spec/DMN/20151101/dmn.xsd',
@@ -101,7 +103,10 @@ export class DmnEditor extends CachedComponent {
         const executionPlatform = executionPlatformHelper.getExecutionPlatform();
 
         if (!executionPlatform) {
-          return DEFAULT_ENGINE_PROFILE;
+          return {
+            executionPlatform: DEFAULT_ENGINE_PROFILE.executionPlatform,
+            executionPlatformVersion: Flags.get(CLOUD_ENGINE_VERSION, DEFAULT_ENGINE_PROFILE.executionPlatformVersion)
+          };
         }
 
         return {

--- a/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
@@ -54,6 +54,8 @@ import {
   DEFAULT_LAYOUT
 } from '../../dmn/OverviewContainer';
 
+import Flags, { CLOUD_ENGINE_VERSION } from '../../../../util/Flags';
+
 const { spy } = sinon;
 
 
@@ -2001,6 +2003,21 @@ describe('<DmnEditor>', function() {
       executionPlatform: 'Camunda Cloud',
       executionPlatformVersion: '8.0.1'
     }));
+
+
+    it('should respect flags', async function() {
+
+      // given
+      Flags.init({
+        [CLOUD_ENGINE_VERSION]: '8.2.0'
+      });
+
+      // then
+      expectEngineProfile(engineProfileXML, {
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '8.2.0'
+      });
+    });
 
 
     it('should reject unknown engine profile', async function() {

--- a/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
@@ -1974,6 +1974,10 @@ describe('<DmnEditor>', function() {
       };
     }
 
+    afterEach(() => {
+      Flags.reset();
+    });
+
 
     it('should show engine profile (no engine profile)', expectEngineProfile(noEngineProfileXML, {
       executionPlatform: 'Camunda Cloud',

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -67,6 +67,8 @@ import EngineProfileHelper from '../EngineProfileHelper';
 
 import { ENGINES } from '../../../util/Engines';
 
+import Flags, { PLATFORM_ENGINE_VERSION } from '../../../util/Flags';
+
 const EXPORT_AS = [ 'png', 'jpeg', 'svg' ];
 
 const NAMESPACE_URL_DMN11 = 'http://www.omg.org/spec/DMN/20151101/dmn.xsd',
@@ -101,7 +103,10 @@ export class DmnEditor extends CachedComponent {
         const executionPlatform = executionPlatformHelper.getExecutionPlatform();
 
         if (!executionPlatform) {
-          return DEFAULT_ENGINE_PROFILE;
+          return {
+            executionPlatform: DEFAULT_ENGINE_PROFILE.executionPlatform,
+            executionPlatformVersion: Flags.get(PLATFORM_ENGINE_VERSION, DEFAULT_ENGINE_PROFILE.executionPlatformVersion)
+          };
         }
 
         return {

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -1975,6 +1975,10 @@ describe('<DmnEditor>', function() {
       };
     }
 
+    afterEach(() => {
+      Flags.reset();
+    });
+
 
     it('should show engine profile (no engine profile)', expectEngineProfile(noEngineProfileXML, {
       executionPlatform: 'Camunda Platform',

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -54,6 +54,8 @@ import {
   DEFAULT_LAYOUT
 } from '../OverviewContainer';
 
+import Flags, { PLATFORM_ENGINE_VERSION } from '../../../../util/Flags';
+
 const { spy } = sinon;
 
 
@@ -2002,6 +2004,21 @@ describe('<DmnEditor>', function() {
       executionPlatform: 'Camunda Platform',
       executionPlatformVersion: '7.16.1'
     }));
+
+
+    it('should respect flags', async function() {
+
+      // given
+      Flags.init({
+        [PLATFORM_ENGINE_VERSION]: '7.19.0'
+      });
+
+      // then
+      expectEngineProfile(engineProfileXML, {
+        executionPlatform: 'Camunda Platform',
+        executionPlatformVersion: '7.19.0'
+      });
+    });
 
 
     it('should reject unknown engine profile', async function() {

--- a/client/src/app/tabs/form/FormEditor.js
+++ b/client/src/app/tabs/form/FormEditor.js
@@ -45,10 +45,13 @@ import { ENGINES } from '../../../util/Engines';
 
 import { FormPreviewToggle } from './FormPreviewToggle';
 
+import Flags, { CLOUD_ENGINE_VERSION } from '../../../util/Flags';
+
 const LOW_PRIORITY = 500;
 
 export const DEFAULT_ENGINE_PROFILE = {
-  executionPlatform: ENGINES.PLATFORM
+  executionPlatform: ENGINES.PLATFORM,
+  executionPlatformVersion: undefined
 };
 
 const FORM_LAYOUT_KEY = 'formEditor';
@@ -91,7 +94,10 @@ export class FormEditor extends CachedComponent {
 
         const schema = form.getSchema();
 
-        return getEngineProfileFromForm(schema, DEFAULT_ENGINE_PROFILE);
+        return getEngineProfileFromForm(schema, {
+          executionPlatform: DEFAULT_ENGINE_PROFILE.executionPlatform,
+          executionPlatformVersion: Flags.get(CLOUD_ENGINE_VERSION, DEFAULT_ENGINE_PROFILE.executionPlatformVersion)
+        });
       },
       set: (engineProfile) => {
         const { form } = this.getCached();

--- a/client/src/app/tabs/form/__tests__/FormEditorSpec.js
+++ b/client/src/app/tabs/form/__tests__/FormEditorSpec.js
@@ -43,6 +43,8 @@ import patchEngineProfile from '../../__tests__/EngineProfile.patch.platform.for
 
 import { SlotFillRoot } from '../../../slot-fill';
 
+import Flags, { PLATFORM_ENGINE_VERSION } from '../../../../util/Flags';
+
 const { spy } = sinon;
 
 
@@ -665,6 +667,20 @@ describe('<FormEditor>', function() {
       executionPlatform: 'Camunda Platform',
       executionPlatformVersion: '7.16.1'
     }));
+
+    it('should respect flags', async function() {
+
+      // given
+      Flags.init({
+        [PLATFORM_ENGINE_VERSION]: '7.19.0'
+      });
+
+      // then
+      expectEngineProfile(engineProfileSchema, {
+        executionPlatform: 'Camunda Platform',
+        executionPlatformVersion: '7.19.0'
+      });
+    });
 
 
     it('should update cached engine profile on change', async function() {

--- a/client/src/app/tabs/form/__tests__/FormEditorSpec.js
+++ b/client/src/app/tabs/form/__tests__/FormEditorSpec.js
@@ -644,6 +644,10 @@ describe('<FormEditor>', function() {
       };
     }
 
+    afterEach(() => {
+      Flags.reset();
+    });
+
 
     it('should show engine profile (no engine profile)', expectEngineProfile(noEngineProfile, {
       executionPlatform: 'Camunda Platform',

--- a/client/src/util/Flags.js
+++ b/client/src/util/Flags.js
@@ -46,5 +46,5 @@ export const SENTRY_DSN = 'sentry-dsn';
 export const MIXPANEL_TOKEN = 'mixpanel-token';
 export const MIXPANEL_STAGE = 'mixpanel-stage';
 export const DISPLAY_VERSION = 'display-version';
-export const CLOUD_ENGINE_VERSION = 'cloud-engine-version';
-export const PLATFORM_ENGINE_VERSION = 'platform-engine-version';
+export const CLOUD_ENGINE_VERSION = 'c8-engine-version';
+export const PLATFORM_ENGINE_VERSION = 'c7-engine-version';

--- a/client/src/util/Flags.js
+++ b/client/src/util/Flags.js
@@ -46,3 +46,5 @@ export const SENTRY_DSN = 'sentry-dsn';
 export const MIXPANEL_TOKEN = 'mixpanel-token';
 export const MIXPANEL_STAGE = 'mixpanel-stage';
 export const DISPLAY_VERSION = 'display-version';
+export const CLOUD_ENGINE_VERSION = 'cloud-engine-version';
+export const PLATFORM_ENGINE_VERSION = 'platform-engine-version';


### PR DESCRIPTION
Another go at https://github.com/camunda/camunda-modeler/pull/3528 with added tests and implementations for all editors.
Closes https://github.com/camunda/camunda-modeler/issues/3515 / https://github.com/camunda/camunda-modeler/issues/3696

Ping @nikku FYI

I tried to add the original remarks of @barmac and additionally added configuration for both, cloud and platform versions.
Please let me know what you think.


