### PR TITLE
Correct completion for non-arg FEEL built-ins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2703,9 +2703,9 @@
       "integrity": "sha512-to+unsToePnm7cUeR9TrMzFlETHd/UXmU+ELTRfWZj5XGT41KF6X3L233o3E/GdEs3sk2Tbw/lOLD1avmWkg8A=="
     },
     "node_modules/@bpmn-io/feel-editor": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-1.9.0.tgz",
-      "integrity": "sha512-O9w+UbajbxenLukbQGcWAfg91zV2FCJi5ba+nD3NN9pwyF0CL0m8Vf2GhJuALlOsJshRW6dJSw/TU0NMax+B7A==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-1.9.1.tgz",
+      "integrity": "sha512-UxSORdh5cwKM4fib4f9ov6J1/BHGpQVNtA+wPyEdKQyCyz3wqwE2/xe5wneVR1j5QFC5m2Na8nTy4a1TDFvZTw==",
       "dependencies": {
         "@bpmn-io/feel-lint": "^1.3.0",
         "@codemirror/autocomplete": "^6.16.2",
@@ -35110,9 +35110,9 @@
       }
     },
     "@bpmn-io/feel-editor": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-1.9.0.tgz",
-      "integrity": "sha512-O9w+UbajbxenLukbQGcWAfg91zV2FCJi5ba+nD3NN9pwyF0CL0m8Vf2GhJuALlOsJshRW6dJSw/TU0NMax+B7A==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-1.9.1.tgz",
+      "integrity": "sha512-UxSORdh5cwKM4fib4f9ov6J1/BHGpQVNtA+wPyEdKQyCyz3wqwE2/xe5wneVR1j5QFC5m2Na8nTy4a1TDFvZTw==",
       "requires": {
         "@bpmn-io/feel-lint": "^1.3.0",
         "@codemirror/autocomplete": "^6.16.2",


### PR DESCRIPTION
### Proposed Changes

Bump to @bpmn-io/feel-editor@1.9.1, correcting variable completion for non-arg FEEL built-ins:

![image](https://github.com/user-attachments/assets/a2875c5e-2adf-4a1a-a192-74286a26176f)

Closes #4539 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
