### PR TITLE
fix: set NODE_ENV=production in release pipeline

### DIFF
--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -29,6 +29,9 @@ jobs:
     permissions:
       contents: write
 
+    env:
+      NODE_ENV: 'production'
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
This will ensure anything we do in the release pipeline is meant for production.

Closes #3835

