### PR TITLE
deps: pin lerna version to `8.1.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "eslint-plugin-camunda-licensed": "^0.4.6",
         "eslint-plugin-import": "^2.29.1",
         "execa": "^1.0.0",
-        "lerna": "^8.0.0",
+        "lerna": "8.1.2",
         "license-webpack-plugin": "^4.0.2",
         "mocha": "^10.3.0",
         "mri": "^1.1.4",
@@ -3864,13 +3864,13 @@
       }
     },
     "node_modules/@lerna/create": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-8.1.3.tgz",
-      "integrity": "sha512-JFvIYrlvR8Txa8h7VZx8VIQDltukEKOKaZL/muGO7Q/5aE2vjOKHsD/jkWYe/2uFy1xv37ubdx17O1UXQNadPg==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-8.1.2.tgz",
+      "integrity": "sha512-GzScCIkAW3tg3+Yn/MKCH9963bzG+zpjGz2NdfYDlYWI7p0f/SH46v1dqpPpYmZ2E/m3JK8HjTNNNL8eIm8/YQ==",
       "dev": true,
       "dependencies": {
         "@npmcli/run-script": "7.0.2",
-        "@nx/devkit": ">=17.1.2 < 20",
+        "@nx/devkit": ">=17.1.2 < 19",
         "@octokit/plugin-enterprise-rest": "6.0.1",
         "@octokit/rest": "19.0.11",
         "byte-size": "8.1.1",
@@ -3907,7 +3907,7 @@
         "npm-packlist": "5.1.1",
         "npm-registry-fetch": "^14.0.5",
         "npmlog": "^6.0.2",
-        "nx": ">=17.1.2 < 20",
+        "nx": ">=17.1.2 < 19",
         "p-map": "4.0.0",
         "p-map-series": "2.1.0",
         "p-queue": "6.6.2",
@@ -3923,7 +3923,7 @@
         "slash": "^3.0.0",
         "ssri": "^9.0.1",
         "strong-log-transformer": "2.1.0",
-        "tar": "6.2.1",
+        "tar": "6.1.11",
         "temp-dir": "1.0.0",
         "upath": "2.0.1",
         "uuid": "^9.0.0",
@@ -4101,6 +4101,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@lerna/create/node_modules/glob/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@lerna/create/node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -4166,13 +4175,16 @@
         "node": "*"
       }
     },
-    "node_modules/@lerna/create/node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+    "node_modules/@lerna/create/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/@lerna/create/node_modules/node-fetch": {
@@ -4283,6 +4295,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/tar": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "dev": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@lerna/create/node_modules/uuid": {
@@ -4927,21 +4956,21 @@
       }
     },
     "node_modules/@nrwl/devkit": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-19.3.0.tgz",
-      "integrity": "sha512-WRcph/7U37HkTLIRzQ2oburZVfEFkPHJUn7vmo46gCq+N2cAKy3qwONO0RbthhjFIsG94YPXqFWFlV6k4nXpxA==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-18.3.5.tgz",
+      "integrity": "sha512-DIvChKMe4q8CtIsbrumL/aYgf85H5vlT6eF3jnCCWORj6LTwoHtK8Q9ky1+uM82KIM0gaKd32NVDw+w64scHyg==",
       "dev": true,
       "dependencies": {
-        "@nx/devkit": "19.3.0"
+        "@nx/devkit": "18.3.5"
       }
     },
     "node_modules/@nrwl/tao": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-19.3.0.tgz",
-      "integrity": "sha512-MyGYeHbh9O4Tv9xmz3Du+/leY5sKUHaPy4ancfNyShHgYi21hemX0/YYjzzoYHi44D8GzSc1XG2rAuwba7Kilw==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-18.3.5.tgz",
+      "integrity": "sha512-gB7Vxa6FReZZEGva03Eh+84W8BSZOjsNyXboglOINu6d8iZZ0eotSXGziKgjpkj3feZ1ofKZMs0PRObVAOROVw==",
       "dev": true,
       "dependencies": {
-        "nx": "19.3.0",
+        "nx": "18.3.5",
         "tslib": "^2.3.0"
       },
       "bin": {
@@ -4949,47 +4978,22 @@
       }
     },
     "node_modules/@nx/devkit": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-19.3.0.tgz",
-      "integrity": "sha512-Natya5nzvHH0qTOIL1w/EZtwMgDx87Dgz0LgeY7te2fULaNFcj5fVrP+mUKEJZR+NccO7GPumT2RPhuEl9rPnQ==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-18.3.5.tgz",
+      "integrity": "sha512-9I0L17t0MN87fL4m4MjDiBxJIx7h5RQY/pTYtt5TBjye0ANb165JeE4oh3ibzfjMzXv42Aej2Gm+cOuSPwzT9g==",
       "dev": true,
       "dependencies": {
-        "@nrwl/devkit": "19.3.0",
+        "@nrwl/devkit": "18.3.5",
         "ejs": "^3.1.7",
         "enquirer": "~2.3.6",
         "ignore": "^5.0.4",
-        "minimatch": "9.0.3",
         "semver": "^7.5.3",
         "tmp": "~0.2.1",
         "tslib": "^2.3.0",
         "yargs-parser": "21.1.1"
       },
       "peerDependencies": {
-        "nx": ">= 17 <= 20"
-      }
-    },
-    "node_modules/@nx/devkit/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@nx/devkit/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "nx": ">= 16 <= 19"
       }
     },
     "node_modules/@nx/devkit/node_modules/semver": {
@@ -5014,9 +5018,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.3.0.tgz",
-      "integrity": "sha512-TMTxjrN7Y/UsKFjmz0YfhVItLTGWqvud8cmQchw5NEjdNakfjXk0mREufO5/5PwoiRIsen6MbThoTprLpjOUiQ==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-18.3.5.tgz",
+      "integrity": "sha512-4I5UpZ/x2WO9OQyETXKjaYhXiZKUTYcLPewruRMODWu6lgTM9hHci0SqMQB+TWe3f80K8VT8J8x3+uJjvllGlg==",
       "cpu": [
         "arm64"
       ],
@@ -5030,9 +5034,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-x64": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-19.3.0.tgz",
-      "integrity": "sha512-GH2L6ftnzdIs7JEdv7ZPCdbpAdB5sW6NijK07riYZSONzq5fEruD1yDWDkyZbYBb8RTxsparUWJnq8q1qxEPHQ==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-18.3.5.tgz",
+      "integrity": "sha512-Drn6jOG237AD/s6OWPt06bsMj0coGKA5Ce1y5gfLhptOGk4S4UPE/Ay5YCjq+/yhTo1gDHzCHxH0uW2X9MN9Fg==",
       "cpu": [
         "x64"
       ],
@@ -5046,9 +5050,9 @@
       }
     },
     "node_modules/@nx/nx-freebsd-x64": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-19.3.0.tgz",
-      "integrity": "sha512-1ow7Xku1yyjHviCKsWiuHCAnTd3fD+5O5c+e4DXHVthT8wnadKSotvBIWf38DMbMthl7na82e72OzxcdSbrVqQ==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-18.3.5.tgz",
+      "integrity": "sha512-8tA8Yw0Iir4liFjffIFS5THTS3TtWY/No2tkVj91gwy/QQ/otvKbOyc5RCIPpbZU6GS3ZWfG92VyCSm06dtMFg==",
       "cpu": [
         "x64"
       ],
@@ -5062,9 +5066,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-19.3.0.tgz",
-      "integrity": "sha512-mYQMIUvNr2gww8vbg766uk/C1RxoC1fwioeP87bmV5NRUKSzJ8WEJVxAsqc9RGhAOUaNXOgEuKYrMcVhKyIKJQ==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-18.3.5.tgz",
+      "integrity": "sha512-BrPGAHM9FCGkB9/hbvlJhe+qtjmvpjIjYixGIlUxL3gGc8E/ucTyCnz5pRFFPFQlBM7Z/9XmbHvGPoUi/LYn5A==",
       "cpu": [
         "arm"
       ],
@@ -5078,9 +5082,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-19.3.0.tgz",
-      "integrity": "sha512-rHL3eQ0RHkeAXnhHHu/NIyouN/ykiXvgyNU3TuCd50+2MZcAbjB+Xq3mwL0MwiP+BQuptiE+snTuxFUJp4ZH6A==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-18.3.5.tgz",
+      "integrity": "sha512-/Xd0Q3LBgJeigJqXC/Jck/9l5b+fK+FCM0nRFMXgPXrhZPhoxWouFkoYl2F1Ofr+AQf4jup4DkVTB5r98uxSCA==",
       "cpu": [
         "arm64"
       ],
@@ -5094,9 +5098,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-19.3.0.tgz",
-      "integrity": "sha512-im0+OgOD6ShpTkI9ZRz7BjzxhQ/Lk3xjYmmCu+PFGmaybEnkNNDFwsgS0iEVKMdWZ/EQoQvJrqOYsX125iIBuQ==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-18.3.5.tgz",
+      "integrity": "sha512-r18qd7pUrl1haAZ/e9Q+xaFTsLJnxGARQcf/Y76q+K2psKmiUXoRlqd3HAOw43KTllaUJ5HkzLq2pIwg3p+xBw==",
       "cpu": [
         "arm64"
       ],
@@ -5110,9 +5114,9 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.3.0.tgz",
-      "integrity": "sha512-k8q/d6WBSXOeUpBq6Mw69yMKL4n9LaX3o4LBNwBkVCEZ8p6s0njwKefLtjwnKlai0g/k5f0NcilU2zTwP/Ex8g==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-18.3.5.tgz",
+      "integrity": "sha512-vYrikG6ff4I9cvr3Ysk3y3gjQ9cDcvr3iAr+4qqcQ4qVE+OLL2++JDS6xfPvG/TbS3GTQpyy2STRBwiHgxTeJw==",
       "cpu": [
         "x64"
       ],
@@ -5126,9 +5130,9 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-19.3.0.tgz",
-      "integrity": "sha512-sahEV99glBlpGKG1TIQ5PkJ0QvpHp69wWsBFK2DKtCETxOtsWqwvIjemxTCXRirTqeHiP7BiR6VWsf2YqqqBdw==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-18.3.5.tgz",
+      "integrity": "sha512-6np86lcYy3+x6kkW/HrBHIdNWbUu/MIsvMuNH5UXgyFs60l5Z7Cocay2f7WOaAbTLVAr0W7p4RxRPamHLRwWFA==",
       "cpu": [
         "x64"
       ],
@@ -5142,9 +5146,9 @@
       }
     },
     "node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-19.3.0.tgz",
-      "integrity": "sha512-w03gFwLijStmhUji70QJHYo/U16ovybNczxGO7+5TT330X8/y+ihw9FCGHiIcujAjTAE88h0DKGn05WlNqRmfg==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-18.3.5.tgz",
+      "integrity": "sha512-H3p2ZVhHV1WQWTICrQUTplOkNId0y3c23X3A2fXXFDbWSBs0UgW7m55LhMcA9p0XZ7wDHgh+yFtVgu55TXLjug==",
       "cpu": [
         "arm64"
       ],
@@ -5158,9 +5162,9 @@
       }
     },
     "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.3.0.tgz",
-      "integrity": "sha512-M7e2zXGfTjH8NLiwqKLdWC9VlfMSQDYlI4/SM4OSpPqhUTfPlRPa+wNKNTG7perKfDXxE9ei8yjocujknXJk/A==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-18.3.5.tgz",
+      "integrity": "sha512-xFwKVTIXSgjdfxkpriqHv5NpmmFILTrWLEkUGSoimuRaAm1u15YWx/VmaUQ+UWuJnmgqvB/so4SMHSfNkq3ijA==",
       "cpu": [
         "x64"
       ],
@@ -8412,9 +8416,9 @@
       "dev": true
     },
     "node_modules/@zkochan/js-yaml": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.7.tgz",
-      "integrity": "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
+      "integrity": "sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==",
       "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
@@ -16051,43 +16055,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/front-matter": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz",
-      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
-      "dev": true,
-      "dependencies": {
-        "js-yaml": "^3.13.1"
-      }
-    },
-    "node_modules/front-matter/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/front-matter/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/front-matter/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
-    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "dev": true,
@@ -18814,14 +18781,14 @@
       }
     },
     "node_modules/lerna": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-8.1.3.tgz",
-      "integrity": "sha512-Dg/r1dGnRCXKsOUC3lol7o6ggYTA6WWiPQzZJNKqyygn4fzYGuA3Dro2d5677pajaqFnFA72mdCjzSyF16Vi2Q==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-8.1.2.tgz",
+      "integrity": "sha512-RCyBAn3XsqqvHbz3TxLfD7ylqzCi1A2UJnFEZmhURgx589vM3qYWQa/uOMeEEf565q6cAdtmulITciX1wgkAtw==",
       "dev": true,
       "dependencies": {
-        "@lerna/create": "8.1.3",
+        "@lerna/create": "8.1.2",
         "@npmcli/run-script": "7.0.2",
-        "@nx/devkit": ">=17.1.2 < 20",
+        "@nx/devkit": ">=17.1.2 < 19",
         "@octokit/plugin-enterprise-rest": "6.0.1",
         "@octokit/rest": "19.0.11",
         "byte-size": "8.1.1",
@@ -18864,7 +18831,7 @@
         "npm-packlist": "5.1.1",
         "npm-registry-fetch": "^14.0.5",
         "npmlog": "^6.0.2",
-        "nx": ">=17.1.2 < 20",
+        "nx": ">=17.1.2 < 19",
         "p-map": "4.0.0",
         "p-map-series": "2.1.0",
         "p-pipe": "3.1.0",
@@ -18882,7 +18849,7 @@
         "slash": "3.0.0",
         "ssri": "^9.0.1",
         "strong-log-transformer": "2.1.0",
-        "tar": "6.2.1",
+        "tar": "6.1.11",
         "temp-dir": "1.0.0",
         "typescript": ">=3 < 6",
         "upath": "2.0.1",
@@ -19138,6 +19105,18 @@
         "node": "*"
       }
     },
+    "node_modules/lerna/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/lerna/node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -19249,6 +19228,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/lerna/node_modules/tar": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "dev": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/lerna/node_modules/uuid": {
@@ -22650,16 +22646,16 @@
       "license": "MIT"
     },
     "node_modules/nx": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-19.3.0.tgz",
-      "integrity": "sha512-WILWiROUkZWwuPJ12tP24Z0NULPEhxFN9i55/fECuVXYaFtkg6FvEne9C4d4bRqhZPcbrz6WhHnzE3NhdjH7XQ==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-18.3.5.tgz",
+      "integrity": "sha512-wWcvwoTgiT5okdrG0RIWm1tepC17bDmSpw+MrOxnjfBjARQNTURkiq4U6cxjCVsCxNHxCrlAaBSQLZeBgJZTzQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@nrwl/tao": "19.3.0",
+        "@nrwl/tao": "18.3.5",
         "@yarnpkg/lockfile": "^1.1.0",
         "@yarnpkg/parsers": "3.0.0-rc.46",
-        "@zkochan/js-yaml": "0.0.7",
+        "@zkochan/js-yaml": "0.0.6",
         "axios": "^1.6.0",
         "chalk": "^4.1.0",
         "cli-cursor": "3.1.0",
@@ -22670,10 +22666,10 @@
         "enquirer": "~2.3.6",
         "figures": "3.2.0",
         "flat": "^5.0.2",
-        "front-matter": "^4.0.2",
         "fs-extra": "^11.1.0",
         "ignore": "^5.0.4",
         "jest-diff": "^29.4.1",
+        "js-yaml": "4.1.0",
         "jsonc-parser": "3.2.0",
         "lines-and-columns": "~2.0.3",
         "minimatch": "9.0.3",
@@ -22696,16 +22692,16 @@
         "nx-cloud": "bin/nx-cloud.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "19.3.0",
-        "@nx/nx-darwin-x64": "19.3.0",
-        "@nx/nx-freebsd-x64": "19.3.0",
-        "@nx/nx-linux-arm-gnueabihf": "19.3.0",
-        "@nx/nx-linux-arm64-gnu": "19.3.0",
-        "@nx/nx-linux-arm64-musl": "19.3.0",
-        "@nx/nx-linux-x64-gnu": "19.3.0",
-        "@nx/nx-linux-x64-musl": "19.3.0",
-        "@nx/nx-win32-arm64-msvc": "19.3.0",
-        "@nx/nx-win32-x64-msvc": "19.3.0"
+        "@nx/nx-darwin-arm64": "18.3.5",
+        "@nx/nx-darwin-x64": "18.3.5",
+        "@nx/nx-freebsd-x64": "18.3.5",
+        "@nx/nx-linux-arm-gnueabihf": "18.3.5",
+        "@nx/nx-linux-arm64-gnu": "18.3.5",
+        "@nx/nx-linux-arm64-musl": "18.3.5",
+        "@nx/nx-linux-x64-gnu": "18.3.5",
+        "@nx/nx-linux-x64-musl": "18.3.5",
+        "@nx/nx-win32-arm64-msvc": "18.3.5",
+        "@nx/nx-win32-x64-msvc": "18.3.5"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.8.0",
@@ -35592,13 +35588,13 @@
       }
     },
     "@lerna/create": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-8.1.3.tgz",
-      "integrity": "sha512-JFvIYrlvR8Txa8h7VZx8VIQDltukEKOKaZL/muGO7Q/5aE2vjOKHsD/jkWYe/2uFy1xv37ubdx17O1UXQNadPg==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-8.1.2.tgz",
+      "integrity": "sha512-GzScCIkAW3tg3+Yn/MKCH9963bzG+zpjGz2NdfYDlYWI7p0f/SH46v1dqpPpYmZ2E/m3JK8HjTNNNL8eIm8/YQ==",
       "dev": true,
       "requires": {
         "@npmcli/run-script": "7.0.2",
-        "@nx/devkit": ">=17.1.2 < 20",
+        "@nx/devkit": ">=17.1.2 < 19",
         "@octokit/plugin-enterprise-rest": "6.0.1",
         "@octokit/rest": "19.0.11",
         "byte-size": "8.1.1",
@@ -35635,7 +35631,7 @@
         "npm-packlist": "5.1.1",
         "npm-registry-fetch": "^14.0.5",
         "npmlog": "^6.0.2",
-        "nx": ">=17.1.2 < 20",
+        "nx": ">=17.1.2 < 19",
         "p-map": "4.0.0",
         "p-map-series": "2.1.0",
         "p-queue": "6.6.2",
@@ -35651,7 +35647,7 @@
         "slash": "^3.0.0",
         "ssri": "^9.0.1",
         "strong-log-transformer": "2.1.0",
-        "tar": "6.2.1",
+        "tar": "6.1.11",
         "temp-dir": "1.0.0",
         "upath": "2.0.1",
         "uuid": "^9.0.0",
@@ -35777,6 +35773,12 @@
               "requires": {
                 "brace-expansion": "^2.0.1"
               }
+            },
+            "minipass": {
+              "version": "4.2.8",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+              "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+              "dev": true
             }
           }
         },
@@ -35824,10 +35826,10 @@
             "brace-expansion": "^1.1.7"
           }
         },
-        "minipass": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-          "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         },
         "node-fetch": {
@@ -35891,6 +35893,20 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "tar": {
+          "version": "6.1.11",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+          "dev": true,
+          "requires": {
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
           }
         },
         "uuid": {
@@ -36355,59 +36371,40 @@
       }
     },
     "@nrwl/devkit": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-19.3.0.tgz",
-      "integrity": "sha512-WRcph/7U37HkTLIRzQ2oburZVfEFkPHJUn7vmo46gCq+N2cAKy3qwONO0RbthhjFIsG94YPXqFWFlV6k4nXpxA==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-18.3.5.tgz",
+      "integrity": "sha512-DIvChKMe4q8CtIsbrumL/aYgf85H5vlT6eF3jnCCWORj6LTwoHtK8Q9ky1+uM82KIM0gaKd32NVDw+w64scHyg==",
       "dev": true,
       "requires": {
-        "@nx/devkit": "19.3.0"
+        "@nx/devkit": "18.3.5"
       }
     },
     "@nrwl/tao": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-19.3.0.tgz",
-      "integrity": "sha512-MyGYeHbh9O4Tv9xmz3Du+/leY5sKUHaPy4ancfNyShHgYi21hemX0/YYjzzoYHi44D8GzSc1XG2rAuwba7Kilw==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-18.3.5.tgz",
+      "integrity": "sha512-gB7Vxa6FReZZEGva03Eh+84W8BSZOjsNyXboglOINu6d8iZZ0eotSXGziKgjpkj3feZ1ofKZMs0PRObVAOROVw==",
       "dev": true,
       "requires": {
-        "nx": "19.3.0",
+        "nx": "18.3.5",
         "tslib": "^2.3.0"
       }
     },
     "@nx/devkit": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-19.3.0.tgz",
-      "integrity": "sha512-Natya5nzvHH0qTOIL1w/EZtwMgDx87Dgz0LgeY7te2fULaNFcj5fVrP+mUKEJZR+NccO7GPumT2RPhuEl9rPnQ==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-18.3.5.tgz",
+      "integrity": "sha512-9I0L17t0MN87fL4m4MjDiBxJIx7h5RQY/pTYtt5TBjye0ANb165JeE4oh3ibzfjMzXv42Aej2Gm+cOuSPwzT9g==",
       "dev": true,
       "requires": {
-        "@nrwl/devkit": "19.3.0",
+        "@nrwl/devkit": "18.3.5",
         "ejs": "^3.1.7",
         "enquirer": "~2.3.6",
         "ignore": "^5.0.4",
-        "minimatch": "9.0.3",
         "semver": "^7.5.3",
         "tmp": "~0.2.1",
         "tslib": "^2.3.0",
         "yargs-parser": "21.1.1"
       },
       "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "9.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        },
         "semver": {
           "version": "7.6.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
@@ -36423,72 +36420,72 @@
       }
     },
     "@nx/nx-darwin-arm64": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.3.0.tgz",
-      "integrity": "sha512-TMTxjrN7Y/UsKFjmz0YfhVItLTGWqvud8cmQchw5NEjdNakfjXk0mREufO5/5PwoiRIsen6MbThoTprLpjOUiQ==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-18.3.5.tgz",
+      "integrity": "sha512-4I5UpZ/x2WO9OQyETXKjaYhXiZKUTYcLPewruRMODWu6lgTM9hHci0SqMQB+TWe3f80K8VT8J8x3+uJjvllGlg==",
       "dev": true,
       "optional": true
     },
     "@nx/nx-darwin-x64": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-19.3.0.tgz",
-      "integrity": "sha512-GH2L6ftnzdIs7JEdv7ZPCdbpAdB5sW6NijK07riYZSONzq5fEruD1yDWDkyZbYBb8RTxsparUWJnq8q1qxEPHQ==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-18.3.5.tgz",
+      "integrity": "sha512-Drn6jOG237AD/s6OWPt06bsMj0coGKA5Ce1y5gfLhptOGk4S4UPE/Ay5YCjq+/yhTo1gDHzCHxH0uW2X9MN9Fg==",
       "dev": true,
       "optional": true
     },
     "@nx/nx-freebsd-x64": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-19.3.0.tgz",
-      "integrity": "sha512-1ow7Xku1yyjHviCKsWiuHCAnTd3fD+5O5c+e4DXHVthT8wnadKSotvBIWf38DMbMthl7na82e72OzxcdSbrVqQ==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-18.3.5.tgz",
+      "integrity": "sha512-8tA8Yw0Iir4liFjffIFS5THTS3TtWY/No2tkVj91gwy/QQ/otvKbOyc5RCIPpbZU6GS3ZWfG92VyCSm06dtMFg==",
       "dev": true,
       "optional": true
     },
     "@nx/nx-linux-arm-gnueabihf": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-19.3.0.tgz",
-      "integrity": "sha512-mYQMIUvNr2gww8vbg766uk/C1RxoC1fwioeP87bmV5NRUKSzJ8WEJVxAsqc9RGhAOUaNXOgEuKYrMcVhKyIKJQ==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-18.3.5.tgz",
+      "integrity": "sha512-BrPGAHM9FCGkB9/hbvlJhe+qtjmvpjIjYixGIlUxL3gGc8E/ucTyCnz5pRFFPFQlBM7Z/9XmbHvGPoUi/LYn5A==",
       "dev": true,
       "optional": true
     },
     "@nx/nx-linux-arm64-gnu": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-19.3.0.tgz",
-      "integrity": "sha512-rHL3eQ0RHkeAXnhHHu/NIyouN/ykiXvgyNU3TuCd50+2MZcAbjB+Xq3mwL0MwiP+BQuptiE+snTuxFUJp4ZH6A==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-18.3.5.tgz",
+      "integrity": "sha512-/Xd0Q3LBgJeigJqXC/Jck/9l5b+fK+FCM0nRFMXgPXrhZPhoxWouFkoYl2F1Ofr+AQf4jup4DkVTB5r98uxSCA==",
       "dev": true,
       "optional": true
     },
     "@nx/nx-linux-arm64-musl": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-19.3.0.tgz",
-      "integrity": "sha512-im0+OgOD6ShpTkI9ZRz7BjzxhQ/Lk3xjYmmCu+PFGmaybEnkNNDFwsgS0iEVKMdWZ/EQoQvJrqOYsX125iIBuQ==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-18.3.5.tgz",
+      "integrity": "sha512-r18qd7pUrl1haAZ/e9Q+xaFTsLJnxGARQcf/Y76q+K2psKmiUXoRlqd3HAOw43KTllaUJ5HkzLq2pIwg3p+xBw==",
       "dev": true,
       "optional": true
     },
     "@nx/nx-linux-x64-gnu": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.3.0.tgz",
-      "integrity": "sha512-k8q/d6WBSXOeUpBq6Mw69yMKL4n9LaX3o4LBNwBkVCEZ8p6s0njwKefLtjwnKlai0g/k5f0NcilU2zTwP/Ex8g==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-18.3.5.tgz",
+      "integrity": "sha512-vYrikG6ff4I9cvr3Ysk3y3gjQ9cDcvr3iAr+4qqcQ4qVE+OLL2++JDS6xfPvG/TbS3GTQpyy2STRBwiHgxTeJw==",
       "dev": true,
       "optional": true
     },
     "@nx/nx-linux-x64-musl": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-19.3.0.tgz",
-      "integrity": "sha512-sahEV99glBlpGKG1TIQ5PkJ0QvpHp69wWsBFK2DKtCETxOtsWqwvIjemxTCXRirTqeHiP7BiR6VWsf2YqqqBdw==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-18.3.5.tgz",
+      "integrity": "sha512-6np86lcYy3+x6kkW/HrBHIdNWbUu/MIsvMuNH5UXgyFs60l5Z7Cocay2f7WOaAbTLVAr0W7p4RxRPamHLRwWFA==",
       "dev": true,
       "optional": true
     },
     "@nx/nx-win32-arm64-msvc": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-19.3.0.tgz",
-      "integrity": "sha512-w03gFwLijStmhUji70QJHYo/U16ovybNczxGO7+5TT330X8/y+ihw9FCGHiIcujAjTAE88h0DKGn05WlNqRmfg==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-18.3.5.tgz",
+      "integrity": "sha512-H3p2ZVhHV1WQWTICrQUTplOkNId0y3c23X3A2fXXFDbWSBs0UgW7m55LhMcA9p0XZ7wDHgh+yFtVgu55TXLjug==",
       "dev": true,
       "optional": true
     },
     "@nx/nx-win32-x64-msvc": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.3.0.tgz",
-      "integrity": "sha512-M7e2zXGfTjH8NLiwqKLdWC9VlfMSQDYlI4/SM4OSpPqhUTfPlRPa+wNKNTG7perKfDXxE9ei8yjocujknXJk/A==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-18.3.5.tgz",
+      "integrity": "sha512-xFwKVTIXSgjdfxkpriqHv5NpmmFILTrWLEkUGSoimuRaAm1u15YWx/VmaUQ+UWuJnmgqvB/so4SMHSfNkq3ijA==",
       "dev": true,
       "optional": true
     },
@@ -38982,9 +38979,9 @@
       }
     },
     "@zkochan/js-yaml": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.7.tgz",
-      "integrity": "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
+      "integrity": "sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
@@ -45037,42 +45034,6 @@
       "version": "1.3.2",
       "dev": true
     },
-    "front-matter": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz",
-      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
-      "dev": true,
-      "requires": {
-        "js-yaml": "^3.13.1"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-          "dev": true
-        }
-      }
-    },
     "fs-constants": {
       "version": "1.0.0",
       "dev": true
@@ -46939,14 +46900,14 @@
       }
     },
     "lerna": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-8.1.3.tgz",
-      "integrity": "sha512-Dg/r1dGnRCXKsOUC3lol7o6ggYTA6WWiPQzZJNKqyygn4fzYGuA3Dro2d5677pajaqFnFA72mdCjzSyF16Vi2Q==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-8.1.2.tgz",
+      "integrity": "sha512-RCyBAn3XsqqvHbz3TxLfD7ylqzCi1A2UJnFEZmhURgx589vM3qYWQa/uOMeEEf565q6cAdtmulITciX1wgkAtw==",
       "dev": true,
       "requires": {
-        "@lerna/create": "8.1.3",
+        "@lerna/create": "8.1.2",
         "@npmcli/run-script": "7.0.2",
-        "@nx/devkit": ">=17.1.2 < 20",
+        "@nx/devkit": ">=17.1.2 < 19",
         "@octokit/plugin-enterprise-rest": "6.0.1",
         "@octokit/rest": "19.0.11",
         "byte-size": "8.1.1",
@@ -46989,7 +46950,7 @@
         "npm-packlist": "5.1.1",
         "npm-registry-fetch": "^14.0.5",
         "npmlog": "^6.0.2",
-        "nx": ">=17.1.2 < 20",
+        "nx": ">=17.1.2 < 19",
         "p-map": "4.0.0",
         "p-map-series": "2.1.0",
         "p-pipe": "3.1.0",
@@ -47007,7 +46968,7 @@
         "slash": "3.0.0",
         "ssri": "^9.0.1",
         "strong-log-transformer": "2.1.0",
-        "tar": "6.2.1",
+        "tar": "6.1.11",
         "temp-dir": "1.0.0",
         "typescript": ">=3 < 6",
         "upath": "2.0.1",
@@ -47187,6 +47148,12 @@
             "brace-expansion": "^1.1.7"
           }
         },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
         "node-fetch": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -47251,6 +47218,20 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "tar": {
+          "version": "6.1.11",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+          "dev": true,
+          "requires": {
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
           }
         },
         "uuid": {
@@ -49542,25 +49523,25 @@
       "dev": true
     },
     "nx": {
-      "version": "19.3.0",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-19.3.0.tgz",
-      "integrity": "sha512-WILWiROUkZWwuPJ12tP24Z0NULPEhxFN9i55/fECuVXYaFtkg6FvEne9C4d4bRqhZPcbrz6WhHnzE3NhdjH7XQ==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-18.3.5.tgz",
+      "integrity": "sha512-wWcvwoTgiT5okdrG0RIWm1tepC17bDmSpw+MrOxnjfBjARQNTURkiq4U6cxjCVsCxNHxCrlAaBSQLZeBgJZTzQ==",
       "dev": true,
       "requires": {
-        "@nrwl/tao": "19.3.0",
-        "@nx/nx-darwin-arm64": "19.3.0",
-        "@nx/nx-darwin-x64": "19.3.0",
-        "@nx/nx-freebsd-x64": "19.3.0",
-        "@nx/nx-linux-arm-gnueabihf": "19.3.0",
-        "@nx/nx-linux-arm64-gnu": "19.3.0",
-        "@nx/nx-linux-arm64-musl": "19.3.0",
-        "@nx/nx-linux-x64-gnu": "19.3.0",
-        "@nx/nx-linux-x64-musl": "19.3.0",
-        "@nx/nx-win32-arm64-msvc": "19.3.0",
-        "@nx/nx-win32-x64-msvc": "19.3.0",
+        "@nrwl/tao": "18.3.5",
+        "@nx/nx-darwin-arm64": "18.3.5",
+        "@nx/nx-darwin-x64": "18.3.5",
+        "@nx/nx-freebsd-x64": "18.3.5",
+        "@nx/nx-linux-arm-gnueabihf": "18.3.5",
+        "@nx/nx-linux-arm64-gnu": "18.3.5",
+        "@nx/nx-linux-arm64-musl": "18.3.5",
+        "@nx/nx-linux-x64-gnu": "18.3.5",
+        "@nx/nx-linux-x64-musl": "18.3.5",
+        "@nx/nx-win32-arm64-msvc": "18.3.5",
+        "@nx/nx-win32-x64-msvc": "18.3.5",
         "@yarnpkg/lockfile": "^1.1.0",
         "@yarnpkg/parsers": "3.0.0-rc.46",
-        "@zkochan/js-yaml": "0.0.7",
+        "@zkochan/js-yaml": "0.0.6",
         "axios": "^1.6.0",
         "chalk": "^4.1.0",
         "cli-cursor": "3.1.0",
@@ -49571,10 +49552,10 @@
         "enquirer": "~2.3.6",
         "figures": "3.2.0",
         "flat": "^5.0.2",
-        "front-matter": "^4.0.2",
         "fs-extra": "^11.1.0",
         "ignore": "^5.0.4",
         "jest-diff": "^29.4.1",
+        "js-yaml": "4.1.0",
         "jsonc-parser": "3.2.0",
         "lines-and-columns": "~2.0.3",
         "minimatch": "9.0.3",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-camunda-licensed": "^0.4.6",
     "eslint-plugin-import": "^2.29.1",
     "execa": "^1.0.0",
-    "lerna": "^8.0.0",
+    "lerna": "8.1.2",
     "license-webpack-plugin": "^4.0.2",
     "mocha": "^10.3.0",
     "mri": "^1.1.4",


### PR DESCRIPTION

### Proposed Changes
the latest lerna release breaks the package-lock during release. To ensure a smooth release, we should use the latest working version.

cf. https://github.com/lerna/lerna/issues/4026


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
