### PR TITLE
feat: add flags for default execution version

### DIFF
--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -28,8 +28,7 @@ import form from './tabs/form/initial.form';
 import cloudForm from './tabs/form/initial-cloud.form';
 
 import {
-  ENGINES,
-  getLatestStable as getLatestStablePlatformVersion
+  ENGINES
 } from '../util/Engines';
 
 import EmptyTab from './EmptyTab';
@@ -48,11 +47,18 @@ import {
   generateId
 } from '../util';
 
-import Flags, { DISABLE_DMN, DISABLE_FORM, DISABLE_ZEEBE, DISABLE_PLATFORM, DISABLE_CMMN } from '../util/Flags';
+import Flags, {
+  DISABLE_DMN,
+  DISABLE_FORM,
+  DISABLE_ZEEBE,
+  DISABLE_PLATFORM,
+  DISABLE_CMMN
+} from '../util/Flags';
 
 import BPMNIcon from '../../resources/icons/file-types/BPMN-16x16.svg';
 import DMNIcon from '../../resources/icons/file-types/DMN-16x16.svg';
 import FormIcon from '../../resources/icons/file-types/Form-16x16.svg';
+import { getDefaultVersion } from './tabs/EngineProfile';
 
 const BPMN_HELP_MENU = [
   {
@@ -692,13 +698,13 @@ function sortByPriority(providers) {
 
 function replaceVersions(contents) {
 
-  const latestPlatformVersion = getLatestStablePlatformVersion(ENGINES.PLATFORM);
-  const latestCloudVersion = getLatestStablePlatformVersion(ENGINES.CLOUD);
+  const platformVersion = getDefaultVersion(ENGINES.PLATFORM);
+  const cloudVersion = getDefaultVersion(ENGINES.CLOUD);
 
   return (
     contents
-      .replace('{{ CAMUNDA_PLATFORM_VERSION }}', latestPlatformVersion)
-      .replace('{{ CAMUNDA_CLOUD_VERSION }}', latestCloudVersion)
+      .replace('{{ CAMUNDA_PLATFORM_VERSION }}', platformVersion)
+      .replace('{{ CAMUNDA_CLOUD_VERSION }}', cloudVersion)
   );
 }
 

--- a/client/src/app/__tests__/TabsProviderSpec.js
+++ b/client/src/app/__tests__/TabsProviderSpec.js
@@ -10,7 +10,14 @@
 
 import TabsProvider from '../TabsProvider';
 
-import Flags, { DISABLE_DMN, DISABLE_ZEEBE, DISABLE_PLATFORM, DISABLE_CMMN } from '../../util/Flags';
+import Flags, {
+  DISABLE_DMN,
+  DISABLE_ZEEBE,
+  DISABLE_PLATFORM,
+  DISABLE_CMMN,
+  CLOUD_ENGINE_VERSION,
+  PLATFORM_ENGINE_VERSION
+} from '../../util/Flags';
 
 import {
   getLatestStable as getLatestStablePlatformVersion,
@@ -233,6 +240,209 @@ describe('TabsProvider', function() {
 
       // then
       expect(contents).to.include(`modeler:executionPlatformVersion="${ expectedPlatformVersion }"`);
+    });
+
+
+    describe('engine version flag support', function() {
+
+      afterEach(Flags.reset);
+
+
+      it('should replace version placeholder with version from flag (BPMN)', function() {
+
+        // given
+        Flags.init({
+          [PLATFORM_ENGINE_VERSION]: '7.18.0'
+        });
+        const tabsProvider = new TabsProvider();
+
+        // when
+        const { file: { contents } } = tabsProvider.createTab('bpmn');
+
+        // then
+        expect(contents).to.include('modeler:executionPlatformVersion="7.18.0"');
+      });
+
+
+      it('should replace version placeholder with version from flag (Cloud BPMN)', function() {
+
+        // given
+        Flags.init({
+          [CLOUD_ENGINE_VERSION]: '8.0.0'
+        });
+        const tabsProvider = new TabsProvider();
+
+        // when
+        const { file: { contents } } = tabsProvider.createTab('cloud-bpmn');
+
+        // then
+        expect(contents).to.include('modeler:executionPlatformVersion="8.0.0"');
+      });
+
+
+      it('should replace version placeholder with version from flag (DMN)', function() {
+
+        // given
+        Flags.init({
+          [PLATFORM_ENGINE_VERSION]: '7.18.0'
+        });
+        const tabsProvider = new TabsProvider();
+
+        // when
+        const { file: { contents } } = tabsProvider.createTab('dmn');
+
+        // then
+        expect(contents).to.include('modeler:executionPlatformVersion="7.18.0"');
+      });
+
+
+      it('should replace version placeholder with version from flag (Cloud DMN)', function() {
+
+        // given
+        Flags.init({
+          [CLOUD_ENGINE_VERSION]: '8.0.0'
+        });
+        const tabsProvider = new TabsProvider();
+
+        // when
+        const { file: { contents } } = tabsProvider.createTab('cloud-dmn');
+
+        // then
+        expect(contents).to.include('modeler:executionPlatformVersion="8.0.0"');
+      });
+
+
+      it('should replace version placeholder with version from flag (FORM)', function() {
+
+        // given
+        Flags.init({
+          [PLATFORM_ENGINE_VERSION]: '7.18.0'
+        });
+        const tabsProvider = new TabsProvider();
+
+        // when
+        const { file: { contents } } = tabsProvider.createTab('form');
+
+        // then
+        expect(contents).to.include('"executionPlatformVersion": "7.18.0"');
+      });
+
+
+      it('should replace version placeholder with version from flag (Cloud FORM)', function() {
+
+        // given
+        Flags.init({
+          [CLOUD_ENGINE_VERSION]: '8.0.0'
+        });
+        const tabsProvider = new TabsProvider();
+
+        // when
+        const { file: { contents } } = tabsProvider.createTab('cloud-form');
+
+        // then
+        expect(contents).to.include('"executionPlatformVersion": "8.0.0"');
+      });
+
+
+      describe('invalid flag', function() {
+
+        beforeEach(function() {
+          Flags.init({
+            [PLATFORM_ENGINE_VERSION]: 'abc',
+            [CLOUD_ENGINE_VERSION]: 'cde'
+          });
+        });
+
+
+        it('should replace version placeholder with actual latest version (BPMN)', function() {
+
+          // given
+          const tabsProvider = new TabsProvider();
+
+          const expectedPlatformVersion = getLatestStablePlatformVersion(ENGINES.PLATFORM);
+
+          // when
+          const { file: { contents } } = tabsProvider.createTab('bpmn');
+
+          // then
+          expect(contents).to.include(`modeler:executionPlatformVersion="${ expectedPlatformVersion }"`);
+        });
+
+
+        it('should replace version placeholder with actual latest version (Cloud BPMN)', function() {
+
+          // given
+          const tabsProvider = new TabsProvider();
+
+          const expectedPlatformVersion = getLatestStablePlatformVersion(ENGINES.CLOUD);
+
+          // when
+          const { file: { contents } } = tabsProvider.createTab('cloud-bpmn');
+
+          // then
+          expect(contents).to.include(`modeler:executionPlatformVersion="${ expectedPlatformVersion }"`);
+        });
+
+
+        it('should replace version placeholder with actual latest version (DMN)', function() {
+
+          // given
+          const tabsProvider = new TabsProvider();
+
+          const expectedPlatformVersion = getLatestStablePlatformVersion(ENGINES.PLATFORM);
+
+          // when
+          const { file: { contents } } = tabsProvider.createTab('dmn');
+
+          // then
+          expect(contents).to.include(`modeler:executionPlatformVersion="${ expectedPlatformVersion }"`);
+        });
+
+
+        it('should replace version placeholder with actual latest version (Cloud DMN)', function() {
+
+          // given
+          const tabsProvider = new TabsProvider();
+
+          const expectedPlatformVersion = getLatestStablePlatformVersion(ENGINES.CLOUD);
+
+          // when
+          const { file: { contents } } = tabsProvider.createTab('cloud-dmn');
+
+          // then
+          expect(contents).to.include(`modeler:executionPlatformVersion="${ expectedPlatformVersion }"`);
+        });
+
+
+        it('should replace version placeholder with actual latest version (FORM)', function() {
+
+          // given
+          const tabsProvider = new TabsProvider();
+
+          const expectedPlatformVersion = getLatestStablePlatformVersion(ENGINES.PLATFORM);
+
+          // when
+          const { file: { contents } } = tabsProvider.createTab('form');
+
+          // then
+          expect(contents).to.include(`"executionPlatformVersion": "${ expectedPlatformVersion }"`);
+        });
+
+
+        it('should replace version placeholder with actual latest version (Cloud FORM)', function() {
+
+          // given
+          const tabsProvider = new TabsProvider();
+
+          const expectedPlatformVersion = getLatestStablePlatformVersion(ENGINES.CLOUD);
+
+          // when
+          const { file: { contents } } = tabsProvider.createTab('cloud-form');
+
+          // then
+          expect(contents).to.include(`"executionPlatformVersion": "${ expectedPlatformVersion }"`);
+        });
+      });
     });
 
 

--- a/client/src/app/tabs/EngineProfile.js
+++ b/client/src/app/tabs/EngineProfile.js
@@ -14,6 +14,12 @@ import classnames from 'classnames';
 
 import semverCompare from 'semver-compare';
 
+
+import Flags, {
+  PLATFORM_ENGINE_VERSION,
+  CLOUD_ENGINE_VERSION
+} from '../../util/Flags';
+
 import {
   Overlay,
   Section
@@ -266,6 +272,29 @@ export function getAnnotatedVersion(version, platform) {
   }
 
   return version;
+}
+
+export function getDefaultVersion(engine) {
+  const flagVersion = getFlagVersion(engine);
+
+  const versions = getVersions(engine);
+  if (isKnownVersion(versions, flagVersion)) {
+    return flagVersion;
+  }
+
+  return getLatestStable(engine);
+}
+
+function getFlagVersion(engine) {
+  if (engine === ENGINES.PLATFORM) {
+    return Flags.get(PLATFORM_ENGINE_VERSION);
+  } else if (engine === ENGINES.CLOUD) {
+    return Flags.get(CLOUD_ENGINE_VERSION);
+  }
+}
+
+function getVersions(engine) {
+  return ENGINE_PROFILES.find(profile => profile.executionPlatform === engine).executionPlatformVersions;
 }
 
 export function engineProfilesEqual(a, b) {

--- a/client/src/util/Flags.js
+++ b/client/src/util/Flags.js
@@ -46,3 +46,5 @@ export const SENTRY_DSN = 'sentry-dsn';
 export const MIXPANEL_TOKEN = 'mixpanel-token';
 export const MIXPANEL_STAGE = 'mixpanel-stage';
 export const DISPLAY_VERSION = 'display-version';
+export const CLOUD_ENGINE_VERSION = 'c8-engine-version';
+export const PLATFORM_ENGINE_VERSION = 'c7-engine-version';


### PR DESCRIPTION
This implements two new flags:

* `c8-engine-version`
* `c7-engine-version`

The version passed to a flag (e.g. `--c8-engine-version=8.2.0`) determines the default engine version for new files.

Closes #3515

---

Thanks to @strangelookingnerd for the initial implementation.
