### PR TITLE
feat: support converging inclusive gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+### General
+
+* `DEPS`: update to `@camunda/linting@3.22.0`
+
+### BPMN
+
+* `FEAT`: support converging inclusive gateway ([#3613](https://github.com/camunda/camunda-modeler/issues/3613))
+
 ## 5.25.0
 
 ### General
@@ -30,9 +38,9 @@ ___Note:__ Yet to be released changes appear here._
 ### BPMN
 
 * `FIX`: do not render properties panel entry with outdated component ([#4382](https://github.com/camunda/camunda-modeler/issues/4382), [bpmn-io/properties-panel#369](https://github.com/bpmn-io/properties-panel/pull/369))
-* `FIX`: do not show boundary event menu for compensation activities ([#4348](https://github.com/camunda/camunda-modeler/issues/4348)) 
+* `FIX`: do not show boundary event menu for compensation activities ([#4348](https://github.com/camunda/camunda-modeler/issues/4348))
 * `FIX`: allow deployment after initial save was cancelled ([#3450](https://github.com/camunda/camunda-modeler/issues/3450))
-* `FIX`: do not suggest root elements in search ([bpmn-js#2143](https://github.com/bpmn-io/bpmn-js/issues/2143)) 
+* `FIX`: do not suggest root elements in search ([bpmn-js#2143](https://github.com/bpmn-io/bpmn-js/issues/2143))
 * `CHORE`: make problem panel entries keyboard-focusable ([#4368](https://github.com/camunda/camunda-modeler/issues/4368))
 * `CHORE`: align template documentation link style ([#4245](https://github.com/camunda/camunda-modeler/issues/4245))
 

--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
     "@camunda/form-linting": "^0.16.0",
     "@camunda/form-playground": "^0.15.0",
     "@camunda/improved-canvas": "^1.7.1",
-    "@camunda/linting": "^3.21.1",
+    "@camunda/linting": "^3.22.0",
     "@codemirror/commands": "^6.1.3",
     "@codemirror/lang-json": "^6.0.1",
     "@codemirror/lang-xml": "^6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
         "@camunda/form-linting": "^0.16.0",
         "@camunda/form-playground": "^0.15.0",
         "@camunda/improved-canvas": "^1.7.1",
-        "@camunda/linting": "^3.21.1",
+        "@camunda/linting": "^3.22.0",
         "@codemirror/commands": "^6.1.3",
         "@codemirror/lang-json": "^6.0.1",
         "@codemirror/lang-xml": "^6.1.0",
@@ -3065,14 +3065,15 @@
       "integrity": "sha512-to+unsToePnm7cUeR9TrMzFlETHd/UXmU+ELTRfWZj5XGT41KF6X3L233o3E/GdEs3sk2Tbw/lOLD1avmWkg8A=="
     },
     "node_modules/@camunda/linting": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-3.21.1.tgz",
-      "integrity": "sha512-rHPrIn0eq28LwI+y1YFWzQp/f5Oi+ckCJBl6vNmE3XbWSIf9NjCmrD33DEAOqf0hWxj0GVR9UgrRtjc7Vv5OhQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-3.22.0.tgz",
+      "integrity": "sha512-zArOeYPigaxOTqymiAEfT/7HaiEzZaUxs4kq58dbVdoVEzQNDX5xL/6b6LGZqu5DoZI9xv8DybAkGiOez4rMYg==",
+      "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "bpmn-moddle": "^9.0.1",
-        "bpmnlint": "^10.2.3",
-        "bpmnlint-plugin-camunda-compat": "^2.20.2",
+        "bpmnlint": "^10.3.0",
+        "bpmnlint-plugin-camunda-compat": "^2.21.0",
         "bpmnlint-utils": "^1.0.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -10056,17 +10057,18 @@
       }
     },
     "node_modules/bpmnlint": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-10.2.3.tgz",
-      "integrity": "sha512-91OZMdgpTcjJcZK/sPWI7JN1StP91B9eQMICTZqTBubOsW4aczQENLajvnhDmbyvWzH8KLsJLTWD/kg2zjipPw==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-10.3.0.tgz",
+      "integrity": "sha512-7z1j7erchQ+vPccUWUsSgQM/8XlMt3q7eKyRa67SeaQFwdswXi3cv1pqyKJhnKBxCbeTcU07q9fH4640CdRu+g==",
+      "license": "MIT",
       "dependencies": {
         "@bpmn-io/moddle-utils": "^0.2.1",
         "ansi-colors": "^4.1.3",
-        "bpmn-moddle": "^8.0.1",
+        "bpmn-moddle": "^8.1.0",
         "bpmnlint-utils": "^1.1.1",
         "cli-table": "^0.3.11",
         "color-support": "^1.1.3",
-        "min-dash": "^4.1.1",
+        "min-dash": "^4.2.1",
         "mri": "^1.2.0",
         "pluralize": "^7.0.0",
         "tiny-glob": "^0.2.9"
@@ -10087,9 +10089,10 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.20.2.tgz",
-      "integrity": "sha512-gOhzb023TYMoYK9XbqTDhf1+VpfSq+pOXWdbUdDrT8fiDBlz+wPN96iX+yaG4/zNsMoRMSOVPlwgPKSNMLvVSw==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.21.0.tgz",
+      "integrity": "sha512-fCmV9bQUCJkxJfRTDnUxBLs/sCV8rsjaP2/8SwTG+74FafDCVJnxLYtWgipGwZ9z81bn2u/DLNAHThJAD1mDww==",
+      "license": "MIT",
       "dependencies": {
         "@bpmn-io/feel-lint": "^1.2.0",
         "@bpmn-io/moddle-utils": "^0.2.1",
@@ -10104,7 +10107,8 @@
     "node_modules/bpmnlint-plugin-camunda-compat/node_modules/min-dash": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.2.1.tgz",
-      "integrity": "sha512-to+unsToePnm7cUeR9TrMzFlETHd/UXmU+ELTRfWZj5XGT41KF6X3L233o3E/GdEs3sk2Tbw/lOLD1avmWkg8A=="
+      "integrity": "sha512-to+unsToePnm7cUeR9TrMzFlETHd/UXmU+ELTRfWZj5XGT41KF6X3L233o3E/GdEs3sk2Tbw/lOLD1avmWkg8A==",
+      "license": "MIT"
     },
     "node_modules/bpmnlint-utils": {
       "version": "1.1.1",
@@ -34992,14 +34996,14 @@
       }
     },
     "@camunda/linting": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-3.21.1.tgz",
-      "integrity": "sha512-rHPrIn0eq28LwI+y1YFWzQp/f5Oi+ckCJBl6vNmE3XbWSIf9NjCmrD33DEAOqf0hWxj0GVR9UgrRtjc7Vv5OhQ==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-3.22.0.tgz",
+      "integrity": "sha512-zArOeYPigaxOTqymiAEfT/7HaiEzZaUxs4kq58dbVdoVEzQNDX5xL/6b6LGZqu5DoZI9xv8DybAkGiOez4rMYg==",
       "requires": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "bpmn-moddle": "^9.0.1",
-        "bpmnlint": "^10.2.3",
-        "bpmnlint-plugin-camunda-compat": "^2.20.2",
+        "bpmnlint": "^10.3.0",
+        "bpmnlint-plugin-camunda-compat": "^2.21.0",
         "bpmnlint-utils": "^1.0.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -40165,17 +40169,17 @@
       }
     },
     "bpmnlint": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-10.2.3.tgz",
-      "integrity": "sha512-91OZMdgpTcjJcZK/sPWI7JN1StP91B9eQMICTZqTBubOsW4aczQENLajvnhDmbyvWzH8KLsJLTWD/kg2zjipPw==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-10.3.0.tgz",
+      "integrity": "sha512-7z1j7erchQ+vPccUWUsSgQM/8XlMt3q7eKyRa67SeaQFwdswXi3cv1pqyKJhnKBxCbeTcU07q9fH4640CdRu+g==",
       "requires": {
         "@bpmn-io/moddle-utils": "^0.2.1",
         "ansi-colors": "^4.1.3",
-        "bpmn-moddle": "^8.0.1",
+        "bpmn-moddle": "^8.1.0",
         "bpmnlint-utils": "^1.1.1",
         "cli-table": "^0.3.11",
         "color-support": "^1.1.3",
-        "min-dash": "^4.1.1",
+        "min-dash": "^4.2.1",
         "mri": "^1.2.0",
         "pluralize": "^7.0.0",
         "tiny-glob": "^0.2.9"
@@ -40225,9 +40229,9 @@
       "requires": {}
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.20.2.tgz",
-      "integrity": "sha512-gOhzb023TYMoYK9XbqTDhf1+VpfSq+pOXWdbUdDrT8fiDBlz+wPN96iX+yaG4/zNsMoRMSOVPlwgPKSNMLvVSw==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.21.0.tgz",
+      "integrity": "sha512-fCmV9bQUCJkxJfRTDnUxBLs/sCV8rsjaP2/8SwTG+74FafDCVJnxLYtWgipGwZ9z81bn2u/DLNAHThJAD1mDww==",
       "requires": {
         "@bpmn-io/feel-lint": "^1.2.0",
         "@bpmn-io/moddle-utils": "^0.2.1",
@@ -40768,7 +40772,7 @@
         "@camunda/form-linting": "^0.16.0",
         "@camunda/form-playground": "^0.15.0",
         "@camunda/improved-canvas": "^1.7.1",
-        "@camunda/linting": "^3.21.1",
+        "@camunda/linting": "^3.22.0",
         "@codemirror/commands": "^6.1.3",
         "@codemirror/lang-json": "^6.0.1",
         "@codemirror/lang-xml": "^6.1.0",


### PR DESCRIPTION
### Proposed Changes

This removes linting error for converging inclusive gateway when execution platform is set to Camunda 8.6

Closes #3613

deps: update to `@camunda/linting@3.22.0`

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
