### PR TITLE
fix: ignore files without metadata

### DIFF
--- a/client/src/plugins/process-applications/ResourcesProvider.js
+++ b/client/src/plugins/process-applications/ResourcesProvider.js
@@ -19,7 +19,7 @@ export class ResourcesProvider {
     const items = this._processApplications.getItems();
 
     const resources = items.map((item) => {
-      switch (item.metadata.type) {
+      switch (item.metadata?.type) {
       case 'bpmn':
         return handleBpmnItem(item);
       case 'dmn':

--- a/client/src/plugins/process-applications/__tests__/ResourcesProviderSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ResourcesProviderSpec.js
@@ -280,6 +280,7 @@ describe('ResourcesProvider', function() {
     // then
     expect(resources).to.eql([]);
   });
+
 });
 
 

--- a/client/src/plugins/process-applications/__tests__/ResourcesProviderSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ResourcesProviderSpec.js
@@ -148,6 +148,19 @@ const DEFAULT_ITEMS_FORM = [
   }
 ];
 
+const NO_METADATA = [
+  {
+    file: {
+      name: 'bar.form',
+      uri: 'file:///C:/bar.form',
+      path: 'C://bar.form',
+      dirname: 'C://',
+      contents: '<?xml version="1.0" encoding="UTF-8"?>'
+    },
+    metadata: null
+  }
+];
+
 
 describe('ResourcesProvider', function() {
 
@@ -242,6 +255,22 @@ describe('ResourcesProvider', function() {
     // given
     const resourceLoader = createResourceLoader();
     const processApplications = createProcessApplications(DEFAULT_ITEMS_PROCESS_APPLICATION);
+
+    const resourcesProvider = new ResourcesProvider(resourceLoader, processApplications);
+
+    // when
+    const resources = resourcesProvider.getResources();
+
+    // then
+    expect(resources).to.eql([]);
+  });
+
+
+  it('should ignore file without metadata', function() {
+
+    // given
+    const resourceLoader = createResourceLoader();
+    const processApplications = createProcessApplications(NO_METADATA);
 
     const resourcesProvider = new ResourcesProvider(resourceLoader, processApplications);
 


### PR DESCRIPTION
### Proposed Changes

This makes sure that a file without metadata (case of broken files) can still be handled correctly by the resources provider. We ignore such files instead of crashing the application.

https://github.com/user-attachments/assets/97be214c-036f-43c7-9ed5-a1819330d8a8

Closes #4917

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
