### PR TITLE
Use `/processes` route for run instance link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+### General
+
+* `FIX`: use `/processes` route for run instance link ([#4741](https://github.com/camunda/camunda-modeler/issues/4741))
+
 ## 5.30.0
 
 ### General

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
@@ -351,7 +351,7 @@ function CloudLink(props) {
   } = response;
 
   const clusterUrl = getClusterUrl(endpoint);
-  const url = `${clusterUrl}/instances/${processInstanceKey}`;
+  const url = `${clusterUrl}/processes/${processInstanceKey}`;
 
   return (
     <div className={ css.CloudLink }>

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginSpec.js
@@ -444,7 +444,7 @@ describe('<StartInstancePlugin> (Zeebe)', function() {
       const notificationHTML = shallow(notification.content).html().replace(/&amp;/g, '&');
 
       expect(notificationHTML).to.include(
-        'https://region.operate.camunda.io/CLUSTER_ID/instances/test'
+        'https://region.operate.camunda.io/CLUSTER_ID/processes/test'
       );
     });
 


### PR DESCRIPTION
### Proposed Changes

This changes the route to accommodate for Operate's routes change.

* [x] Works with 8.5
* [x] Works with 8.6

Closes #4741


https://github.com/user-attachments/assets/5dccac7d-9670-4ade-9793-1d75c14189a5



### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
