### PR TITLE
fix(resizable-container): use last width/height if closed through resize

### DIFF
--- a/client/src/app/resizable-container/ResizableContainer.js
+++ b/client/src/app/resizable-container/ResizableContainer.js
@@ -118,7 +118,7 @@ export default function ResizableContainer(props) {
       const newOpen = newWidth > CLOSED_THRESHOLD;
 
       onResized({
-        width: newOpen ? newWidth : 0,
+        width: newOpen ? newWidth : width,
         open: newOpen
       });
     } else {
@@ -127,7 +127,7 @@ export default function ResizableContainer(props) {
       const newOpen = newHeight > CLOSED_THRESHOLD;
 
       onResized({
-        height: newOpen ? newHeight : 0,
+        height: newOpen ? newHeight : height,
         open: newOpen
       });
     }

--- a/client/src/app/resizable-container/__tests__/ResizableContainerSpec.js
+++ b/client/src/app/resizable-container/__tests__/ResizableContainerSpec.js
@@ -131,7 +131,7 @@ describe('<ResizableContainer>', function() {
         // then
         expect(onResized).to.have.been.calledWith({
           open: false,
-          [ dimension ]: 0
+          [ dimension ]: 300
         });
       });
 


### PR DESCRIPTION
Instead of setting the width or height to 0, it's set to the last width or height.

![electron_Q62yBbEp7G](https://github.com/camunda/camunda-modeler/assets/7633572/35b3dd32-cc3f-4af4-a940-bb1f948592f1)

Closes #3753