### PR TITLE
Make multi file deployment work again

### DIFF
--- a/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
@@ -680,5 +680,5 @@ async function withSerializedAttachments(deployment, getPath) {
 }
 
 function basename(filePath) {
-  return filePath.split('\\').pop().split('/').pop();
+  return filePath ? filePath.split('\\').pop().split('/').pop() : '<unnamed>';
 }

--- a/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentToolSpec.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentToolSpec.js
@@ -270,12 +270,11 @@ describe('<DeploymentTool>', function() {
 
       // given
       const file = {
-        path: '/file/path/user.form',
         name: 'user.form',
         contents: []
       };
       const attachments = [ {
-        path: file.path
+        path: '/non/existing/path/user.form'
       } ];
       const savedConfiguration = createConfiguration({ attachments });
       const config = {
@@ -310,7 +309,6 @@ describe('<DeploymentTool>', function() {
       const { attachments: deployedAttachments } = deploySpy.args[0][1].deployment;
 
       expect(deployedAttachments[0]).have.property('name', file.name);
-      expect(deployedAttachments[0]).have.property('path', file.path);
       expect(deployedAttachments[0]).have.property('contents');
       expect(deployedAttachments[0].contents).not.to.be.null;
     });
@@ -1523,6 +1521,9 @@ function createSavedConfiguration(configuration) {
 
 function createFileSystem(overrides = {}) {
   return {
+    getFilePath() {
+      return '/file/path';
+    },
     readFile() {},
     ...overrides
   };

--- a/client/src/shared/ui/form/FileInput.js
+++ b/client/src/shared/ui/form/FileInput.js
@@ -47,8 +47,9 @@ export default function FileInput(props) {
   function onChange() {
     const { files } = inputRef.current;
     const fileDescriptors = toFileDescriptors(files);
+    const newValue = uniqueBy(file => fileToKey(file), value, fileDescriptors);
 
-    form.setFieldValue(name, uniqueBy('path', value, fileDescriptors));
+    form.setFieldValue(name, newValue);
   }
 
   function removeFile(fileToRemove) {

--- a/client/src/shared/ui/form/FileInput.js
+++ b/client/src/shared/ui/form/FileInput.js
@@ -26,7 +26,7 @@ import ErrorIcon from '../../../../resources/icons/Error.svg';
  * @typedef FileDescriptor
  * @property {Uint8Array|Blob|null} contents
  * @property {string} name
- * @property {string} path
+ * @property {number} lastModified
  */
 
 export default function FileInput(props) {
@@ -82,6 +82,10 @@ export default function FileInput(props) {
   );
 }
 
+/**
+ * @param {object} props
+ * @param {FileDescriptor[]} props.files
+ */
 function FileList(props) {
   const {
     errors: formErrors,
@@ -96,7 +100,7 @@ function FileList(props) {
     <ul className={ classNames('file-list', { 'is-invalid': invalid }) }>
       { files.map((file, index) => (
         <ListItem
-          key={ file.path } name={ file.name } onRemove={ () => onRemove(file) }
+          key={ fileToKey(file) } name={ file.name } onRemove={ () => onRemove(file) }
           error={ getIn(formErrors, `${fieldName}[${index}]`) } />
       ))}
     </ul>
@@ -134,7 +138,6 @@ function toFileDescriptors(fileList) {
     .map(file => {
       return {
         name: file.name,
-        path: file.path,
         lastModified: file.lastModified,
         contents: file
       };
@@ -166,4 +169,12 @@ function getIconFromFileType(name, error) {
   default:
     return <div className="default_file-icon" />;
   }
+}
+
+/**
+ * @param {FileDescriptor} file
+ * @returns {string}
+ */
+function fileToKey(file) {
+  return `${file.name}_${file.lastModified}`;
 }

--- a/client/src/shared/ui/form/__tests__/FileInputSpec.js
+++ b/client/src/shared/ui/form/__tests__/FileInputSpec.js
@@ -154,7 +154,6 @@ function createFileInput(options = {}, render = shallow) {
 function createFile(options = {}) {
   return {
     name: 'file',
-    path: '/fake/path',
     lastModified: 1,
     contents: 'contents',
     ...options
@@ -164,7 +163,6 @@ function createFile(options = {}) {
 function createFileDescriptor(file = {}) {
   return {
     name: 'file',
-    path: '/fake/path',
     lastModified: 1,
     contents: file
   };


### PR DESCRIPTION
### Proposed Changes

This makes sure we can again deploy with attachments which was broken since the Electron 32 migration.

We solve both the new file deployment as well as the already broken config:

![image](https://github.com/user-attachments/assets/d6aed28c-91c3-4970-ab0d-c7d40c1574cb)

Closes #4694

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
