### PR TITLE
fix: handle linting reports without name and id

### DIFF
--- a/client/src/app/panel/tabs/linting/LintingTab.js
+++ b/client/src/app/panel/tabs/linting/LintingTab.js
@@ -92,8 +92,6 @@ function LintingTabItem(props) {
   const {
     category,
     documentation = {},
-    id,
-    name,
     message,
     rule
   } = report;
@@ -112,6 +110,7 @@ function LintingTabItem(props) {
   }
 
   const { url: documentationUrl = null } = documentation;
+  const reportName = getReportName(report);
 
   return <div
     onClick={ onClick }
@@ -124,7 +123,7 @@ function LintingTabItem(props) {
       { category === 'error' ? <ErrorIcon width="16" height="16" /> : null }
       { category === 'warn' ? <WarningIcon width="16" height="16" /> : null }
       { category === 'info' ? <InfoIcon width="16" height="16" /> : null }
-      <span className="linting-tab-item__label">{ name || id }</span>
+      <span className="linting-tab-item__label">{ reportName }</span>
     </button>
     <div className="linting-tab-item__content">
       { message }
@@ -147,14 +146,11 @@ function LintingTabItem(props) {
 function getReportName(report) {
   const {
     id,
-    name
+    name,
   } = report;
 
-  if (name) {
-    return name.toLowerCase();
-  }
-
-  return id.toLowerCase();
+  const reportName = name || id || '';
+  return reportName.toLowerCase();
 }
 
 /**

--- a/client/src/app/panel/tabs/linting/__tests__/LintingTabSpec.js
+++ b/client/src/app/panel/tabs/linting/__tests__/LintingTabSpec.js
@@ -168,6 +168,25 @@ describe('<LintingTab>', function() {
     expect(wrapper.find('.linting-tab-item__content').at(6).text()).to.equal('Rule <baz-rule> errored with the following message: Baz');
   });
 
+  it('should render when report is missing id and name', function() {
+
+    // when
+    const wrapper = renderLintingTab({
+      linting: [
+        {
+          category: 'error',
+          message: 'foo error',
+          rule: 'foo-rule'
+        }
+      ]
+    });
+
+    // then
+    expect(wrapper.find('.linting-tab-item')).to.have.length(1);
+    expect(wrapper.find('.linting-tab-item__label').at(0).text()).to.equal('');
+    expect(wrapper.find('.linting-tab-item__content').at(0).text()).to.equal('foo error');
+  });
+
 
   it('should show lint error on click', function() {
 


### PR DESCRIPTION
Closes #4473

Linting tab can now handle reports that are missing both name and id.

![image](https://github.com/user-attachments/assets/2d6b9bcf-3861-4925-a542-495e6afbf4a9)

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [X] __Brief textual description__ of the changes present
* [X] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
