### PR TITLE
feat: support Camunda 8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ___Note:__ Yet to be released changes appear here._
 
 ### General
 
+* `FEAT`: support Camunda 8.8
 * `DEPS`: update to `@camunda/improved-canvas@1.7.6`
 
 ### BPMN

--- a/client/src/util/Engines.js
+++ b/client/src/util/Engines.js
@@ -21,7 +21,7 @@ export const ENGINE_PROFILES = [
   },
   {
     executionPlatform: ENGINES.CLOUD,
-    executionPlatformVersions: [ '8.7.0', '8.6.0', '8.5.0', '8.4.0', '8.3.0', '8.2.0', '8.1.0', '8.0.0' ],
+    executionPlatformVersions: [ '8.8.0', '8.7.0', '8.6.0', '8.5.0', '8.4.0', '8.3.0', '8.2.0', '8.1.0', '8.0.0' ],
     latestStable: '8.6.0'
   }
 ];


### PR DESCRIPTION
### Proposed Changes

This adds Camunda 8.8 to the engines map. This allows to validate diagrams with Camunda 8.8 features, e.g. user task listeners.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
