### PR TITLE
docs: document file bindings

### DIFF
--- a/docs/.project/INTEGRATION_TEST.md
+++ b/docs/.project/INTEGRATION_TEST.md
@@ -105,8 +105,12 @@ Based on the [test diagram](./test.bpmn.png):
 * [ ] Reference the form in the user task via `Camunda Forms -> reference=foo`
 * [ ] Verify that deployment of BPMN + Form file works
 
-#### FS integration (platform specific)
+#### File system integration (platform specific)
 
+* [ ] bindings register:
+  * [ ] [Windows](https://github.com/camunda/camunda-modeler/tree/develop/resources/platform/win32/support)
+  * [ ] [Linux](https://github.com/camunda/camunda-modeler/tree/develop/resources/platform/linux/support)
+  * [ ] MacOS - done automatically
 * [ ] external change detection works
   * [ ] change file in external editor
   * [ ] focus editor with file open


### PR DESCRIPTION
### Proposed Changes

This adds missing links on file type bindings.
To check: Do we still need them on Windows? How does it work on Linux?

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
