### PR TITLE
fix(deploy): color troubleshooting link in standard way

### DIFF
--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.less
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.less
@@ -20,8 +20,4 @@
   .toggle-switch__label {
     font-size: 13px !important;
   }
-
-  .invalid-feedback a[href] {
-    color: inherit;
-  }
 }


### PR DESCRIPTION
Applies standard link styles.

![screenshot XKBliC](https://github.com/camunda/camunda-modeler/assets/58601/5674532e-3e84-4571-a168-21291f9036d6)

---

This unifies across desktop and web modeler. 
