### PR TITLE
Integrate new context pad

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "@camunda/execution-platform": "^0.3.2",
     "@camunda/form-linting": "^0.16.0",
     "@camunda/form-playground": "^0.14.0",
+    "@camunda/improved-canvas": "^1.7.0",
     "@camunda/linting": "^3.20.0",
     "@codemirror/commands": "^6.1.3",
     "@codemirror/lang-json": "^6.0.1",

--- a/client/src/app/tabs/bpmn/BpmnEditor.less
+++ b/client/src/app/tabs/bpmn/BpmnEditor.less
@@ -21,6 +21,15 @@
     --bjs-font-family: var(--font-family);
   }
 
+  /* @camunda/improved-canvas restets */
+  .djs-container.bio-improved-canvas {
+    background-color: var(--color-white);
+  }
+
+  .bio-improved-canvas defs pattern circle {
+    fill: #ccc !important;
+  }
+
   .djs-minimap {
 
     .toggle {

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -54,6 +54,8 @@ import {
 
 import { SlotFillRoot } from '../../../slot-fill';
 
+import Flags, { ENABLE_NEW_CONTEXT_PAD } from '../../../../util/Flags';
+
 const { spy } = sinon;
 
 
@@ -2087,6 +2089,43 @@ describe('<BpmnEditor>', function() {
       expect(onImportSpy).to.have.been.calledWith(sinon.match({ message: 'An unknown execution platform (Camunda Unknown 7.15.0) was detected.' }), []);
 
       expect(instance.getCached().engineProfile).to.be.null;
+    });
+
+  });
+
+
+  describe('new context pad', function() {
+
+    beforeEach(function() {
+      Flags.reset();
+    });
+
+
+    it('should disable new context pad by default', async function() {
+
+      // when
+      const { instance } = await renderEditor(diagramXML);
+
+      // then
+      expect(instance).to.exist;
+      expect(instance.getModeler().additionalModules).to.exist;
+      expect(instance.getModeler().additionalModules).to.have.length(0);
+    });
+
+
+    it('should enable new context pad if enabled through flag', async function() {
+
+      // when
+      Flags.init({
+        [ ENABLE_NEW_CONTEXT_PAD ]: true
+      });
+
+      const { instance } = await renderEditor(diagramXML);
+
+      // then
+      expect(instance).to.exist;
+      expect(instance.getModeler().additionalModules).to.exist;
+      expect(instance.getModeler().additionalModules).to.have.length(1);
     });
 
   });

--- a/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
+++ b/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
@@ -18,8 +18,6 @@ import handToolOnSpaceModule from './features/hand-tool-on-space';
 import propertiesPanelKeyboardBindingsModule from './features/properties-panel-keyboard-bindings';
 import lintingAnnotationsModule from '@camunda/linting/modeler';
 
-import Flags, { DISABLE_ADJUST_ORIGIN } from '../../../../util/Flags';
-
 import { BpmnJSTracking as bpmnJSTracking } from 'bpmn-js-tracking';
 
 import contextPadTracking from 'bpmn-js-tracking/lib/features/context-pad';
@@ -28,22 +26,40 @@ import modelingTracking from 'bpmn-js-tracking/lib/features/modeling';
 import popupMenuTracking from 'bpmn-js-tracking/lib/features/popup-menu';
 import paletteTracking from 'bpmn-js-tracking/lib/features/palette';
 
+import { BpmnImprovedCanvasModule } from '@camunda/improved-canvas';
+
+import Flags, {
+  DISABLE_ADJUST_ORIGIN,
+  ENABLE_NEW_CONTEXT_PAD
+} from '../../../../util/Flags';
 
 export default class PlatformBpmnModeler extends BpmnModeler {
 
   constructor(options = {}) {
 
-    const {
-      moddleExtensions,
+    let {
+      additionalModules = [],
+      moddleExtensions = {},
       ...otherOptions
     } = options;
 
+    if (Flags.get(ENABLE_NEW_CONTEXT_PAD, false)) {
+      additionalModules = [
+        ...additionalModules,
+        {
+          __depends__: [ BpmnImprovedCanvasModule ],
+          resourceLinkingContextPadProvider: [ 'value', null ],
+          resourceLinkingRules: [ 'value', null ],
+          showComments: [ 'value', null ]
+        }
+      ];
+    }
+
     super({
       ...otherOptions,
-      disableAdjustOrigin: Flags.get(DISABLE_ADJUST_ORIGIN),
-      moddleExtensions: {
-        ...(moddleExtensions || {})
-      }
+      additionalModules,
+      moddleExtensions,
+      disableAdjustOrigin: Flags.get(DISABLE_ADJUST_ORIGIN)
     });
   }
 }

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.less
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.less
@@ -16,9 +16,17 @@
     }
   }
 
