### PR TITLE
chore(sentry): fix sourcemaps

### DIFF
--- a/app/lib/util/error-tracking.js
+++ b/app/lib/util/error-tracking.js
@@ -184,5 +184,5 @@ function normalizeUrl(path) {
 
   // eslint-disable-next-line
   const filename = path.replace(/^.*[\\\/]/, '');
-  return '~/build/' + filename;
+  return 'build/' + filename;
 }

--- a/client/src/plugins/error-tracking/ErrorTracking.js
+++ b/client/src/plugins/error-tracking/ErrorTracking.js
@@ -234,7 +234,7 @@ function normalizeUrl(path) {
 
   // eslint-disable-next-line
   const filename = path.replace(/^.*[\\\/]/, '');
-  return '~/build/' + filename;
+  return 'build/' + filename;
 }
 
 function generatePluginsTag(plugins) {

--- a/client/src/plugins/error-tracking/__tests__/ErrorTrackingSpec.js
+++ b/client/src/plugins/error-tracking/__tests__/ErrorTrackingSpec.js
@@ -446,8 +446,8 @@ async function expectNormalization(prefix) {
   beforeSend(event);
 
   // then
-  expect(event.request.url).to.eql('~/build/2.2.js');
-  expect(event.exception.values[0].stacktrace.frames[0].filename).to.eql('~/build/2.2.js');
+  expect(event.request.url).to.eql('build/2.2.js');
+  expect(event.exception.values[0].stacktrace.frames[0].filename).to.eql('build/2.2.js');
 }
 
 function createMockSentryEvent(path) {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -147,10 +147,7 @@ function sentryIntegration() {
   // variables are injected via CI when building.
   return [
     sentryWebpackPlugin({
-      release: NODE_ENV === 'production' ? version : 'dev',
-      sourcemaps: {
-        assets: [ '../app/public/**' ]
-      }
+      release: NODE_ENV === 'production' ? version : 'dev'
     })
   ];
 }


### PR DESCRIPTION
related to #3689

As we have no easy way of experimenting with sentry releases, let's try this out on nightly builds instead.

b2316208e90ff7e89cb0ddad68c6225182500703 should fix sentry not recognizing the URL of reported file paths:
![image](https://github.com/camunda/camunda-modeler/assets/21984219/0a2cee3b-8dd4-486a-bfeb-af28d77a5ca5)

1c6b1be2ff1057e412c9618900ae985af24a84c3 should fix source-map uploading
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
