### PR TITLE
chore: remove flex-spacer from welcome tab

### DIFF
--- a/client/src/app/EmptyTab.js
+++ b/client/src/app/EmptyTab.js
@@ -136,8 +136,8 @@ export default class EmptyTab extends PureComponent {
       <Tab className={ css.EmptyTab }>
         {!Flags.get(DISABLE_ZEEBE) && !Flags.get(DISABLE_PLATFORM) && <h2 className="welcome-header">Choose the right version for your project:</h2>}
         <div className="welcome-cards">
-          {!Flags.get(DISABLE_ZEEBE) && <>{this.renderCloudColumn()}<div className="flex-spacer" /></>}
-          {!Flags.get(DISABLE_PLATFORM) && <>{this.renderPlatformColumn()}<div className="flex-spacer" /></>}
+          {!Flags.get(DISABLE_ZEEBE) && <>{this.renderCloudColumn()}</>}
+          {!Flags.get(DISABLE_PLATFORM) && <>{this.renderPlatformColumn()}</>}
           {this.renderLearnMoreColumn()}
         </div>
       </Tab>

--- a/client/src/app/EmptyTab.less
+++ b/client/src/app/EmptyTab.less
@@ -13,12 +13,6 @@
   bottom: 0;
   left: 0;
 
-  .flex-spacer {
-    min-width: 5px;
-    max-width: 40px;
-    width: 1%;
-  }
-
   h2.welcome-header {
     font-size: 18px;
     font-weight: 400;
@@ -43,6 +37,7 @@
     justify-content: center;
     display: flex;
     flex-direction: row;
+    gap: clamp(5px, 1%, 40px);
   }
 
   .welcome-card {
@@ -113,7 +108,7 @@
         }
       }
     }
-  
+
     button {
       margin: 0 auto 1em auto;
       background-color: var(--color-blue-205-100-50);


### PR DESCRIPTION
### Proposed Changes

The gap can be configured directly in CSS. This is a cleanup so there are no visual changes.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
