### PR TITLE
Improve Variables Tab Access and Bottom Panel Controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ ___Note:__ Yet to be released changes appear here._
 
 ### General
 
-* `FEAT`: show update button if update available ([#4606](https://github.com/camunda/camunda-modeler/pull/4606)) 
+* `FEAT`: show update button if update available ([#4606](https://github.com/camunda/camunda-modeler/pull/4606))
+* `FEAT`: make variables tab accessible via the application footer ([#4516](https://github.com/camunda/camunda-modeler/issues/4516))
+* `FEAT`: make bottom panel toggleable via keyboard ([#4516](https://github.com/camunda/camunda-modeler/issues/4516))
+* `CHORE`: remove reset properties panel menu item ([#4516](https://github.com/camunda/camunda-modeler/issues/4516))
 * `FIX`: correct default extension used when saving Camunda 8 BPMN diagrams ([#4661](https://github.com/camunda/camunda-modeler/issues/4661))
 * `DEPS`: update to Electron 33 ([#4609](https://github.com/camunda/camunda-modeler/pull/4609))
 

--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -462,6 +462,10 @@ class MenuBuilder {
     });
 
     submenuTemplate.push({
+      label: 'Toggle Bottom Panel',
+      accelerator: 'CommandOrControl+B',
+      click: () => app.emit('menu:action', 'toggle-panel')
+    }, {
       label: 'Toggle DevTools',
       accelerator: 'F12',
       click: (_, browserWindow) => {

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1946,6 +1946,11 @@ export class App extends PureComponent {
       return this.emitWithTab(type, activeTab, payload);
     }
 
+    if (action === 'toggle-panel') {
+      const { panel } = this.state.layout;
+      return panel.open ? this.closePanel() : this.openPanel(panel.tab);
+    }
+
     const tab = this.tabRef.current;
 
     return tab.triggerAction(action, options);

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -2114,6 +2114,92 @@ describe('<App>', function() {
 
     });
 
+
+    describe('bottom-panel', function() {
+
+      describe('#triggerAction', function() {
+
+        it('should open', function() {
+
+          // given
+          const { app } = createApp();
+
+          app.setLayout({
+            panel: {
+              open: false,
+            }
+          });
+
+          // when
+          app.triggerAction('toggle-panel');
+
+          // then
+          expect(app.state.layout).to.eql({
+            panel: {
+              open: true,
+              tab: 'log'
+            }
+          });
+        });
+
+
+        it('should close', function() {
+
+          // given
+          const { app } = createApp();
+
+          app.setLayout({
+            panel: {
+              open: true,
+            }
+          });
+
+          // when
+          app.triggerAction('toggle-panel');
+
+          // then
+          expect(app.state.layout).to.eql({
+            panel: {
+              open: false
+            }
+          });
+        });
+
+
+        it('should preserve state when reopened after being closed', function() {
+
+          // given
+          const { app } = createApp();
+
+          app.setLayout({
+            panel: {
+              open: true,
+              tab: 'variable-outline'
+            }
+          });
+
+          // when
+
+          // close
+          app.triggerAction('toggle-panel');
+
+          // open
+          app.triggerAction('toggle-panel');
+
+
+          // then
+          expect(app.state.layout).to.eql({
+            panel: {
+              open: true,
+              tab: 'variable-outline'
+            }
+          });
+        });
+
+      });
+
+    });
+
   });
 
 

--- a/client/src/app/panel/tabs/variable-outline/VariableOutlineStatusBarItem.js
+++ b/client/src/app/panel/tabs/variable-outline/VariableOutlineStatusBarItem.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+
+import classnames from 'classnames';
+
+import { Fill } from '../../../slot-fill';
+
+export default function VariableOutlineStatusBarItem(props) {
+  const {
+    onToggle,
+    layout
+  } = props;
+
+  const { panel = {} } = layout;
+
+  return <Fill slot="status-bar__file" group="9_variables">
+    <button
+      className={ classnames(
+        'btn',
+        { 'btn--active': panel.open && panel.tab === 'variable-outline' }
+      ) }
+      onClick={ onToggle }
+    > Variables </button>
+  </Fill>;
+}

--- a/client/src/app/panel/tabs/variable-outline/VariableOutlineTab.js
+++ b/client/src/app/panel/tabs/variable-outline/VariableOutlineTab.js
@@ -16,13 +16,25 @@ import './VariableOutlineTab.less';
 
 import { Fill } from '../../../slot-fill';
 
+import VariableOutlineStatusBarItem from './VariableOutlineStatusBarItem';
 
 export default function VariableTab(props) {
   const {
     layout = {},
     injector,
-    id
+    id,
+    onAction
   } = props;
+
+  const onToggle = () => {
+    const { panel = {} } = layout;
+
+    if (!panel.open || panel.tab !== 'variable-outline') {
+      onAction('open-panel', { tab: 'variable-outline' });
+    } else if (panel.tab === 'variable-outline') {
+      onAction('close-panel');
+    }
+  };
 
   return <>
     <Fill slot="bottom-panel"
@@ -34,5 +46,9 @@ export default function VariableTab(props) {
         <VariableOutline injector={ injector } key={ id } />
       </div>
     </Fill>
+
+    <VariableOutlineStatusBarItem
+      layout={ layout }
+      onToggle={ onToggle } />
   </>;
 }

--- a/client/src/app/panel/tabs/variable-outline/__tests__/VariableOutlineStatusBarItemSpec.js
+++ b/client/src/app/panel/tabs/variable-outline/__tests__/VariableOutlineStatusBarItemSpec.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/* global sinon */
+
+import React from 'react';
+
+import { mount } from 'enzyme';
+
+import {
+  SlotFillRoot,
+  Slot
+} from '../../../../slot-fill';
+
+import VariableOutlineStatusBarItem from '../VariableOutlineStatusBarItem';
+
+const spy = sinon.spy;
+
+
+describe('VariableOutlineStatusBarItem', function() {
+
+  it('should render', function() {
+
+    // when
+    const wrapper = renderVariableOutlineStatusBarItem();
+
+    // then
+    expect(wrapper.find(VariableOutlineStatusBarItem).exists()).to.be.true;
+  });
+
+
+  describe('toggle', function() {
+
+    it('should be active (open)', function() {
+
+      // when
+      const wrapper = renderVariableOutlineStatusBarItem({
+        layout: {
+          panel: {
+            open: true,
+            tab: 'variable-outline'
+          }
+        }
+      });
+
+      // then
+      expect(wrapper.find('.btn').hasClass('btn--active')).to.be.true;
+    });
+
+
+    it('should not be active (closed)', function() {
+
+      // when
+      const wrapper = renderVariableOutlineStatusBarItem();
+
+      // then
+      expect(wrapper.find('.btn').hasClass('btn--active')).to.be.false;
+    });
+
+
+    it('should call callback on toggle', function() {
+
+      // given
+      const onToggleSpy = spy();
+
+      const wrapper = renderVariableOutlineStatusBarItem({
+        onToggle: onToggleSpy
+      });
+
+      // when
+      wrapper.find('.btn').simulate('click');
+
+      // then
+      expect(onToggleSpy).to.have.been.calledOnce;
+    });
+
+  });
+
+});
+
+
+// helpers //////////
+
+const defaultLayout = {
+  panel: {
+    open: false,
+    tab: 'variable-outline'
+  }
+};
+
+
+function renderVariableOutlineStatusBarItem(options = {}) {
+  const {
+    layout = defaultLayout,
+    onToggle
+  } = options;
+
+  return mount(
+    <SlotFillRoot>
+      <Slot name="status-bar__file" />
+      <VariableOutlineStatusBarItem
+        layout={ layout }
+        onToggle={ onToggle } />
+    </SlotFillRoot>
+  );
+}

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -691,17 +691,6 @@ export class BpmnEditor extends CachedComponent {
       return this.handleLayoutChange(newLayout);
     }
 
-    if (action === 'resetProperties') {
-      const newLayout = {
-        propertiesPanel: {
-          ...PROPERTIES_PANEL_DEFAULT_LAYOUT,
-          open: true
-        }
-      };
-
-      return this.handleLayoutChange(newLayout);
-    }
-
     if (action === 'zoomIn') {
       action = 'stepZoom';
 

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -1865,29 +1865,6 @@ describe('<BpmnEditor>', function() {
       });
     });
 
-
-    it('should reset properties panel', async function() {
-
-      // given
-      const onLayoutChangedSpy = sinon.spy();
-      const {
-        instance
-      } = await renderEditor(diagramXML, {
-        onLayoutChanged: onLayoutChangedSpy
-      });
-
-      // when
-      instance.triggerAction('resetProperties');
-
-      // then
-      expect(onLayoutChangedSpy).to.be.calledOnceWith({
-        propertiesPanel: {
-          open: true,
-          width: 280
-        }
-      });
-    });
-
   });
 
 

--- a/client/src/app/tabs/bpmn/getBpmnWindowMenu.js
+++ b/client/src/app/tabs/bpmn/getBpmnWindowMenu.js
@@ -45,9 +45,5 @@ function getPropertiesPanelEntries({ propertiesPanel }) {
     label: 'Toggle Properties Panel',
     accelerator: 'CommandOrControl+P',
     action: 'toggleProperties'
-  }, {
-    label: 'Reset Properties Panel',
-    accelerator: 'CommandOrControl+Shift+P',
-    action: 'resetProperties'
   } ] : [];
 }

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -654,17 +654,6 @@ export class BpmnEditor extends CachedComponent {
       return this.handleLayoutChange(newLayout);
     }
 
-    if (action === 'resetProperties') {
-      const newLayout = {
-        propertiesPanel: {
-          ...PROPERTIES_PANEL_DEFAULT_LAYOUT,
-          open: true
-        }
-      };
-
-      return this.handleLayoutChange(newLayout);
-    }
-
     if (action === 'zoomIn') {
       action = 'stepZoom';
 

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -758,7 +758,7 @@ export class BpmnEditor extends CachedComponent {
   render() {
     const engineProfile = this.engineProfile.getCached();
 
-    const { layout } = this.props;
+    const { layout, onAction } = this.props;
 
     const modeler = this.getModeler();
     const imported = modeler.getDefinitions();
@@ -796,7 +796,8 @@ export class BpmnEditor extends CachedComponent {
         <VariableTab
           id={ this.props.id }
           layout={ layout }
-          injector={ injector } />
+          injector={ injector }
+          onAction={ onAction } />
       </div>
     );
   }

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -1787,29 +1787,6 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
       });
     });
 
-
-    it('should reset properties panel', async function() {
-
-      // given
-      const onLayoutChangedSpy = sinon.spy();
-      const {
-        instance
-      } = await renderEditor(diagramXML, {
-        onLayoutChanged: onLayoutChangedSpy
-      });
-
-      // when
-      instance.triggerAction('resetProperties');
-
-      // then
-      expect(onLayoutChangedSpy).to.be.calledOnceWith({
-        propertiesPanel: {
-          open: true,
-          width: 280
-        }
-      });
-    });
-
   });
 
 

--- a/client/src/app/tabs/cloud-dmn/DmnEditor.js
+++ b/client/src/app/tabs/cloud-dmn/DmnEditor.js
@@ -697,17 +697,6 @@ export class DmnEditor extends CachedComponent {
       return handleLayoutChange(newLayout);
     }
 
-    if (action === 'resetProperties') {
-      const newLayout = {
-        propertiesPanel: {
-          ...PROPERTIES_PANEL_DEFAULT_LAYOUT,
-          open: true
-        }
-      };
-
-      return handleLayoutChange(newLayout);
-    }
-
     if (action === 'zoomIn') {
       action = 'stepZoom';
 

--- a/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
@@ -1852,29 +1852,6 @@ describe('<DmnEditor>', function() {
       });
     });
 
-
-    it('should reset properties panel', async function() {
-
-      // given
-      const onLayoutChangedSpy = sinon.spy();
-      const {
-        instance
-      } = await renderEditor(diagramXML, {
-        onLayoutChanged: onLayoutChangedSpy
-      });
-
-      // when
-      instance.triggerAction('resetProperties');
-
-      // then
-      expect(onLayoutChangedSpy).to.be.calledOnceWith({
-        propertiesPanel: {
-          open: true,
-          width: 280
-        }
-      });
-    });
-
   });
 
 

--- a/client/src/app/tabs/cmmn/CmmnEditor.js
+++ b/client/src/app/tabs/cmmn/CmmnEditor.js
@@ -406,17 +406,6 @@ export class CmmnEditor extends CachedComponent {
       return handleLayoutChange(newLayout);
     }
 
-    if (action === 'resetProperties') {
-      const newLayout = {
-        propertiesPanel: {
-          width: 280,
-          open: true
-        }
-      };
-
-      return handleLayoutChange(newLayout);
-    }
-
     if (action === 'zoomIn') {
       action = 'stepZoom';
 

--- a/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
+++ b/client/src/app/tabs/cmmn/__tests__/CmmnEditorSpec.js
@@ -832,29 +832,6 @@ describe('<CmmnEditor>', function() {
       });
     });
 
-
-    it('should reset properties panel', async function() {
-
-      // given
-      const onLayoutChangedSpy = sinon.spy();
-      const {
-        instance
-      } = await renderEditor(diagramXML, {
-        onLayoutChanged: onLayoutChangedSpy
-      });
-
-      // when
-      instance.triggerAction('resetProperties');
-
-      // then
-      expect(onLayoutChangedSpy).to.be.calledOnceWith({
-        propertiesPanel: {
-          open: true,
-          width: 280
-        }
-      });
-    });
-
   });
 
 

