### PR TITLE
feat(engineProfile): open all diagrams

### DIFF
--- a/client/src/app/tabs/EngineProfile.js
+++ b/client/src/app/tabs/EngineProfile.js
@@ -157,7 +157,7 @@ function EditableVersionSection(props) {
   const currentMinorVersion = toSemverMinor(engineProfile.executionPlatformVersion);
   const minorVersions = engineProfileVersions.map(toSemverMinor);
 
-  const isKnowVersion = isKnownVersion(engineProfileVersions, engineProfile.executionPlatformVersion);
+  const versionRecognized = isKnownVersion(engineProfileVersions, engineProfile.executionPlatformVersion);
 
   return (
     <Section>
@@ -176,7 +176,7 @@ function EditableVersionSection(props) {
               id={ name }
               name={ name }>
               {
-                isKnowVersion
+                versionRecognized
                   ? null
                   : <option value={ currentMinorVersion || '' }>{ currentMinorVersion ? `${currentMinorVersion} (unsupported)` : '<unset>' }</option>
               }
@@ -192,7 +192,7 @@ function EditableVersionSection(props) {
             </select>
           </div>
 
-          {(isKnowVersion || !currentMinorVersion) ?
+          {(versionRecognized || !currentMinorVersion) ?
             <PlatformHint className="form-group form-description" executionPlatform={ executionPlatform } displayLabel={ engineLabel } /> :
             <UnknownVerisonHint className="form-group form-description" executionPlatform={ executionPlatform } executionPlatformVersion={ engineProfile.executionPlatformVersion } displayLabel={ engineLabel } />
           }

--- a/client/src/app/tabs/EngineProfileHelper.js
+++ b/client/src/app/tabs/EngineProfileHelper.js
@@ -25,7 +25,7 @@ export default class EngineProfileHelper {
     const engineProfile = this._get();
 
     if (!isKnownEngineProfile(engineProfile)) {
-      throw new Error(getUnknownEngineProfileErrorMessage(engineProfile));
+      return fixExecutionPlatform(engineProfile);
     }
 
     return engineProfile;
@@ -54,11 +54,17 @@ export default class EngineProfileHelper {
   }
 }
 
-function getUnknownEngineProfileErrorMessage(engineProfile = {}) {
+function fixExecutionPlatform(engineProfile = {}) {
   const {
-    executionPlatform = '<no-execution-platform>',
-    executionPlatformVersion = '<no-execution-platform-version>'
+    executionPlatform = 'Camunda Cloud'
   } = engineProfile;
 
-  return `An unknown execution platform (${ executionPlatform } ${ executionPlatformVersion }) was detected.`;
+  if ([ 'Camunda Platform', 'Camunda Cloud' ].includes(executionPlatform)) {
+    return engineProfile;
+  }
+
+  return {
+    ...engineProfile,
+    executionPlatform: 'Camunda Cloud'
+  };
 }

--- a/client/src/app/tabs/__tests__/EngineProfileSpec.js
+++ b/client/src/app/tabs/__tests__/EngineProfileSpec.js
@@ -19,7 +19,7 @@ import {
   Slot
 } from '../../slot-fill';
 
-import { EngineProfile, getAnnotatedVersion, getStatusBarLabel } from '../EngineProfile';
+import { EngineProfile, getAnnotatedVersion, getStatusBarLabel, toSemverMinor } from '../EngineProfile';
 
 import { ENGINES, ENGINE_PROFILES } from '../../../util/Engines';
 
@@ -125,7 +125,7 @@ describe('<EngineProfile>', function() {
         // then
         expect(wrapper.find('EngineProfileOverlay').exists()).to.be.true;
 
-        expectVersion(wrapper, executionPlatformVersion);
+        expectVersion(wrapper, toSemverMinor(executionPlatformVersion));
       });
 
     });
@@ -199,13 +199,13 @@ describe('<EngineProfile>', function() {
 
       // given
       const inputs =
-      [ [ ENGINES.PLATFORM, '7.0', 'Camunda 7.0' ],
-        [ ENGINES.PLATFORM, '7.14', 'Camunda 7.14' ],
-        [ ENGINES.PLATFORM, '7.500', 'Camunda 7.500 (alpha)' ],
+      [ [ ENGINES.PLATFORM, '7.0', 'Camunda 7.0 (unsupported)' ],
+        [ ENGINES.PLATFORM, '7.15', 'Camunda 7.15' ],
+        [ ENGINES.PLATFORM, '7.500', 'Camunda 7.500 (unsupported)' ],
         [ ENGINES.PLATFORM, '', 'Camunda 7' ],
         [ ENGINES.CLOUD, '1.3', 'Camunda 8 (Zeebe 1.3)' ],
         [ ENGINES.CLOUD, '8.1', 'Camunda 8.1' ],
-        [ ENGINES.CLOUD, '8.100', 'Camunda 8.100 (alpha)' ],
+        [ ENGINES.CLOUD, '8.100', 'Camunda 8.100 (unsupported)' ],
         [ ENGINES.CLOUD, '', 'Camunda 8' ] ];
 
       // then
@@ -422,7 +422,11 @@ function renderEngineProfile(options = {}) {
 
 function eachProfile(fn) {
   ENGINE_PROFILES.forEach(({ executionPlatform, executionPlatformVersions }) => {
-    [ undefined, ...executionPlatformVersions ].forEach((executionPlatformVersion) => {
+    [
+      undefined,
+      ...executionPlatformVersions,
+      ...executionPlatformVersions.map(incrementPatchVersion)
+    ].forEach((executionPlatformVersion) => {
       fn(executionPlatform, executionPlatformVersion);
     });
   });
@@ -459,4 +463,10 @@ function expectVersion(wrapper, version) {
   const select = wrapper.find('select');
 
   expect(select.prop('value')).to.equal(version || '');
+}
+
+function incrementPatchVersion(version) {
+  const [ major, minor, patch ] = version.split('.').map(Number);
+
+  return `${major}.${minor}.${patch + 1}`;
 }

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -2074,7 +2074,7 @@ describe('<BpmnEditor>', function() {
     }));
 
 
-    it('should not open form if unknown execution profile', async function() {
+    it('should open as Camunda Cloud if unknown execution profile', async function() {
 
       // given
       const onImportSpy = spy();
@@ -2086,9 +2086,10 @@ describe('<BpmnEditor>', function() {
 
       // then
       expect(onImportSpy).to.have.been.calledOnce;
-      expect(onImportSpy).to.have.been.calledWith(sinon.match({ message: 'An unknown execution platform (Camunda Unknown 7.15.0) was detected.' }), []);
-
-      expect(instance.getCached().engineProfile).to.be.null;
+      expect(instance.getCached().engineProfile).to.be.eql({
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '7.15.0',
+      });
     });
 
   });

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -1995,7 +1995,7 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
     }));
 
 
-    it('should not open form if unknown execution profile', async function() {
+    it('should open unknown execution profile form as Camunda Cloud', async function() {
 
       // given
       const onImportSpy = spy();
@@ -2007,9 +2007,10 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
 
       // then
       expect(onImportSpy).to.have.been.calledOnce;
-      expect(onImportSpy).to.have.been.calledWith(sinon.match({ message: 'An unknown execution platform (Camunda Unknown 7.15.0) was detected.' }), []);
-
-      expect(instance.getCached().engineProfile).to.be.null;
+      expect(instance.getCached().engineProfile).to.eql({
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '7.15.0'
+      });
     });
 
   });

--- a/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
@@ -2187,7 +2187,7 @@ describe('<DmnEditor>', function() {
     }));
 
 
-    it('should reject unknown engine profile', async function() {
+    it('should open unknown engine profile as Camunda Cloud', async function() {
 
       // given
       const onImportSpy = spy();
@@ -2197,9 +2197,11 @@ describe('<DmnEditor>', function() {
 
       // then
       expect(onImportSpy).to.have.been.calledOnce;
-      expect(onImportSpy).to.have.been.calledWith(sinon.match({ message: 'An unknown execution platform (Camunda Unknown 7.15.0) was detected.' }), []);
 
-      expect(instance.getCached().engineProfile).to.be.null;
+      expect(instance.getCached().engineProfile).to.eql({
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '7.15.0'
+      });
     });
 
   });

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -2188,7 +2188,7 @@ describe('<DmnEditor>', function() {
     }));
 
 
-    it('should reject unknown engine profile', async function() {
+    it('should open unknown engine profile as Camunda Cloud', async function() {
 
       // given
       const onImportSpy = spy();
@@ -2198,9 +2198,11 @@ describe('<DmnEditor>', function() {
 
       // then
       expect(onImportSpy).to.have.been.calledOnce;
-      expect(onImportSpy).to.have.been.calledWith(sinon.match({ message: 'An unknown execution platform (Camunda Unknown 7.15.0) was detected.' }), []);
 
-      expect(instance.getCached().engineProfile).to.be.null;
+      expect(instance.getCached().engineProfile).to.eql({
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '7.15.0'
+      });
     });
 
   });

--- a/client/src/app/tabs/form/__tests__/FormEditorSpec.js
+++ b/client/src/app/tabs/form/__tests__/FormEditorSpec.js
@@ -698,7 +698,7 @@ describe('<FormEditor>', function() {
     });
 
 
-    it('should not open form if unknown execution profile', async function() {
+    it('should open unknown execution profile form as Camunda Cloud', async function() {
 
       // given
       const onImportSpy = spy();
@@ -710,9 +710,11 @@ describe('<FormEditor>', function() {
 
       // then
       expect(onImportSpy).to.have.been.calledOnce;
-      expect(onImportSpy).to.have.been.calledWith(sinon.match({ message: 'An unknown execution platform (Camunda Unknown 7.16.0) was detected.' }), []);
 
-      expect(instance.getCached().engineProfile).to.be.null;
+      expect(instance.getCached().engineProfile).to.eql({
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '7.16.0'
+      });
     });
 
   });


### PR DESCRIPTION
closes #2682

### Proposed Changes
Optimistically open all diagrams, even if the engine/version is not supported. 

- If the version is unsupported, show it as `unsupported` in the Version selection and add link to the modeler download page to update the modeler:
![image](https://github.com/camunda/camunda-modeler/assets/21984219/90921575-cca8-4e67-b109-97e686510909)
- If the execution platform is unknown, open it as C8 diagram
- (fix) If unknown patch version is set in the diagram, map to minor version

You can try it out by either editing the XML directly in the modeler or changing the file externally and then open it using the file dialog.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
