### PR TITLE
chore: allow focus on dmn buttons

### DIFF
--- a/client/src/app/tabs/dmn/DmnEditor.less
+++ b/client/src/app/tabs/dmn/DmnEditor.less
@@ -37,7 +37,6 @@
       color: var(--color-grey-225-10-15);
       font-weight: bold;
       font-family: inherit;
-      outline: none;
       margin-right: 10px;
 
       &:last-child {


### PR DESCRIPTION
Closes #4053

This `outline: none` is not adding anything (not present in the bpmn.io demo) and breaks the focus style. Alternatively, we could just reinforce on focus but as far as I can see, this doesn't change anything.
