### PR TITLE
fix(zeebe-plugin): drop missleading hint

### DIFF
--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.js
@@ -311,7 +311,6 @@ export default class DeploymentPluginOverlay extends React.PureComponent {
                                 label={ AUDIENCE }
                                 fieldError={ this.endpointConfigurationFieldError }
                                 validate={ validatorFunctionsByFieldNames.audience }
-                                description="Identifier for the access token. Usually the base URI of the cluster endpoint."
                               />
                             </React.Fragment>
                           )


### PR DESCRIPTION
Proposes to drop the miss-leading audience hint. Cf. #3864 for rationale.

![screenshot vxgAWd](https://github.com/camunda/camunda-modeler/assets/58601/0ac8264f-fc6e-4644-81cf-15de60e7029c)

Closes #3864
