### PR TITLE
deps: update to `bpmn-js-tracking@0.3.2`

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,7 @@
     "@sentry/browser": "^7.57.0",
     "bpmn-js": "^13.2.1",
     "bpmn-js-properties-panel": "^2.1.0",
-    "bpmn-js-tracking": "0.3.1",
+    "bpmn-js-tracking": "0.3.2",
     "bpmn-moddle": "^8.0.1",
     "camunda-bpmn-js": "^2.7.0",
     "camunda-bpmn-moddle": "^7.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -144,7 +144,7 @@
         "@sentry/browser": "^7.57.0",
         "bpmn-js": "^13.2.1",
         "bpmn-js-properties-panel": "^2.1.0",
-        "bpmn-js-tracking": "0.3.1",
+        "bpmn-js-tracking": "0.3.2",
         "bpmn-moddle": "^8.0.1",
         "camunda-bpmn-js": "^2.7.0",
         "camunda-bpmn-moddle": "^7.0.1",
@@ -9120,9 +9120,9 @@
       }
     },
     "node_modules/bpmn-js-tracking": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-tracking/-/bpmn-js-tracking-0.3.1.tgz",
-      "integrity": "sha512-j45FOro7sO88esw/2s+5RpeBGI2tn77xQrjp40x62wBVAFUKXIXbeSQA9arOCY4CdUkAORr0Hc+KmIVvU1C+hg=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/bpmn-js-tracking/-/bpmn-js-tracking-0.3.2.tgz",
+      "integrity": "sha512-1TbVvPzq+tQ/dwLNIhRCe9W2kZzqiRiU+esgTauVSWJ4IkjEF9I9ldJih+WwwJexIHn2jFJRrpecQ36yi/hlfw=="
     },
     "node_modules/bpmn-js/node_modules/component-event": {
       "version": "0.2.1",
@@ -33677,9 +33677,9 @@
       }
     },
     "bpmn-js-tracking": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-tracking/-/bpmn-js-tracking-0.3.1.tgz",
-      "integrity": "sha512-j45FOro7sO88esw/2s+5RpeBGI2tn77xQrjp40x62wBVAFUKXIXbeSQA9arOCY4CdUkAORr0Hc+KmIVvU1C+hg=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/bpmn-js-tracking/-/bpmn-js-tracking-0.3.2.tgz",
+      "integrity": "sha512-1TbVvPzq+tQ/dwLNIhRCe9W2kZzqiRiU+esgTauVSWJ4IkjEF9I9ldJih+WwwJexIHn2jFJRrpecQ36yi/hlfw=="
     },
     "bpmn-moddle": {
       "version": "8.0.1",
@@ -34211,7 +34211,7 @@
         "babel-plugin-istanbul": "^5.1.3",
         "bpmn-js": "^13.2.1",
         "bpmn-js-properties-panel": "^2.1.0",
-        "bpmn-js-tracking": "0.3.1",
+        "bpmn-js-tracking": "0.3.2",
         "bpmn-moddle": "^8.0.1",
         "bpmnlint-loader": "^0.1.6",
         "camunda-bpmn-js": "^2.7.0",


### PR DESCRIPTION
Includes https://github.com/bpmn-io/bpmn-js-tracking/issues/34 fix