### PR TITLE
chore: use `@axe-core/react` in dev

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -71,6 +71,7 @@
   },
   "homepage": ".",
   "devDependencies": {
+    "@axe-core/react": "^4.9.1",
     "@babel/core": "^7.23.9",
     "@babel/preset-env": "^7.23.9",
     "@babel/preset-react": "^7.23.3",

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -74,6 +74,11 @@ const globals = {
 
 async function render() {
 
+  if (process.env.NODE_ENV !== 'production') {
+    const { loadA11yHelper } = await import('./util/a11y');
+    await loadA11yHelper();
+  }
+
   // load plugins
   plugins.bindHelpers(window);
 

--- a/client/src/util/a11y.js
+++ b/client/src/util/a11y.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+const DEFAULT_TAGS = [ 'wcag2a', 'wcag21a' ];
+
+export async function loadA11yHelper() {
+
+  // TODO(@barmac): remove or replace when upgraded to React 18
+  const axe = await import('@axe-core/react');
+  axe.default(React, ReactDOM, 1000, {
+    runOnly: DEFAULT_TAGS
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,6 +155,7 @@
         "zeebe-bpmn-moddle": "^1.1.0"
       },
       "devDependencies": {
+        "@axe-core/react": "^4.9.1",
         "@babel/core": "^7.23.9",
         "@babel/preset-env": "^7.23.9",
         "@babel/preset-react": "^7.23.3",
@@ -768,6 +769,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@axe-core/react": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.9.1.tgz",
+      "integrity": "sha512-DibuylB94B2200NjfbfVrQODWqVdqkSjdgvaHDAwrBRSNdI4ZbPwGNL1kicnh2W9EgOQ4MFFbkWvM23h0Z1bVg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.9.1",
+        "requestidlecallback": "^0.3.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -9246,6 +9258,16 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.1.tgz",
+      "integrity": "sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axios": {
@@ -28252,6 +28274,13 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/requestidlecallback": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "license": "MIT",
@@ -33407,6 +33436,16 @@
             "@jridgewell/sourcemap-codec": "^1.4.10"
           }
         }
+      }
+    },
+    "@axe-core/react": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.9.1.tgz",
+      "integrity": "sha512-DibuylB94B2200NjfbfVrQODWqVdqkSjdgvaHDAwrBRSNdI4ZbPwGNL1kicnh2W9EgOQ4MFFbkWvM23h0Z1bVg==",
+      "dev": true,
+      "requires": {
+        "axe-core": "~4.9.1",
+        "requestidlecallback": "^0.3.0"
       }
     },
     "@babel/code-frame": {
@@ -39682,6 +39721,12 @@
         }
       }
     },
+    "axe-core": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.1.tgz",
+      "integrity": "sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==",
+      "dev": true
+    },
     "axios": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
@@ -40766,6 +40811,7 @@
     "camunda-modeler-client": {
       "version": "file:client",
       "requires": {
+        "@axe-core/react": "^4.9.1",
         "@babel/core": "^7.23.9",
         "@babel/preset-env": "^7.23.9",
         "@babel/preset-react": "^7.23.3",
@@ -53523,6 +53569,12 @@
           "dev": true
         }
       }
+    },
+    "requestidlecallback": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1"


### PR DESCRIPTION

<img width="1585" alt="image" src="https://github.com/camunda/camunda-modeler/assets/28307541/230c8bc8-173a-4e5f-97e2-29e49a7cfd61">


This dev tool should help us to identify accessibility issues. We will need to drop it with React 18 upgrade (some day...), but until then it should be useful.

Related to https://github.com/bpmn-io/internal-docs/issues/909

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
