### PR TITLE
ci: handle release issue reassignment correctly

### DIFF
--- a/.github/workflows/RELEASE_ISSUE.yml
+++ b/.github/workflows/RELEASE_ISSUE.yml
@@ -110,4 +110,4 @@ jobs:
       env:
         # Release manager is either the assignee from the newly created issue or the new assigned from the `assigned` trigger
         RELEASE_MANAGER: ${{ needs.create_release_issue.outputs.assignee || github.event.issue.assignee.login }}
-        ISSUE_LINK: https://github.com/${{ github.repository }}/issues/${{ fromJson(needs.create_release_issue.outputs.issue).number }}
+        ISSUE_LINK: https://github.com/${{ github.repository }}/issues/${{ needs.create_release_issue.outputs.issue && fromJson(needs.create_release_issue.outputs.issue).number || github.event.issue.number }}


### PR DESCRIPTION
### Proposed Changes

This aims to fix the blowup from https://github.com/camunda/camunda-modeler/actions/runs/13674718309
Since no issue was created, JSON parser could not parse missing output. This caused the action to fail. 
With the change from this PR, the reassigned issue will be used instead.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
