### PR TITLE
feat: adjust resizer position to be more friendly

### DIFF
--- a/client/src/app/resizable-container/ResizableContainer.less
+++ b/client/src/app/resizable-container/ResizableContainer.less
@@ -1,4 +1,12 @@
 :local(.ResizableContainer) {
+
+  --resize-box-height: 10px;
+  --resize-box-top: calc(var(--resize-box-height) / -2);
+  --resize-box-closed-offset: -2px;
+
+  --resizer-height: 3px;
+  --resizer-handlebar-offset: calc(var(--resizer-height) * -2);
+
   position: relative;
 
   .children {
@@ -27,53 +35,53 @@
   }
 
   .resizer-top .resizer-border {
-    height: 3px;
-    bottom: 0;
+    height: var(--resizer-height);
+    bottom: var(--resizer-height);
     right: 0;
     left: 0;
   }
 
   .resizer-left .resizer-border {
-    width: 3px;
-    right: 0;
+    width: var(--resizer-height);
+    right: var(--resizer-height);
     top: 0;
     bottom: 0;
   }
 
   .resizer-top {
-    top: -13px;
+    top: var(--resize-box-top);
     width: 100%;
-    height: 16px;
+    height: var(--resize-box-height);
     cursor: ns-resize;
   }
 
   &:not(.open) .resizer-top {
-    height: 13px;
+    margin-top: var(--resize-box-closed-offset);
   }
 
   .resizer-top .handlebar {
     position: absolute;
     transform: translate(-50%, 0);
     left: 50%;
-    top: 0;
+    top: var(--resizer-handlebar-offset);
   }
 
   .resizer-left {
-    left: -13px;
-    width: 16px;
+    left: var(--resize-box-top);
+    width: var(--resize-box-height);
     height: 100%;
     cursor: ew-resize;
   }
 
   &:not(.open) .resizer-left {
-    width: 13px;
+    margin-left: var(--resize-box-closed-offset);
   }
 
   .resizer-left .handlebar {
     position: absolute;
     transform: translate(0, -50%);
     top: 50%;
-    left: 0;
+    left: var(--resizer-handlebar-offset);
   }
 
   .handlebar {


### PR DESCRIPTION
### Proposed Changes

This slightly adjusts the position of the resizer, so folks can somewhat interact with crowded contents above or right to it, cf. the following screen captures:


##### In BPMN editor

![capture wRSMmk_optimized](https://github.com/user-attachments/assets/c60054c7-26e7-47b4-aac1-4165973e2ebe)

##### In Forms editor

![capture Z224IJ_optimized](https://github.com/user-attachments/assets/da8d0933-278e-4a39-b0d5-dc2fd6fb6648)

Closes #4093

Try out via 

```
npx @bpmn-io/sr camunda/camunda-modeler#reposition-resizer
```

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [x] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
