### PR TITLE
fix: add explicit styles for welcome tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: correct broken styles after loading variable outline ([#4555](https://github.com/camunda/camunda-modeler/issues/4555))
 * `FIX`: show lint errors for FEEL expressions used in BPMN processes ([camunda/bpmnlint-plugin-camunda-compat#175](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/175))
 * `DEPS`: update to `@camunda/linting@3.27.2`
-* `FIX`: add explicit styles for welcome tab ([#4555](https://github.com/camunda/camunda-modeler/issues/4555))
 
 ## 5.28.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ___Note:__ Yet to be released changes appear here._
 
 * `FIX`: show lint errors for FEEL expressions used in BPMN processes ([camunda/bpmnlint-plugin-camunda-compat#175](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/175))
 * `DEPS`: update to `@camunda/linting@3.27.2`
+* `FIX`: add explicit styles for welcome tab ([#4555](https://github.com/camunda/camunda-modeler/issues/4555))
 
 ## 5.28.0
 

--- a/client/src/app/EmptyTab.less
+++ b/client/src/app/EmptyTab.less
@@ -13,8 +13,7 @@
   bottom: 0;
   left: 0;
 
-
-  font-size: 14px;
+  font-size: var(--font-size-default);
   font-weight: 400;
   font-family: 'IBM Plex Sans';
 
@@ -28,6 +27,14 @@
     font-size: 18px;
     font-weight: 400;
     margin-bottom: 35px;
+  }
+
+  /* Carbon override */
+  p {
+    font-size: 14px;
+
+    margin-top: 1em;
+    margin-bottom: 1em;
   }
 
   .welcome-cards {

--- a/client/src/app/EmptyTab.less
+++ b/client/src/app/EmptyTab.less
@@ -13,10 +13,6 @@
   bottom: 0;
   left: 0;
 
-  font-size: var(--font-size-default);
-  font-weight: 400;
-  font-family: 'IBM Plex Sans';
-
   .flex-spacer {
     min-width: 5px;
     max-width: 40px;
@@ -29,13 +25,17 @@
     margin-bottom: 35px;
   }
 
-  /* Carbon override */
+  /* <carbon-override> */
+  line-height: var(--line-height-default);
+  font-size: var(--font-size-default);
+
   p {
-    font-size: 14px;
+    font-size: var(--font-size-default);
 
     margin-top: 1em;
     margin-bottom: 1em;
   }
+  /* </carbon-override> */
 
   .welcome-cards {
     width: 100%;

--- a/client/src/app/primitives/TabLinks.js
+++ b/client/src/app/primitives/TabLinks.js
@@ -133,7 +133,7 @@ export default class TabLinks extends PureComponent {
               onClick={ placeholder.onClick }
               title={ placeholder.title }
             >
-              <span className="tab__content">
+              <span className="tab__content tab__name">
                 { placeholder.label }
               </span>
             </div>

--- a/client/src/plugins/privacy-preferences/PrivacyPreferencesView.less
+++ b/client/src/plugins/privacy-preferences/PrivacyPreferencesView.less
@@ -1,7 +1,5 @@
 :local(.View) {
 
-  font-size: 1.2em;
-
   .form-submit {
     text-align: right;
   }

--- a/client/src/plugins/update-checks/NewVersionInfoView.less
+++ b/client/src/plugins/update-checks/NewVersionInfoView.less
@@ -1,8 +1,6 @@
 :local(.NewVersionInfo) {
   user-select: none;
 
-  font-size: 1.2em;
-
   button + button {
     margin-left: 10px;
   }

--- a/client/src/shared/ui/overlay/Overlay.less
+++ b/client/src/shared/ui/overlay/Overlay.less
@@ -32,7 +32,17 @@
   min-width: var(--overlay-min-width);
   overflow-y: auto;
 
-  font-size: 14px;
+  /* <carbon-override> */
+  line-height: var(--line-height-default);
+  font-size: var(--font-size-default);
+
+  p {
+    font-size: var(--font-size-default);
+
+    margin-top: 1em;
+    margin-bottom: 1em;
+  }
+  /* </carbon-override> */
 
   h1, h2, h3, h4 {
     font-weight: 500;

--- a/client/src/styles/_base.less
+++ b/client/src/styles/_base.less
@@ -4,7 +4,7 @@
 
 body {
   font-family: var(--font-family);
-  font-size: 12px;
+  font-size: var(--font-size-default);
   background-color: var(--color-white);
   overflow: hidden;
 }

--- a/client/src/styles/_font.less
+++ b/client/src/styles/_font.less
@@ -50,4 +50,5 @@
   --font-family: 'IBM Plex Sans', system-ui, Arial, sans-serif;
   --font-family-monospace: 'IBM Plex Mono', monospace;
   --font-size-default: 14px;
+  --line-height-default: 1.5;
 }

--- a/client/src/styles/_forms.less
+++ b/client/src/styles/_forms.less
@@ -181,15 +181,15 @@
     // border of the radio
     .custom-control-input:checked + .custom-control-label:before,
     .custom-control-input:not(:checked) + .custom-control-label:before {
-        content: '';
-        position: absolute;
-        left: 0;
-        top: 0;
-        width: 16px;
-        height: 16px;
-        border: 1px solid var(--color-grey-225-10-75);
-        border-radius: 3px;
-        background: var(--color-white);
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 16px;
+      height: 16px;
+      border: 1px solid var(--color-grey-225-10-75);
+      border-radius: 3px;
+      background: var(--color-white);
     }
 
     // inside the checkbox
@@ -209,36 +209,36 @@
     // border of the radio
     .custom-control-input:checked + .custom-control-label:before,
     .custom-control-input:not(:checked) + .custom-control-label:before {
-        content: '';
-        position: absolute;
-        left: 0;
-        top: 0;
-        width: 16px;
-        height: 16px;
-        border: 1px solid var(--color-grey-225-10-75);
-        border-radius: 100%;
-        background: var(--color-white);
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 16px;
+      height: 16px;
+      border: 1px solid var(--color-grey-225-10-75);
+      border-radius: 100%;
+      background: var(--color-white);
     }
 
     // inside the radio
     .custom-control-input:checked + .custom-control-label:after,
     .custom-control-input:not(:checked) + .custom-control-label:after {
-        content: '';
-        width: 8px;
-        height: 8px;
-        background-color: var(--color-grey-225-10-15);
-        position: absolute;
-        top: 5px;
-        left: 5px;
-        border-radius: 100%;
+      content: '';
+      width: 8px;
+      height: 8px;
+      background-color: var(--color-grey-225-10-15);
+      position: absolute;
+      top: 5px;
+      left: 5px;
+      border-radius: 100%;
     }
 
     // radio control
     .custom-control-input:not(:checked) + .custom-control-label:after {
-        opacity: 0;
+      opacity: 0;
     }
     .custom-control-input:checked + .custom-control-label:after {
-        opacity: 1;
+      opacity: 1;
     }
 
     .custom-control-label:focus {
@@ -253,10 +253,10 @@
 
   // feedback / tooltip
   .invalid-feedback {
-      color: var(--color-red-360-100-45);
-      margin-top: 6px;
-      font-size: 13px;
-      display: inline-block;
+    color: var(--color-red-360-100-45);
+    margin-top: 6px;
+    font-size: 13px;
+    display: inline-block;
 
     .invalid-tooltip {
       visibility: hidden;

--- a/client/src/styles/_forms.less
+++ b/client/src/styles/_forms.less
@@ -190,6 +190,7 @@
       border: 1px solid var(--color-grey-225-10-75);
       border-radius: 3px;
       background: var(--color-white);
+      box-sizing: content-box;
     }
 
     // inside the checkbox
@@ -201,6 +202,7 @@
       height: 16px;
       content: "";
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpolygon fill-rule='evenodd' points='5.743 14.314 1 9.57 2.897 7.673 5.743 10.519 13.103 3.16 15 5.057'/%3E%3C/svg%3E%0A");
+      box-sizing: content-box;
     }
   }
 
@@ -218,6 +220,7 @@
       border: 1px solid var(--color-grey-225-10-75);
       border-radius: 100%;
       background: var(--color-white);
+      box-sizing: content-box;
     }
 
     // inside the radio
@@ -231,6 +234,7 @@
       top: 5px;
       left: 5px;
       border-radius: 100%;
+      box-sizing: content-box;
     }
 
     // radio control

--- a/client/src/styles/_modal.less
+++ b/client/src/styles/_modal.less
@@ -71,7 +71,17 @@
 
   overflow-y: auto;
 
-  font-size: 14px;
+  /* <carbon-override> */
+  line-height: var(--line-height-default);
+  font-size: var(--font-size-default);
+
+  p {
+    font-size: var(--font-size-default);
+
+    margin-top: 1em;
+    margin-bottom: 1em;
+  }
+  /* </carbon-override> */
 
   background-color: var(--color-white);
 


### PR DESCRIPTION
Closes #4555

### Proposed Changes

Welcome tab now always looks the same, even if you open and close some diagrams.

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [X] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [X] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
