### PR TITLE
Fix links in the release notice

### DIFF
--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -163,11 +163,10 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        # Fetch the list of milestones for the repository
-        # Filter for milestones that start with 'M' and are open
+        # Fetch the milestone of the currently open release issue
         MILESTONE=$(gh api -H "Accept: application/vnd.github.v3+json" \
-          /repos/${{ github.repository }}/milestones \
-          --jq '[.[] | select(.title | startswith("M")) | .number ][0]'
+          "/repos/camunda/camunda-modeler/issues?state=open&labels=release" \
+          --jq "[.[] | .milestone.title ][0]"
         )
         echo "LINK=https://github.com/camunda/camunda-modeler/issues?q=is%3Aissue+label%3Achannel%3Asupport+milestone%3A$MILESTONE" >> $GITHUB_OUTPUT
     - name: Post to a Slack channel

--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -153,6 +153,7 @@ jobs:
         secrets: |
           secret/data/products/desktop-modeler/ci/slack_integration SUPPORT_SLACK_CHANNEL_ID;
           secret/data/products/desktop-modeler/ci/slack_integration SLACK_BOT_TOKEN;
+          secret/data/products/desktop-modeler/ci/slack_integration RELEASE_MANAGER_GROUP_ID;
     - name: Get changelog link
       id: changelog
       run: |
@@ -179,8 +180,8 @@ jobs:
           blocks:
             - type: section
               text:
-                type: plain_text
-                text: '[fyi] Hi, Desktop Modeler ${{ needs.pre_release.outputs.tag }} release is upcoming. Contact @desktop-modeler-release-manager in case of any questions.'
+                type: mrkdwn
+                text: '[fyi] Hi, Desktop Modeler ${{ needs.pre_release.outputs.tag }} release is upcoming. Contact <!subteam^${{ steps.secrets.outputs.RELEASE_MANAGER_GROUP_ID }}> in case of any questions.'
             - type: section
               text:
                 type: mrkdwn

--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -185,7 +185,7 @@ jobs:
             - type: section
               text:
                 type: mrkdwn
-                text: '${{ steps.changelog.outputs.LINK }}|Changelog>'
+                text: '<${{ steps.changelog.outputs.LINK }}|Changelog>'
             - type: section
               text:
                 type: mrkdwn


### PR DESCRIPTION
### Proposed Changes

Changelog link missed the opening (`<`) but it's now added.

The milestone part expects that there is only a single issue, so if merge this, I will change the labels of [the remaining `release` issues](https://github.com/camunda/camunda-modeler/issues?q=is%3Aissue%20state%3Aopen%20label%3Arelease) to `infrastructure`.

```
❯ gh api -H "Accept: application/vnd.github.v3+json" \
          "/repos/camunda/camunda-modeler/issues?state=open&labels=release" \
          --jq "[.[] | .milestone.title ][0]"
M86
```

Syntax for highlighting the user group: https://api.slack.com/reference/surfaces/formatting#mentioning-groups

Closes #4866

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
