### PR TITLE
Notify the release manager & slack integration improvements

### DIFF
--- a/.github/workflows/ADD_TO_PROJECT.yml
+++ b/.github/workflows/ADD_TO_PROJECT.yml
@@ -12,7 +12,7 @@ on:
       - labeled
 
 jobs:
-  Exec:
+  exec:
     name: Add issue to project
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ASSIGN_MILESTONE.yml
+++ b/.github/workflows/ASSIGN_MILESTONE.yml
@@ -7,7 +7,7 @@ on:
     types: ['closed']
 
 jobs:
-  check-permissions:
+  check_permissions:
     runs-on: ubuntu-latest
     name: Check Repo Permission
     outputs:
@@ -24,13 +24,13 @@ jobs:
             --jq '.permission')
           echo "PERMISSION=$PERMISSION" >> $GITHUB_OUTPUT
 
-  assign-milestone:
+  assign_milestone:
     runs-on: ubuntu-latest
     name: Assign Milestone
-    needs: check-permissions
+    needs: check_permissions
     if: | 
-      needs.check-permissions.outputs.permission == 'admin' || 
-      needs.check-permissions.outputs.permission == 'write'
+      needs.check_permissions.outputs.permission == 'admin' || 
+      needs.check_permissions.outputs.permission == 'write'
     steps:
       - name: Get current Milestone
         id: getMilestone

--- a/.github/workflows/BUILD_ON_DEMAND.yml
+++ b/.github/workflows/BUILD_ON_DEMAND.yml
@@ -9,7 +9,7 @@ on:
         description: 'Dependencies to link from GitHub (format: bpmn-js#develop,dmn-js#9.0.0)'
         default: ''
 jobs:
-  Build:
+  build:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-2022 ]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
 name: CI
 on: [ push, pull_request ]
 jobs:
-  Build:
+  build:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CODE_SCANNING.yml
+++ b/.github/workflows/CODE_SCANNING.yml
@@ -10,7 +10,9 @@ on:
       - '**/*.md'
 
 jobs:
-  CodeQL-Build:
+  codeql_build:
+    name: Scan with CodeQL
+
     # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
     runs-on: ubuntu-latest
 

--- a/.github/workflows/COMMENT_DEVELOP_FIX.yml
+++ b/.github/workflows/COMMENT_DEVELOP_FIX.yml
@@ -8,7 +8,8 @@ on:
 permissions:
   pull-requests: write
 jobs:
-  comment-on-fix-to-develop:
+  comment:
+    name: Comment on fix to develop
     runs-on: ubuntu-latest
     steps:
       - name: Check for fix commits

--- a/.github/workflows/CREATE_MILESTONE.yml
+++ b/.github/workflows/CREATE_MILESTONE.yml
@@ -5,7 +5,7 @@ on:
     types: ['closed']
 
 jobs:
-  create-milestone:
+  create_milestone:
     runs-on: ubuntu-latest
     name: Create new Milestone
     if: startsWith(github.event.milestone.title, 'M')

--- a/.github/workflows/MERGE_MAIN_TO_DEVELOP.yml
+++ b/.github/workflows/MERGE_MAIN_TO_DEVELOP.yml
@@ -5,7 +5,7 @@ on:
     - "main"
 
 jobs:
-  Merge_main_to_develop:
+  merge_main_to_develop:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -23,8 +23,9 @@ jobs:
         git merge -m 'chore: merge main to develop' --no-edit origin/main
         git push
 
-  Post-Failure:
-    needs: Merge_main_to_develop
+  post_failure:
+    name: Notify failure
+    needs: merge_main_to_develop
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/MERGE_MAIN_TO_DEVELOP.yml
+++ b/.github/workflows/MERGE_MAIN_TO_DEVELOP.yml
@@ -22,11 +22,29 @@ jobs:
         git config user.email github-actions@github.com
         git merge -m 'chore: merge main to develop' --no-edit origin/main
         git push
+
+  Post-Failure:
+    needs: Merge_main_to_develop
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v3.0.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        exportEnv: false
+        secrets: |
+          secret/data/products/desktop-modeler/ci/slack_integration SLACK_CHANNEL_ID;
+          secret/data/products/desktop-modeler/ci/slack_integration SLACK_BOT_TOKEN;
     - name: Notify on Slack if merge fails
