### PR TITLE
Migrate sentry to new org / import sentry secrets from vault

### DIFF
--- a/.github/workflows/NIGHTLY.yml
+++ b/.github/workflows/NIGHTLY.yml
@@ -32,6 +32,21 @@ jobs:
         cache: 'npm'
     - name: Install dependencies
       run: npm ci
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v3.0.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        exportEnv: false
+        secrets: |
+          secret/data/products/desktop-modeler/ci/sentry SENTRY_AUTH_TOKEN;
+          secret/data/products/desktop-modeler/ci/sentry SENTRY_DSN;
+          secret/data/products/desktop-modeler/ci/sentry SENTRY_ORG;
+          secret/data/products/desktop-modeler/ci/sentry SENTRY_PROJECT;
+          secret/data/common/jenkins/downloads-camunda-cloud_google_sa_key DOWNLOAD_CENTER_GCLOUD_KEY_BYTES | GCP_CREDENTIALS_NAME;
 
     - name: Build nightly (Linux)
       if: ${{ runner.os == 'Linux' }}
@@ -41,10 +56,10 @@ jobs:
         MIXPANEL_TOKEN: "${{ secrets.MIXPANEL_PROJECT_TOKEN }}"
         MIXPANEL_STAGE: "int"
         NIGHTLY: 1
-        SENTRY_AUTH_TOKEN: "${{ secrets.SENTRY_AUTH_TOKEN }}"
-        SENTRY_DSN: "${{ secrets.SENTRY_DSN }}"
-        SENTRY_ORG: "${{ secrets.SENTRY_ORG }}"
-        SENTRY_PROJECT: "${{ secrets.SENTRY_PROJECT }}"
+        SENTRY_AUTH_TOKEN: "${{ steps.secrets.outputs.SENTRY_AUTH_TOKEN }}"
+        SENTRY_DSN: "${{ steps.secrets.outputs.SENTRY_DSN }}"
+        SENTRY_ORG: "${{ steps.secrets.outputs.SENTRY_ORG }}"
+        SENTRY_PROJECT: "${{ steps.secrets.outputs.SENTRY_PROJECT }}"
         UPDATES_SERVER_PRODUCT_NAME: "${{ secrets.UPDATES_SERVER_PRODUCT_NAME }}"
       run: npm run build -- --linux
 
@@ -59,10 +74,10 @@ jobs:
         MIXPANEL_TOKEN: "${{ secrets.MIXPANEL_PROJECT_TOKEN }}"
         MIXPANEL_STAGE: "int"
         NIGHTLY: 1
-        SENTRY_AUTH_TOKEN: "${{ secrets.SENTRY_AUTH_TOKEN }}"
-        SENTRY_DSN: "${{ secrets.SENTRY_DSN }}"
-        SENTRY_ORG: "${{ secrets.SENTRY_ORG }}"
-        SENTRY_PROJECT: "${{ secrets.SENTRY_PROJECT }}"
+        SENTRY_AUTH_TOKEN: "${{ steps.secrets.outputs.SENTRY_AUTH_TOKEN }}"
+        SENTRY_DSN: "${{ steps.secrets.outputs.SENTRY_DSN }}"
+        SENTRY_ORG: "${{ steps.secrets.outputs.SENTRY_ORG }}"
+        SENTRY_PROJECT: "${{ steps.secrets.outputs.SENTRY_PROJECT }}"
         UPDATES_SERVER_PRODUCT_NAME: "${{ secrets.UPDATES_SERVER_PRODUCT_NAME }}"
       run: npm run build -- --mac
 
@@ -72,24 +87,13 @@ jobs:
         MIXPANEL_TOKEN: "${{ secrets.MIXPANEL_PROJECT_TOKEN }}"
         MIXPANEL_STAGE: "int"
         NIGHTLY: 1
-        SENTRY_AUTH_TOKEN: "${{ secrets.SENTRY_AUTH_TOKEN }}"
-        SENTRY_DSN: "${{ secrets.SENTRY_DSN }}"
-        SENTRY_ORG: "${{ secrets.SENTRY_ORG }}"
-        SENTRY_PROJECT: "${{ secrets.SENTRY_PROJECT }}"
+        SENTRY_AUTH_TOKEN: "${{ steps.secrets.outputs.SENTRY_AUTH_TOKEN }}"
+        SENTRY_DSN: "${{ steps.secrets.outputs.SENTRY_DSN }}"
+        SENTRY_ORG: "${{ steps.secrets.outputs.SENTRY_ORG }}"
+        SENTRY_PROJECT: "${{ steps.secrets.outputs.SENTRY_PROJECT }}"
         UPDATES_SERVER_PRODUCT_NAME: "${{ secrets.UPDATES_SERVER_PRODUCT_NAME }}"
       run: npm run build -- --win
 
