### PR TITLE
fix(App): stop showing dialogs after first cancel

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1992,13 +1992,14 @@ export class App extends PureComponent {
   async quit() {
     const { tabs } = this.state;
 
-    const quitTasks = tabs.map((tab) => {
-      return () => this.saveBeforeClose(tab);
-    });
+    let canQuit = true;
+    for (const tab of tabs) {
+      canQuit = await this.saveBeforeClose(tab);
 
-    const quitResults = await pSeries(quitTasks);
-
-    const canQuit = quitResults.every(result => result);
+      if (!canQuit) {
+        break;
+      }
+    }
 
     try {
       await this.workspaceChanged(false);

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -720,6 +720,86 @@ describe('<App>', function() {
     });
 
 
+    it('should ask user to save or discard changes before quiting', async function() {
+
+      // given
+      const dialog = new Dialog();
+
+      const {
+        app
+      } = createApp({
+        globals: {
+          dialog
+        }
+      });
+
+      const showCloseFileDialogSpy = spy(dialog, 'showCloseFileDialog'),
+            saveTabSpy = spy(app, 'saveTab');
+
+      const tab = await app.createDiagram();
+
+      app.setState({
+        ...app.setDirty(tab)
+      });
+
+      dialog.setShowCloseFileDialogResponse({ button: 'discard' });
+
+      // when
+      await app.quit();
+
+      // then
+      expect(showCloseFileDialogSpy).to.have.been.calledWith({
+        name: tab.file.name
+      });
+
+      expect(saveTabSpy).not.to.have.been.called;
+    });
+
+
+    it('should stop asking the user on cancel', async function() {
+
+      // given
+      const dialog = new Dialog();
+
+      const {
+        app
+      } = createApp({
+        globals: {
+          dialog
+        }
+      });
+
+      const showCloseFileDialogSpy = spy(dialog, 'showCloseFileDialog'),
+            saveTabSpy = spy(app, 'saveTab');
+
+      const tab = await app.createDiagram();
+      const tab2 = await app.createDiagram();
+
+
+      app.setState({
+        ...app.setDirty(tab)
+      });
+
+      app.setState({
+        ...app.setDirty(tab2)
+      });
+
+      dialog.setShowCloseFileDialogResponse({ button: 'cancel' });
+
+      // when
+      await app.quit();
+
+      // then
+      expect(showCloseFileDialogSpy).to.have.been.calledOnce;
+
+      expect(showCloseFileDialogSpy).to.have.been.calledWith({
+        name: tab.file.name
+      });
+
+      expect(saveTabSpy).not.to.have.been.called;
+    });
+
+
     it('should not close tab when saving dialog is canceled', async function() {
 
       // given
@@ -984,7 +1064,7 @@ describe('<App>', function() {
     });
 
 
-    it('should save  multiple times', async function() {
+    it('should save multiple times', async function() {
 
       // given
       const file = createFile('diagram_1.bpmn');


### PR DESCRIPTION
closes #4186

![Recording 2024-05-30 at 14 43 13](https://github.com/camunda/camunda-modeler/assets/21984219/431a73a3-d794-4299-9398-64f4425f25be)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
