### PR TITLE
fix: display status bar in correct order

### DIFF
--- a/client/src/plugins/report-feedback/ReportFeedback.js
+++ b/client/src/plugins/report-feedback/ReportFeedback.js
@@ -100,7 +100,7 @@ export class ReportFeedback extends PureComponent {
 
     return (
       <Fragment>
-        <Fill slot="status-bar__app" group="8_feedback">
+        <Fill slot="status-bar__app" group="9_feedback">
           <button
             className={ classNames('btn', { 'btn--active': open }, css.ReportFeedback) }
             title="Provide Feedback"

--- a/client/src/plugins/update-checks/UpdateChecks.js
+++ b/client/src/plugins/update-checks/UpdateChecks.js
@@ -378,10 +378,12 @@ export default class UpdateChecks extends PureComponent {
       updateAvailable
     } = this.state;
 
+    // using group starting with Z to display at the end of the status bar
+    // cf. https://github.com/camunda/camunda-modeler/commit/b79fe1dec26fac603980b2639a46dc8656661dcd#r149356417
     return (
       <React.Fragment>
         {
-          updateAvailable && <Fill slot="status-bar__app" group="9_update_checks">
+          updateAvailable && <Fill slot="status-bar__app" group="Z_update_checks">
             <button
               className="btn btn--primary"
               title="Toggle update info"

--- a/client/src/plugins/version-info/VersionInfo.js
+++ b/client/src/plugins/version-info/VersionInfo.js
@@ -113,7 +113,7 @@ export class VersionInfo extends PureComponent {
 
     return (
       <Fragment>
-        <Fill slot="status-bar__app" group="8_version-info">
+        <Fill slot="status-bar__app" group="9_version-info">
           <button
             className={ classNames('btn', { 'btn--active': open }) }
             title="Toggle version info"


### PR DESCRIPTION
This reverts the recent change of the group names which caused the issue in the linked comment.

Related to https://github.com/camunda/camunda-modeler/commit/b79fe1dec26fac603980b2639a46dc8656661dcd#r149356417

### Proposed Changes

Use group name starting with `Z` for the nudge, and old group names for other buttons.

![image](https://github.com/user-attachments/assets/2f4c3f0c-aa9d-48da-afac-930d3f5d51bd)

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
