### PR TITLE
Gracefully handle creating milestone with existing name

### DIFF
--- a/.github/workflows/CREATE_MILESTONE.yml
+++ b/.github/workflows/CREATE_MILESTONE.yml
@@ -22,8 +22,22 @@ jobs:
         env:
           TITLE: ${{steps.getTitle.outputs.MILESTONE_NAME}}
           GH_TOKEN: ${{ github.token }}
+        shell: bash
         run: |
-          gh api \
+          response=$(gh api \
             --method POST \
             /repos/${{ github.repository }}/milestones \
-            -f "title=$TITLE" -f "state=open"
+            -f "title=$TITLE" -f "state=open")
+
+          # if response has a errors[].code === "already_exists" in a JSON response, we do nothing
+          if echo "$response" | jq -e '.errors | map(select(.code == "already_exists")) | length > 0' > /dev/null; then
+            echo "Milestone $TITLE already exists, no action needed"
+          # if there is .title === $TITLE in the response, we successfully created the milestone
+          elif echo "$response" | jq -e ".title == \"$TITLE\"" >/dev/null; then
+            echo "Milestone $TITLE created successfully"
+          # otherwise, we print the error
+          else
+            echo "Error creating milestone $TITLE"
+            echo $response
+            exit 1
+          fi


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

- add some basic error handling to the `create milestone` action, to gracefully handle the case when we try to create a milestone that already exists (e.g. https://github.com/camunda/camunda-modeler/actions/runs/11072955308/job/30768404834)

related to https://github.com/bpmn-io/internal-docs/issues/1052

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
