### PR TITLE
ci: build on MacOS 12

### DIFF
--- a/.github/workflows/BUILD_ON_DEMAND.yml
+++ b/.github/workflows/BUILD_ON_DEMAND.yml
@@ -12,7 +12,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-11, windows-2022 ]
+        os: [ ubuntu-latest, macos-12, windows-2022 ]
     runs-on: ${{ matrix.os }}
     env:
       ON_DEMAND: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-11, windows-2022 ]
+        os: [ ubuntu-latest, macos-12, windows-2022 ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/NIGHTLY.yml
+++ b/.github/workflows/NIGHTLY.yml
@@ -10,7 +10,7 @@ jobs:
         - os: ubuntu-latest
           files:
           - 'dist/camunda-modeler-nightly-linux-x64.tar.gz'
-        - os: macos-11
+        - os: macos-12
           files:
           - 'dist/camunda-modeler-nightly-mac.dmg'
           - 'dist/camunda-modeler-nightly-mac.zip'

--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -22,7 +22,7 @@ jobs:
     needs: Pre_release
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-11, windows-2022 ]
+        os: [ ubuntu-latest, macos-12, windows-2022 ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
MacOS 11 is not supported anymore.

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