-
   .bjs-container {
     --bjs-font-family: var(--font-family);
+  }
+
+  /* @camunda/improved-canvas restets */
+  .djs-container.bio-improved-canvas {
+    background-color: var(--color-white);
+  }
+
+  .bio-improved-canvas defs pattern circle {
+    fill: #ccc !important;
   }
 
   .djs-minimap {

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -52,6 +52,8 @@ import {
 
 import { SlotFillRoot } from '../../../slot-fill';
 
+import Flags, { ENABLE_NEW_CONTEXT_PAD } from '../../../../util/Flags';
+
 const { spy } = sinon;
 
 
@@ -2008,6 +2010,43 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
       expect(onImportSpy).to.have.been.calledWith(sinon.match({ message: 'An unknown execution platform (Camunda Unknown 7.15.0) was detected.' }), []);
 
       expect(instance.getCached().engineProfile).to.be.null;
+    });
+
+  });
+
+
+  describe('new context pad', function() {
+
+    beforeEach(function() {
+      Flags.reset();
+    });
+
+
+    it('should disable new context pad by default', async function() {
+
+      // when
+      const { instance } = await renderEditor(diagramXML);
+
+      // then
+      expect(instance).to.exist;
+      expect(instance.getModeler().additionalModules).to.exist;
+      expect(instance.getModeler().additionalModules).to.have.length(0);
+    });
+
+
+    it('should enable new context pad if enabled through flag', async function() {
+
+      // when
+      Flags.init({
+        [ ENABLE_NEW_CONTEXT_PAD ]: true
+      });
+
+      const { instance } = await renderEditor(diagramXML);
+
+      // then
+      expect(instance).to.exist;
+      expect(instance.getModeler().additionalModules).to.exist;
+      expect(instance.getModeler().additionalModules).to.have.length(1);
     });
 
   });

--- a/client/src/app/tabs/cloud-bpmn/modeler/BpmnModeler.js
+++ b/client/src/app/tabs/cloud-bpmn/modeler/BpmnModeler.js
@@ -27,8 +27,11 @@ import modelingTracking from 'bpmn-js-tracking/lib/features/modeling';
 import popupMenuTracking from 'bpmn-js-tracking/lib/features/popup-menu';
 import paletteTracking from 'bpmn-js-tracking/lib/features/palette';
 
+import { BpmnImprovedCanvasModule } from '@camunda/improved-canvas';
+
 import Flags, {
-  DISABLE_ADJUST_ORIGIN
+  DISABLE_ADJUST_ORIGIN,
+  ENABLE_NEW_CONTEXT_PAD
 } from '../../../../util/Flags';
 
 