-    - name: Import Secrets
-      id: secrets
-      uses: hashicorp/vault-action@v3.0.0
-      with:
-        url: ${{ secrets.VAULT_ADDR }}
-        method: approle
-        roleId: ${{ secrets.VAULT_ROLE_ID }}
-        secretId: ${{ secrets.VAULT_SECRET_ID }}
-        exportEnv: false
-        secrets: |
-          secret/data/common/jenkins/downloads-camunda-cloud_google_sa_key DOWNLOAD_CENTER_GCLOUD_KEY_BYTES | GCP_CREDENTIALS_NAME;
     - name: Upload artifact to Camunda Download Center
       uses: camunda/infra-global-github-actions/download-center-upload@40a4ed3a870fa58eb5e994737c79ef690e949ea7
       with:

--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -40,6 +40,20 @@ jobs:
         cache: 'npm'
     - name: Install dependencies
       run: npm ci
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v3.0.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        exportEnv: false
+        secrets: |
+          secret/data/products/desktop-modeler/ci/sentry SENTRY_AUTH_TOKEN;
+          secret/data/products/desktop-modeler/ci/sentry SENTRY_DSN;
+          secret/data/products/desktop-modeler/ci/sentry SENTRY_ORG;
+          secret/data/products/desktop-modeler/ci/sentry SENTRY_PROJECT;
 
     - name: Build release (Linux)
       if: ${{ runner.OS == 'Linux' }}
@@ -48,10 +62,10 @@ jobs:
         CSC_KEY_PASSWORD: "${{ secrets.CSC_KEY_PASSWORD }}"
         MIXPANEL_TOKEN: "${{ secrets.MIXPANEL_PROJECT_TOKEN }}"
         MIXPANEL_STAGE: "prod"
-        SENTRY_AUTH_TOKEN: "${{ secrets.SENTRY_AUTH_TOKEN }}"
-        SENTRY_DSN: "${{ secrets.SENTRY_DSN }}"
-        SENTRY_ORG: "${{ secrets.SENTRY_ORG }}"
-        SENTRY_PROJECT: "${{ secrets.SENTRY_PROJECT }}"
+        SENTRY_AUTH_TOKEN: "${{ steps.secrets.outputs.SENTRY_AUTH_TOKEN }}"
+        SENTRY_DSN: "${{ steps.secrets.outputs.SENTRY_DSN }}"
+        SENTRY_ORG: "${{ steps.secrets.outputs.SENTRY_ORG }}"
+        SENTRY_PROJECT: "${{ steps.secrets.outputs.SENTRY_PROJECT }}"
         UPDATES_SERVER_PRODUCT_NAME: "${{ secrets.UPDATES_SERVER_PRODUCT_NAME }}"
         GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         NODE_ENV: "production"
@@ -66,10 +80,10 @@ jobs:
         CSC_KEY_PASSWORD: "${{ secrets.CSC_KEY_PASSWORD }}"
         MIXPANEL_TOKEN: "${{ secrets.MIXPANEL_PROJECT_TOKEN }}"
         MIXPANEL_STAGE: "prod"
-        SENTRY_AUTH_TOKEN: "${{ secrets.SENTRY_AUTH_TOKEN }}"
-        SENTRY_DSN: "${{ secrets.SENTRY_DSN }}"
-        SENTRY_ORG: "${{ secrets.SENTRY_ORG }}"
-        SENTRY_PROJECT: "${{ secrets.SENTRY_PROJECT }}"
+        SENTRY_AUTH_TOKEN: "${{ steps.secrets.outputs.SENTRY_AUTH_TOKEN }}"
+        SENTRY_DSN: "${{ steps.secrets.outputs.SENTRY_DSN }}"
+        SENTRY_ORG: "${{ steps.secrets.outputs.SENTRY_ORG }}"
+        SENTRY_PROJECT: "${{ steps.secrets.outputs.SENTRY_PROJECT }}"
         UPDATES_SERVER_PRODUCT_NAME: "${{ secrets.UPDATES_SERVER_PRODUCT_NAME }}"
         GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         NODE_ENV: "production"
@@ -79,10 +93,10 @@ jobs:
       env:
         MIXPANEL_TOKEN: "${{ secrets.MIXPANEL_PROJECT_TOKEN }}"
         MIXPANEL_STAGE: "prod"
-        SENTRY_AUTH_TOKEN: "${{ secrets.SENTRY_AUTH_TOKEN }}"
-        SENTRY_DSN: "${{ secrets.SENTRY_DSN }}"
-        SENTRY_ORG: "${{ secrets.SENTRY_ORG }}"
-        SENTRY_PROJECT: "${{ secrets.SENTRY_PROJECT }}"
+        SENTRY_AUTH_TOKEN: "${{ steps.secrets.outputs.SENTRY_AUTH_TOKEN }}"
+        SENTRY_DSN: "${{ steps.secrets.outputs.SENTRY_DSN }}"
+        SENTRY_ORG: "${{ steps.secrets.outputs.SENTRY_ORG }}"
+        SENTRY_PROJECT: "${{ steps.secrets.outputs.SENTRY_PROJECT }}"
         UPDATES_SERVER_PRODUCT_NAME: "${{ secrets.UPDATES_SERVER_PRODUCT_NAME }}"
         GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         NODE_ENV: "production"


### PR DESCRIPTION
### Proposed Changes

This PR migrates nightly and release jobs to use Sentry secrets pulled from the vault. The secrets are also migrated to the new organisation.

Closes #4413

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
