### PR TITLE
fix(errorTracking): add user configuration to sentry

### DIFF
--- a/app/lib/util/__tests__/error-tracking-spec.js
+++ b/app/lib/util/__tests__/error-tracking-spec.js
@@ -149,6 +149,29 @@ describe('error-tracking', function() {
   });
 
 
+  it('should configure user', function() {
+
+    // given
+    const setUserSpy = sinon.spy();
+
+    const config = mockConfig({
+      'editor.id': 'TEST_EDITOR_ID',
+      'editor.privacyPreferences': { 'ENABLE_CRASH_REPORTS': true }
+    });
+    const flags = mockFlags();
+    const renderer = mockRenderer();
+    const Sentry = mockSentry({ setUserSpy });
+
+    // when
+    errorTracking.start(Sentry, 'v2', config, flags, renderer);
+
+    // then
+    expect(setUserSpy).to.have.been.calledWith({
+      id: 'TEST_EDITOR_ID'
+    });
+  });
+
+
   it('should listen to frontend', function() {
 
     // given
@@ -300,14 +323,15 @@ function mockSentry(props = {}) {
         props.sentryInitSpy(initParam);
       }
     },
-    configureScope: (fn) => {
-      fn({
-        setTag: (key, value) => {
-          if (props.setTagSpy) {
-            props.setTagSpy({ key, value });
-          }
-        }
-      });
+    setTag: (key, value) => {
+      if (props.setTagSpy) {
+        props.setTagSpy({ key, value });
+      }
+    },
+    setUser: (user) => {
+      if (props.setUserSpy) {
+        props.setUserSpy(user);
+      }
     },
     close: () => {
       if (props.sentryCloseSpy) {

--- a/app/lib/util/error-tracking.js
+++ b/app/lib/util/error-tracking.js
@@ -57,9 +57,7 @@ module.exports.setTag = function(Sentry, key, value) {
   additionalTags.push({ key, value });
 
   if (isActive) {
-    Sentry.configureScope(scope => {
-      scope.setTag(key, value);
-    });
+    Sentry.setTag(key, value);
   }
 };
 
@@ -132,16 +130,16 @@ function initializeSentry(Sentry, editorID, release, dsn) {
       ]
     });
 
-    Sentry.configureScope(scope => {
-      scope.setTag('editor-id', editorID);
-      scope.setTag('is-backend-error', true);
-      scope.setTag('platform', os.platform());
-      scope.setTag('os-version', os.release());
+    Sentry.setTag('editor-id', editorID);
+    Sentry.setTag('is-backend-error', true);
+    Sentry.setTag('platform', os.platform());
+    Sentry.setTag('os-version', os.release());
 
-      additionalTags.forEach(({ key, value }) => {
-        scope.setTag(key, value);
-      });
+    additionalTags.forEach(({ key, value }) => {
+      Sentry.setTag(key, value);
     });
+
+    Sentry.setUser({ id: editorID });
 
     log.info('Sentry initialized.');
     isActive = true;

--- a/client/src/plugins/error-tracking/ErrorTracking.js
+++ b/client/src/plugins/error-tracking/ErrorTracking.js
@@ -100,13 +100,12 @@ export default class ErrorTracking extends PureComponent {
 
       // OS information already exists by default in Sentry.
       // We'll set editor ID and Camunda Modeler version.
-      this._sentry.configureScope(scope => { scope.setTag('editor-id', editorID); });
+      this._sentry.setTag('editor-id', editorID);
+      this._sentry.setUser({ id: editorID });
 
       // add plugins information
       const plugins = _getGlobal('plugins').getAppPlugins();
-      this._sentry.configureScope(scope => {
-        scope.setTag('plugins', generatePluginsTag(plugins));
-      });
+      this._sentry.setTag('plugins', generatePluginsTag(plugins));
 
       const { subscribe } = this.props;
 

--- a/client/src/plugins/error-tracking/__tests__/ErrorTrackingSpec.js
+++ b/client/src/plugins/error-tracking/__tests__/ErrorTrackingSpec.js
@@ -210,6 +210,30 @@ describe('<ErrorTracking>', function() {
   });
 
 
+  it('should configure Sentry user', async function() {
+
+    // given
+    const setUserSpy = sinon.spy();
+
+    const instance = createErrorTracking({
+      setUserSpy,
+      dsn: 'TEST_DSN',
+      configValues: {
+        'editor.privacyPreferences': { ENABLE_CRASH_REPORTS: true },
+        'editor.id': 'TEST_EDITOR_ID'
+      }
+    });
+
+    // when
+    await instance.componentDidMount();
+
+    // then
+    expect(setUserSpy).to.have.been.calledWith({
+      id: 'TEST_EDITOR_ID'
+    });
+  });
+
+
   it('should subscribe to app.error-handled event on initialization', async function() {
 
     // given
@@ -498,14 +522,15 @@ function createErrorTracking(props = {}) {
         props.sentryInitSpy(initParam);
       }
     },
-    configureScope: (fn) => {
-      fn({
-        setTag: (key, value) => {
-          if (props.setTagSpy) {
-            props.setTagSpy({ key, value });
-          }
-        }
-      });
+    setTag: (key, value) => {
+      if (props.setTagSpy) {
+        props.setTagSpy({ key, value });
+      }
+    },
+    setUser: (user) => {
+      if (props.setUserSpy) {
+        props.setUserSpy(user);
+      }
     },
     captureException: (err) => {
       if (props.sentryCaptureExceptionSpy) {


### PR DESCRIPTION
### Proposed Changes

- set Sentry tags according to v8 standards (cf. https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#other-deprecation-removalschanges). `configureScope` is deprecated.
- Explicitly set user to editor ID

closes https://github.com/bpmn-io/internal-docs/issues/1062

You can see the user is set in this sample report: https://camunda.sentry.io/issues/6018899142/events/a2096dc4c3724384bd6ab2db61403ed5/

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
