### PR TITLE
chore(client): migrate webpack config to use @sentry/webpack-plugin@2

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -30,7 +30,7 @@ const {
 
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const SentryWebpackPlugin = require('@sentry/webpack-plugin');
+const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
 
 const { LicenseWebpackPlugin } = require('license-webpack-plugin');
 
@@ -144,10 +144,11 @@ function sentryIntegration() {
   // necessary SENTRY_AUTH_TOKEN, SENTRY_ORG and SENTRY_PROJECT environment
   // variables are injected via CI when building.
   return [
-    new SentryWebpackPlugin({
+    sentryWebpackPlugin({
       release: NODE_ENV === 'production' ? version : 'dev',
-      include: '.',
-      ignore: [ 'node_modules', 'webpack.config.js', '*Spec.js' ],
+      sourcemaps: {
+        assets: [ '../app/public/**' ]
+      }
     })
   ];
 }


### PR DESCRIPTION
Applies upgrade notices as found [here](https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/main/MIGRATION.md#upgrading-from-1x-to-2x-webpack-plugin-only).

Fixes [our release building](https://github.com/camunda/camunda-modeler/actions/runs/5461919291/jobs/9940561568).

----

Related to https://github.com/camunda/camunda-modeler/issues/3689