### PR TITLE
feat(tabs): close tabs on middle mouse button click

### DIFF
--- a/client/src/app/primitives/TabLinks.js
+++ b/client/src/app/primitives/TabLinks.js
@@ -33,6 +33,8 @@ const TABS_OPTS = {
   }
 };
 
+const MIDDLE_MOUSE_BUTTON = 1;
+
 /**
  * markers to indicate a tab has less width than
  * a defined threshold

--- a/client/src/app/primitives/TabLinks.js
+++ b/client/src/app/primitives/TabLinks.js
@@ -188,6 +188,14 @@ function Tab(props) {
         'tab--smaller': smaller
       }) }
       onClick={ (event) => onSelect(tab, event) }
+      onAuxClick={ (event) => {
+        if (event.button === MIDDLE_MOUSE_BUTTON) {
+          event.preventDefault();
+          event.stopPropagation();
+
+          onClose && onClose(tab);
+        }
+      } }
       onContextMenu={ (event) => (onContextMenu || noop)(tab, event) }
       draggable
     >
@@ -235,9 +243,9 @@ function TabClose(props) {
     <span
       className="tab__close"
       title="Close tab"
-      onClick={ e => {
-        e.preventDefault();
-        e.stopPropagation();
+      onClick={ (event) => {
+        event.preventDefault();
+        event.stopPropagation();
 
         onClose && onClose(tab);
       } }


### PR DESCRIPTION
Closes #3729.

I wasn't sure if any additional tests are needed for this, as it basically is just a copy of what is done when clicking the "x" button on the right side of a tab. Let me know if I should add anything here.