### PR TITLE
chore: always show linting documentation link if available

### DIFF
--- a/client/src/app/panel/tabs/linting/LintingTab.less
+++ b/client/src/app/panel/tabs/linting/LintingTab.less
@@ -44,10 +44,6 @@
     }
   }
 
-  &:not(:hover) .linting-tab-item__link {
-    display: none;
-  }
-
   .linting-tab-item__content {
     width: calc(100% - 200px);
     padding: var(--linting-tab-item-padding);
@@ -60,6 +56,10 @@
         color: var(--color-blue-205-100-50);
         position: relative;
         top: 2px;
+      }
+
+      &:hover svg {
+        color: var(--color-blue-205-100-45);
       }
     }
 


### PR DESCRIPTION
![image](https://github.com/camunda/camunda-modeler/assets/7633572/1834c46f-89fd-4f97-909f-407b9d3dc020)

---

Closes #3972

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
