### PR TITLE
ci: set NODE_ENV=production for build only

### DIFF
--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -29,9 +29,6 @@ jobs:
     permissions:
       contents: write
 
-    env:
-      NODE_ENV: 'production'
-
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -56,6 +53,7 @@ jobs:
         SENTRY_PROJECT: "${{ secrets.SENTRY_PROJECT }}"
         UPDATES_SERVER_PRODUCT_NAME: "${{ secrets.UPDATES_SERVER_PRODUCT_NAME }}"
         GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        NODE_ENV: "production"
       run: npm run build -- --linux --publish
     - name: Build release (MacOS)
       if: ${{ runner.os == 'macOS' }}
@@ -73,6 +71,7 @@ jobs:
         SENTRY_PROJECT: "${{ secrets.SENTRY_PROJECT }}"
         UPDATES_SERVER_PRODUCT_NAME: "${{ secrets.UPDATES_SERVER_PRODUCT_NAME }}"
         GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        NODE_ENV: "production"
       run: npm run build -- --mac --publish
     - name: Build release (Windows)
       if: ${{ runner.os == 'Windows' }}
@@ -87,6 +86,7 @@ jobs:
         SENTRY_PROJECT: "${{ secrets.SENTRY_PROJECT }}"
         UPDATES_SERVER_PRODUCT_NAME: "${{ secrets.UPDATES_SERVER_PRODUCT_NAME }}"
         GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        NODE_ENV: "production"
       run: npm run build -- --win --publish
 
   Post_release:


### PR DESCRIPTION
In the very recent https://github.com/camunda/camunda-modeler/commit/0573f6d57e21d6025f5064ae2f779876561d1b2f, I set `NODE_ENV=production` for each of the steps of the release pipeline. This broke installation due to:

>  With the --production flag (or when the NODE_ENV environment variable is set to production), npm will not install modules listed in devDependencies. To install all modules listed in both dependencies and devDependencies when NODE_ENV environment variable is set to production, you can use --production=false.

With that change, the build step couldn't use the devDependencies as they were not installed at all.