### PR TITLE
Add accessible names and tabindex to code editors

### DIFF
--- a/client/src/app/tabs/json/CodeMirror.js
+++ b/client/src/app/tabs/json/CodeMirror.js
@@ -55,6 +55,9 @@ export default function create() {
         language,
         tabSize,
         searchExtension,
+        EditorView.contentAttributes.of({
+          'aria-label': 'JSON editor'
+        }),
         ...extensions
       ]
     });

--- a/client/src/app/tabs/json/CodeMirror.js
+++ b/client/src/app/tabs/json/CodeMirror.js
@@ -56,7 +56,8 @@ export default function create() {
         tabSize,
         searchExtension,
         EditorView.contentAttributes.of({
-          'aria-label': 'JSON editor'
+          'aria-label': 'JSON editor',
+          'tabindex': 0
         }),
         ...extensions
       ]

--- a/client/src/app/tabs/xml/CodeMirror.js
+++ b/client/src/app/tabs/xml/CodeMirror.js
@@ -56,7 +56,8 @@ export default function create() {
         tabSize,
         searchExtension,
         EditorView.contentAttributes.of({
-          'aria-label': 'XML editor'
+          'aria-label': 'XML editor',
+          'tabindex': 0
         }),
         ...extensions
       ]

--- a/client/src/app/tabs/xml/CodeMirror.js
+++ b/client/src/app/tabs/xml/CodeMirror.js
@@ -55,6 +55,9 @@ export default function create() {
         language,
         tabSize,
         searchExtension,
+        EditorView.contentAttributes.of({
+          'aria-label': 'XML editor'
+        }),
         ...extensions
       ]
     });


### PR DESCRIPTION


https://github.com/camunda/camunda-modeler/assets/28307541/d4edf538-e103-42a1-bb01-cbf00878a568



### Proposed Changes

This PR:
- adds accessible names to the code editors
- adds tabindex necessary to satisfy ~~the beast~~ axe-core which currently reports lack of interactive content in the code editor.

Closes #4370

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
