### PR TITLE
chore: remove old Zeebe versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ___Note:__ Yet to be released changes appear here._
 
 ### General
 
+* `CHORE`: remove outdated Camunda 8 platform versions ([#4396](https://github.com/camunda/camunda-modeler/issues/4396))
 * `DEPS`: update to `camunda-bpmn-js@4.12.1`
 * `DEPS`: update to `bpmn-js@17.9.1`
 * `DEPS`: update to `diagram-js@14.8.0`

--- a/client/src/util/Engines.js
+++ b/client/src/util/Engines.js
@@ -21,7 +21,7 @@ export const ENGINE_PROFILES = [
   },
   {
     executionPlatform: ENGINES.CLOUD,
-    executionPlatformVersions: [ '8.6.0', '8.5.0', '8.4.0', '8.3.0', '8.2.0', '8.1.0', '8.0.0', '1.3.0', '1.2.0', '1.1.0', '1.0.0' ],
+    executionPlatformVersions: [ '8.6.0', '8.5.0', '8.4.0', '8.3.0', '8.2.0', '8.1.0', '8.0.0' ],
     latestStable: '8.5.0'
   }
 ];


### PR DESCRIPTION
Closes #4396

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

Removes Camunda 8 versions < 8.0.

![image](https://github.com/user-attachments/assets/da16ea04-58d8-4e48-b377-965964af3ccd)


### Checklist

To ensure you provided everything we need to look at your PR:

* [X] **Brief textual description** of the changes present
* [X] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [X] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
