### PR TITLE
feat(zeebe-api): infer error codes (where unavailable) from message

### DIFF
--- a/app/test/spec/zeebe-api/zeebe-api-spec.js
+++ b/app/test/spec/zeebe-api/zeebe-api-spec.js
@@ -157,6 +157,60 @@ describe('ZeebeAPI', function() {
       });
 
 
+      it('for <endpoint-unavailable> (self-managed)', async () => {
+
+        // given
+        const zeebeAPI = mockZeebeNode({
+          ZBClient: function() {
+            return {
+              topology: function() {
+                throw new NetworkError('Error: 13 INTERNAL:');
+              }
+            };
+          }
+        });
+
+        const parameters = {
+          endpoint: {
+            type: 'selfHosted',
+            url: TEST_URL
+          }
+        };
+
+        // when
+        const result = await zeebeAPI.checkConnection(parameters);
+
+        expect(result.reason).to.eql('CONTACT_POINT_UNAVAILABLE');
+      });
+
+
+      it('for <endpoint-unavailable> (self-managed)', async () => {
+
+        // given
+        const zeebeAPI = mockZeebeNode({
+          ZBClient: function() {
+            return {
+              topology: function() {
+                throw new NetworkError('Error: 14 UNAVAILABLE:');
+              }
+            };
+          }
+        });
+
+        const parameters = {
+          endpoint: {
+            type: 'selfHosted',
+            url: TEST_URL
+          }
+        };
+
+        // when
+        const result = await zeebeAPI.checkConnection(parameters);
+
+        expect(result.reason).to.eql('CONTACT_POINT_UNAVAILABLE');
+      });
+
+
       it('for <not-found>', async () => {
 
         // given


### PR DESCRIPTION
Recent versions of `zeebe-node` do not return the error code anymore (for self-managed at least), instead I get the following error:

```
ERROR app:zeebe-api connection check failed {                            
  parameters: {                                                          
    endpoint: {                                                          
      type: 'oauth',     
      url: 'https://****non-existing-zeepe-api',
      oauthURL: 'https://login.cloud.ultrawombat.com/oauth/token',
      audience: 'zeebe-api',
      clientId: '******',                                                
      clientSecret: '******'   
    }                                                                    
  }                                                                      
} Error: 13 INTERNAL: Received RST_STREAM with code 2 triggered by internal client error: Protocol error
...
```

This PR ensures we parse the `code` that we rely on from the error message, restoring proper detection of cluster unavailability in the process.

---

Related to https://github.com/camunda/camunda-modeler/issues/3808