### PR TITLE
fix: use directory name to match element templates

### DIFF
--- a/app/lib/config/providers/ElementTemplatesProvider.js
+++ b/app/lib/config/providers/ElementTemplatesProvider.js
@@ -36,7 +36,7 @@ class ElementTemplatesProvider {
    * @returns {Array<Template>}
    */
   get(_, file) {
-    const localPaths = file && file.path ? parents(file.path) : [];
+    const localPaths = file && file.path ? parents(path.dirname(file.path)) : [];
 
     const paths = [
       ...suffixAll(localPaths, '.camunda'),


### PR DESCRIPTION
Parents assumes the argument passed in is a directory name, not a file name.

fast-glob handles non-directory files that are glob roots with an error that we want to avoid. Hence we fix this bug. 

----

Error reported through the application log (also console) without this fix when reading local to `test (51).bpmn` element templates:

```
ERROR app:config:element-templates templates /home/foo/test (51).bpmn/.camunda glob error Error: ENOTDIR: not a directory, scandir '/home/foo/test (51).bpmn/.camunda/element-templates'
    at Object.readdirSync (node:fs:1452:3)                                                                 
    at Object.readdirSync (node:electron/js2c/asar_bundle:2:10837)                                         
    at readdirWithFileTypes (/home/foo/projects/camunda-modeler/node_modules/@nodelib/fs.scandir/out/providers/sync.js:16:33)
    at Object.read (/home/foo/projects/camunda-modeler/node_modules/@nodelib/fs.scandir/out/providers/sync.js:10:16)
    at SyncReader.scandirSync [as _scandir] (/home/foo/projects/camunda-modeler/node_modules/@nodelib/fs.scandir/out/index.js:18:17)
    at SyncReader._handleDirectory (/home/foo/projects/camunda-modeler/node_modules/@nodelib/fs.walk/out/readers/sync.js:28:34)
    at SyncReader._handleQueue (/home/foo/projects/camunda-modeler/node_modules/@nodelib/fs.walk/out/readers/sync.js:23:18)
    at SyncReader.read (/home/foo/projects/camunda-modeler/node_modules/@nodelib/fs.walk/out/readers/sync.js:15:14)
    at SyncProvider.read (/home/foo/projects/camunda-modeler/node_modules/@nodelib/fs.walk/out/providers/sync.js:11:29)
    at ReaderSync.walkSync [as _walkSync] (/home/foo/projects/camunda-modeler/node_modules/@nodelib/fs.walk/out/index.js:20:21) {
  errno: -20,                                            
```