### PR TITLE
fix: make text in tooltip selectable

### DIFF
--- a/client/src/app/resizable-container/PropertiesPanelContainer.less
+++ b/client/src/app/resizable-container/PropertiesPanelContainer.less
@@ -21,4 +21,9 @@
     --font-family-monospace: inherit;
     background: var(--color-white);
   }
+
+  // This makes the text inside of a tooltip selectable
+  .bio-properties-panel :has(.bio-properties-panel-tooltip-content) * {
+    user-select: text;
+  }
 }


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/4834

### Proposed Changes

Make text inside of a tooltip selectable.

![Screenshot 2025-02-20 at 12 47 54](https://github.com/user-attachments/assets/6d7dd3c8-dd1b-4a01-a04a-542a0824831e)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
