### PR TITLE
feat: allow to disable HTTL hint via flag

### DIFF
--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -52,7 +52,8 @@ import Flags, {
   DISABLE_FORM,
   DISABLE_ZEEBE,
   DISABLE_PLATFORM,
-  DISABLE_CMMN
+  DISABLE_CMMN,
+  DISABLE_HTTL_HINT
 } from '../util/Flags';
 
 import BPMNIcon from '../../resources/icons/file-types/BPMN-16x16.svg';
@@ -246,6 +247,14 @@ export default class TabsProvider {
           } ];
         },
         getLinter(plugins) {
+
+          if (Flags.get(DISABLE_HTTL_HINT)) {
+            plugins = [
+              DisableHTTLHintPlugin(),
+              ...plugins
+            ];
+          }
+
           return new BpmnLinter({
             modeler: 'desktop',
             type: 'platform',
@@ -730,4 +739,14 @@ function replaceExporter(contents) {
       .replace('{{ EXPORTER_NAME }}', name)
       .replace('{{ EXPORTER_VERSION }}', version)
   );
+}
+
+function DisableHTTLHintPlugin() {
+  return {
+    config: {
+      rules: {
+        'bpmnlint-plugin-camunda-compat/history-time-to-live': 'off'
+      }
+    }
+  };
 }

--- a/client/src/app/__tests__/TabsProviderSpec.js
+++ b/client/src/app/__tests__/TabsProviderSpec.js
@@ -16,7 +16,8 @@ import Flags, {
   DISABLE_PLATFORM,
   DISABLE_CMMN,
   CLOUD_ENGINE_VERSION,
-  PLATFORM_ENGINE_VERSION
+  PLATFORM_ENGINE_VERSION,
+  DISABLE_HTTL_HINT
 } from '../../util/Flags';
 
 import {
@@ -1131,6 +1132,32 @@ describe('TabsProvider', function() {
 
       // then
       expect(tabsProvider.hasProvider('cmmn')).to.be.true;
+    });
+
+
+    it('should disable HTTL hint', async function() {
+
+      // given
+      const tabsProvider = new TabsProvider().getProvider('bpmn');
+
+      // when
+      const defaultLinter = await tabsProvider.getLinter([]);
+
+      // then
+      expect(defaultLinter).to.exist;
+      expect(defaultLinter.getPlugins()).to.be.empty;
+
+      // but when
+      Flags.init({
+        [DISABLE_HTTL_HINT]: true
+      });
+
+      // when
+      const customLinter = await tabsProvider.getLinter([]);
+
+      // then
+      expect(customLinter).to.exist;
+      expect(customLinter.getPlugins()).to.have.length(1);
     });
 
   });

--- a/client/src/util/Flags.js
+++ b/client/src/util/Flags.js
@@ -48,3 +48,4 @@ export const MIXPANEL_STAGE = 'mixpanel-stage';
 export const DISPLAY_VERSION = 'display-version';
 export const CLOUD_ENGINE_VERSION = 'c8-engine-version';
 export const PLATFORM_ENGINE_VERSION = 'c7-engine-version';
+export const DISABLE_HTTL_HINT = 'disable-httl-hint';


### PR DESCRIPTION
The `disable-httl-hint` flag stops the modeler from validating (hinting) on HTTL.

![capture sB17vg_optimized](https://github.com/camunda/camunda-modeler/assets/58601/5258a380-cb6d-4fed-bac5-91fbb43ce249)

Related to https://github.com/camunda/camunda-modeler/issues/4062