### PR TITLE
chore: add v5.28.0 release info

### DIFF
--- a/client/src/plugins/version-info/ReleaseInfo.js
+++ b/client/src/plugins/version-info/ReleaseInfo.js
@@ -44,16 +44,8 @@ export function ReleaseInfo(props) {
     <div className={ css.ReleaseInfo }>
       <ul className="dashed">
         <li>
-          <h4>New variable overview</h4>
-          Get an overview of the variables used in your process through the new <i>Variables</i> tab in the bottom panel.
-        </li>
-        <li>
           <h4>Support for new Camunda 8 features</h4>
-          Edit new Camunda 8 properties such as the new <i>Version tag</i> and the new user task <i>Priority</i>.
-        </li>
-        <li>
-          <h4>Camunda 8 Connectors enabled by default</h4>
-          You can now use pre-built Camunda 8 Connectors by default. To learn how to configure this feature, check out the <a href="https://docs.camunda.io/docs/components/modeler/desktop-modeler/use-connectors/">connectors documentation</a>.
+          Enjoy code completion for built-in FEEL functions that ship with Camunda 8.6.
         </li>
         <li>
           <h4>Bug fixes and more</h4>


### PR DESCRIPTION
### Proposed Changes

Adds release info for [v5.28.0 release](https://github.com/camunda/camunda-modeler/issues/4521):

![image](https://github.com/user-attachments/assets/1229b046-5208-4f47-803f-d645aea5e993)


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
