### PR TITLE
chore: update release info for v5.24.0

### DIFF
--- a/client/src/plugins/version-info/ReleaseInfo.js
+++ b/client/src/plugins/version-info/ReleaseInfo.js
@@ -44,16 +44,16 @@ export function ReleaseInfo(props) {
     <div className={ css.ReleaseInfo }>
       <ul className="dashed">
         <li>
-          <h4>Business knowledge model editing added to DMN modeling</h4>
-          DMN modeling now supports implementing business knowledge models as literal expressions, offering more flexibility in decision modeling.
+          <h4>Properties panel quality of life improvements</h4>
+          We removed automatic (magic) sorting from all properties panels. Additional minor improvements ensure that implementing Camunda 7 and 8 is simpler then ever.
         </li>
         <li>
-          <h4>Basic auth support for deployments to Camunda 8 self-managed</h4>
-          For deployments to self-managed Camunda 8 instances secured with basic auth, you can now provide credentials when deploying.
+          <h4>More robust BPMN diagram import</h4>
+          Various improvements ensure that the modeler is able to import even what is (accidentally) broken.
         </li>
         <li>
-          <h4>Support for arm64 on MacOS</h4>
-          This release introduces arm64 support for MacOS, ensuring compatibility with Apple's latest hardware.
+          <h4>New modeling experience inside</h4>
+          You can now enable our reworked modeling experience via <a href="https://docs.camunda.io/docs/next/components/modeler/desktop-modeler/flags/#enable-new-context-pad" target="_blank" rel="noopener">a feature toggle</a>.
         </li>
         <li>
           <h4>Bug fixes and more</h4>

--- a/client/src/plugins/version-info/ReleaseInfo.js
+++ b/client/src/plugins/version-info/ReleaseInfo.js
@@ -42,7 +42,7 @@ import * as css from './ReleaseInfo.less';
 export function ReleaseInfo(props) {
   return (
     <div className={ css.ReleaseInfo }>
-       <ul className="dashed">
+      <ul className="dashed">
         <li>
           <h4>Properties panel quality of life improvements</h4>
           We removed automatic (magic) sorting from all properties panels. Additional minor improvements ensure that implementing Camunda 7 and 8 is simpler than ever.

--- a/client/src/plugins/version-info/ReleaseInfo.js
+++ b/client/src/plugins/version-info/ReleaseInfo.js
@@ -52,7 +52,7 @@ export function ReleaseInfo(props) {
           Various improvements ensure that the modeler can import even what is (accidentally) broken.
         </li>
         <li>
-          <h4>New context pad inside</h4>
+          <h4>New modeling experience inside</h4>
           You can now enable our reworked context pad via <a href="https://docs.camunda.io/docs/next/components/modeler/desktop-modeler/flags/#enable-new-context-pad" target="_blank" rel="noopener">a feature toggle</a>.
         </li>
         <li>

--- a/client/src/plugins/version-info/ReleaseInfo.js
+++ b/client/src/plugins/version-info/ReleaseInfo.js
@@ -42,18 +42,18 @@ import * as css from './ReleaseInfo.less';
 export function ReleaseInfo(props) {
   return (
     <div className={ css.ReleaseInfo }>
-      <ul className="dashed">
+       <ul className="dashed">
         <li>
           <h4>Properties panel quality of life improvements</h4>
-          We removed automatic (magic) sorting from all properties panels. Additional minor improvements ensure that implementing Camunda 7 and 8 is simpler then ever.
+          We removed automatic (magic) sorting from all properties panels. Additional minor improvements ensure that implementing Camunda 7 and 8 is simpler than ever.
         </li>
         <li>
           <h4>More robust BPMN diagram import</h4>
-          Various improvements ensure that the modeler is able to import even what is (accidentally) broken.
+          Various improvements ensure that the modeler can import even what is (accidentally) broken.
         </li>
         <li>
-          <h4>New modeling experience inside</h4>
-          You can now enable our reworked modeling experience via <a href="https://docs.camunda.io/docs/next/components/modeler/desktop-modeler/flags/#enable-new-context-pad" target="_blank" rel="noopener">a feature toggle</a>.
+          <h4>New context pad inside</h4>
+          You can now enable our reworked context pad via <a href="https://docs.camunda.io/docs/next/components/modeler/desktop-modeler/flags/#enable-new-context-pad" target="_blank" rel="noopener">a feature toggle</a>.
         </li>
         <li>
           <h4>Bug fixes and more</h4>


### PR DESCRIPTION
This updates the release information to v5.24.0, proposal:

![image](https://github.com/camunda/camunda-modeler/assets/58601/b7874775-dd81-4799-8837-f6c3d315810e)

