### PR TITLE
fix(menu-builder): remove new file options from tab menu

### DIFF
--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -94,13 +94,9 @@ class MenuBuilder {
     const { contextMenu } = this.options.state;
 
     if (this.options.type === 'tab') {
-      return this.appendNewFile()
+      return this.appendContextCloseTab()
         .appendSeparator()
-        .appendContextCloseTab()
-        .appendSeparator()
-        .appendContextRevealInFileExplorerTab()
-        .appendSeparator()
-        .appendOpenRecent();
+        .appendContextRevealInFileExplorerTab();
     }
 
     if (contextMenu) {

--- a/app/test/spec/menu/menu-builder-spec.js
+++ b/app/test/spec/menu/menu-builder-spec.js
@@ -67,6 +67,13 @@ describe('MenuBuilder', () => {
     const contextMenu = menuBuilder.buildContextMenu();
 
     expect(contextMenu).to.exist;
+    expectMenu(contextMenu, [
+      'Close Tab',
+      'Close All Tabs',
+      'Close Other Tabs',
+      undefined,
+      'Reveal in File Explorer'
+    ]);
   });
 
 
@@ -531,4 +538,10 @@ function callAction(fn, browserWindow = {}, triggeredByAccelerator = false) {
   }
 
   return fn(null, browserWindow, { triggeredByAccelerator });
+}
+
+function expectMenu(actual, expected) {
+  const menu = actual.menu.map(item => item.label);
+
+  expect(menu).to.eql(expected);
 }


### PR DESCRIPTION
closes #4181

![image](https://github.com/camunda/camunda-modeler/assets/21984219/f6205bae-0ac8-433a-99a2-8efdcc365cfa)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
