### PR TITLE
Use POSIX Paths Consistently With `fast-glob`

### DIFF
--- a/app/lib/config/providers/ElementTemplatesProvider.js
+++ b/app/lib/config/providers/ElementTemplatesProvider.js
@@ -9,11 +9,12 @@
  */
 
 const fs = require('fs');
-const { globSync } = require('fast-glob');
 const parents = require('parents');
 const path = require('path');
 
 const { isArray } = require('min-dash');
+
+const { globFiles } = require('../../util/files');
 
 const log = require('../../log')('app:config:element-templates');
 
@@ -143,11 +144,7 @@ function getTemplatesForPath(path) {
  * @return {Array<string>}
  */
 function globTemplates(path) {
-  const globOptions = {
-    cwd: path,
-    onlyFiles: true,
-    absolute: true
-  };
-
-  return globSync('element-templates/**/*.json', globOptions);
+  return globFiles('element-templates/**/*.json', {
+    cwd: path
+  });
 }

--- a/app/lib/flags.js
+++ b/app/lib/flags.js
@@ -30,9 +30,8 @@ class Flags {
       config,
       files,
       errors
-    } = globJSON({
-      searchPaths,
-      pattern: FLAGS_PATTERN
+    } = globJSON(FLAGS_PATTERN, {
+      searchPaths
     });
 
     log.info('found %O', files);

--- a/app/lib/plugins.js
+++ b/app/lib/plugins.js
@@ -9,13 +9,10 @@
  */
 
 const path = require('path');
-const { globSync } = require('fast-glob');
 
 const log = require('./log')('app:plugins');
 
-const {
-  globFiles
-} = require('./util/files');
+const { globFiles } = require('./util/files');
 
 const PLUGINS_PATTERN = 'plugins/*/index.js';
 
@@ -42,9 +39,8 @@ class Plugins {
 
     log.info('searching for %s in paths %O', PLUGINS_PATTERN, searchPaths);
 
-    const pluginPaths = globFiles({
-      searchPaths,
-      pattern: PLUGINS_PATTERN
+    const pluginPaths = globFiles(PLUGINS_PATTERN, {
+      searchPaths
     });
 
     log.info('found plug-in entries %O', pluginPaths);
@@ -86,10 +82,9 @@ class Plugins {
         };
 
         if (style) {
-          const stylePath = path.join(base, style);
-          const styleFiles = globSync(stylePath, {
-            absolute: true
-          });
+          const stylePath = path.posix.join(base, style);
+
+          const styleFiles = globFiles(stylePath);
 
           if (!styleFiles.length) {
             plugin.error = true;
@@ -99,10 +94,9 @@ class Plugins {
         }
 
         if (script) {
-          const scriptPath = path.join(base, script);
-          const scriptFiles = globSync(scriptPath, {
-            absolute: true
-          });
+          const scriptPath = path.posix.join(base, script);
+
+          const scriptFiles = globFiles(scriptPath);
 
           if (!scriptFiles.length) {
             plugin.error = true;

--- a/app/lib/util/__tests__/files-spec.js
+++ b/app/lib/util/__tests__/files-spec.js
@@ -12,7 +12,8 @@ const path = require('path');
 
 const {
   globJSON,
-  globFiles
+  globFiles,
+  toPosixPath
 } = require('../files');
 
 
@@ -20,13 +21,12 @@ describe('files', function() {
 
   describe('#globJSON', function() {
 
-    it('should load by name', function() {
+    it('should read given file name', function() {
 
       // when
-      const { config } = globJSON({
-        name: 'config.json',
+      const { config } = globJSON('config.json', {
         searchPaths: [
-          absPath('files/bar')
+          toAbsolutePath('files/bar')
         ]
       });
 
@@ -35,13 +35,12 @@ describe('files', function() {
     });
 
 
-    it('should load by pattern', function() {
+    it('should read given pattern', function() {
 
       // when
-      const { config } = globJSON({
-        name: '**/config.json',
+      const { config } = globJSON('**/config.json', {
         searchPaths: [
-          absPath('files')
+          toAbsolutePath('files')
         ]
       });
 
@@ -56,10 +55,9 @@ describe('files', function() {
     it('should consider defaults', function() {
 
       // when
-      const { config } = globJSON({
-        name: 'config.json',
+      const { config } = globJSON('config.json', {
         searchPaths: [
-          absPath('files/bar')
+          toAbsolutePath('files/bar')
         ],
         defaults: {
           foo: 'default FOO',
@@ -78,10 +76,9 @@ describe('files', function() {
     it('should handle errors gracefully', function() {
 
       // when
-      const { config } = globJSON({
-        name: '**/*-json.json',
+      const { config } = globJSON('**/*-json.json', {
         searchPaths: [
-          absPath('files')
+          toAbsolutePath('files')
         ]
       });
 
@@ -99,17 +96,16 @@ describe('files', function() {
     it('should find files by pattern', function() {
 
       // when
-      const files = globFiles({
-        pattern: '**/*-json.json',
+      const files = globFiles('**/*-json.json', {
         searchPaths: [
-          absPath('files')
+          toAbsolutePath('files')
         ]
       });
 
       // then
       expect(files).to.eql([
-        absPath('files/bar/good-json.json'),
-        absPath('files/foo/not-json.json')
+        toAbsolutePath('files/bar/good-json.json'),
+        toAbsolutePath('files/foo/not-json.json')
       ]);
 
     });
@@ -119,6 +115,6 @@ describe('files', function() {
 });
 
 
-function absPath(file) {
-  return path.resolve(__dirname, file);
+function toAbsolutePath(file) {
+  return toPosixPath(path.resolve(__dirname, file));
 }

--- a/app/lib/util/files.js
+++ b/app/lib/util/files.js
@@ -134,6 +134,7 @@ function globFiles(pattern, options = {}) {
 
   const {
     searchPaths,
+    cwd,
     ...otherOptions
   } = options;
 
@@ -141,22 +142,22 @@ function globFiles(pattern, options = {}) {
     return searchPaths.reduce((paths, searchPath) => {
       return [
         ...paths,
-        ...globSync(toPosixPath(pattern), {
-          ...defaultOptions,
+        ...globFiles(pattern, {
           ...otherOptions,
-          cwd: toPosixPath(searchPath)
-        }).map(toPosixPath)
+          cwd: searchPath
+        })
       ];
     }, []);
   }
 
-  if (otherOptions.cwd) {
-    otherOptions.cwd = toPosixPath(otherOptions.cwd);
-  }
+  const cwdOptions = cwd
+    ? { cwd: toPosixPath(cwd) }
+    : {};
 
   return globSync(toPosixPath(pattern), {
     ...defaultOptions,
-    ...otherOptions
+    ...otherOptions,
+    ...cwdOptions
   }).map(toPosixPath);
 }
 

--- a/app/lib/util/files.js
+++ b/app/lib/util/files.js
@@ -122,7 +122,7 @@ function readFileAsJSON(file) {
  * @param {Object} [options]
  * @param {string[]} [options.searchPaths]
  * @param {boolean} [options.absolute=true]
- * @param {boolean} [options.nodir=true]
+ * @param {boolean} [options.onlyFiles=true]
  *
  * @return {string[]}
  */

--- a/app/lib/util/files.js
+++ b/app/lib/util/files.js
@@ -13,34 +13,45 @@ const { globSync } = require('fast-glob');
 const path = require('path');
 const fs = require('fs');
 
+const { merge } = require('min-dash');
+
 /**
- * Load JSON configuration from multiple paths.
+ * Find JSON files in one or more paths. Return the merged result, the files
+ * that were read and errors that occurred. Optionally, provide defaults that
+ * will be merged into the result.
+ *
+ * @param {string} pattern
+ * @param {Object} [options]
+ * @param {string[]} [options.searchPaths]
+ * @param {Object} [options.defaults]
  *
  * @example
  *
  * const {
+ *   config,
  *   errors,
- *   files,
- *   config
- * } = globJSON({
- *   name: 'config.json',
- *   searchPaths: [ __dirname, process.cwd() ]
+ *   files
+ * } = globJSON('config.json', {
+ *   searchPaths: [
+ *     __dirname,
+ *     process.cwd()
+ *   ]
  * });
  *
- * @return { config, files, errors }
+ * @return { {
+ *   config: Object,
+ *   errors: Error[],
+ *   files: string[]
+ * } }
  */
-function globJSON(options) {
-
+function globJSON(pattern, options) {
   const {
-    name,
-    pattern,
     searchPaths,
-    defaults
+    defaults = {}
   } = options;
 
-  const files = globFiles({
-    searchPaths,
-    pattern: name || pattern
+  const files = globFiles(pattern, {
+    searchPaths
   });
 
   const {
@@ -59,10 +70,6 @@ function globJSON(options) {
 
 module.exports.globJSON = globJSON;
 
-
-function merge(...objects) {
-  return Object.assign({}, ...objects);
-}
 
 /**
  * Read the given files and return { contents: [], errors: [] }.
@@ -99,7 +106,6 @@ module.exports.readJSON = readJSON;
 
 
 function readFileAsJSON(file) {
-
   try {
     const contents = fs.readFileSync(file, { encoding: 'UTF-8' });
 
@@ -110,35 +116,54 @@ function readFileAsJSON(file) {
 }
 
 /**
- * Find files by pattern in a list of search paths.
+ * Find files matching a given pattern in one or more search paths.
  *
- * @param {Object} options
- * @param {Array<string>} options.searchPaths
- * @param {string} options.pattern
+ * @param {string} pattern
+ * @param {Object} [options]
+ * @param {string[]} [options.searchPaths]
+ * @param {boolean} [options.absolute=true]
+ * @param {boolean} [options.nodir=true]
  *
- * @return {Array<string>} list of found, absolute path names
+ * @return {string[]}
  */
-function globFiles(options) {
+function globFiles(pattern, options = {}) {
+  const defaultOptions = {
+    absolute: true,
+    onlyFiles: true
+  };
 
   const {
     searchPaths,
-    pattern
+    ...otherOptions
   } = options;
 
-  return searchPaths.reduce((paths, searchPath) => {
+  if (searchPaths) {
+    return searchPaths.reduce((paths, searchPath) => {
+      return [
+        ...paths,
+        ...globSync(toPosixPath(pattern), {
+          ...defaultOptions,
+          ...otherOptions,
+          cwd: toPosixPath(searchPath)
+        }).map(toPosixPath)
+      ];
+    }, []);
+  }
 
-    const newPaths = globSync(pattern, {
-      cwd: searchPath,
-      nodir: true,
-      absolute: true
-    }).map(p => p.split(path.posix.sep).join(path.sep));
+  if (otherOptions.cwd) {
+    otherOptions.cwd = toPosixPath(otherOptions.cwd);
+  }
 
-    return [
-      ...paths,
-      ...newPaths
-    ];
-  }, []);
-
+  return globSync(toPosixPath(pattern), {
+    ...defaultOptions,
+    ...otherOptions
+  }).map(toPosixPath);
 }
 
 module.exports.globFiles = globFiles;
+
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join(path.posix.sep);
+}
+
+module.exports.toPosixPath = toPosixPath;

--- a/app/test/spec/plugins-spec.js
+++ b/app/test/spec/plugins-spec.js
@@ -50,12 +50,12 @@ describe('Plugins', function() {
       // then
       const registeredPlugins = plugins.getAll();
 
-      expect(registeredPlugins.map(p => p.name)).to.eql([
-        'broken-menu',
-        'ghost-paths',
-        'OK',
-        'with-script',
-        'with-style'
+      expect(registeredPlugins.map(({ name, error }) => [ name, error ])).to.eql([
+        [ 'broken-menu', true ],
+        [ 'ghost-paths', true ],
+        [ 'OK', undefined ],
+        [ 'with-script', undefined ],
+        [ 'with-style', undefined ]
       ]);
     });
 


### PR DESCRIPTION
Added https://github.com/camunda/camunda-modeler/pull/3863/commits/5578416fedbe8caa32b555fb09c5140ab398b284 to verify the fix. `globFiles` is now being used by element templates and plugins feature.

Closes https://github.com/camunda/camunda-modeler/issues/3862
