### PR TITLE
deps: update to bpmn-js-element-templates@1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
-* `DEPS`: update to `bpmn-js-element-templates@1.15.0`
+* `DEPS`: update to `bpmn-js-element-templates@1.15.1`
 * `FIX`: prevent infinite loop when applying conditional template ([bpmn-io/bpmn-js-element-templates#78](https://github.com/bpmn-io/bpmn-js-element-templates/issues/78))
+* `FIX`: preserve valid user input when changing element template ([bpmn-io/bpmn-js-element-templates#86](https://github.com/bpmn-io/bpmn-js-element-templates/pull/86), [#4249](https://github.com/camunda/camunda-modeler/issues/4249))
 
 ## 5.22.0
 

--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,7 @@
     "@sentry/browser": "^7.108.0",
     "@sentry/integrations": "^7.108.0",
     "bpmn-js": "^17.2.1",
-    "bpmn-js-element-templates": "^1.15.0",
+    "bpmn-js-element-templates": "^1.15.1",
     "bpmn-js-properties-panel": "^5.14.0",
     "bpmn-js-tracking": "^0.5.0",
     "bpmn-moddle": "^9.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,7 +125,7 @@
         "@sentry/browser": "^7.108.0",
         "@sentry/integrations": "^7.108.0",
         "bpmn-js": "^17.2.1",
-        "bpmn-js-element-templates": "^1.15.0",
+        "bpmn-js-element-templates": "^1.15.1",
         "bpmn-js-properties-panel": "^5.14.0",
         "bpmn-js-tracking": "^0.5.0",
         "bpmn-moddle": "^9.0.1",
@@ -8386,9 +8386,9 @@
       }
     },
     "node_modules/bpmn-js-element-templates": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-1.15.0.tgz",
-      "integrity": "sha512-zrlNMPoZKtD9Pt3SNOJX4X3h8meO2pZfIvNvs6cdpr4mb0+z4MyaKiRCG/ECeV+FfDjz6UfTV/8IWTsfK+3L/A==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-1.15.1.tgz",
+      "integrity": "sha512-ncgKB0SrlEOAhdHQbfRrfvqmNHw+lKwHshwsYctQyYx41M6f2xjJn3A4kgls+YGkLpnw3r0O1Yn1xHxL/zK7vg==",
       "dependencies": {
         "@bpmn-io/element-templates-validator": "^2.0.1",
         "@bpmn-io/extract-process-variables": "^0.8.0",
@@ -37385,9 +37385,9 @@
       }
     },
     "bpmn-js-element-templates": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-1.15.0.tgz",
-      "integrity": "sha512-zrlNMPoZKtD9Pt3SNOJX4X3h8meO2pZfIvNvs6cdpr4mb0+z4MyaKiRCG/ECeV+FfDjz6UfTV/8IWTsfK+3L/A==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-1.15.1.tgz",
+      "integrity": "sha512-ncgKB0SrlEOAhdHQbfRrfvqmNHw+lKwHshwsYctQyYx41M6f2xjJn3A4kgls+YGkLpnw3r0O1Yn1xHxL/zK7vg==",
       "requires": {
         "@bpmn-io/element-templates-validator": "^2.0.1",
         "@bpmn-io/extract-process-variables": "^0.8.0",
@@ -38107,7 +38107,7 @@
         "babel-loader": "^9.0.0",
         "babel-plugin-istanbul": "^6.0.0",
         "bpmn-js": "^17.2.1",
-        "bpmn-js-element-templates": "^1.15.0",
+        "bpmn-js-element-templates": "^1.15.1",
         "bpmn-js-properties-panel": "^5.14.0",
         "bpmn-js-tracking": "^0.5.0",
         "bpmn-moddle": "^9.0.1",


### PR DESCRIPTION
  Changelog: https://github.com/bpmn-io/bpmn-js-element-templates/releases/tag/v1.15.1

fix: preserve valid user input when changing element template

  Closes https://github.com/camunda/camunda-modeler/issues/4249
