### PR TITLE
ci: always complete matrix builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,6 +3,7 @@ on: [ push, pull_request ]
 jobs:
   Build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-11, windows-2019 ]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This improves our CI behavior, working around shaky MacOS builds.

We'll not fail all other jobs (so feedback is discarted), but let them continue.
