### PR TITLE
fix(client): fix initial diagram coordinates

### DIFF
--- a/client/src/app/tabs/bpmn/diagram.bpmn
+++ b/client/src/app/tabs/bpmn/diagram.bpmn
@@ -5,8 +5,8 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_{{ ID:process }}">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="159" width="36" height="36" />
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="162" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/client/src/app/tabs/cloud-bpmn/__tests__/DiagramSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/DiagramSpec.js
@@ -8,7 +8,7 @@
  * except in compliance with the MIT License.
  */
 
-describe('tabs/bpmn', function() {
+describe('tabs/cloud-bpmn', function() {
 
   describe('initial diagram', function() {
 
@@ -20,7 +20,6 @@ describe('tabs/bpmn', function() {
       // then
       expect(contents).to.contain('id="Definitions_{{ ID }}"');
       expect(contents).to.contain('id="Process_{{ ID:process }}"');
-      expect(contents).to.contain('historyTimeToLive="{{ DEFAULT_HTTL }}');
     });
 
 

--- a/client/src/app/tabs/cloud-bpmn/diagram.bpmn
+++ b/client/src/app/tabs/cloud-bpmn/diagram.bpmn
@@ -5,8 +5,8 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_{{ ID:process }}">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="159" width="36" height="36" />
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="162" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
closes #4488

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

Changes the initial positioning of the initial diagrams start event so it snaps properly to the grid

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
