### PR TITLE
docs(project): update PATCH_RELEASE_TEMPLATE

### DIFF
--- a/docs/.project/PATCH_RELEASE_TEMPLATE.md
+++ b/docs/.project/PATCH_RELEASE_TEMPLATE.md
@@ -18,12 +18,13 @@ _To be done to prepare and build the release._
   * `bpmn-js`, `dmn-js`, `*-properties-panel`, `*-moddle`, `camunda-bpmn-js`, `form-js`, ...
 * [ ] make sure dependencies to upstream libraries are updated and can be installed (`rm -rf node_modules && npm i && npm run all` works)
 * [ ] close all issues which are solved by dependency updates
-* [ ] ensure that the modeler is free of major security vulnerabilities via `npm audit`
 * [ ] smoke test to verify all diagrams can be created
-* [ ] update [Release Info](https://github.com/camunda/camunda-modeler/blob/master/client/src/plugins/version-info/ReleaseInfo.js)
+* [ ] ~~update [Release Info](https://github.com/camunda/camunda-modeler/blob/master/client/src/plugins/version-info/ReleaseInfo.js)~~
+  * [ ] We don't usually do this
 * [ ] update [`CHANGELOG`](https://github.com/camunda/camunda-modeler/blob/master/CHANGELOG.md)
-* [ ] create release (`npm run release`), cf. [release schema](https://github.com/bpmn-io/internal-docs/tree/master/release-schema)
+* [ ] create release (`npm run release`), cf. [release schema](https://github.com/bpmn-io/internal-docs/blob/main/releases/RELEASE_SCHEMA.md)
   * [ ] wait for [release build](https://github.com/camunda/camunda-modeler/actions/workflows/RELEASE.yml) to create the [artifacts](https://github.com/camunda/camunda-modeler/releases)
+* [ ] make sure Windows artifacts are signed
 * [ ] prepare a list of what was changed or needs to be tested
 * [ ] execute integration test, verifying fixed things are actually fixed
 * [ ] (optional) trigger QA for testing
@@ -33,6 +34,7 @@ _To be done to make the release publicly available._
 * [ ] publish release on [Github Releases](https://github.com/camunda/camunda-modeler/releases)
 * [ ] trigger [downloads page](https://camunda.com/download/modeler/) update via [marketing request form](https://confluence.camunda.com/display/MAR/Marketing+Request+Form)
 * [ ] add new version to [update server releases](https://github.com/camunda/camunda-modeler-update-server/blob/master/releases.json)
+  * Usually this does not contain an updated release info 
 * [ ] publish release via update server (push to `live`)
 
 _To be done post release._


### PR DESCRIPTION
### Proposed Changes

Ensure the template is reasonably up to date with [RELEASE_TEMPLATE](https://github.com/camunda/camunda-modeler/blob/main/docs/.project/RELEASE_TEMPLATE.md), but also meaningful for the purpose at hand ("cut a patch release, quickly"):

* Removed need to check for vulnerabilities: This may introduce additional unwanted noise during a patch release, we want to ship these with maximum confidence, minimum uncertainty, and prevent any kind of unneeded noise.
* Ensure that it is clear that we usually don't update the release info (in modeler)
* Link Windows signing, mirroring https://github.com/camunda/camunda-modeler/pull/4880
* Fix dead link 

----

Identified when cutting the [v5.33.1 patch](https://github.com/camunda/camunda-modeler/issues/4881).

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
