### PR TITLE
chore: correct `element-templates/new-fields` example

### DIFF
--- a/resources/element-templates/new-fields.json
+++ b/resources/element-templates/new-fields.json
@@ -66,7 +66,7 @@
     {
       "id": "boolean-required",
       "type": "Boolean",
-      "value": true,
+      "value": "true",
       "label": "boolean-required",
       "binding": {
         "name": "boolean-required",


### PR DESCRIPTION
We'd otherwise get an error message due to new validation.

Related to 681d53db43ca47d84b68b9cb871bc93ef1f23743