### PR TITLE
fix: do not mark job worker user task as incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FIX`: correct dangling selection after search pad interaction ([bpmn-io/diagram-js#947](https://github.com/bpmn-io/diagram-js/pull/947))
 * `FIX`: create new user task form only if user task form referenced ([camunda/camunda-bpmn-js-behaviors#85](https://github.com/camunda/camunda-bpmn-js-behaviors/pull/85), [#4658](https://github.com/camunda/camunda-modeler/issues/4658))
 * `FIX`: keep multi-instance characteristics on type change ([#4310](https://github.com/camunda/camunda-modeler/issues/4310))
+* `FIX`: do not mark job worker user task as incorrect
 
 ### DMN
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FIX`: correct dangling selection after search pad interaction ([bpmn-io/diagram-js#947](https://github.com/bpmn-io/diagram-js/pull/947))
 * `FIX`: create new user task form only if user task form referenced ([camunda/camunda-bpmn-js-behaviors#85](https://github.com/camunda/camunda-bpmn-js-behaviors/pull/85), [#4658](https://github.com/camunda/camunda-modeler/issues/4658))
 * `FIX`: keep multi-instance characteristics on type change ([#4310](https://github.com/camunda/camunda-modeler/issues/4310))
-* `FIX`: do not mark job worker user task as incorrect
+* `FIX`: do not mark job worker user task as incorrect ([#4718](https://github.com/camunda/camunda-modeler/issues/4718))
 
 ### DMN
 

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
     "@camunda/form-linting": "^0.18.0",
     "@camunda/form-playground": "^0.18.0",
     "@camunda/improved-canvas": "^1.7.5",
-    "@camunda/linting": "^3.29.0",
+    "@camunda/linting": "^3.29.1",
     "@codemirror/commands": "^6.6.2",
     "@codemirror/lang-json": "^6.0.1",
     "@codemirror/lang-xml": "^6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,7 @@
         "@camunda/form-linting": "^0.18.0",
         "@camunda/form-playground": "^0.18.0",
         "@camunda/improved-canvas": "^1.7.5",
-        "@camunda/linting": "^3.29.0",
+        "@camunda/linting": "^3.29.1",
         "@codemirror/commands": "^6.6.2",
         "@codemirror/lang-json": "^6.0.1",
         "@codemirror/lang-xml": "^6.1.0",
@@ -3121,15 +3121,15 @@
       "integrity": "sha512-to+unsToePnm7cUeR9TrMzFlETHd/UXmU+ELTRfWZj5XGT41KF6X3L233o3E/GdEs3sk2Tbw/lOLD1avmWkg8A=="
     },
     "node_modules/@camunda/linting": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-3.29.0.tgz",
-      "integrity": "sha512-E8IuLwt+u/8T7/BpemE/j0hElzp0RVcosB+TTeRgl5u8X2f7r7Exqdj4LLDYX5ACUmjjzJzxwQtUqiz9cDSkjQ==",
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-3.29.1.tgz",
+      "integrity": "sha512-BGmiGNF2Xm7uGHaeCraWmk5gGzNKvkukZMeUJROGlodjLiXWLlXacHReGSfpt1AVB0hekkSN0gQzfzPn/O8yKQ==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "bpmn-moddle": "^9.0.1",
         "bpmnlint": "^10.3.1",
-        "bpmnlint-plugin-camunda-compat": "^2.28.0",
+        "bpmnlint-plugin-camunda-compat": "^2.28.1",
         "bpmnlint-utils": "^1.0.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -11455,9 +11455,9 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.28.0.tgz",
-      "integrity": "sha512-NAdJZuOnopHrmuGf3+QAMLmAOLcBPxjTI+YCP2YXeAQ0A/3OD1Ek3NhcYfy3im19OA9TRVECzLsH97D32NzANA==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.28.1.tgz",
+      "integrity": "sha512-HBs5mqru2txC11g8wJALYd1xAbB24BL1LiXZyWWfWtdhh467FfELmibHZ0U+MUwv1QX2lACMQfVqb/A8HFV9wA==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/feel-lint": "^1.2.0",
@@ -34417,14 +34417,14 @@
       }
     },
     "@camunda/linting": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-3.29.0.tgz",
-      "integrity": "sha512-E8IuLwt+u/8T7/BpemE/j0hElzp0RVcosB+TTeRgl5u8X2f7r7Exqdj4LLDYX5ACUmjjzJzxwQtUqiz9cDSkjQ==",
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-3.29.1.tgz",
+      "integrity": "sha512-BGmiGNF2Xm7uGHaeCraWmk5gGzNKvkukZMeUJROGlodjLiXWLlXacHReGSfpt1AVB0hekkSN0gQzfzPn/O8yKQ==",
       "requires": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "bpmn-moddle": "^9.0.1",
         "bpmnlint": "^10.3.1",
-        "bpmnlint-plugin-camunda-compat": "^2.28.0",
+        "bpmnlint-plugin-camunda-compat": "^2.28.1",
         "bpmnlint-utils": "^1.0.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -40589,9 +40589,9 @@
       "requires": {}
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.28.0.tgz",
-      "integrity": "sha512-NAdJZuOnopHrmuGf3+QAMLmAOLcBPxjTI+YCP2YXeAQ0A/3OD1Ek3NhcYfy3im19OA9TRVECzLsH97D32NzANA==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.28.1.tgz",
+      "integrity": "sha512-HBs5mqru2txC11g8wJALYd1xAbB24BL1LiXZyWWfWtdhh467FfELmibHZ0U+MUwv1QX2lACMQfVqb/A8HFV9wA==",
       "requires": {
         "@bpmn-io/feel-lint": "^1.2.0",
         "@bpmn-io/moddle-utils": "^0.2.1",
@@ -41115,7 +41115,7 @@
         "@camunda/form-linting": "^0.18.0",
         "@camunda/form-playground": "^0.18.0",
         "@camunda/improved-canvas": "^1.7.5",
-        "@camunda/linting": "^3.29.0",
+        "@camunda/linting": "^3.29.1",
         "@codemirror/commands": "^6.6.2",
         "@codemirror/lang-json": "^6.0.1",
         "@codemirror/lang-xml": "^6.1.0",


### PR DESCRIPTION
Closes #4718

### Proposed Changes

This removes the error as user tasks implemented as job workers are still allowed in Camunda 8.7.

![image](https://github.com/user-attachments/assets/de48f2ba-6115-4850-92c0-c46d556232cc)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