-      uses: slackapi/slack-github-action@v1.15.0
+      uses: slackapi/slack-github-action@v1
       if: failure()
       with:
-        channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+        channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
         slack-message: "Automatic merge of <https://github.com/${{ github.repository }}/tree/${{ github.ref }}|${{ github.ref }}> to <https://github.com/${{ github.repository }}/tree/develop|${{ github.repository }}#develop> failed."
       env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}

--- a/.github/workflows/NEW_ALPHA_ISSUE.yml
+++ b/.github/workflows/NEW_ALPHA_ISSUE.yml
@@ -4,7 +4,8 @@ on:
     # After the April and October releases
     - cron: '0 8 15 APR,OCT *'
 jobs:
-  createIssue:
+  create_issue:
+    name: Create issue
     runs-on: ubuntu-latest
     steps:
       - run: gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" --label "ready" --repo $GITHUB_REPOSITORY

--- a/.github/workflows/NEW_MAJOR_ISSUE.yml
+++ b/.github/workflows/NEW_MAJOR_ISSUE.yml
@@ -4,7 +4,8 @@ on:
     # Before the April and October releases
     - cron: '0 8 15 MAR,SEP *'
 jobs:
-  createIssue:
+  create_issue:
+    name: Create issue
     runs-on: ubuntu-latest
     steps:
       - run: gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" --label "ready" --repo $GITHUB_REPOSITORY

--- a/.github/workflows/NIGHTLY.yml
+++ b/.github/workflows/NIGHTLY.yml
@@ -107,10 +107,22 @@ jobs:
     if: failure()
     runs-on: ubuntu-latest
     steps:
-    - name: Post to a Slack channel
-      uses: slackapi/slack-github-action@v1.15.0
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v3.0.0
       with:
-        channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        exportEnv: false
+        secrets: |
+          secret/data/products/desktop-modeler/ci/slack_integration SLACK_CHANNEL_ID;
+          secret/data/products/desktop-modeler/ci/slack_integration SLACK_BOT_TOKEN;
+    - name: Post to a Slack channel
+      uses: slackapi/slack-github-action@v1
+      with:
+        channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
         slack-message: "Nightly build failed. <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Go to the build.>"
       env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}

--- a/.github/workflows/NIGHTLY.yml
+++ b/.github/workflows/NIGHTLY.yml
@@ -3,7 +3,8 @@ on:
   schedule:
     - cron: '0 18 * * *'
 jobs:
-  Build_nightly:
+  build_nightly:
+    name: Build nightly
     strategy:
       matrix:
         include:
@@ -102,8 +103,9 @@ jobs:
         artifact_subpath: 'nightly'
         artifact_file: "${{ join(matrix.files, ' ') }}"
 
-  Post-Failure:
-    needs: Build_nightly
+  post_failure:
+    name: Notify failure
+    needs: build_nightly
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/PUBLISH_RELEASE.yml
+++ b/.github/workflows/PUBLISH_RELEASE.yml
@@ -4,7 +4,7 @@ on:
     types:
     - released
 jobs:
-  Publish:
+  publish:
     runs-on: ubuntu-latest
 
     steps:
@@ -37,8 +37,9 @@ jobs:
         version: ${{ steps.retrieveVersion.outputs.version }}
         artifact_file: 'artifacts/*'
 
-  Post-Failure:
-    needs: Publish
+  post_failure:
+    name: Notify failure
+    needs: publish
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/PUBLISH_RELEASE.yml
+++ b/.github/workflows/PUBLISH_RELEASE.yml
@@ -42,10 +42,22 @@ jobs:
     if: failure()
     runs-on: ubuntu-latest
     steps:
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v3.0.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        exportEnv: false
+        secrets: |
+          secret/data/products/desktop-modeler/ci/slack_integration SLACK_CHANNEL_ID;
+          secret/data/products/desktop-modeler/ci/slack_integration SLACK_BOT_TOKEN;
     - name: Post to a Slack channel
       uses: slackapi/slack-github-action@v1.15.0
       with:
-        channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+        channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
         slack-message: "Failed to upload release. <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Go to the build.>"
       env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}

--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -4,7 +4,8 @@ on:
     tags:
       - 'v*'
 jobs:
-  Pre_release:
+  pre_release:
+    name: Prepare release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -18,8 +19,9 @@ jobs:
         TAG=$(git describe --tags --abbrev=0)
         gh release create $TAG --draft --title $TAG
 
