### PR TITLE
ci: make curl fail on unsuccessful call to slack API

### DIFF
--- a/.github/workflows/RELEASE_ISSUE.yml
+++ b/.github/workflows/RELEASE_ISSUE.yml
@@ -76,4 +76,4 @@ jobs:
         # User ID is either the assignee from the newly created issue or the new assigned from the `assigned` trigger
         USER_ID: ${{ fromJSON(steps.secrets.outputs.TEAM_MEMBER_IDS)[ needs.createReleaseIssue.outputs.assignee || github.event.issue.assignee.login ] }}
       run: |
-        curl -X POST -H "application/x-www-form-urlencoded" -d "token=${BOT_TOKEN}&usergroup=${GROUP_ID}&users=${USER_ID}" https://slack.com/api/usergroups.users.update
+        curl --fail-with-body -X POST -H "application/x-www-form-urlencoded" -d "token=${BOT_TOKEN}&usergroup=${GROUP_ID}&users=${USER_ID}" https://slack.com/api/usergroups.users.update


### PR DESCRIPTION
Closes #4417

### Proposed Changes

This PR makes us use `curl --fail-with-body` so that when API call fails, the action fails too.

Cf. https://superuser.com/questions/590099/can-i-make-curl-fail-with-an-exitcode-different-than-0-if-the-http-status-code-i

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
