### PR TITLE
Use `zeebe-node@8.3.0-alpha4` to stub `tenantId`

### DIFF
--- a/app/lib/zeebe-api/zeebe-api.js
+++ b/app/lib/zeebe-api/zeebe-api.js
@@ -143,9 +143,11 @@ class ZeebeAPI {
     const client = await this._getZeebeClient(endpoint);
 
     try {
-      const response = await client.deployProcess({
-        definition: contents,
-        name: this._prepareDeploymentName(name, filePath, diagramType)
+      const response = await client.deployResource({
+        process: contents,
+        name: this._prepareDeploymentName(name, filePath, diagramType),
+
+        // tenantId
       });
 
       return {
@@ -181,7 +183,12 @@ class ZeebeAPI {
 
     try {
 
-      const response = await client.createProcessInstance(processId, variables);
+      const response = await client.createProcessInstance({
+        bpmnProcessId: processId,
+        variables,
+
+        // tenantId
+      });
 
       return {
         success: true,

--- a/app/package.json
+++ b/app/package.json
@@ -20,7 +20,7 @@
     "mri": "^1.1.6",
     "node-fetch": "^2.6.1",
     "parents": "^1.0.1",
-    "zeebe-node": "^8.2.5"
+    "zeebe-node": "8.3.0-alpha4"
   },
   "homepage": "https://github.com/camunda/camunda-modeler",
   "repository": {

--- a/app/test/spec/zeebe-api/zeebe-api-spec.js
+++ b/app/test/spec/zeebe-api/zeebe-api-spec.js
@@ -546,7 +546,7 @@ describe('ZeebeAPI', function() {
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployProcess: function() {
+            deployResource: function() {
               throw error;
             }
           };
@@ -578,7 +578,7 @@ describe('ZeebeAPI', function() {
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployProcess: function() {
+            deployResource: function() {
               throw error;
             }
           };
@@ -632,12 +632,12 @@ describe('ZeebeAPI', function() {
     it('should suffix deployment name with .bpmn if necessary', async () => {
 
       // given
-      const deployProcessSpy = sinon.spy();
+      const deployResourceSpy = sinon.spy();
 
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployProcess: deployProcessSpy,
+            deployResource: deployResourceSpy,
           };
         }
       });
@@ -652,7 +652,7 @@ describe('ZeebeAPI', function() {
         }
       });
 
-      const { args } = deployProcessSpy.getCall(0);
+      const { args } = deployResourceSpy.getCall(0);
 
       // then
       expect(args[0].name).to.eql('not_suffixed.bpmn');
@@ -662,12 +662,12 @@ describe('ZeebeAPI', function() {
     it('should suffix deployment name with .dmn if necessary', async () => {
 
       // given
-      const deployProcessSpy = sinon.spy();
+      const deployResourceSpy = sinon.spy();
 
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployProcess: deployProcessSpy,
+            deployResource: deployResourceSpy,
           };
         }
       });
@@ -683,7 +683,7 @@ describe('ZeebeAPI', function() {
         diagramType: 'dmn'
       });
 
-      const { args } = deployProcessSpy.getCall(0);
+      const { args } = deployResourceSpy.getCall(0);
 
       // then
       expect(args[0].name).to.eql('not_suffixed.dmn');
@@ -693,12 +693,12 @@ describe('ZeebeAPI', function() {
     it('should not suffix deployment name with .bpmn if not necessary', async () => {
 
       // given
-      const deployProcessSpy = sinon.spy();
+      const deployResourceSpy = sinon.spy();
 
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployProcess: deployProcessSpy,
+            deployResource: deployResourceSpy,
           };
         }
       });
@@ -713,7 +713,7 @@ describe('ZeebeAPI', function() {
         }
       });
 
-      const { args } = deployProcessSpy.getCall(0);
+      const { args } = deployResourceSpy.getCall(0);
 
       // then
       expect(args[0].name).to.eql('suffixed.bpmn');
@@ -723,12 +723,12 @@ describe('ZeebeAPI', function() {
     it('should not suffix deployment name with .dmn if not necessary', async () => {
 
       // given
-      const deployProcessSpy = sinon.spy();
+      const deployResourceSpy = sinon.spy();
 
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployProcess: deployProcessSpy,
+            deployResource: deployResourceSpy,
           };
         }
       });
@@ -744,7 +744,7 @@ describe('ZeebeAPI', function() {
         diagramType: 'dmn'
       });
 
-      const { args } = deployProcessSpy.getCall(0);
+      const { args } = deployResourceSpy.getCall(0);
 
       // then
       expect(args[0].name).to.eql('suffixed.dmn');
@@ -754,12 +754,12 @@ describe('ZeebeAPI', function() {
     it('should use file path if deployment name is empty', async () => {
 
       // given
-      const deployProcessSpy = sinon.spy();
+      const deployResourceSpy = sinon.spy();
 
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployProcess: deployProcessSpy,
+            deployResource: deployResourceSpy,
           };
         }
       });
@@ -774,7 +774,7 @@ describe('ZeebeAPI', function() {
         }
       });
 
-      const { args } = deployProcessSpy.getCall(0);
+      const { args } = deployResourceSpy.getCall(0);
 
       // then
       expect(args[0].name).to.eql('process.bpmn');
@@ -784,12 +784,12 @@ describe('ZeebeAPI', function() {
     it('should add bpmn suffix to filename if extension is other than bpmn', async () => {
 
       // given
-      const deployProcessSpy = sinon.spy();
+      const deployResourceSpy = sinon.spy();
 
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployProcess: deployProcessSpy,
+            deployResource: deployResourceSpy,
           };
         }
       });
@@ -804,7 +804,7 @@ describe('ZeebeAPI', function() {
         }
       });
 
-      const { args } = deployProcessSpy.getCall(0);
+      const { args } = deployResourceSpy.getCall(0);
 
       // then
       expect(args[0].name).to.eql('xmlFile.bpmn');
@@ -814,12 +814,12 @@ describe('ZeebeAPI', function() {
     it('should add bpmn extension if name ends with bpmn without extension', async () => {
 
       // given
-      const deployProcessSpy = sinon.spy();
+      const deployResourceSpy = sinon.spy();
 
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployProcess: deployProcessSpy,
+            deployResource: deployResourceSpy,
           };
         }
       });
@@ -834,7 +834,7 @@ describe('ZeebeAPI', function() {
         }
       });
 
-      const { args } = deployProcessSpy.getCall(0);
+      const { args } = deployResourceSpy.getCall(0);
 
       // then
       expect(args[0].name).to.eql('orchestrae-location-check-bpmn.bpmn');
@@ -844,12 +844,12 @@ describe('ZeebeAPI', function() {
     it('should add dmn suffix if extension is other than dmn and diagramType=dmn', async () => {
 
       // given
-      const deployProcessSpy = sinon.spy();
+      const deployResourceSpy = sinon.spy();
 
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployProcess: deployProcessSpy,
+            deployResource: deployResourceSpy,
           };
         }
       });
@@ -865,7 +865,7 @@ describe('ZeebeAPI', function() {
         diagramType: 'dmn'
       });
 
-      const { args } = deployProcessSpy.getCall(0);
+      const { args } = deployResourceSpy.getCall(0);
 
       // then
       expect(args[0].name).to.eql('xmlFile.dmn');
@@ -875,12 +875,12 @@ describe('ZeebeAPI', function() {
     it('should add dmn extension if name ends with dmn without extension', async () => {
 
       // given
-      const deployProcessSpy = sinon.spy();
+      const deployResourceSpy = sinon.spy();
 
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployProcess: deployProcessSpy,
+            deployResource: deployResourceSpy,
           };
         }
       });
@@ -896,7 +896,7 @@ describe('ZeebeAPI', function() {
         diagramType: 'dmn'
       });
 
-      const { args } = deployProcessSpy.getCall(0);
+      const { args } = deployResourceSpy.getCall(0);
 
       // then
       expect(args[0].name).to.eql('orchestrae-location-check-dmn.dmn');
@@ -1334,7 +1334,7 @@ describe('ZeebeAPI', function() {
           usedConfig = args;
 
           return {
-            deployProcess: noop
+            deployResource: noop
           };
         }
       });
@@ -1407,7 +1407,7 @@ describe('ZeebeAPI', function() {
 
       // given
       const createSpy = sinon.stub().returns({
-        deployProcess: noop,
+        deployResource: noop,
         close: noop
       });
 
@@ -1446,7 +1446,7 @@ describe('ZeebeAPI', function() {
       const zeebeAPI = mockZeebeNode({
         ZBClient: function() {
           return {
-            deployProcess: noop,
+            deployResource: noop,
             close: closeSpy
           };
         }
@@ -1484,7 +1484,7 @@ describe('ZeebeAPI', function() {
           usedConfig = args;
 
           return {
-            deployProcess: noop
+            deployResource: noop
           };
         }
       });
@@ -1514,7 +1514,7 @@ describe('ZeebeAPI', function() {
           usedConfig = args;
 
           return {
-            deployProcess: noop
+            deployResource: noop
           };
         }
       });
@@ -1544,7 +1544,7 @@ describe('ZeebeAPI', function() {
           usedConfig = args;
 
           return {
-            deployProcess: noop
+            deployResource: noop
           };
         }
       });
@@ -1574,7 +1574,7 @@ describe('ZeebeAPI', function() {
           usedConfig = args;
 
           return {
-            deployProcess: noop
+            deployResource: noop
           };
         }
       });
@@ -1604,7 +1604,7 @@ describe('ZeebeAPI', function() {
           usedConfig = args;
 
           return {
-            deployProcess: noop
+            deployResource: noop
           };
         }
       });
@@ -1634,7 +1634,7 @@ describe('ZeebeAPI', function() {
           usedConfig = args;
 
           return {
-            deployProcess: noop
+            deployResource: noop
           };
         }
       });
@@ -1664,7 +1664,7 @@ describe('ZeebeAPI', function() {
           usedConfig = args;
 
           return {
-            deployProcess: noop
+            deployResource: noop
           };
         }
       });
@@ -1697,7 +1697,7 @@ describe('ZeebeAPI', function() {
             configSpy(...args);
 
             return {
-              deployProcess: noop
+              deployResource: noop
             };
           },
           flags: {
@@ -1947,7 +1947,7 @@ function mockZeebeNode(options = {}) {
     ZBClient: options.ZBClient || function() {
       return {
         topology: noop,
-        deployProcess: noop,
+        deployResource: noop,
         createProcessInstance: noop,
         close: noop
       };

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "mri": "^1.1.6",
         "node-fetch": "^2.6.1",
         "parents": "^1.0.1",
-        "zeebe-node": "^8.2.5"
+        "zeebe-node": "8.3.0-alpha4"
       },
       "optionalDependencies": {
         "vscode-windows-ca-certs": "^0.3.0"
@@ -29965,9 +29965,9 @@
       "license": "MIT"
     },
     "node_modules/zeebe-node": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.2.5.tgz",
-      "integrity": "sha512-QhEnnchsuM7j0v8cCtOKMPfV/MdtJm8o/NY2abKyB45X6oNOUJGKuTCpt5WFiPjHdmD+VWUXfEm6ATl1OZevGQ==",
+      "version": "8.3.0-alpha4",
+      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.3.0-alpha4.tgz",
+      "integrity": "sha512-GhTd5ZosNqbrNtfe3Qz1q8vflmizW3ukHSkzEkz0rtPsEAmmRjGkroyb4II+6kFVicrOgva0N/XrpHgwt1nVsQ==",
       "dependencies": {
         "@grpc/grpc-js": "1.8.7",
         "@grpc/proto-loader": "0.7.4",
@@ -36764,7 +36764,7 @@
         "node-fetch": "^2.6.1",
         "parents": "^1.0.1",
         "vscode-windows-ca-certs": "^0.3.0",
-        "zeebe-node": "^8.2.5"
+        "zeebe-node": "8.3.0-alpha4"
       },
       "dependencies": {
         "@sentry/node": {
@@ -50441,9 +50441,9 @@
       "version": "0.19.0"
     },
     "zeebe-node": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.2.5.tgz",
-      "integrity": "sha512-QhEnnchsuM7j0v8cCtOKMPfV/MdtJm8o/NY2abKyB45X6oNOUJGKuTCpt5WFiPjHdmD+VWUXfEm6ATl1OZevGQ==",
+      "version": "8.3.0-alpha4",
+      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.3.0-alpha4.tgz",
+      "integrity": "sha512-GhTd5ZosNqbrNtfe3Qz1q8vflmizW3ukHSkzEkz0rtPsEAmmRjGkroyb4II+6kFVicrOgva0N/XrpHgwt1nVsQ==",
       "requires": {
         "@grpc/grpc-js": "1.8.7",
         "@grpc/proto-loader": "0.7.4",


### PR DESCRIPTION
Closes #3772. 

Adds the alpha package of zeebe-node, and modifies the code to use the new APIs that support tenantId.