### PR TITLE
deps: upgrade to `electron@31.4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ ___Note:__ Yet to be released changes appear here._
 * `DEPS`: update to `zeebe-bpmn-moddle@1.5.1`
 * `DEPS`: update to `camunda-bpmn-js@4.18.0`
 * `DEPS`: update to `@camunda/linting@3.25.0`
+* `DEPS`: update to `electron@31.4.0`
 
 ### General
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "del": "^3.0.0",
         "del-cli": "^5.0.0",
         "diff2html": "^3.4.19",
-        "electron": "^32.0.0",
+        "electron": "^31.4.0",
         "electron-builder": "^24.9.1",
         "electron-extension-installer": "^1.2.0",
         "electron-publisher-s3": "^20.17.2",
@@ -14419,11 +14419,12 @@
       }
     },
     "node_modules/electron": {
-      "version": "32.0.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-32.0.1.tgz",
-      "integrity": "sha512-5Hd5Jaf9niYVR2hZxoRd3gOrcxPOxQV1XPV5WaoSfT9jLJHFadhlKtuSDIk3U6rQZke+aC7GqPPAv55nWFCMsA==",
+      "version": "31.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-31.4.0.tgz",
+      "integrity": "sha512-YTwKoAA+nrJMlI1TTHnIXLYWoQLKnhbkz0qxZcI7Hadcy0UaFMFs9xzwvH2MnrRpVJy7RKo49kVGuvSdRl8zMA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^20.9.0",
@@ -43322,9 +43323,9 @@
       }
     },
     "electron": {
-      "version": "32.0.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-32.0.1.tgz",
-      "integrity": "sha512-5Hd5Jaf9niYVR2hZxoRd3gOrcxPOxQV1XPV5WaoSfT9jLJHFadhlKtuSDIk3U6rQZke+aC7GqPPAv55nWFCMsA==",
+      "version": "31.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-31.4.0.tgz",
+      "integrity": "sha512-YTwKoAA+nrJMlI1TTHnIXLYWoQLKnhbkz0qxZcI7Hadcy0UaFMFs9xzwvH2MnrRpVJy7RKo49kVGuvSdRl8zMA==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "del": "^3.0.0",
     "del-cli": "^5.0.0",
     "diff2html": "^3.4.19",
-    "electron": "^32.0.0",
+    "electron": "^31.4.0",
     "electron-builder": "^24.9.1",
     "electron-extension-installer": "^1.2.0",
     "electron-publisher-s3": "^20.17.2",


### PR DESCRIPTION
Related to #4483
Related to https://github.com/camunda/camunda-modeler/issues/4467

### Proposed Changes

Since electron@32 introduces breaking changes which require to modify multiple parts of the app (cf. https://github.com/camunda/camunda-modeler/issues/4483#issuecomment-2311778398), for now we can keep electron@31. The version in this PR contains a fix for https://github.com/camunda/camunda-modeler/issues/4467

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
