### PR TITLE
chore(RELEASE_TEMPLATE): update branch names

### DIFF
--- a/docs/.project/RELEASE_TEMPLATE.md
+++ b/docs/.project/RELEASE_TEMPLATE.md
@@ -24,26 +24,26 @@ _To be done before the code freeze._
 
 * [ ] inform QA about the release and its details so they can prepare for testing
 * [ ] get in touch with the team (PM, UX and Engineering side), to clarify what topics will be included in the Release and their priority. Use this information to start preparing a concept for the *blog post* (see below) and *release info* (see below)
-    * [ ] (optional) if possible, already create feature branch to update [Release Info](https://github.com/camunda/camunda-modeler/blob/develop/client/src/plugins/version-info/ReleaseInfo.js) following our [guidelines](https://github.com/bpmn-io/internal-docs/blob/master/releases/modeler/CAMUNDA_MODELER.md#whats-new-communication)
+    * [ ] (optional) if possible, already create feature branch to update [Release Info](https://github.com/camunda/camunda-modeler/blob/develop/client/src/plugins/version-info/ReleaseInfo.js) following our [guidelines](https://github.com/bpmn-io/internal-docs/blob/main/releases/modeler/CAMUNDA_MODELER.md#whats-new-communication)
 
 _To be done after code freeze to prepare and test the release._
 
 * [ ] make sure changes in upstream libraries are merged and released
     * `bpmn-js`, `dmn-js`, `*-properties-panel`, `*-moddle`, `camunda-bpmn-js`, `form-js`, ...
 * [ ] make sure dependencies to upstream libraries are updated and can be installed (`rm -rf node_modules && npm i && npm run all` works)
-* [ ] verify `develop` is up to date with `master`: `git checkout master && git pull && git checkout develop && git merge master`
+* [ ] verify `develop` is up to date with `main`: `git checkout main && git pull && git checkout develop && git merge main`
 * [ ] close all issues which are solved by dependency updates
 * [ ] ensure that the modeler is free of major security vulnerabilities via `npm audit`
 * [ ] smoke test to verify all diagrams can be created
 * [ ] update [Release Info](https://github.com/camunda/camunda-modeler/blob/develop/client/src/plugins/version-info/ReleaseInfo.js)
-    * [ ] create a draft following [our guidelines](https://github.com/bpmn-io/internal-docs/blob/master/releases/modeler/CAMUNDA_MODELER.md#whats-new-communication) and based on priorities which were aligned with the team (PM, UX, and Engineering side)
+    * [ ] create a draft following [our guidelines](https://github.com/bpmn-io/internal-docs/blob/main/releases/modeler/CAMUNDA_MODELER.md#whats-new-communication) and based on priorities which were aligned with the team (PM, UX, and Engineering side)
    * [ ] create PR to merge the draft into `develop`. Assign to PM, UX and Engineering for review 
 * [ ] update [`CHANGELOG`](https://github.com/camunda/camunda-modeler/blob/develop/CHANGELOG.md)
 * [ ] compile a list of blog worthy changes as input to [release blog](https://confluence.camunda.com/pages/viewpage.action?pageId=178590449)
-* [ ] merge to master: `git checkout master && git merge develop`
-* [ ] create release candidate (`npm run release:rc -- [preminor|premajor|prerelease]`), cf. [release schema](https://github.com/bpmn-io/internal-docs/blob/master/releases/RELEASE_SCHEMA.md)
+* [ ] merge to main: `git checkout main && git merge develop`
+* [ ] create release candidate (`npm run release:rc -- [preminor|premajor|prerelease]`), cf. [release schema](https://github.com/bpmn-io/internal-docs/blob/main/releases/RELEASE_SCHEMA.md)
     * [ ] wait for [release build](https://github.com/camunda/camunda-modeler/actions/workflows/RELEASE.yml) to create the [artifacts](https://github.com/camunda/camunda-modeler/releases)
-* [ ] execute [integration test](https://github.com/camunda/camunda-modeler/blob/master/docs/.project/INTEGRATION_TEST.md) on [released artifacts](https://github.com/camunda/camunda-modeler/releases)
+* [ ] execute [integration test](https://github.com/camunda/camunda-modeler/blob/main/docs/.project/INTEGRATION_TEST.md) on [released artifacts](https://github.com/camunda/camunda-modeler/releases)
     * [ ] Works on Linux
     * [ ] Works on Mac
     * [ ] Works on Windows
@@ -51,7 +51,7 @@ _To be done after code freeze to prepare and test the release._
 
 _To be done to build the release after release testing completed._
 
-* [ ] create release (`npm run release`), cf. [release schema](https://github.com/bpmn-io/internal-docs/blob/master/releases/RELEASE_SCHEMA.md)
+* [ ] create release (`npm run release`), cf. [release schema](https://github.com/bpmn-io/internal-docs/blob/main/releases/RELEASE_SCHEMA.md)
     * [ ] wait for [release build](https://github.com/camunda/camunda-modeler/actions/workflows/RELEASE.yml) to create the [artifacts](https://github.com/camunda/camunda-modeler/releases)
 
 _To be done once the release is built._
@@ -63,7 +63,7 @@ _To be done once the release is built._
    * [ ] [camunda-docs](https://github.com/camunda/camunda-docs)
 * [ ] provide content to the [release presentation and notice](https://confluence.camunda.com/x/Uq-gBQ#ReleasePresentationProcess-OrganisingtheReleasePresentation)
 * [ ] trigger [downloads page](https://camunda.com/download/modeler/) update via [marketing request form](https://confluence.camunda.com/x/rTGSBg)
-* [ ] add new version to [update server releases](https://github.com/camunda/camunda-modeler-update-server/blob/master/releases.json)
+* [ ] add new version to [update server releases](https://github.com/camunda/camunda-modeler-update-server/blob/main/releases.json)
 * [ ] (optional) update [supported environments page](https://docs.camunda.io/docs/reference/supported-environments/)
 
 _To be done once release is publicly announced on release day._


### PR DESCRIPTION
We moved to branch names `main` for this and all referenced projects. This Updates links and snippets to reflect that

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
