### PR TITLE
feat: allow custom filetype support via plugins

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1803,6 +1803,10 @@ export class App extends PureComponent {
       return this.createDiagram('cloud-dmn');
     }
 
+    if (action === 'create-diagram') {
+      return this.createDiagram(options);
+    }
+
     if (action === 'reopen-file') {
       return this.openFiles([ options.file ]);
     }
@@ -2186,11 +2190,15 @@ export class App extends PureComponent {
       items = [
         ...items,
         ...entries.map(entry => {
+
+          // This allows tab providers to pass options, e.g. for the diagram type
+          const actionArgs = typeof action === 'string' ? [ entry.action ] : entry.action;
+
           return {
             text: entry.label,
             group: entry.group,
             icon: provider.getIcon(),
-            onClick: () => this.triggerAction(entry.action)
+            onClick: () => this.triggerAction(...actionArgs)
           };
         })
       ];

--- a/client/src/app/EmptyTab.js
+++ b/client/src/app/EmptyTab.js
@@ -23,6 +23,7 @@ import {
 } from './primitives';
 
 import Flags, { DISABLE_DMN, DISABLE_FORM, DISABLE_ZEEBE, DISABLE_PLATFORM } from '../util/Flags';
+import { Slot } from './slot-fill';
 
 
 export default class EmptyTab extends PureComponent {
@@ -39,12 +40,20 @@ export default class EmptyTab extends PureComponent {
       onAction
     } = this.props;
 
+    const actionArgs = typeof action === 'string' ? [ action ] : action;
+
     return (
-      <button className="btn btn-secondary" onClick={ () => onAction(action) }>
+      <button className="btn btn-secondary" onClick={ () => onAction(...actionArgs) }>
         {icon}
         {title}
       </button>
     );
+  };
+
+  AdditionalButton = (props) => {
+    const { action, title, icon } = props;
+
+    return this.renderDiagramButton(action, title, icon);
   };
 
   renderCloudColumn = () => {
@@ -72,6 +81,7 @@ export default class EmptyTab extends PureComponent {
             this.renderDiagramButton('create-cloud-form', 'Form', <FormIcon />)
           )
         }
+        <Slot name="cloud-welcome" Component={ this.AdditionalButton } />
       </div>
     );
   };
@@ -101,6 +111,7 @@ export default class EmptyTab extends PureComponent {
             this.renderDiagramButton('create-form', 'Form', <FormIcon />)
           )
         }
+        <Slot name="platform-welcome" Component={ this.AdditionalButton } />
       </div>
     );
   };

--- a/client/src/app/__tests__/TabsProviderSpec.js
+++ b/client/src/app/__tests__/TabsProviderSpec.js
@@ -45,6 +45,35 @@ describe('TabsProvider', function() {
   });
 
 
+  it('should be pluggable', function() {
+
+    // given
+    const tabsProvider = new TabsProvider([ {
+      coolTab: {
+        canOpen(file) {
+          return true;
+        },
+        getComponent() {
+          return 'MyComponent';
+        },
+        getInitialContents() {
+          return 'initial contents';
+        },
+        getIcon() {
+          return null;
+        }
+      },
+    } ]);
+
+    // when
+    const provider = tabsProvider.getProvider('coolTab');
+
+    // then
+    expect(provider.getComponent()).to.eql('MyComponent');
+    expect(provider.getInitialContents()).to.eql('initial contents');
+  });
+
+
   it('should provide BPMN, DMN, FORM and empty tab without flags', function() {
 
     // given

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -56,8 +56,6 @@ const keyboardBindings = new KeyboardBindings({
   isMac
 });
 
-const tabsProvider = new TabsProvider();
-
 const globals = {
   backend,
   config,
@@ -91,6 +89,8 @@ async function render() {
     // mark as finished loading
     document.querySelector('body > .spinner-border').classList.add('hidden');
   };
+
+  const tabsProvider = new TabsProvider(plugins.get('tabs'));
 
   ReactDOM.render(
     <AppParent

--- a/client/src/remote/Plugins.js
+++ b/client/src/remote/Plugins.js
@@ -14,8 +14,19 @@ import {
   Modal,
   Overlay,
   Section,
+  TextInput,
   ToggleSwitch
 } from '../shared/ui';
+
+import {
+  WithCache,
+  WithCachedState,
+  CachedComponent
+} from '../app/cached';
+
+import {
+  createTab
+} from '../app/tabs/EditorTab';
 
 import { Fill } from '../app/slot-fill';
 
@@ -69,7 +80,12 @@ export default class Plugins {
       Modal,
       Overlay,
       Section,
-      ToggleSwitch
+      TextInput,
+      ToggleSwitch,
+      CachedComponent,
+      WithCache,
+      WithCachedState,
+      createTab
     };
 
     // deprecated helpers

--- a/client/src/remote/__tests__/PluginsSpec.js
+++ b/client/src/remote/__tests__/PluginsSpec.js
@@ -198,6 +198,31 @@ describe('plugins', function() {
     );
 
 
+    it('should expose UI components via window#components', () => {
+
+      // given
+      const global = {};
+
+      const plugins = new Plugins();
+
+      // when
+      plugins.bindHelpers(global);
+
+      // then
+      expect(global.components).to.exist;
+      expect(global.components).to.have.property('Fill');
+      expect(global.components).to.have.property('Modal');
+      expect(global.components).to.have.property('Overlay');
+      expect(global.components).to.have.property('Section');
+      expect(global.components).to.have.property('TextInput');
+      expect(global.components).to.have.property('ToggleSwitch');
+      expect(global.components).to.have.property('CachedComponent');
+      expect(global.components).to.have.property('WithCache');
+      expect(global.components).to.have.property('WithCachedState');
+      expect(global.components).to.have.property('createTab');
+    });
+
+
     it('should expose properties panel preact with subpackages via window#vendor.propertiesPanel.preact[...]',
       function() {
 


### PR DESCRIPTION
### Proposed Changes
This PR adds the client plugin point `tabs` that allows users to create custom file type editors. This can be used to ship editors, e.g. for `.robot` files as a plugin.

The changes are fairly straight forward:

- allow expansion of `TabsProvider`
- Export commonly used Tab Components in `Plugins.js` so they can be used in Plugins
- Add Slot for additional file types on Welcome page

To allow tabs to be created, I added a new command `create-diagram` in `App.js`. This allows files to trigger `createDiagram` without hardcoding the file type in the command, which is not possible from Plugins.

You can check an example integration of the plugin point here: https://github.com/camunda/camunda-modeler/blob/RPA-spike/resources/plugins/test-tab/client/index.js

related to https://github.com/camunda/product-hub/issues/2412

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [x] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
