### PR TITLE
fix: set document title

### DIFF
--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -419,7 +419,6 @@ app.createEditorWindow = function() {
   const windowOptions = {
     resizable: true,
     show: false,
-    title: 'Camunda Modeler' + getTitleSuffix(app.metadata.version),
     minWidth: MINIMUM_SIZE.width,
     minHeight: MINIMUM_SIZE.height,
     webPreferences: {
@@ -692,20 +691,6 @@ function bootstrap() {
     windowManager,
     zeebeAPI
   };
-}
-
-/**
- * Returns the app title suffix based on app version.
- *
- * @param {string} version
- * @return {string}
- */
-function getTitleSuffix(version) {
-  if (version.includes('dev')) {
-    return ' (dev)';
-  }
-
-  return '';
 }
 
 function generatePluginsTag(plugins) {

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta http-equiv="Content-Security-Policy" content="script-src 'self'" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>Camunda Modeler</title>
 
   <style>
     body, html {


### PR DESCRIPTION
![image](https://github.com/camunda/camunda-modeler/assets/28307541/d9d2e29b-eb09-449d-a917-0e8fe011ddf5)

Closes #4376

### Proposed Changes

This PR replaces the main process code used for the window title with an HTML `<title>` tag. The content is hard-coded as "Camunda Modeler" in contrast to the old solution where we added "(dev)" for dev mode, but this piece of information is already represented in the bottom-right "what's new" button. The main advantage of the current solution is that the a11y tools won't report missing title anymore.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
