### PR TITLE
chore(CI): automatically create and assign Milestones

### DIFF
--- a/.github/workflows/ASSIGN_MILESTONE.yml
+++ b/.github/workflows/ASSIGN_MILESTONE.yml
@@ -1,0 +1,55 @@
+name: Assign Milestones
+
+on:
+  issues:
+    types: ['closed']
+  pull_request:
+    types: ['closed']
+
+jobs:
+  assignMilestone:
+    runs-on: ubuntu-latest
+    name: Assign Milestone
+    steps:
+      - name: Get current Milestone
+        id: getMilestone
+        env: 
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Fetch the list of milestones for the repository
+          # Filter for milestones that start with 'M' and are open
+          MILESTONE=$(gh api -H "Accept: application/vnd.github.v3+json" \
+            /repos/${{ github.repository }}/milestones \
+            --jq '.[] | select(.title | startswith("M")) | .number'
+          )
+          
+          echo "MILESTONE_NUMBER=$MILESTONE" >> $GITHUB_OUTPUT
+      - name: Assign Issue
+        if: |
+          github.event.issue &&
+          github.event.issue.state_reason != 'not_planned' &&
+          github.event.issue.milestone == null
+        env:
+          MILESTONE_NUMBER: ${{steps.getMilestone.outputs.MILESTONE_NUMBER}}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method PATCH \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/issues/${{github.event.issue.number}} \
+            -F "milestone=$MILESTONE_NUMBER"
+
+      - name: Assign PR
+        if: |
+          github.event.pull_request &&
+          github.event.pull_request.merged_at &&
+          github.event.pull_request.milestone == null
+        env:
+          MILESTONE_NUMBER: ${{steps.getMilestone.outputs.MILESTONE_NUMBER}}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method PATCH \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/issues/${{github.event.pull_request.number}} \
+            -F "milestone=$MILESTONE_NUMBER"

--- a/.github/workflows/RELEASE_ISSUE.yml
+++ b/.github/workflows/RELEASE_ISSUE.yml
@@ -19,6 +19,50 @@ jobs:
         template-path: 'docs/.project/RELEASE_TEMPLATE.md'
         package-path: 'app/package.json'
 
+  createMilestone:
+    needs: createReleaseIssue
+    if: github.event.issue.milestone
+    runs-on: ubuntu-latest
+    name: Create new Milestones
+    steps:
+      - name: Close old Milestone
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method PATCH \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/milestones/${{ github.event.issue.milestone.number }} \
+            -f "state=closed"
+      - name: Create and Assign new Milestone
+        env: 
+          GH_TOKEN: ${{ github.token }}
+          TITLE: ${{github.event.issue.milestone.title}}
+        run: |
+          # Generate new Milestone Title (M<number+1>)
+          MILESTONE_NUMBER=${TITLE:1}
+          INCREMENTED_NUMBER=$((MILESTONE_NUMBER + 1))
+          MILESTONE_NAME=M$INCREMENTED_NUMBER
+
+          # Create new Milestone
+          echo "Creating Milestone" $MILESTONE_NAME
+          NEW_MILESTONE_NUMBER=$(gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/milestones \
+            -f "title=$MILESTONE_NAME" -f "state=open" \
+            --jq '.number'
+          )
+          echo "Created Milestone" $NEW_MILESTONE_NUMBER
+
+          # Assign new Milestone to new issue
+          echo "Assigning Milestone to release issue"
+          gh api \
+            --method PATCH \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/issues/${{ fromJson(needs.createReleaseIssue.outputs.issue).number }} \
+            -F "milestone=$MILESTONE_NUMBER"
+ 
   updateSlackRole:
     runs-on: ubuntu-latest
     if: |

--- a/docs/.project/RELEASE_TEMPLATE.md
+++ b/docs/.project/RELEASE_TEMPLATE.md
@@ -68,4 +68,3 @@ _To be done once release is publicly announced on release day._
 * [ ] publish release via update server (push to `live`)
 * [ ] announce the release via the Camunda internal [#c8-release-announcements](https://camunda.slack.com/archives/C03NFMH4KC6) channel
 * [ ] communicate closed support related issues to [#ask-support](https://camunda.slack.com/archives/CHAC0L80M)
-* [ ] close [current milestone](https://github.com/camunda/camunda-modeler/milestones)


### PR DESCRIPTION
### Proposed Changes

This PR introduces 2 new actions. I tested these in a private repo to verify they work

**ASSIGN_MILESTONE.yml**
- Runs for every closed Issue/PR
- Gets the Milestone starting with "M"
- Assigns the PR/issue to the Milestone, if it does not have one assigned manually

**RELEASE_ISSUE.yml > createMilestone**
- Closes Milestone attached to Release issue
- Creates a new milestone with increased version number (Schema M<number>)
- Assigns new milestone to created release issue

closes https://github.com/camunda/camunda-modeler/issues/4311

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
