### PR TITLE
feat: mark Camunda 7.22 and Camunda 8.6 as latest

### DIFF
--- a/client/src/util/Engines.js
+++ b/client/src/util/Engines.js
@@ -17,12 +17,12 @@ export const ENGINE_PROFILES = [
   {
     executionPlatform: ENGINES.PLATFORM,
     executionPlatformVersions: [ '7.22.0', '7.21.0', '7.20.0', '7.19.0', '7.18.0', '7.17.0', '7.16.0', '7.15.0' ],
-    latestStable: '7.21.0'
+    latestStable: '7.22.0'
   },
   {
     executionPlatform: ENGINES.CLOUD,
     executionPlatformVersions: [ '8.6.0', '8.5.0', '8.4.0', '8.3.0', '8.2.0', '8.1.0', '8.0.0' ],
-    latestStable: '8.5.0'
+    latestStable: '8.6.0'
   }
 ];
 

--- a/client/src/util/__tests__/EnginesSpec.js
+++ b/client/src/util/__tests__/EnginesSpec.js
@@ -27,9 +27,9 @@ describe('util/Engines', function() {
       };
     }
 
-    it('Platform', verifyLatestStable(ENGINES.PLATFORM, '7.21.0'));
+    it('Platform', verifyLatestStable(ENGINES.PLATFORM, '7.22.0'));
 
-    it('Cloud', verifyLatestStable(ENGINES.CLOUD, '8.5.0'));
+    it('Cloud', verifyLatestStable(ENGINES.CLOUD, '8.6.0'));
 
   });
 


### PR DESCRIPTION
### Proposed Changes

Makes Camunda 7.22 and Camunda 8.6 the latest released versions.

![capture bxLoJD_optimized](https://github.com/user-attachments/assets/a7d36eb7-9851-4484-a759-47a7e257217a)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