-  Build_release:
-    needs: Pre_release
+  build_release:
+    name: Build release
+    needs: pre_release
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-2022 ]
@@ -102,8 +104,9 @@ jobs:
         NODE_ENV: "production"
       run: npm run build -- --win --publish
 
-  Post_release:
-    needs: Build_release
+  post_release:
+    name: Post release
+    needs: build_release
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/RELEASE_ISSUE.yml
+++ b/.github/workflows/RELEASE_ISSUE.yml
@@ -24,7 +24,6 @@ jobs:
     needs: create_release_issue
     if: github.event.issue.milestone
     runs-on: ubuntu-latest
-    name: Assign Milestone
     steps:
       - name: Get current Milestone
         id: getMilestone

--- a/.github/workflows/RELEASE_ISSUE.yml
+++ b/.github/workflows/RELEASE_ISSUE.yml
@@ -70,10 +70,40 @@ jobs:
           secret/data/products/desktop-modeler/ci/slack_integration SLACK_BOT_TOKEN;
           secret/data/products/desktop-modeler/ci/slack_integration TEAM_MEMBER_IDS;
     - name: Update slack
-      env: 
-        BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+      env:
+        SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
         GROUP_ID: ${{ steps.secrets.outputs.RELEASE_MANAGER_GROUP_ID }}
         # User ID is either the assignee from the newly created issue or the new assigned from the `assigned` trigger
         USER_ID: ${{ fromJSON(steps.secrets.outputs.TEAM_MEMBER_IDS)[ needs.createReleaseIssue.outputs.assignee || github.event.issue.assignee.login ] }}
       run: |
-        curl --fail-with-body -X POST -H "application/x-www-form-urlencoded" -d "token=${BOT_TOKEN}&usergroup=${GROUP_ID}&users=${USER_ID}" https://slack.com/api/usergroups.users.update
+        curl --fail-with-body -X POST -H "application/x-www-form-urlencoded" -d "token=${SLACK_BOT_TOKEN}&usergroup=${GROUP_ID}&users=${USER_ID}" https://slack.com/api/usergroups.users.update
+
+  notifyOnSlack:
+    needs: createReleaseIssue
+    if: |
+      always() &&
+      contains(github.event.issue.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v3.0.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        exportEnv: false
+        secrets: |
+          secret/data/products/desktop-modeler/ci/slack_integration SLACK_CHANNEL_ID;
+          secret/data/products/desktop-modeler/ci/slack_integration SLACK_BOT_TOKEN;
+    - name: Post to a Slack channel
+      uses: slackapi/slack-github-action@v1
+      with:
+        channel-id: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+        slack-message: "Assigned <https://github.com/$RELEASE_MANAGER|@$RELEASE_MANAGER> as the release manager. Go to <$ISSUE_LINK|the release issue> to update if necessary."
+      env:
+        SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+        # Release manager is either the assignee from the newly created issue or the new assigned from the `assigned` trigger
+        RELEASE_MANAGER: ${{ needs.createReleaseIssue.outputs.assignee || github.event.issue.assignee.login }}
+        ISSUE_LINK: https://github.com/${{ github.repository }}/issues/${{ fromJson(needs.createReleaseIssue.outputs.issue).number }}

--- a/.github/workflows/RELEASE_ISSUE.yml
+++ b/.github/workflows/RELEASE_ISSUE.yml
@@ -6,7 +6,7 @@ jobs:
   createReleaseIssue:
     runs-on: ubuntu-latest
     name: Create new Release Issue
-    if: | 
+    if: |
       contains(github.event.issue.labels.*.name, 'release') &&
       github.event.action == 'closed'
     outputs:
@@ -36,10 +36,10 @@ jobs:
             /repos/${{ github.repository }}/milestones \
             --jq '.[] | select(.title | startswith("M")) | .number'
           )
-          
+
           echo "MILESTONE_NUMBER=$MILESTONE" >> $GITHUB_OUTPUT
       - name: Assign Milestone to new Issue
-        env: 
+        env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh api \
@@ -47,7 +47,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             /repos/${{ github.repository }}/issues/${{ fromJson(needs.createReleaseIssue.outputs.issue).number }} \
             -F "milestone=${{steps.getMilestone.outputs.MILESTONE_NUMBER}}"
- 
+
   updateSlackRole:
     runs-on: ubuntu-latest
     if: |

