### PR TITLE
chore(docs): remove manual slack assignment step

### DIFF
--- a/docs/.project/RELEASE_TEMPLATE.md
+++ b/docs/.project/RELEASE_TEMPLATE.md
@@ -18,7 +18,6 @@ labels:
 
 _To be done immediately after creating this issue._
 
-* [ ] add Slack role to release manager (`@desktop-modeler-release-manager`)
 * [ ] (optional) update [release presentation](https://confluence.camunda.com/display/HAN/Release+Presentation+Process) page
 
 _To be done before the code freeze._


### PR DESCRIPTION
Follow-up to https://github.com/camunda/camunda-modeler/pull/3923
This is done automatically now

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
