### PR TITLE
chore(CI): do not sign windows app

### DIFF
--- a/.github/workflows/BUILD_ON_DEMAND.yml
+++ b/.github/workflows/BUILD_ON_DEMAND.yml
@@ -67,6 +67,4 @@ jobs:
         AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_ON_DEMAND_SECRET_ACCESS_KEY }}"
         AWS_REGION: "${{ secrets.AWS_ON_DEMAND_REGION }}"
         AWS_BUCKET: "${{ secrets.AWS_ON_DEMAND_BUCKET }}"
-        CSC_LINK: "${{ secrets.WIN_CSC_LINK }}"
-        CSC_KEY_PASSWORD: "${{ secrets.WIN_CSC_KEY_PASSWORD }}"
       run: npm run build -- --win --publish --on-demand

--- a/.github/workflows/NIGHTLY.yml
+++ b/.github/workflows/NIGHTLY.yml
@@ -67,8 +67,6 @@ jobs:
     - name: Build nightly (Windows)
       if: ${{ runner.os == 'Windows' }}
       env:
-        CSC_LINK: "${{ secrets.WIN_CSC_LINK }}"
-        CSC_KEY_PASSWORD: "${{ secrets.WIN_CSC_KEY_PASSWORD }}"
         MIXPANEL_TOKEN: "${{ secrets.MIXPANEL_PROJECT_TOKEN }}"
         MIXPANEL_STAGE: "int"
         NIGHTLY: 1

--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -77,8 +77,6 @@ jobs:
     - name: Build release (Windows)
       if: ${{ runner.os == 'Windows' }}
       env:
-        CSC_LINK: "${{ secrets.WIN_CSC_LINK }}"
-        CSC_KEY_PASSWORD: "${{ secrets.WIN_CSC_KEY_PASSWORD }}"
         MIXPANEL_TOKEN: "${{ secrets.MIXPANEL_PROJECT_TOKEN }}"
         MIXPANEL_STAGE: "prod"
         SENTRY_AUTH_TOKEN: "${{ secrets.SENTRY_AUTH_TOKEN }}"


### PR DESCRIPTION
This ensures we can build windows releases until a solution for #4243 is integrated.

Tested with build on demand:
https://github.com/camunda/camunda-modeler/actions/runs/8874773314/job/24362837554

Windows artifacts from the build are available here: 
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/disable-signing-on-windows/camunda-modeler-disable-signing-on-windows-win-ia32.zip
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/disable-signing-on-windows/camunda-modeler-disable-signing-on-windows-win-x64.zip

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