--- a/.github/workflows/RELEASE_ISSUE.yml
+++ b/.github/workflows/RELEASE_ISSUE.yml
@@ -3,24 +3,25 @@ on:
   issues:
     types: [closed, assigned]
 jobs:
-  createReleaseIssue:
+  create_release_issue:
     runs-on: ubuntu-latest
     name: Create new Release Issue
     if: |
       contains(github.event.issue.labels.*.name, 'release') &&
       github.event.action == 'closed'
     outputs:
-      assignee: ${{ steps.createReleaseIssue.outputs.assignee }}
+      assignee: ${{ steps.create_release_issue.outputs.assignee }}
     steps:
-    - id: createReleaseIssue
+    - id: create_release_issue
       name: Create new Release Issue
       uses: bpmn-io/actions/release-issue@latest
       with:
         template-path: 'docs/.project/RELEASE_TEMPLATE.md'
         package-path: 'app/package.json'
 
-  assignMilestone:
-    needs: createReleaseIssue
+  assign_milestone:
+    name: Assign milestone
+    needs: create_release_issue
     if: github.event.issue.milestone
     runs-on: ubuntu-latest
     name: Assign Milestone
@@ -45,16 +46,16 @@ jobs:
           gh api \
             --method PATCH \
             -H "Accept: application/vnd.github+json" \
-            /repos/${{ github.repository }}/issues/${{ fromJson(needs.createReleaseIssue.outputs.issue).number }} \
+            /repos/${{ github.repository }}/issues/${{ fromJson(needs.create_release_issue.outputs.issue).number }} \
             -F "milestone=${{steps.getMilestone.outputs.MILESTONE_NUMBER}}"
 
-  updateSlackRole:
+  update_slack_role:
+    name: Sync Slack roles
+    needs: create_release_issue
     runs-on: ubuntu-latest
     if: |
       always() &&
       contains(github.event.issue.labels.*.name, 'release')
-    name: Sync Slack roles
-    needs: createReleaseIssue
     steps:
     - name: Import Secrets
       id: secrets
@@ -74,12 +75,13 @@ jobs:
         SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
         GROUP_ID: ${{ steps.secrets.outputs.RELEASE_MANAGER_GROUP_ID }}
         # User ID is either the assignee from the newly created issue or the new assigned from the `assigned` trigger
-        USER_ID: ${{ fromJSON(steps.secrets.outputs.TEAM_MEMBER_IDS)[ needs.createReleaseIssue.outputs.assignee || github.event.issue.assignee.login ] }}
+        USER_ID: ${{ fromJSON(steps.secrets.outputs.TEAM_MEMBER_IDS)[ needs.create_release_issue.outputs.assignee || github.event.issue.assignee.login ] }}
       run: |
         curl --fail-with-body -X POST -H "application/x-www-form-urlencoded" -d "token=${SLACK_BOT_TOKEN}&usergroup=${GROUP_ID}&users=${USER_ID}" https://slack.com/api/usergroups.users.update
 
-  notifyOnSlack:
-    needs: createReleaseIssue
+  notify_on_slack:
+    name: Notify new release manager on Slack
+    needs: create_release_issue
     if: |
       always() &&
       contains(github.event.issue.labels.*.name, 'release')
@@ -105,5 +107,5 @@ jobs:
       env:
         SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
         # Release manager is either the assignee from the newly created issue or the new assigned from the `assigned` trigger
-        RELEASE_MANAGER: ${{ needs.createReleaseIssue.outputs.assignee || github.event.issue.assignee.login }}
-        ISSUE_LINK: https://github.com/${{ github.repository }}/issues/${{ fromJson(needs.createReleaseIssue.outputs.issue).number }}
+        RELEASE_MANAGER: ${{ needs.create_release_issue.outputs.assignee || github.event.issue.assignee.login }}
+        ISSUE_LINK: https://github.com/${{ github.repository }}/issues/${{ fromJson(needs.create_release_issue.outputs.issue).number }}


### PR DESCRIPTION
### Proposed Changes

As discussed today in the morning, we want the release manager update to be explicitly notified to the team. This allows to react early in case the new release manager is not available. The PR is aiming to achieve that.

In [the boy scout rule](https://backendtea.com/post/boyscout-rule/) spirit, I also unified the slack integration in this repo to use the same version tag of the action, and consistently import the secrets from the vault.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
