### PR TITLE
Add migrate link to help menu

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,8 @@ jobs:
         cache: 'npm'
     - name: Install dependencies
       run: npm ci
+    - name: Project setup
+      uses: bpmn-io/actions/setup@latest
     - name: Build with code coverage
       if: ${{ runner.OS == 'Linux' }}
       run: COVERAGE=1 npm run all -- --x64 --no-compress

--- a/client/src/app/EmptyTab.js
+++ b/client/src/app/EmptyTab.js
@@ -115,7 +115,7 @@ export default class EmptyTab extends PureComponent {
           </div>
           <div className="article relative">
             <p>Migrating from Camunda 7</p>
-            <a href="https://docs.camunda.io/docs/guides/migrating-from-Camunda-Platform/">Camunda Docs</a>
+            <a href="https://docs.camunda.io/docs/guides/migrating-from-Camunda-Platform/?utm_source=modeler&utm_medium=referral">Camunda Docs</a>
           </div>
           <div className="article">
             <p>About Modeler 5</p>
@@ -123,7 +123,7 @@ export default class EmptyTab extends PureComponent {
           </div>
           <div className="article">
             <p>Model your first diagram</p>
-            <a href="https://docs.camunda.io/docs/components/modeler/desktop-modeler/model-your-first-diagram/">Camunda Modeler Docs</a>
+            <a href="https://docs.camunda.io/docs/components/modeler/desktop-modeler/model-your-first-diagram/?utm_source=modeler&utm_medium=referral">Camunda Modeler Docs</a>
           </div>
         </div>
       </div>

--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -80,7 +80,7 @@ const BPMN_HELP_MENU = [
 
 const C7_HELP_MENU = [
   {
-    label: 'Migrate to Camunda 8',
+    label: 'Camunda 8 Migration Guide',
     action: 'https://docs.camunda.io/docs/guides/migrating-from-camunda-7/?utm_source=modeler&utm_medium=referral'
   }
 ];

--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -78,6 +78,13 @@ const BPMN_HELP_MENU = [
   }
 ];
 
+const C7_HELP_MENU = [
+  {
+    label: 'Migrate to Camunda 8',
+    action: 'https://docs.camunda.io/docs/guides/migrating-from-camunda-7/?utm_source=modeler&utm_medium=referral'
+  }
+];
+
 const DMN_HELP_MENU = [
   {
     label: 'DMN Tutorial',
@@ -242,7 +249,7 @@ export default class TabsProvider {
           return `diagram_${suffix}.bpmn`;
         },
         getHelpMenu() {
-          return BPMN_HELP_MENU;
+          return BPMN_HELP_MENU.concat(C7_HELP_MENU);
         },
         getNewFileMenu() {
           return [ {
@@ -354,7 +361,7 @@ export default class TabsProvider {
           return `diagram_${suffix}.dmn`;
         },
         getHelpMenu() {
-          return DMN_HELP_MENU;
+          return DMN_HELP_MENU.concat(C7_HELP_MENU);
         },
         getNewFileMenu() {
           return [ {


### PR DESCRIPTION
### Proposed Changes

This adds the migration page link to the help menu so that it's always accessible:

![Screenshot 2025-01-07 at 16 15 17](https://github.com/user-attachments/assets/69cfecee-0a98-4f8d-81a3-8780ea352b68)

It also adds `utm` tags to the empty page camunda docs links so that we can see whether users use them.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
