### PR TITLE
deps: bump to @camunda/form-playground@0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ ___Note:__ Yet to be released changes appear here._
 * `DEPS`: update to `camunda-bpmn-js@4.20.0`
 * `DEPS`: update to `@camunda/linting@3.27.1`
 * `DEPS`: update to `@bpmn-io/form-js@1.10.1`
+* `DEPS`: update to `@camunda/form-playground@0.16.1`
 
 ### BPMN
 

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,7 @@
     "@bpmn-io/variable-outline": "1.0.2",
     "@camunda/execution-platform": "^0.3.2",
     "@camunda/form-linting": "^0.17.0",
-    "@camunda/form-playground": "^0.15.0",
+    "@camunda/form-playground": "^0.16.1",
     "@camunda/improved-canvas": "^1.7.2",
     "@camunda/linting": "^3.27.1",
     "@codemirror/commands": "^6.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
         "@bpmn-io/variable-outline": "1.0.2",
         "@camunda/execution-platform": "^0.3.2",
         "@camunda/form-linting": "^0.17.0",
-        "@camunda/form-playground": "^0.15.0",
+        "@camunda/form-playground": "^0.16.1",
         "@camunda/improved-canvas": "^1.7.2",
         "@camunda/linting": "^3.27.1",
         "@codemirror/commands": "^6.1.3",
@@ -3022,24 +3022,24 @@
       }
     },
     "node_modules/@camunda/form-playground": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@camunda/form-playground/-/form-playground-0.15.0.tgz",
-      "integrity": "sha512-DTVnBvKZqi8YNXeybRfY2hpPdWk4YAg+zfYkXO8RtJW67QCNQqwZyOY2fLB6/ESCjvQt55H+hwis9C+8sYv0Nw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@camunda/form-playground/-/form-playground-0.16.1.tgz",
+      "integrity": "sha512-Y2/z3qwLSalWyrj+6qayS86tEC3gYM+WcnG7Q6m87P0YBPCvkO1sS0Xnai9BvhlIRof1KoInefZRFAXEo+Qb4A==",
       "workspaces": [
         "example"
       ],
       "dependencies": {
-        "classnames": "^2.3.2",
-        "diagram-js": "^14.0.0",
+        "classnames": "^2.5.1",
+        "diagram-js": "^14.11.1",
         "min-dash": "^4.2.1",
-        "min-dom": "^5.0.0",
+        "min-dom": "^5.1.1",
         "mitt": "^3.0.1"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@bpmn-io/form-js": "^1.9.0"
+        "@bpmn-io/form-js": "^1.10.1"
       }
     },
     "node_modules/@camunda/form-playground/node_modules/domify": {
@@ -35393,14 +35393,14 @@
       }
     },
     "@camunda/form-playground": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@camunda/form-playground/-/form-playground-0.15.0.tgz",
-      "integrity": "sha512-DTVnBvKZqi8YNXeybRfY2hpPdWk4YAg+zfYkXO8RtJW67QCNQqwZyOY2fLB6/ESCjvQt55H+hwis9C+8sYv0Nw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@camunda/form-playground/-/form-playground-0.16.1.tgz",
+      "integrity": "sha512-Y2/z3qwLSalWyrj+6qayS86tEC3gYM+WcnG7Q6m87P0YBPCvkO1sS0Xnai9BvhlIRof1KoInefZRFAXEo+Qb4A==",
       "requires": {
-        "classnames": "^2.3.2",
-        "diagram-js": "^14.0.0",
+        "classnames": "^2.5.1",
+        "diagram-js": "^14.11.1",
         "min-dash": "^4.2.1",
-        "min-dom": "^5.0.0",
+        "min-dom": "^5.1.1",
         "mitt": "^3.0.1"
       },
       "dependencies": {
@@ -41937,7 +41937,7 @@
         "@bpmn-io/variable-outline": "1.0.2",
         "@camunda/execution-platform": "^0.3.2",
         "@camunda/form-linting": "^0.17.0",
-        "@camunda/form-playground": "^0.15.0",
+        "@camunda/form-playground": "^0.16.1",
         "@camunda/improved-canvas": "^1.7.2",
         "@camunda/linting": "^3.27.1",
         "@codemirror/commands": "^6.1.3",


### PR DESCRIPTION
### Proposed Changes

@nikku When updating `form-js` we forgot to bump playground. This caused the CSS to be broken
Not sure if we can still make the release since the freeze is already in place

![image](https://github.com/user-attachments/assets/9a23d3be-c1f8-4f37-ac70-3dd91efd49a2)


<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
