### PR TITLE
Fix variable outline styles

### DIFF
--- a/client/src/app/panel/tabs/variable-outline/VariableOutlineTab.js
+++ b/client/src/app/panel/tabs/variable-outline/VariableOutlineTab.js
@@ -12,6 +12,7 @@ import React from 'react';
 
 import VariableOutline from '@bpmn-io/variable-outline';
 import '@bpmn-io/variable-outline/dist/style.css';
+import './VariableOutlineTab.less';
 
 import { Fill } from '../../../slot-fill';
 

--- a/client/src/app/panel/tabs/variable-outline/VariableOutlineTab.less
+++ b/client/src/app/panel/tabs/variable-outline/VariableOutlineTab.less
@@ -1,0 +1,74 @@
+.bio-vo-tab-content {
+  .bio-vo-label {
+    font-size: 14px !important;
+  }
+
+  .bio-vo-search .cds--search-input,
+  .bio-vo-search .cds--search-close {
+    block-size: 2rem !important;
+  }
+
+  .bio-vo-search .cds--search-close:before {
+    block-size: calc(100% - 2.5px) !important;
+    inset-block-start: 1.5px !important;
+  }
+
+  .bio-vo-empty-search {
+    h3 {
+      font-size: 14px !important;
+      font-weight: bold !important;
+      margin-bottom: 7px !important;
+    }
+
+    p {
+      font-size: 14px !important;
+    }
+  }
+
+  .bio-vo-search-container,
+  .bio-vo-search-container>*+* {
+    border-color: var(--color-grey-225-10-75) !important;
+  }
+
+  .bio-vo-tab-coloumn {
+    display: flex !important;
+
+    .bio-vo-element-list,
+    .bio-vo-variable-table {
+      flex-grow: 1;
+    }
+  }
+
+  .bio-vo-variable-table {
+    border-left: none !important;
+    border-right: none !important;
+  }
+
+  .bio-vo-tab-coloumn:has(.bio-vo-variable-table),
+  .bio-vo-tab-coloumn:has(.bio-vo-empty-search) {
+    border-left: 1px solid var(--color-grey-225-10-75) !important;
+  }
+
+  .bio-vo-empty-search {
+    align-self: center !important;
+    margin: auto !important;
+    padding: 0 !important;
+  }
+
+  th,
+  tr {
+    block-size: 2rem !important;
+
+    .cds--table-sort__flex {
+      min-block-size: 2rem !important;
+    }
+  }
+
+  tr:last-child td {
+    border-block-end: none !important;
+  }
+
+  .cds--popover {
+    z-index: 100000 !important;
+  }
+}


### PR DESCRIPTION
### Proposed Changes

Adjusts the IBM Carbon styles of the variable outline tab so that it looks more like it's part of the modeler. This is a proposal that needs discussion in terms of how and where to actually fix the IBM Carbon styles and whether the fixes should also work for the next IBM Carbon component we introduce.

#### Before

![image](https://github.com/user-attachments/assets/9ce47033-8b3d-44bf-aa2e-7b4e7929c024)

#### After

![image](https://github.com/user-attachments/assets/b7ad2d3a-60eb-4e2f-bbb3-f8d59175d20c)
