### PR TITLE
fix: adjust code base to ZeebeNode#deployResource API responses

### DIFF
--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
@@ -638,7 +638,14 @@ describe('<DeploymentPlugin> (Zeebe)', () => {
     // given
     const displayNotification = sinon.spy();
     const { instance } = createDeploymentPlugin({
-      zeebeAPI: new MockZeebeAPI({ deploymentResult: { success: true, response: { processes: [] } } }),
+      zeebeAPI: new MockZeebeAPI({
+        deploymentResult: {
+          success: true,
+          response: {
+            deployments: []
+          }
+        }
+      }),
       displayNotification,
       endpoint : {
         targetType: CAMUNDA_CLOUD,
@@ -1508,8 +1515,19 @@ function MockZeebeAPI(options = {}) {
       deploySpy(...args);
     }
 
-    const result = deploymentResult ||
-      { success: true, response: { processes: [ { bpmnProcessId: 'test', version: 1 } ] } };
+    const result = deploymentResult || {
+      success: true,
+      response: {
+        deployments: [
+          {
+            process: {
+              bpmnProcessId: 'test',
+              version: 1
+            }
+          }
+        ]
+      }
+    };
 
     return Promise.resolve(result);
   };

--- a/client/src/plugins/zeebe-plugin/shared/__tests__/utilSpec.js
+++ b/client/src/plugins/zeebe-plugin/shared/__tests__/utilSpec.js
@@ -41,9 +41,11 @@ describe('util', () => {
 
       // given
       const response = {
-        processes: [
+        deployments: [
           {
-            bpmnProcessId: 'processId'
+            process: {
+              bpmnProcessId: 'processId'
+            }
           }
         ]
       };
@@ -73,7 +75,7 @@ describe('util', () => {
 
       // given
       const response = {
-        processes: []
+        deployments: []
       };
 
       // when
@@ -91,10 +93,12 @@ describe('util', () => {
 
       // given
       const response = {
-        processes: [
+        deployments: [
           {
-            bpmnProcessId: 'processId',
-            version: 2
+            process: {
+              bpmnProcessId: 'processId',
+              version: 2
+            }
           }
         ]
       };
@@ -124,7 +128,7 @@ describe('util', () => {
 
       // given
       const response = {
-        processes: []
+        deployments: []
       };
 
       // when
@@ -135,4 +139,5 @@ describe('util', () => {
     });
 
   });
+
 });

--- a/client/src/plugins/zeebe-plugin/shared/util.js
+++ b/client/src/plugins/zeebe-plugin/shared/util.js
@@ -25,7 +25,7 @@ export function getClusterUrl(endpoint) {
 }
 
 function getProcess(apiResponse) {
-  return apiResponse?.processes?.[0] || null;
+  return apiResponse?.deployments?.[0]?.process || null;
 }
 
 export function getProcessId(response) {

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
@@ -142,7 +142,8 @@ export default class StartInstancePlugin extends PureComponent {
     } = this.props;
 
     const zeebeAPI = _getGlobal('zeebeAPI');
-    const processId = deploymentResult.response.processes[0].bpmnProcessId;
+    const processId = deploymentResult.response.deployments[0].process.bpmnProcessId;
+
     const decoratedConfig = this.decorateVariables(startInstanceConfig);
 
     try {

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginSpec.js
@@ -218,7 +218,16 @@ describe('<StartInstancePlugin> (Zeebe)', () => {
       // given
       const processId = '123';
       const deploymentResult = {
-        success: true, response: { processes: [ { bpmnProcessId: processId } ] }
+        success: true,
+        response: {
+          deployments: [
+            {
+              process: {
+                bpmnProcessId: processId
+              }
+            }
+          ]
+        }
       };
       const runSpy = sinon.spy();
       const zeebeAPI = new MockZeebeAPI({ runSpy });
@@ -423,7 +432,16 @@ function createStartInstancePlugin({
   zeebeAPI = new MockZeebeAPI(),
   activeTab = createTab(),
   deploymentResult = {
-    success: true, response: { processes: [ { bpmnProcessId: 'test' } ] }
+    success: true,
+    response: {
+      deployments: [
+        {
+          process: {
+            bpmnProcessId: 'test'
+          }
+        }
+      ]
+    }
   },
   deploymentEndpoint = {},
   ...props


### PR DESCRIPTION
Adjusts an oversight from https://github.com/camunda/camunda-modeler/pull/3773.

Previously I did not properly adjust client-side usages of the new response.