### PR TITLE
camunda self managed oauth not connecting

### DIFF
--- a/app/lib/zeebe-api/zeebe-api.js
+++ b/app/lib/zeebe-api/zeebe-api.js
@@ -371,7 +371,7 @@ class ZeebeAPI {
         ZEEBE_CLIENT_SECRET: endpoint.clientSecret,
         CAMUNDA_OAUTH_URL: endpoint.oauthURL,
         CAMUNDA_TOKEN_SCOPE: endpoint.scope,
-        CAMUNDA_CONSOLE_OAUTH_AUDIENCE: endpoint.audience,
+        CAMUNDA_ZEEBE_OAUTH_AUDIENCE: endpoint.audience,
         CAMUNDA_TOKEN_DISK_CACHE_DISABLE: true
       };
     } else if (type === ENDPOINT_TYPES.CAMUNDA_CLOUD) {
@@ -379,7 +379,7 @@ class ZeebeAPI {
         ...options,
         CAMUNDA_AUTH_STRATEGY: 'OAUTH',
         CAMUNDA_OAUTH_URL: 'https://login.cloud.camunda.io/oauth/token',
-        CAMUNDA_CONSOLE_OAUTH_AUDIENCE: endpoint.audience,
+        CAMUNDA_ZEEBE_OAUTH_AUDIENCE: endpoint.audience,
         CAMUNDA_TOKEN_SCOPE: endpoint.scope,
         ZEEBE_CLIENT_ID: endpoint.clientId,
         ZEEBE_CLIENT_SECRET: endpoint.clientSecret,

--- a/app/test/spec/zeebe-api/zeebe-api-spec.js
+++ b/app/test/spec/zeebe-api/zeebe-api-spec.js
@@ -1223,7 +1223,7 @@ describe('ZeebeAPI', function() {
 
         expect(config).to.include.keys({
           CAMUNDA_AUTH_STRATEGY: 'OAUTH',
-          CAMUNDA_CONSOLE_OAUTH_AUDIENCE: 'audience',
+          CAMUNDA_ZEEBE_OAUTH_AUDIENCE: 'audience',
           ZEEBE_CLIENT_ID: 'clientId',
           ZEEBE_CLIENT_SECRET: 'clientSecret',
           CAMUNDA_TOKEN_SCOPE: 'scope',
@@ -2363,7 +2363,7 @@ describe('ZeebeAPI', function() {
           CAMUNDA_TOKEN_SCOPE: 'scope',
           ZEEBE_CLIENT_ID: 'clientId',
           ZEEBE_CLIENT_SECRET: '******',
-          CAMUNDA_CONSOLE_OAUTH_AUDIENCE: 'audience',
+          CAMUNDA_ZEEBE_OAUTH_AUDIENCE: 'audience',
           CAMUNDA_OAUTH_URL: 'oauthURL',
           CAMUNDA_SECURE_CONNECTION: false
         }


### PR DESCRIPTION
Closes #4871

Issue initially reported in https://camunda.slack.com/archives/C0693F1NFK5/p1740732406983989

Stage env https://ultrawombat.com/

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Previously
Zeebe audience property was not setup and it was taking default property for audience. 
![Mar-04-2025 22-48-18 (old behavior)](https://github.com/user-attachments/assets/24afa56d-4997-45c5-925e-41d3932267b9)

logs: 
![Screenshot 2025-03-04 at 22 49 12](https://github.com/user-attachments/assets/0d9ce528-859c-47a4-a89e-34360df8b4cf)

### Proposed Changes

Audience property can be set by `CAMUNDA_ZEEBE_OAUTH_AUDIENCE`.
![Mar-04-2025 22-50-50 (new)](https://github.com/user-attachments/assets/292f0daa-543e-4770-8264-70eb3553c063)

logs: ![Screenshot 2025-03-04 at 22 51 16](https://github.com/user-attachments/assets/27be6877-0d0c-4ca1-b44b-0087c9dac707)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
