### PR TITLE
Prevent Duplicate React ™️ Keys in Problems Panel

### DIFF
--- a/client/src/app/panel/tabs/linting/LintingTab.js
+++ b/client/src/app/panel/tabs/linting/LintingTab.js
@@ -68,14 +68,9 @@ export default function LintingTab(props) {
         )
       }
       {
-        sortReports(reports).map((report => {
-          const {
-            id,
-            message
-          } = report;
-
+        sortReports(reports).map(((report, index) => {
           return <LintingTabItem
-            key={ `${ id }-${ message }` }
+            key={ index }
             report={ report }
             onClick={ onClick(report) }
           />;


### PR DESCRIPTION
We cannot rely on the report being unique. For example, there can easily be two equal reports caused by a rule error:

```
{
  "message": "I blow up",
  "category": "rule-error",
  "executionPlatform": "Camunda Cloud",
  "executionPlatformVersion": "8.3.0",
  "propertiesPanel": {
      "entryIds": []
  },
  "documentation": {
      "url": null
  },
  "rule": "custom/rule-error"
}
```

Reports don't have unique IDs and even if they had, they wouldn't be stable since the linter is stateless and the IDs would change every time we lint. Therefore we can only use the index as the key even though it's considered a bad practice. Alternatively, we could assign a random ID to every report. 🤔