@@ -36,14 +39,28 @@ export default class CloudBpmnModeler extends BpmnModeler {
 
   constructor(options = {}) {
 
-    const {
-      moddleExtensions,
+    let {
+      additionalModules = [],
+      moddleExtensions = {},
       ...otherOptions
     } = options;
 
+    if (Flags.get(ENABLE_NEW_CONTEXT_PAD, false)) {
+      additionalModules = [
+        ...additionalModules,
+        {
+          __depends__: [ BpmnImprovedCanvasModule ],
+          resourceLinkingContextPadProvider: [ 'value', null ],
+          resourceLinkingRules: [ 'value', null ],
+          showComments: [ 'value', null ]
+        }
+      ];
+    }
+
     super({
       ...otherOptions,
-      moddleExtensions: moddleExtensions || {},
+      additionalModules,
+      moddleExtensions,
       disableAdjustOrigin: Flags.get(DISABLE_ADJUST_ORIGIN)
     });
   }

--- a/client/src/app/tabs/cloud-dmn/modeler/DmnModeler.js
+++ b/client/src/app/tabs/cloud-dmn/modeler/DmnModeler.js
@@ -18,13 +18,18 @@ import completeDirectEditingModule from '../../bpmn/modeler/features/complete-di
 import propertiesPanelKeyboardBindingsModule from '../../bpmn/modeler/features/properties-panel-keyboard-bindings';
 import decisionTableKeyboardModule from '../../dmn/modeler/features/decision-table-keyboard';
 
-import Flags, { DISABLE_ADJUST_ORIGIN } from '../../../../util/Flags';
+import Flags, {
+  DISABLE_ADJUST_ORIGIN,
+  ENABLE_NEW_CONTEXT_PAD
+} from '../../../../util/Flags';
 
 import openDrgElementModule from '../../dmn/modeler/features/overview/open-drg-element';
 import overviewRendererModule from '../../dmn/modeler/features/overview/overview-renderer';
 
 import executionPlatformModule from '@camunda/execution-platform';
 import modelerModdle from 'modeler-moddle/resources/dmn-modeler.json';
+
+import { DmnImprovedCanvasModule } from '@camunda/improved-canvas';
 
 const NOOP_MODULE = [ 'value', null ];
 
@@ -44,7 +49,7 @@ export default class CamundaDmnModeler extends DmnModeler {
 
     const {
       moddleExtensions = {},
-      drd: drdConfig,
+      drd,
       decisionTable,
       literalExpression,
       exporter,
@@ -52,10 +57,14 @@ export default class CamundaDmnModeler extends DmnModeler {
       ...otherOptions
     } = options;
 
-    const drd = {
-      ...drdConfig,
-      disableAdjustOrigin: Flags.get(DISABLE_ADJUST_ORIGIN)
-    };
+    let additionalModules = [];
+
+    if (Flags.get(ENABLE_NEW_CONTEXT_PAD, false)) {
+      additionalModules = [
+        ...additionalModules,
+        DmnImprovedCanvasModule
+      ];
+    }
 
     super({
       ...otherOptions,
@@ -66,9 +75,13 @@ export default class CamundaDmnModeler extends DmnModeler {
           viewDrd: NOOP_MODULE
         }
       ]),
-      drd: mergeModules(drd, [
+      drd: mergeModules({
+        ...drd,
+        disableAdjustOrigin: Flags.get(DISABLE_ADJUST_ORIGIN)
+      }, [
         propertiesPanelKeyboardBindingsModule,
-        executionPlatformModule
+        executionPlatformModule,
+        ...additionalModules
       ]),
       decisionTable: mergeModules(decisionTable, [
         decisionTableKeyboardModule,

--- a/client/src/app/tabs/dmn/DmnEditor.less
+++ b/client/src/app/tabs/dmn/DmnEditor.less
@@ -9,6 +9,15 @@
     --drd-font-family-monospace: var(--font-family-monospace);
   }
 
+  /* @camunda/improved-canvas restets */
+  .djs-container.bio-improved-canvas {
+    background-color: var(--color-white);
+  }
+
+  .bio-improved-canvas defs pattern circle {
+    fill: #ccc !important;
+  }
+
   .dmn-decision-table-container {
     --decision-table-font-family: var(--font-family);
   }

--- a/client/src/app/tabs/dmn/modeler/DmnModeler.js
+++ b/client/src/app/tabs/dmn/modeler/DmnModeler.js
@@ -18,13 +18,18 @@ import completeDirectEditingModule from '../../bpmn/modeler/features/complete-di
 import propertiesPanelKeyboardBindingsModule from '../../bpmn/modeler/features/properties-panel-keyboard-bindings';
 import decisionTableKeyboardModule from './features/decision-table-keyboard';
 
-import Flags, { DISABLE_ADJUST_ORIGIN } from '../../../../util/Flags';
+import Flags, {
+  DISABLE_ADJUST_ORIGIN,
+  ENABLE_NEW_CONTEXT_PAD
+} from '../../../../util/Flags';
 
 import openDrgElementModule from './features/overview/open-drg-element';
 import overviewRendererModule from './features/overview/overview-renderer';
 
 import executionPlatformModule from '@camunda/execution-platform';
 import modelerModdle from 'modeler-moddle/resources/dmn-modeler.json';
+
+import { DmnImprovedCanvasModule } from '@camunda/improved-canvas';
 
 const NOOP_MODULE = [ 'value', null ];
 
@@ -44,7 +49,7 @@ export default class CamundaDmnModeler extends DmnModeler {
 
     const {
       moddleExtensions = {},
-      drd: drdConfig,
+      drd,
       decisionTable,
       literalExpression,
       exporter,
@@ -52,10 +57,14 @@ export default class CamundaDmnModeler extends DmnModeler {
       ...otherOptions
     } = options;
 
-    const drd = {
-      ...drdConfig,
-      disableAdjustOrigin: Flags.get(DISABLE_ADJUST_ORIGIN)
-    };
+    let additionalModules = [];
+
+    if (Flags.get(ENABLE_NEW_CONTEXT_PAD, false)) {
+      additionalModules = [
+        ...additionalModules,
+        DmnImprovedCanvasModule
+      ];
+    }
 
     super({
       ...otherOptions,
@@ -66,9 +75,13 @@ export default class CamundaDmnModeler extends DmnModeler {
           viewDrd: NOOP_MODULE
         }
       ]),
-      drd: mergeModules(drd, [
+      drd: mergeModules({
+        ...drd,
+        disableAdjustOrigin: Flags.get(DISABLE_ADJUST_ORIGIN)
+      }, [
         propertiesPanelKeyboardBindingsModule,
-        executionPlatformModule
+        executionPlatformModule,
+        ...additionalModules
       ]),
       decisionTable: mergeModules(decisionTable, [
         decisionTableKeyboardModule,

--- a/client/src/util/Flags.js
+++ b/client/src/util/Flags.js
@@ -50,4 +50,5 @@ export const CLOUD_ENGINE_VERSION = 'c8-engine-version';
 export const PLATFORM_ENGINE_VERSION = 'c7-engine-version';
 export const DISABLE_HTTL_HINT = 'disable-httl-hint';
 export const DEFAULT_HTTL = 'default-httl';
+export const ENABLE_NEW_CONTEXT_PAD = 'enable-new-context-pad';
 

--- a/client/test/bpmn-io-modelers/dmn/DmnModelerSpec.js
+++ b/client/test/bpmn-io-modelers/dmn/DmnModelerSpec.js
@@ -17,6 +17,8 @@ import DrdViewer from '../../../src/app/tabs/dmn/modeler/DrdViewer';
 
 import diagramXML from './diagram.dmn';
 
+import Flags, { ENABLE_NEW_CONTEXT_PAD } from '../../../src/util/Flags';
+
 const DEFAULT_OPTIONS = {
   exporter: {
     name: 'my-tool',
@@ -418,6 +420,39 @@ describe('DmnModeler', function() {
       });
       expect(xml).to.contain('xmlns:modeler="http://camunda.org/schema/modeler/1.0"');
     });
+  });
+
+
+  describe('new context pad', function() {
+
+    beforeEach(function() {
+      Flags.reset();
+    });
+
+
+    it('should disable new context pad by default', async function() {
+
+      // when
+      const modeler = await createModeler();
+
+      // then
+      expect(modeler.getActiveViewer().get('improvedCanvas', false)).not.to.exist;
+    });
+
+
+    it('should enable new context pad if enabled through flag', async function() {
+
+      // when
+      Flags.init({
+        [ ENABLE_NEW_CONTEXT_PAD ]: true
+      });
+
+      const modeler = await createModeler();
+
+      // then
+      expect(modeler.getActiveViewer().get('improvedCanvas', false)).to.exist;
+    });
+
   });
 
 });

--- a/client/test/mocks/bpmn-js/Modeler.js
+++ b/client/test/mocks/bpmn-js/Modeler.js
@@ -105,6 +105,8 @@ export default class Modeler {
 
     this.modules = assign(this._getDefaultModules(options), options.modules || {});
 
+    this.additionalModules = options.additionalModules || [];
+
     this.xml = null;
 
     this.listeners = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,7 @@
         "@camunda/execution-platform": "^0.3.2",
         "@camunda/form-linting": "^0.16.0",
         "@camunda/form-playground": "^0.14.0",
+        "@camunda/improved-canvas": "^1.7.0",
         "@camunda/linting": "^3.20.0",
         "@codemirror/commands": "^6.1.3",
         "@codemirror/lang-json": "^6.0.1",
@@ -3046,6 +3047,23 @@
         "domify": "^1.4.1",
         "min-dash": "^4.0.0"
       }
+    },
+    "node_modules/@camunda/improved-canvas": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@camunda/improved-canvas/-/improved-canvas-1.7.0.tgz",
+      "integrity": "sha512-Qo/G9MrCMiwEV2kOBP6snHFLM3hMuXlzcDRwHii8tC/nmwWRkTpR+qbcBlVnDt2YqQ5oAULHaj8f8hCOTg97Tg==",
+      "dependencies": {
+        "diagram-js-grid": "^1.0.0",
+        "min-dash": "^4.2.1"
+      },
+      "peerDependencies": {
+        "bpmn-js-create-append-anything": "^0.5.0"
+      }
+    },
+    "node_modules/@camunda/improved-canvas/node_modules/min-dash": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.1.tgz",
+      "integrity": "sha512-to+unsToePnm7cUeR9TrMzFlETHd/UXmU+ELTRfWZj5XGT41KF6X3L233o3E/GdEs3sk2Tbw/lOLD1avmWkg8A=="
     },
     "node_modules/@camunda/linting": {
       "version": "3.20.0",
@@ -35021,6 +35039,22 @@
         }
       }
     },
+    "@camunda/improved-canvas": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@camunda/improved-canvas/-/improved-canvas-1.7.0.tgz",
+      "integrity": "sha512-Qo/G9MrCMiwEV2kOBP6snHFLM3hMuXlzcDRwHii8tC/nmwWRkTpR+qbcBlVnDt2YqQ5oAULHaj8f8hCOTg97Tg==",
+      "requires": {
+        "diagram-js-grid": "^1.0.0",
+        "min-dash": "^4.2.1"
+      },
+      "dependencies": {
+        "min-dash": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.1.tgz",
+          "integrity": "sha512-to+unsToePnm7cUeR9TrMzFlETHd/UXmU+ELTRfWZj5XGT41KF6X3L233o3E/GdEs3sk2Tbw/lOLD1avmWkg8A=="
+        }
+      }
+    },
     "@camunda/linting": {
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-3.20.0.tgz",
@@ -40714,6 +40748,7 @@
         "@camunda/execution-platform": "^0.3.2",
         "@camunda/form-linting": "^0.16.0",
         "@camunda/form-playground": "^0.14.0",
+        "@camunda/improved-canvas": "^1.7.0",
         "@camunda/linting": "^3.20.0",
         "@codemirror/commands": "^6.1.3",
         "@codemirror/lang-json": "^6.0.1",


### PR DESCRIPTION
Adds the ability to enable the new context pad through the `enable-new-context-pad` flag.

![electron_RvzZDnvUz7](https://github.com/camunda/camunda-modeler/assets/7633572/0aa75366-fcb1-4169-b412-e833082ad236)


----

Related to https://github.com/camunda/camunda-modeler/issues/4263
