### PR TITLE
chore: rename flag to `disable-connector-templates`

### DIFF
--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -630,7 +630,7 @@ function bootstrap() {
   // (3) config
   const ignoredPaths = [];
 
-  if (!flags.get('enable-connector-templates', true)) {
+  if (flags.get('disable-connector-templates', false)) {
     ignoredPaths.push(getConnectorTemplatesPath(userPath));
   }
 
@@ -693,7 +693,7 @@ function bootstrap() {
   const zeebeAPI = new ZeebeAPI({ readFile }, ZeebeNode, flags);
 
   // (10) connector templates
-  if (flags.get('enable-connector-templates', true)) {
+  if (!flags.get('disable-connector-templates', false)) {
     registerConnectorTemplateUpdater(renderer, userPath);
   }
 


### PR DESCRIPTION
### Proposed Changes

Renames the flag from `enable-connector-templates` to `disable-*`, as you explicitly have to "opt out".

Related to https://github.com/camunda/camunda-modeler/issues/4455.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
