### PR TITLE
Fix file context file closed

### DIFF
--- a/app/lib/preload.js
+++ b/app/lib/preload.js
@@ -43,6 +43,7 @@ const allowedEvents = [
   'file:read-stats',
   'file:write',
   'file-context:add-root',
+  'file-context:remove-root',
   'file-context:changed',
   'file-context:file-closed',
   'file-context:file-opened',

--- a/client/src/plugins/process-applications/ProcessApplications.js
+++ b/client/src/plugins/process-applications/ProcessApplications.js
@@ -62,6 +62,12 @@ export default class ProcessApplications {
 
       const item = this._items.find(item => item.file.path === file.path);
 
+      if (!item) {
+        this.close();
+
+        return;
+      }
+
       const processApplicationItem = this.findProcessApplicationItemForItem(item);
 
       if (processApplicationItem) {

--- a/client/src/plugins/process-applications/__tests__/ProcessApplicationsSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ProcessApplicationsSpec.js
@@ -119,6 +119,34 @@ describe('ProcessApplications', function() {
     });
 
 
+    it('should close process application on <activeTab-changed> (item not found)', function() {
+
+      // given
+      processApplications.emit('items-changed', [
+        DEFAULT_ITEMS_PROCESS_APPLICATION[0],
+        DEFAULT_ITEMS_PROCESS_APPLICATION[1]
+      ]);
+      processApplications.emit('activeTab-changed', DEFAULT_ACTIVE_TAB);
+
+      expect(processApplications.hasOpen()).to.be.true;
+
+      const changedSpy = spy();
+
+      processApplications.on('changed', changedSpy);
+
+      // when
+      processApplications.emit('activeTab-changed', {
+        file: DEFAULT_ITEMS_PROCESS_APPLICATION[2].file
+      });
+
+      // then
+      expect(processApplications.hasOpen()).to.be.false;
+      expect(processApplications.getItems()).to.have.length(0);
+
+      expect(changedSpy).to.have.been.calledOnce;
+    });
+
+
     it('should close process application on <activeTab-changed> (unsaved tab)', function() {
 
       // given


### PR DESCRIPTION
### Proposed Changes

Closes https://github.com/camunda/camunda-modeler/issues/4915

Fixes two issues:

* indexer item not found when active tab changed and process applications feature is trying to find process application item
* root cause of the issue above: when closing a tab the item is removed from the file context even if it is part of a process application

![electron_M8mVKL4eco](https://github.com/user-attachments/assets/f079f381-b207-43ce-8df2-0ebb20f00974)

A little more context:

The file context is a generic feature controlled by [App.js](https://github.com/camunda/camunda-modeler/blob/develop/client/src/app/App.js#L2092) when opening, saving or closing a tab. All tabs will be added to the file context regardless of whether they are part of a process application. The file context doesn't know about process applications, only about roots and items.

Example:

```
roots = [
    "C:\\Users\\PhilippFromme\\Desktop\\foo-process-application",
    "C:\\Users\\PhilippFromme\\Desktop\\foo-process-application",
]
items = [
    "C:\\Users\\PhilippFromme\\Desktop\\foo-process-application\\main.bpmn",
    "C:\\Users\\PhilippFromme\\Desktop\\foo-process-application\\child.bpmn",
    "C:\\Users\\PhilippFromme\\Desktop\\foo-process-application\\child.dmn",
    "C:\\Users\\PhilippFromme\\Desktop\\foo-process-application\\.process-application",
    "C:\\Users\\PhilippFromme\\Desktop\\bar-process-application\\main.bpmn",
    "C:\\Users\\PhilippFromme\\Desktop\\bar-process-application\\child.bpmn",
    "C:\\Users\\PhilippFromme\\Desktop\\bar-process-application\\.process-application",
    "C:\\Users\\PhilippFromme\\Desktop\\foo.bpmn",
    "C:\\Users\\PhilippFromme\\Desktop\\bar.bpmn"
]
```

In this example there are effectively two open process applications and most of the files are part of one or the other, but from the file context perspective it's just roots and items without any particular relationship. At least 4 of the items must have a corresponding tab: The two on the bottom, because they aren't part of a process application and at least 1 item of each process application.

When closing a tab the item would get removed from the file context without considering that it might be part of a process application. After all App.js doesn't know about process applications. Even the fact that it is a child of one of the roots is completely ignored. The relationship between roots and items is not clearly defined at the moment. Adding a root will add any number of items but removing a root doesn't remove any items.

If we want to keep the file context generic we have to implement the process application logic somewhere else. Right now it's implemented in [index.js](https://github.com/camunda/camunda-modeler/blob/develop/app/lib/index.js#L768) which isn't great. 🫠

I think the file context should remain generic and any additional logic (e.g. _you opened file x so I'm going to go and find file y because that would mean z_) should be implemented outside of it.

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
