### PR TITLE
ci: use macos-latest runner

### DIFF
--- a/.github/workflows/BUILD_ON_DEMAND.yml
+++ b/.github/workflows/BUILD_ON_DEMAND.yml
@@ -12,7 +12,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-12, windows-2022 ]
+        os: [ ubuntu-latest, macos-latest, windows-2022 ]
     runs-on: ${{ matrix.os }}
     env:
       ON_DEMAND: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, windows-2022 ]
+        os: [ ubuntu-latest, macos-latest, windows-2022 ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/NIGHTLY.yml
+++ b/.github/workflows/NIGHTLY.yml
@@ -10,7 +10,7 @@ jobs:
         - os: ubuntu-latest
           files:
           - 'dist/camunda-modeler-nightly-linux-x64.tar.gz'
-        - os: macos-12
+        - os: macos-latest
           files:
           - 'dist/camunda-modeler-nightly-mac-arm64.dmg'
           - 'dist/camunda-modeler-nightly-mac-arm64.zip'

--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -22,7 +22,7 @@ jobs:
     needs: Pre_release
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-12, windows-2022 ]
+        os: [ ubuntu-latest, macos-latest, windows-2022 ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Related to https://github.com/actions/runner-images/issues/10721

### Proposed Changes

MacOS-12 runner is soon going out of support. I suggest we run on the latest version from now on.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
