### PR TITLE
fix: configure line wrapping via codemirror extension

### DIFF
--- a/client/src/app/tabs/json/CodeMirror.js
+++ b/client/src/app/tabs/json/CodeMirror.js
@@ -59,6 +59,7 @@ export default function create() {
           'aria-label': 'JSON editor',
           'tabindex': 0
         }),
+        EditorView.lineWrapping,
         ...extensions
       ]
     });

--- a/client/src/app/tabs/json/JSONEditor.less
+++ b/client/src/app/tabs/json/JSONEditor.less
@@ -37,7 +37,6 @@
 
     .cm-content {
       width: 100%;
-      white-space: normal;
       padding-right: 18px;
     }
 
@@ -64,7 +63,7 @@
       background-color: var(--json-editor-button-background-color);
       text-transform: capitalize;
     }
-    
+
     .cm-textfield {
       padding: 4px 8px;
       font-family: var(--font-family-monospace);
@@ -76,7 +75,7 @@
         font-family: var(--font-family);
       }
     }
-    
+
     .cm-panel.cm-search {
       label {
         font-size: var(--json-editor-font-size-small);
@@ -90,7 +89,7 @@
 
       [name=close] {
         font-size: 24px;
-        padding: 0px 8px; 
+        padding: 0px 8px;
       }
     }
   }

--- a/client/src/app/tabs/xml/CodeMirror.js
+++ b/client/src/app/tabs/xml/CodeMirror.js
@@ -59,6 +59,7 @@ export default function create() {
           'aria-label': 'XML editor',
           'tabindex': 0
         }),
+        EditorView.lineWrapping,
         ...extensions
       ]
     });

--- a/client/src/app/tabs/xml/XMLEditor.less
+++ b/client/src/app/tabs/xml/XMLEditor.less
@@ -38,7 +38,6 @@
 
     .cm-content {
       width: 100%;
-      white-space: normal;
       padding-right: 18px;
     }
 
@@ -65,7 +64,7 @@
       background-color: var(--xml-editor-button-background-color);
       text-transform: capitalize;
     }
-    
+
     .cm-textfield {
       padding: 4px 8px;
       font-family: var(--font-family-monospace);
@@ -77,7 +76,7 @@
         font-family: var(--font-family);
       }
     }
-    
+
     .cm-panel.cm-search {
       label {
         font-size: var(--xml-editor-font-size-small);
@@ -91,7 +90,7 @@
 
       [name=close] {
         font-size: 24px;
-        padding: 0px 8px; 
+        padding: 0px 8px;
       }
     }
   }


### PR DESCRIPTION
### Proposed Changes

This makes sure indentation works correctly in XML and JSON editors while maintaining the line wrapping.

![image](https://github.com/user-attachments/assets/092f99a4-f959-4e81-88a1-d3ee32f921e6)
![image](https://github.com/user-attachments/assets/402b942a-707c-4970-97df-dde544c30fe9)

Closes #4556

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
