### PR TITLE
fix(client): don't bundle `cjs` files as strings

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -101,7 +101,7 @@ module.exports = {
           {
 
             // exclude files served otherwise
-            exclude: [ /\.(js|jsx|mjs|bpmnlintrc)$/, /\.html$/, /\.json$/ ],
+            exclude: [ /\.(js|jsx|cjs|mjs|bpmnlintrc)$/, /\.html$/, /\.json$/ ],
             type: 'asset/resource'
           }
         ]


### PR DESCRIPTION
This is a common extension for ES module exports.

Adresses [`[headsu`](https://camunda.slack.com/archives/GP70M0J6M/p1706869768978479).