### PR TITLE
Allow passing `tenantId` to Camunda 8 self-managed

### DIFF
--- a/app/lib/zeebe-api/zeebe-api.js
+++ b/app/lib/zeebe-api/zeebe-api.js
@@ -108,6 +108,10 @@ class ZeebeAPI {
 
     const client = await this._getZeebeClient(endpoint);
 
+    this._log.debug('check connection', {
+      parameters: withoutSecrets(parameters)
+    });
+
     try {
       await client.topology();
       return { success: true };
@@ -136,6 +140,7 @@ class ZeebeAPI {
       endpoint,
       filePath,
       name,
+      tenantId,
       diagramType
     } = parameters;
 
@@ -150,12 +155,16 @@ class ZeebeAPI {
     const client = await this._getZeebeClient(endpoint);
 
     try {
-      const response = await client.deployResource({
+      const resource = {
         process: contents,
         name: this._prepareDeploymentName(name, filePath, diagramType),
+      };
 
-        // tenantId
-      });
+      if (tenantId) {
+        resource.tenantId = tenantId;
+      }
+
+      const response = await client.deployResource(resource);
 
       return {
         success: true,
@@ -183,7 +192,8 @@ class ZeebeAPI {
     const {
       endpoint,
       variables,
-      processId
+      processId,
+      tenantId
     } = parameters;
 
     this._log.debug('run', {
@@ -197,8 +207,7 @@ class ZeebeAPI {
       const response = await client.createProcessInstance({
         bpmnProcessId: processId,
         variables,
-
-        // tenantId
+        tenantId
       });
 
       return {

--- a/app/package.json
+++ b/app/package.json
@@ -19,7 +19,7 @@
     "min-dash": "^4.1.1",
     "mri": "^1.1.6",
     "parents": "^1.0.1",
-    "zeebe-node": "8.3.0-alpha4"
+    "zeebe-node": "^8.3.0-alpha9"
   },
   "homepage": "https://github.com/camunda/camunda-modeler",
   "repository": {

--- a/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentToolSpec.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentToolSpec.js
@@ -593,7 +593,7 @@ describe('<DeploymentTool>', () => {
               actionTriggered = {
                 emitEvent: 'emit-event',
                 type: 'deployment.done',
-                handler:actionSpy
+                handler: actionSpy
               };
 
         const {

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
@@ -208,7 +208,10 @@ export default class DeploymentPlugin extends PureComponent {
   deployTab(tab, config) {
     const { file: { path } } = tab;
     const {
-      deployment: { name },
+      deployment: {
+        name,
+        tenantId
+      },
       endpoint
     } = config;
 
@@ -217,6 +220,7 @@ export default class DeploymentPlugin extends PureComponent {
     return zeebeAPI.deploy({
       filePath: path,
       name,
+      tenantId,
       endpoint,
       diagramType: tab.type === 'cloud-dmn' ? 'dmn' : 'bpmn'
     });

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginConstants.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginConstants.js
@@ -28,6 +28,7 @@ export const CLIENT_ID = 'Client ID';
 export const CLIENT_SECRET = 'Client secret';
 export const CLUSTER_URL = 'Cluster URL';
 export const REMEMBER_CREDENTIALS = 'Remember credentials';
+export const TENANT_ID = 'Tenant ID';
 
 export const MUST_PROVIDE_A_VALUE = 'Must provide a value.';
 export const CONTACT_POINT_MUST_NOT_BE_EMPTY = 'Cluster endpoint must not be empty.';

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.js
@@ -24,6 +24,7 @@ import {
   CONTACT_POINT_HINT,
   OAUTH_URL,
   AUDIENCE,
+  TENANT_ID,
   CLIENT_ID,
   CLIENT_SECRET,
   CLUSTER_URL,
@@ -193,12 +194,19 @@ export default class DeploymentPluginOverlay extends React.PureComponent {
   }
 
   handleFormSubmit = async (values, { setSubmitting }) => {
-    const { endpoint } = values;
+    const {
+      deployment,
+      endpoint
+    } = values;
 
     // Extract clusterId and clusterRegion as required by zeebeAPI for camundaCloud
     if (endpoint.targetType === CAMUNDA_CLOUD && endpoint.camundaCloudClusterUrl) {
       endpoint.camundaCloudClusterId = extractClusterId(endpoint.camundaCloudClusterUrl);
       endpoint.camundaCloudClusterRegion = extractClusterRegion(endpoint.camundaCloudClusterUrl);
+    }
+
+    if (endpoint.authType === AUTH_TYPES.NONE) {
+      delete deployment.tenantId;
     }
 
     // check connection
@@ -273,6 +281,17 @@ export default class DeploymentPluginOverlay extends React.PureComponent {
                                 hint={ CONTACT_POINT_HINT }
                                 autoFocus
                               />
+                              {
+                                form.values.endpoint.targetType === SELF_HOSTED &&
+                                  form.values.endpoint.authType === AUTH_TYPES.OAUTH && (
+                                  <Field
+                                    name="deployment.tenantId"
+                                    component={ TextInput }
+                                    label={ TENANT_ID }
+                                    hint="Optional"
+                                  />
+                                )
+                              }
                               <Field
                                 name="endpoint.authType"
                                 component={ Radio }

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
@@ -1448,12 +1448,16 @@ function createDeploymentPlugin({
   };
 
   const triggerAction = (event, context) => {
-    switch (true) {
-    case (event === 'save'):
+
+    if (event === 'save') {
       return activeTab;
-    case (props.actionTriggered &&
-      props.actionTriggered.emitEvent == event &&
-      props.actionTriggered.type == (context ? context.type : undefined)):
+    }
+
+    if (
+      props.actionTriggered &&
+      props.actionTriggered.emitEvent === event &&
+      props.actionTriggered.type === (context ? context.type : undefined)
+    ) {
       props.actionTriggered.handler(context);
     }
   };

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
@@ -133,7 +133,7 @@ describe('<DeploymentPlugin> (Zeebe)', () => {
 
     // then
     expect(deploySpy).to.have.been.calledOnce;
-    expect(userActionSpy).to.not.have.been.called;
+    expect(userActionSpy).not.to.have.been.called;
   });
 
 
@@ -410,7 +410,7 @@ describe('<DeploymentPlugin> (Zeebe)', () => {
         callSubscriber({ activeTab: createTab() });
 
         // expect
-        expect(wrapper.html().includes('form')).to.not.be.true;
+        expect(wrapper.html().includes('form')).not.to.be.true;
       });
 
     });
@@ -749,7 +749,7 @@ describe('<DeploymentPlugin> (Zeebe)', () => {
       silent: true
     });
 
-    expect(actionSpy).to.not.have.been.called;
+    expect(actionSpy).not.to.have.been.called;
     notification.content.props.onClick();
     expect(actionSpy).to.have.been.calledOnce;
 
@@ -1127,7 +1127,7 @@ describe('<DeploymentPlugin> (Zeebe)', () => {
       await instance.deploy();
 
       // then
-      expect(actionSpy).to.not.have.been.calledOnce;
+      expect(actionSpy).not.to.have.been.called;
     });
 
 
@@ -1284,7 +1284,7 @@ describe('<DeploymentPlugin> (Zeebe)', () => {
 
       // then
       expect(actionSpy).to.have.been.calledOnce;
-      expect(deployedTo).to.not.exist;
+      expect(deployedTo).not.to.exist;
     });
 
 
@@ -1352,7 +1352,7 @@ describe('<DeploymentPlugin> (Zeebe)', () => {
       await instance.deploy();
 
       // then
-      expect(actionSpy).to.not.have.been.calledOnce;
+      expect(actionSpy).not.to.have.been.calledOnce;
     });
 
   });

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
@@ -149,7 +149,12 @@ export default class StartInstancePlugin extends PureComponent {
     try {
 
       // (3.1) trigger run
-      const startInstanceResult = await zeebeAPI.run({ processId, endpoint, ...decoratedConfig });
+      const startInstanceResult = await zeebeAPI.run({
+        processId,
+        tenantId: deploymentConfig.tenantId,
+        endpoint,
+        ...decoratedConfig
+      });
 
       // (3.1.1) handle start instance error
       if (!startInstanceResult.success) {

--- a/client/src/remote/__tests__/ZeebeAPISpec.js
+++ b/client/src/remote/__tests__/ZeebeAPISpec.js
@@ -171,7 +171,7 @@ describe('<ZeebeAPI>', function() {
 
   describe('#deploy', () => {
 
-    it('should execute', () => {
+    it('should deploy without OAuth', () => {
 
       // given
       const zeebeAPI = new ZeebeAPI(backend);
@@ -202,6 +202,55 @@ describe('<ZeebeAPI>', function() {
         endpoint: {
           type: targetTypes.SELF_HOSTED,
           url: contactPoint
+        }
+      });
+
+    });
+
+
+    it('should deploy with OAuth', () => {
+
+      // given
+      const zeebeAPI = new ZeebeAPI(backend);
+
+      const contactPoint = 'contactPoint';
+
+      const filePath = 'filePath';
+
+      const name = 'deployment';
+
+      const tenantId = 'tenant-1';
+
+      const endpoint = {
+        targetType: targetTypes.SELF_HOSTED,
+        authType: authTypes.OAUTH,
+        contactPoint,
+        oauthURL: 'oauthURL',
+        audience: 'audience',
+        clientId: 'oauthClientId',
+        clientSecret: 'oauthClientSecret'
+      };
+
+      // when
+      zeebeAPI.deploy({
+        filePath,
+        name,
+        endpoint,
+        tenantId
+      });
+
+      // then
+      expect(sendSpy).to.have.been.calledWith('zeebe:deploy', {
+        filePath,
+        name,
+        tenantId,
+        endpoint: {
+          type: authTypes.OAUTH,
+          url: contactPoint,
+          oauthURL: 'oauthURL',
+          audience: 'audience',
+          clientId: 'oauthClientId',
+          clientSecret: 'oauthClientSecret'
         }
       });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "min-dash": "^4.1.1",
         "mri": "^1.1.6",
         "parents": "^1.0.1",
-        "zeebe-node": "8.3.0-alpha4"
+        "zeebe-node": "^8.3.0-alpha9"
       },
       "optionalDependencies": {
         "vscode-windows-ca-certs": "^0.3.0"
@@ -31802,9 +31802,9 @@
       "integrity": "sha512-ZXEe+0s6Z1jf0hfK4VfRr71p4FcXkYz+MxVx6vMCiey2KVZqY1uj6KCpzK9+tEJzTdxGRS3FymK3oxAkjzs1GA=="
     },
     "node_modules/zeebe-node": {
-      "version": "8.3.0-alpha4",
-      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.3.0-alpha4.tgz",
-      "integrity": "sha512-GhTd5ZosNqbrNtfe3Qz1q8vflmizW3ukHSkzEkz0rtPsEAmmRjGkroyb4II+6kFVicrOgva0N/XrpHgwt1nVsQ==",
+      "version": "8.3.0-alpha9",
+      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.3.0-alpha9.tgz",
+      "integrity": "sha512-iTEtxhJ6j9nZuYyldeENuSjvZ3byTIPKVpYdJuZKItbp0R4mX5slYTtrZKLBUoY0W0hC4V4GaWze01pyA74k3A==",
       "dependencies": {
         "@grpc/grpc-js": "1.8.7",
         "@grpc/proto-loader": "0.7.4",
@@ -38343,7 +38343,7 @@
         "mri": "^1.1.6",
         "parents": "^1.0.1",
         "vscode-windows-ca-certs": "^0.3.0",
-        "zeebe-node": "8.3.0-alpha4"
+        "zeebe-node": "^8.3.0-alpha9"
       },
       "dependencies": {
         "braces": {
@@ -54346,9 +54346,9 @@
       "integrity": "sha512-ZXEe+0s6Z1jf0hfK4VfRr71p4FcXkYz+MxVx6vMCiey2KVZqY1uj6KCpzK9+tEJzTdxGRS3FymK3oxAkjzs1GA=="
     },
     "zeebe-node": {
-      "version": "8.3.0-alpha4",
-      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.3.0-alpha4.tgz",
-      "integrity": "sha512-GhTd5ZosNqbrNtfe3Qz1q8vflmizW3ukHSkzEkz0rtPsEAmmRjGkroyb4II+6kFVicrOgva0N/XrpHgwt1nVsQ==",
+      "version": "8.3.0-alpha9",
+      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.3.0-alpha9.tgz",
+      "integrity": "sha512-iTEtxhJ6j9nZuYyldeENuSjvZ3byTIPKVpYdJuZKItbp0R4mX5slYTtrZKLBUoY0W0hC4V4GaWze01pyA74k3A==",
       "requires": {
         "@grpc/grpc-js": "1.8.7",
         "@grpc/proto-loader": "0.7.4",


### PR DESCRIPTION
This adds visual editing of `tenantId`. We keep the existing pattern that `tenantId` is maintained with the _deployment_, and simply carried over by the _run_ tool.

----

![capture yWcH2o_optimized](https://github.com/camunda/camunda-modeler/assets/58601/2d263ec2-da0c-4437-84fe-f07c9aae6292)

----

### TODO

* [x] UI test coverage
* [ ] ~~Tenant specific error handling (https://github.com/camunda/web-modeler/issues/5765#issuecomment-1704894105)~~
* [x] [Do not show input field for tenant ID if "Authentication: None" is selected](https://camunda.slack.com/archives/C0555930H7F/p1695982426629079)