### PR TITLE
fix: do not spellcheck Variables JSON

### DIFF
--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstanceConfigOverlay.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstanceConfigOverlay.js
@@ -86,6 +86,7 @@ export default class StartInstanceConfigOverlay extends React.PureComponent {
                             return null;
                           }
                         } }
+                        spellcheck="false"
                       />
                     </div>
                   </fieldset>


### PR DESCRIPTION
Spellchecking the _Variables_ JSON doesn't make sense. Ideally, the textarea should be a code editor anyway.

![image](https://github.com/camunda/camunda-modeler/assets/7633572/559708e4-256d-4705-aff7-d890b6f9712c)