--- a/client/src/app/tabs/cmmn/getCmmnWindowMenu.js
+++ b/client/src/app/tabs/cmmn/getCmmnWindowMenu.js
@@ -45,9 +45,5 @@ function getPropertiesPanelEntries({ propertiesPanel }) {
     label: 'Toggle Properties Panel',
     accelerator: 'CommandOrControl+P',
     action: 'toggleProperties'
-  }, {
-    label: 'Reset Properties Panel',
-    accelerator: 'CommandOrControl+Shift+P',
-    action: 'resetProperties'
   } ] : [];
 }

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -698,17 +698,6 @@ export class DmnEditor extends CachedComponent {
       return handleLayoutChange(newLayout);
     }
 
-    if (action === 'resetProperties') {
-      const newLayout = {
-        propertiesPanel: {
-          ...PROPERTIES_PANEL_DEFAULT_LAYOUT,
-          open: true
-        }
-      };
-
-      return handleLayoutChange(newLayout);
-    }
-
     if (action === 'zoomIn') {
       action = 'stepZoom';
 

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -1853,29 +1853,6 @@ describe('<DmnEditor>', function() {
       });
     });
 
-
-    it('should reset properties panel', async function() {
-
-      // given
-      const onLayoutChangedSpy = sinon.spy();
-      const {
-        instance
-      } = await renderEditor(diagramXML, {
-        onLayoutChanged: onLayoutChangedSpy
-      });
-
-      // when
-      instance.triggerAction('resetProperties');
-
-      // then
-      expect(onLayoutChangedSpy).to.be.calledOnceWith({
-        propertiesPanel: {
-          open: true,
-          width: 280
-        }
-      });
-    });
-
   });
 
 

--- a/client/src/app/tabs/dmn/getDmnWindowMenu.js
+++ b/client/src/app/tabs/dmn/getDmnWindowMenu.js
@@ -46,10 +46,6 @@ function getPropertiesPanelEntries({ propertiesPanel }) {
     label: 'Toggle Properties Panel',
     accelerator: 'CommandOrControl+P',
     action: 'toggleProperties'
-  }, {
-    label: 'Reset Properties Panel',
-    accelerator: 'CommandOrControl+Shift+P',
-    action: 'resetProperties'
   } ] : [];
 }
 


### PR DESCRIPTION
Closes #4516 

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Variables Application Menu 

![Variables_Tab](https://github.com/user-attachments/assets/6ec94638-e244-4e50-8075-f2f5618362fc)


### Variables Tab Keyboard shortcut 
(For Mac OS): Press `Command + Shift + V`

![Variable Tab keyboard shortcut](https://github.com/user-attachments/assets/0c679f0c-e431-4292-927d-e19708f3d6a6)

### Variables Bottom Tab 

![Variable bottom tab](https://github.com/user-attachments/assets/604d698c-3540-48c9-a1c1-e5cd91aec91d)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
