### PR TITLE
ci: correctly handle multiple open milestones

### DIFF
--- a/.github/workflows/ASSIGN_MILESTONE.yml
+++ b/.github/workflows/ASSIGN_MILESTONE.yml
@@ -41,7 +41,7 @@ jobs:
           # Filter for milestones that start with 'M' and are open
           MILESTONE=$(gh api -H "Accept: application/vnd.github.v3+json" \
             /repos/${{ github.repository }}/milestones \
-            --jq '.[] | select(.title | startswith("M")) | .number'
+            --jq '[.[] | select(.title | startswith("M")) | .number' ][0]
           )
           
           echo "MILESTONE_NUMBER=$MILESTONE" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Proposed Changes

As observed in [this action run](https://github.com/camunda/camunda-modeler/actions/runs/10983777044/job/30493543868) our automatic assignment utility insufficiently handles multiple open [development milestones](https://github.com/camunda/camunda-modeler/milestones). These can be open in case we push things to a future milestone.

The following query properly returns only the first (supposed to be active) development milestone:

```
gh api -H "Accept: application/vnd.github.v3+json" \
    /repos/camunda/camunda-modeler/milestones \
    --jq '[.[] | select(.title | startswith("M")) | .number ][0]'
```

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [x] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
