### PR TITLE
Ensure we updated engine profiles before/after major releases

### DIFF
--- a/.github/workflows/NEW_ALPHA_ISSUE.yml
+++ b/.github/workflows/NEW_ALPHA_ISSUE.yml
@@ -1,0 +1,21 @@
+name: Add Alpha version reminder
+on:
+  schedule:
+    # After the April and October releases
+    - cron: '0 8 15 APR,OCT *'
+jobs:
+  createIssue:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" --label "ready" --repo $GITHUB_REPOSITORY
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_TITLE: "Add new alpha engine profile"
+          ISSUE_BODY: |
+            **What should we do?**
+            Add a new Alpha Version to the version select.
+            - [ ] Update the version select (C7, C8)
+            - [ ] Update linting profiles (C7, C8)
+
+            **Why should we do it?**
+            To support the next alpha release of the engine.

--- a/.github/workflows/NEW_ALPHA_ISSUE.yml
+++ b/.github/workflows/NEW_ALPHA_ISSUE.yml
@@ -12,10 +12,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_TITLE: "Add new alpha engine profile"
           ISSUE_BODY: |
-            **What should we do?**
+            ### What should we do?
             Add a new Alpha Version to the version select.
             - [ ] Update the version select (C7, C8)
             - [ ] Update linting profiles (C7, C8)
 
-            **Why should we do it?**
+            ### Why should we do it?
             To support the next alpha release of the engine.

--- a/.github/workflows/NEW_MAJOR_ISSUE.yml
+++ b/.github/workflows/NEW_MAJOR_ISSUE.yml
@@ -1,0 +1,19 @@
+name: Add Major version reminder
+on:
+  schedule:
+    # Before the April and October releases
+    - cron: '0 8 15 MAR,SEP *'
+jobs:
+  createIssue:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" --label "ready" --repo $GITHUB_REPOSITORY
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_TITLE: "Remove alpha tag from latest engine profile"
+          ISSUE_BODY: |
+            **What should we do?**
+            Mark the latest alpha versions as stable.
+
+            **Why should we do it?**
+            In the next release cycle, the current alpha versions will be relased as stable.

--- a/.github/workflows/NEW_MAJOR_ISSUE.yml
+++ b/.github/workflows/NEW_MAJOR_ISSUE.yml
@@ -12,8 +12,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_TITLE: "Remove alpha tag from latest engine profile"
           ISSUE_BODY: |
-            **What should we do?**
+            ### What should we do?
             Mark the latest alpha versions as stable.
 
-            **Why should we do it?**
+            ### Why should we do it?
             In the next release cycle, the current alpha versions will be relased as stable.

--- a/docs/.project/RELEASE_TEMPLATE.md
+++ b/docs/.project/RELEASE_TEMPLATE.md
@@ -30,6 +30,7 @@ _To be done after code freeze to prepare and test the release._
 
 * [ ] make sure changes in upstream libraries are merged and released
     * `bpmn-js`, `dmn-js`, `*-properties-panel`, `*-moddle`, `camunda-bpmn-js`, `form-js`, ...
+* [ ] make sure potential new engine versions are available and marked correctly (alpha/stable)
 * [ ] make sure dependencies to upstream libraries are updated and can be installed (`rm -rf node_modules && npm i && npm run all` works)
 * [ ] verify `develop` is up to date with `main`: `git checkout main && git pull && git checkout develop && git merge main`
 * [ ] close all issues which are solved by dependency updates


### PR DESCRIPTION
With this PR we:
 - automatically open issues before and after scheduled minor engine releases to remind us
 - add a step to the release procedure as a sanity check and for unscheduled releases

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
