### PR TITLE
fix(process-applications): handle unsaved tab

### DIFF
--- a/client/src/plugins/process-applications/ProcessApplications.js
+++ b/client/src/plugins/process-applications/ProcessApplications.js
@@ -35,11 +35,15 @@ export default class ProcessApplications {
       } else if (this._activeTab) {
         const { file } = this._activeTab;
 
-        if (!file) {
+        if (!file || !file.path) {
           return;
         }
 
         const item = this._items.find(item => item.file.path === file.path);
+
+        if (!item) {
+          return;
+        }
 
         const processApplicationItem = this.findProcessApplicationItemForItem(item);
 

--- a/client/src/plugins/process-applications/__tests__/ProcessApplicationsSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ProcessApplicationsSpec.js
@@ -48,7 +48,7 @@ describe('ProcessApplications', function() {
     });
 
 
-    it('should not open process application on <items-changed>', function() {
+    it('should not open process application on <items-changed> (no process application)', function() {
 
       // given
       const changedSpy = spy();
@@ -61,6 +61,75 @@ describe('ProcessApplications', function() {
 
       // when
       processApplications.emit('items-changed', DEFAULT_ITEMS);
+
+      // then
+      expect(processApplications.hasOpen()).to.be.false;
+      expect(processApplications.getItems()).to.have.length(0);
+
+      expect(changedSpy).to.not.have.been.called;
+    });
+
+
+    it('should not open process application on <items-changed> (item not found)', function() {
+
+      // given
+      const changedSpy = spy();
+
+      processApplications.on('changed', changedSpy);
+
+      processApplications.emit('activeTab-changed', DEFAULT_ITEMS_PROCESS_APPLICATION[2]);
+
+      expect(processApplications.hasOpen()).to.be.false;
+
+      // when
+      processApplications.emit('items-changed', [
+        DEFAULT_ITEMS_PROCESS_APPLICATION[0],
+        DEFAULT_ITEMS_PROCESS_APPLICATION[1]
+      ]);
+
+      // then
+      expect(processApplications.hasOpen()).to.be.false;
+      expect(processApplications.getItems()).to.have.length(0);
+
+      expect(changedSpy).to.not.have.been.called;
+    });
+
+
+    it('should not open process application on <items-changed> (empty tab)', function() {
+
+      // given
+      const changedSpy = spy();
+
+      processApplications.on('changed', changedSpy);
+
+      processApplications.emit('activeTab-changed', EMPTY_TAB);
+
+      expect(processApplications.hasOpen()).to.be.false;
+
+      // when
+      processApplications.emit('items-changed', DEFAULT_ITEMS_PROCESS_APPLICATION);
+
+      // then
+      expect(processApplications.hasOpen()).to.be.false;
+      expect(processApplications.getItems()).to.have.length(0);
+
+      expect(changedSpy).to.not.have.been.called;
+    });
+
+
+    it('should not open process application on <items-changed> (unsaved tab)', function() {
+
+      // given
+      const changedSpy = spy();
+
+      processApplications.on('changed', changedSpy);
+
+      processApplications.emit('activeTab-changed', UNSAVED_TAB);
+
+      expect(processApplications.hasOpen()).to.be.false;
+
+      // when
+      processApplications.emit('items-changed', DEFAULT_ITEMS_PROCESS_APPLICATION);
 
       // then
       expect(processApplications.hasOpen()).to.be.false;


### PR DESCRIPTION
* on both `activeTab-changed` and `items-changed`
  * tab might not have a file (empty tab)
  * file might not have path (unsaved tab)
  * item might not be found
* we have account for that

Closes #4924

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
