### PR TITLE
DRD overview resizing fix

### DIFF
--- a/client/src/app/drop-zone/DropHandler.js
+++ b/client/src/app/drop-zone/DropHandler.js
@@ -38,6 +38,10 @@ export class DropHandler {
   }
 
   handleDragLeave(event) {
+    if (!this.isDragAllowed(event)) {
+      return DropHandler.STATES.NOT_DRAGGING;
+    }
+
     event.preventDefault();
     event.stopPropagation();
 

--- a/client/src/util/dom/dragger.js
+++ b/client/src/util/dom/dragger.js
@@ -8,10 +8,10 @@
  * except in compliance with the MIT License.
  */
 
-import {
-  domify
-} from 'min-dom';
-
+// This is a 1x1px transparent GIF. It's used to override the default drag preview image.
+// For macOS, this has to be an actual image and has to be loaded before we set it.
+const EMPTY_IMAGE = new Image(1, 1);
+EMPTY_IMAGE.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
 
 /**
  * Add a dragger that calls back the passed function with
@@ -45,7 +45,7 @@ export default function createDragger(fn) {
 
     // (1) prevent preview image
     if (event.dataTransfer) {
-      event.dataTransfer.setDragImage(emptyCanvas(), 0, 0);
+      event.dataTransfer.setDragImage(EMPTY_IMAGE, 0, 0);
     }
 
     // (2) setup drag listeners
@@ -73,11 +73,6 @@ export default function createDragger(fn) {
   }
 
   return onDragStart;
-}
-
-
-function emptyCanvas() {
-  return domify('<canvas width="0" height="0" />');
 }
 
 function preventDefault(event) {


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

This pull requests fixes two problems I found when resizing DRD preview:
1. When resizing, diagram drop zone would trigger occasionally and flash.
3. When resizing on macOS, the default (unloaded image) icon would show next to the cursor.

Before:

https://github.com/user-attachments/assets/716c9aa4-a0bc-492f-946d-95a41c3c9361




After:

https://github.com/user-attachments/assets/42816b13-b439-4903-a265-5aa49948d50b


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
