### PR TITLE
chore(app): restore windows path handling

### DIFF
--- a/app/lib/util/__tests__/files-spec.js
+++ b/app/lib/util/__tests__/files-spec.js
@@ -120,5 +120,5 @@ describe('files', function() {
 
 
 function absPath(file) {
-  return path.resolve(__dirname, file).split(path.sep).join(path.posix.sep);
+  return path.resolve(__dirname, file);
 }

--- a/app/lib/util/files.js
+++ b/app/lib/util/files.js
@@ -10,6 +10,7 @@
 
 const { globSync } = require('fast-glob');
 
+const path = require('path');
 const fs = require('fs');
 
 /**
@@ -129,9 +130,8 @@ function globFiles(options) {
     const newPaths = globSync(pattern, {
       cwd: searchPath,
       nodir: true,
-      absolute: true,
-
-    });
+      absolute: true
+    }).map(p => p.split(path.posix.sep).join(path.sep));
 
     return [
       ...paths,


### PR DESCRIPTION
This ensures we don't change path handling semantics on Windows as we migrate from `glob` to `fast-glob` (https://github.com/camunda/camunda-modeler/commit/e33c4b68f4c479188ea484f2efa120ab1afd1c22).