### PR TITLE
chore: enable rpa by default

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
     "@camunda/form-playground": "^0.20.0",
     "@camunda/improved-canvas": "^1.7.6",
     "@camunda/linting": "^3.33.0",
-    "@camunda/rpa-integration": "0.1.0",
+    "@camunda/rpa-integration": "0.2.0",
     "@carbon/icons-react": "^11.53.0",
     "@codemirror/commands": "^6.6.2",
     "@codemirror/lang-json": "^6.0.1",

--- a/client/src/app/TabsProvider.js
+++ b/client/src/app/TabsProvider.js
@@ -597,7 +597,7 @@ export default class TabsProvider {
       delete this.providersByFileType.form;
     }
 
-    if (Flags.get(DISABLE_RPA, true)) {
+    if (Flags.get(DISABLE_RPA)) {
       delete this.providers.rpa;
       delete this.providersByFileType.rpa;
     }

--- a/client/src/app/__tests__/EmptyTabSpec.js
+++ b/client/src/app/__tests__/EmptyTabSpec.js
@@ -39,11 +39,12 @@ describe('<EmptyTab>', function() {
       buttons.forEach(wrapper => wrapper.simulate('click'));
 
       // then
-      expect(onAction).to.have.callCount(6);
+      expect(onAction).to.have.callCount(7);
       expect(onAction.args).to.eql([
         [ 'create-cloud-bpmn-diagram', undefined ],
         [ 'create-cloud-dmn-diagram', undefined ],
         [ 'create-cloud-form', undefined ],
+        [ 'create-diagram', { type: 'rpa' } ],
         [ 'create-bpmn-diagram', undefined ],
         [ 'create-dmn-diagram', undefined ],
         [ 'create-form', undefined ]

--- a/client/src/app/__tests__/TabsProviderSpec.js
+++ b/client/src/app/__tests__/TabsProviderSpec.js
@@ -218,10 +218,6 @@ describe('TabsProvider', function() {
     it('should replace version placeholder with actual latest version (BPMN)', function() {
 
       // given
-      Flags.init({
-        [DISABLE_RPA]: false
-      });
-
       const tabsProvider = new TabsProvider();
 
       const expectedPlatformVersion = getLatestStablePlatformVersion(ENGINES.PLATFORM);
@@ -482,10 +478,6 @@ describe('TabsProvider', function() {
 
         it('should replace version placeholder with actual latest version (RPA)', function() {
 
-          Flags.init({
-            [DISABLE_RPA]: false
-          });
-
           // given
           const tabsProvider = new TabsProvider();
 
@@ -568,8 +560,7 @@ describe('TabsProvider', function() {
 
     // given
     Flags.init({
-      [DISABLE_CMMN]: false,
-      [DISABLE_RPA]: false
+      [DISABLE_CMMN]: false
     });
 
     const tabsProvider = new TabsProvider();
@@ -882,8 +873,7 @@ describe('TabsProvider', function() {
 
     // given
     Flags.init({
-      [DISABLE_CMMN]: false,
-      [DISABLE_RPA]: false
+      [DISABLE_CMMN]: false
     });
 
     const tabsProvider = new TabsProvider();
@@ -914,7 +904,7 @@ describe('TabsProvider', function() {
       const providerNames = tabsProvider.getProviderNames();
 
       // then
-      expect(providerNames).to.eql([ 'BPMN', 'DMN', 'FORM' ]);
+      expect(providerNames).to.eql([ 'BPMN', 'DMN', 'FORM', 'RPA' ]);
 
     });
 
@@ -923,8 +913,7 @@ describe('TabsProvider', function() {
 
       // given
       Flags.init({
-        [DISABLE_CMMN]: false,
-        [DISABLE_RPA]: false
+        [DISABLE_CMMN]: false
       });
       const tabsProvider = new TabsProvider();
 
@@ -941,8 +930,7 @@ describe('TabsProvider', function() {
 
       // given
       Flags.init({
-        [DISABLE_PLATFORM]: true,
-        [DISABLE_RPA]: false
+        [DISABLE_PLATFORM]: true
       });
       const tabsProvider = new TabsProvider();
 
@@ -1275,8 +1263,7 @@ describe('TabsProvider', function() {
 
     beforeEach(function() {
       Flags.init({
-        [DISABLE_CMMN]: false,
-        [DISABLE_RPA]: false
+        [DISABLE_CMMN]: false
       });
 
       tabsProvider = new TabsProvider();

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
         "@camunda/form-playground": "^0.20.0",
         "@camunda/improved-canvas": "^1.7.6",
         "@camunda/linting": "^3.33.0",
-        "@camunda/rpa-integration": "0.1.0",
+        "@camunda/rpa-integration": "0.2.0",
         "@carbon/icons-react": "^11.53.0",
         "@codemirror/commands": "^6.6.2",
         "@codemirror/lang-json": "^6.0.1",
@@ -3193,9 +3193,9 @@
       }
     },
     "node_modules/@camunda/rpa-integration": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@camunda/rpa-integration/-/rpa-integration-0.1.0.tgz",
-      "integrity": "sha512-oziFoqGLicZJ7pqf0tvxtaMMpHMn3i94hwVsP3lTJjcfNWoTOvWTLZ0yuvb1ke7rkvWZeSWD8lI9sBCAnMn+xQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@camunda/rpa-integration/-/rpa-integration-0.2.0.tgz",
+      "integrity": "sha512-GTLf/KGfWkbU7wlz0cabwmMMXsjLpxvKlldT6vaxS7HKluFbzspb5HMsugvyIgPt35XSKw67NptUGhqGNrdBnA==",
       "license": "Camunda License 1.0",
       "dependencies": {
         "@bpmn-io/properties-panel": "^3.25.0",
@@ -35676,9 +35676,9 @@
       }
     },
     "@camunda/rpa-integration": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@camunda/rpa-integration/-/rpa-integration-0.1.0.tgz",
-      "integrity": "sha512-oziFoqGLicZJ7pqf0tvxtaMMpHMn3i94hwVsP3lTJjcfNWoTOvWTLZ0yuvb1ke7rkvWZeSWD8lI9sBCAnMn+xQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@camunda/rpa-integration/-/rpa-integration-0.2.0.tgz",
+      "integrity": "sha512-GTLf/KGfWkbU7wlz0cabwmMMXsjLpxvKlldT6vaxS7HKluFbzspb5HMsugvyIgPt35XSKw67NptUGhqGNrdBnA==",
       "requires": {
         "@bpmn-io/properties-panel": "^3.25.0",
         "@carbon/icons-react": "^11.52.0",
@@ -42781,7 +42781,7 @@
         "@camunda/form-playground": "^0.20.0",
         "@camunda/improved-canvas": "^1.7.6",
         "@camunda/linting": "^3.33.0",
-        "@camunda/rpa-integration": "0.1.0",
+        "@camunda/rpa-integration": "0.2.0",
         "@carbon/icons-react": "^11.53.0",
         "@codemirror/commands": "^6.6.2",
         "@codemirror/lang-json": "^6.0.1",


### PR DESCRIPTION
### Proposed Changes

This PR enables the RPA as default. It also bumps the RPA library to the latest version, which includes some minor fixes.

![image](https://github.com/user-attachments/assets/6735934f-1095-47fd-8ceb-dea497060ac2)


closes https://github.com/camunda/camunda-modeler/issues/4895

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
