### PR TITLE
ci: do not cancel release when one step fails

### DIFF
--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -23,6 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-11, windows-2019 ]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
 
     # Required to upload release artifacts to GitHub


### PR DESCRIPTION
This is to prevent a situation when an otherwise successful step is cancelled due to other step failing. For example, in https://github.com/camunda/camunda-modeler/actions/runs/6249575466/attempts/1 the Windows job was cancelled, even though it succeeded to upload the artifacts.

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
