### PR TITLE
docs: update integration test to refer to the a11y plugin UI

### DIFF
--- a/docs/.project/INTEGRATION_TEST.md
+++ b/docs/.project/INTEGRATION_TEST.md
@@ -123,8 +123,8 @@ Based on the [test diagram](./test.bpmn.png):
 
 #### Accessibility
 
-- [ ] No new issues were reported in the devtools console
-- [ ] Running `window.__A11Y_CHECKER__.getViolations()` returns an empty array
+- [ ] No new issues were reported during the tests
+- [ ] The modal opened via "Accessibility issues" button is empty
 
 #### Installers (platform specific)
 


### PR DESCRIPTION
Related to https://github.com/bpmn-io/camunda-modeler-plugin-a11y-checker/issues/1

We don't need to use dev console anymore.