### PR TITLE
fix(Panel): rerender Tab on prop changes

### DIFF
--- a/client/src/app/panel/Panel.js
+++ b/client/src/app/panel/Panel.js
@@ -8,7 +8,7 @@
  * except in compliance with the MIT License.
  */
 
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import classnames from 'classnames';
 
@@ -134,7 +134,7 @@ Panel.Tab = Tab;
 
 function Tab(props) {
   const {
-    actions = [],
+    actions,
     children,
     id,
     label,
@@ -144,32 +144,34 @@ function Tab(props) {
 
   const { addTab, removeTab } = useContext(TabContext);
 
-  const Link = <>
-    <span className="panel__link-label">
-      { label }
-    </span>
-    {
-      isDefined(number)
-        ? <span className="panel__link-number">{ number }</span>
-        : null
-    }
-  </>;
+  const TabContent = useMemo(() => {
+    const Link = <>
+      <span className="panel__link-label">
+        { label }
+      </span>
+      {
+        isDefined(number)
+          ? <span className="panel__link-number">{ number }</span>
+          : null
+      }
+    </>;
 
-  const Actions = actions.map(action => {
-    const Icon = action.icon;
+    const Actions = (actions || []).map(action => {
+      const Icon = action.icon;
 
-    return <button key={ action.title } className="panel__action" title={ action.title } onClick={ action.onClick }>
-      <Icon />
-    </button>;
-  });
+      return <button key={ action.title } className="panel__action" title={ action.title } onClick={ action.onClick }>
+        <Icon />
+      </button>;
+    });
 
-  const TabContent = {
-    id: id || label,
-    priority,
-    link: Link,
-    actions: Actions,
-    body: children
-  };
+    return {
+      id: id || label,
+      priority: priority || 0,
+      link: Link,
+      actions: Actions,
+      body: children
+    };
+  }, [ actions, children, id, label, number, priority ]);
 
   useEffect(() => {
     addTab(TabContent);
@@ -177,7 +179,7 @@ function Tab(props) {
     return () => {
       removeTab(TabContent);
     };
-  }, []);
+  }, [ TabContent ]);
 
   return null;
 }

--- a/client/src/app/panel/__tests__/PanelSpec.js
+++ b/client/src/app/panel/__tests__/PanelSpec.js
@@ -10,7 +10,7 @@
 
 /* global sinon */
 
-import React from 'react';
+import React, { Component } from 'react';
 
 import { mount } from 'enzyme';
 
@@ -76,6 +76,47 @@ describe('<Panel>', function() {
 
       expect(wrapper.find('.foo')).to.have.length(1);
     });
+
+
+    it('should update Tab on prop changes', async function() {
+
+      // given
+      class CustomComponent extends Component {
+        constructor(props) {
+          super(props);
+          this.state = { label: 'Foo' };
+        }
+
+        render() {
+          const { label } = this.state;
+
+          return <Fill slot="bottom-panel" label={ label } id="foo">
+            <div className={ 'foo' } />
+          </Fill>;
+        }
+      }
+
+      const wrapper = renderPanel({
+        children: <CustomComponent />
+      });
+
+      // assume
+      expect(wrapper.find('.panel__link')).to.have.length(1);
+      expect(wrapper.find('.panel__link--active')).to.have.length(1);
+
+      expect(wrapper.find('.panel__link').at(0).find('.panel__link-label').text()).to.equal('Foo');
+      expect(wrapper.find('.panel__link').at(0).hasClass('panel__link--active')).to.be.true;
+
+      // when
+      wrapper.find(CustomComponent).setState({ label: 'Bar' });
+
+      // then
+      return expectEventually(() => {
+        expect(wrapper.find('.panel__link').at(0).find('.panel__link-label').text()).to.equal('Bar');
+        expect(wrapper.find('.panel__link').at(0).hasClass('panel__link--active')).to.be.true;
+      });
+    });
+
 
     it('should render two tabs', function() {
 
@@ -287,4 +328,31 @@ function renderPanel(options = {}) {
       </Panel>
     </SlotFillRoot>
   );
+}
+
+async function expectEventually(expectStatement) {
+  const sleep = time => {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        resolve();
+      }, time);
+    });
+  };
+
+  for (let i = 0; i < 10; i++) {
+    try {
+      expectStatement();
+
+      // success
+      return;
+    } catch {
+
+      // do nothing
+    }
+
+    await sleep(50);
+  }
+
+  // let it fail correctly
+  expectStatement();
 }


### PR DESCRIPTION
fixes #4021

![Recording 2023-12-11 at 16 29 49](https://github.com/camunda/camunda-modeler/assets/21984219/b57d50cf-8ce1-477a-b4dc-58da8f6780f7)

We now rerender the Tab entry when the content (children/label/id/...) changes
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
