### PR TITLE
chore: transpile to electron version

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,14 +1,9 @@
 {
-  "plugins": [
-    "@babel/plugin-syntax-dynamic-import",
-    "@babel/plugin-proposal-class-properties"
-  ],
   "presets": [
     [
       "@babel/preset-env", {
-        "modules": false,
         "targets": {
-          "chrome": "78"
+          "electron": "26"
         }
       }
     ],

--- a/client/package.json
+++ b/client/package.json
@@ -69,8 +69,6 @@
   "homepage": ".",
   "devDependencies": {
     "@babel/core": "^7.4.3",
-    "@babel/plugin-proposal-class-properties": "^7.4.0",
-    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/preset-env": "^7.4.3",
     "@babel/preset-react": "^7.0.0",
     "@sentry/webpack-plugin": "^2.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -243,8 +243,6 @@
       },
       "devDependencies": {
         "@babel/core": "^7.4.3",
-        "@babel/plugin-proposal-class-properties": "^7.4.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/preset-env": "^7.4.3",
         "@babel/preset-react": "^7.0.0",
         "@sentry/webpack-plugin": "^2.6.2",
@@ -1813,6 +1811,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
       "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -32174,6 +32173,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
       "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
+      "peer": true,
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -38117,8 +38117,6 @@
       "version": "file:client",
       "requires": {
         "@babel/core": "^7.4.3",
-        "@babel/plugin-proposal-class-properties": "^7.4.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/preset-env": "^7.4.3",
         "@babel/preset-react": "^7.0.0",
         "@bpmn-io/add-exporter": "^0.2.0",


### PR DESCRIPTION
We now target current Electron version via `@babel/preset-env`, and can safely remove some babel plugins.