### PR TITLE
fix: show Camunda 7 files as errors

### DIFF
--- a/app/lib/file-context/__tests__/file-context-spec.js
+++ b/app/lib/file-context/__tests__/file-context-spec.js
@@ -439,7 +439,7 @@ describe('FileContext', function() {
     });
 
 
-    it('should NOT throw for form without `id`', async function() {
+    it('should NOT throw for null form', async function() {
 
       // given
       const filePath = path.resolve(__dirname, './tmp/broken-files/form-null.form');
@@ -454,7 +454,7 @@ describe('FileContext', function() {
       expectMessages(item, [
         {
           error: true,
-          message: /Failed to parse form file: Cannot read/,
+          message: /Failed to parse form file: Cannot/,
           source: 'process-error'
         }
       ]);

--- a/app/lib/file-context/processors/__tests__/fixtures/camunda7.bpmn
+++ b/app/lib/file-context/processors/__tests__/fixtures/camunda7.bpmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_06j46ca" targetNamespace="http://bpmn.io/schema/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" exporter="Camunda Modeler" exporterVersion="5.33.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.22.0">
+  <bpmn:process id="Process_0w0914q" isExecutable="true" >
+    <bpmn:startEvent id="StartEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0w0914q">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/app/lib/file-context/processors/__tests__/fixtures/camunda7.dmn
+++ b/app/lib/file-context/processors/__tests__/fixtures/camunda7.dmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="Definitions_0ff0m3a" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" exporter="Camunda Modeler" exporterVersion="5.33.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.22.0">
+  <decision id="Decision_1d4eh0d" name="Decision 1">
+    <decisionTable id="DecisionTable_1nn2ped">
+      <input id="Input_1">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text></text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" typeRef="string" />
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="Decision_1d4eh0d">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/app/lib/file-context/processors/__tests__/fixtures/camunda7.form
+++ b/app/lib/file-context/processors/__tests__/fixtures/camunda7.form
@@ -1,0 +1,11 @@
+{
+  "type": "default",
+  "id": "Form_0i2vl8q",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.34.0-dev"
+  },
+  "components": [],
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.23.0"
+}

--- a/app/lib/file-context/processors/__tests__/fixtures/camunda8.bpmn
+++ b/app/lib/file-context/processors/__tests__/fixtures/camunda8.bpmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_1v51b11" targetNamespace="http://bpmn.io/schema/bpmn" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" exporter="Camunda Modeler" exporterVersion="5.33.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="Process_10cx27k" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_10cx27k">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/app/lib/file-context/processors/__tests__/fixtures/camunda8.dmn
+++ b/app/lib/file-context/processors/__tests__/fixtures/camunda8.dmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="Definitions_1ue8l38" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" exporter="Camunda Modeler" exporterVersion="5.33.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <decision id="Decision_06kpetq" name="Decision 1">
+    <decisionTable id="DecisionTable_0ufk7iv">
+      <input id="Input_1">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text></text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" typeRef="string" />
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="Decision_06kpetq">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/app/lib/file-context/processors/__tests__/fixtures/camunda8.form
+++ b/app/lib/file-context/processors/__tests__/fixtures/camunda8.form
@@ -1,0 +1,7 @@
+{
+  "type": "default",
+  "id": "Form_0n58jz5",
+  "components": [],
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.7.0"
+}

--- a/app/lib/file-context/processors/__tests__/util-spec.js
+++ b/app/lib/file-context/processors/__tests__/util-spec.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const {
+  isCamunda8BPMN,
+  isCamunda8DMN,
+  isCamunda8Form
+} = require('../util');
+
+describe('util', function() {
+
+  describe('isCamunda8', function() {
+
+    it('should return true for Camunda 8 BPMN file', function() {
+
+      // given
+      const file = fs.readFileSync(path.resolve(__dirname, './fixtures/camunda8.bpmn'), 'utf8');
+
+      // when
+      const result = isCamunda8BPMN(file);
+
+      expect(result).to.be.true;
+    });
+
+
+    it('should return false for Camunda 7 BPMN file', function() {
+
+      // given
+      const file = fs.readFileSync(path.resolve(__dirname, './fixtures/camunda7.bpmn'), 'utf8');
+
+      // when
+      const result = isCamunda8BPMN(file);
+
+      expect(result).to.be.false;
+    });
+
+
+    it('should return true for Camunda 8 DMN file', function() {
+
+      // given
+      const file = fs.readFileSync(path.resolve(__dirname, './fixtures/camunda8.dmn'), 'utf8');
+
+      // when
+      const result = isCamunda8DMN(file);
+
+      expect(result).to.be.true;
+    });
+
+
+    it('should return false for Camunda 7 DMN file', function() {
+
+      // given
+      const file = fs.readFileSync(path.resolve(__dirname, './fixtures/camunda7.dmn'), 'utf8');
+
+      // when
+      const result = isCamunda8DMN(file);
+
+      expect(result).to.be.false;
+    });
+
+
+    it('should return true for Camunda 8 form file', function() {
+
+      // given
+      const file = fs.readFileSync(path.resolve(__dirname, './fixtures/camunda8.form'), 'utf8');
+
+      // when
+      const result = isCamunda8Form(file);
+
+      expect(result).to.be.true;
+    });
+
+
+    it('should return false for Camunda 7 form file', function() {
+
+      // given
+      const file = fs.readFileSync(path.resolve(__dirname, './fixtures/camunda7.form'), 'utf8');
+
+      // when
+      const result = isCamunda8Form(file);
+
+      expect(result).to.be.false;
+    });
+
+  });
+
+});

--- a/app/lib/file-context/processors/bpmnProcessor.js
+++ b/app/lib/file-context/processors/bpmnProcessor.js
@@ -17,6 +17,7 @@ const moddle = new BpmnModdle({ zeebe });
 const {
   findExtensionElement,
   is,
+  isCamunda8BPMN,
   traverse
 } = require('./util');
 
@@ -32,6 +33,10 @@ module.exports = {
         processes: [],
         linkedIds: []
       };
+    }
+
+    if (!isCamunda8BPMN(item.file.contents)) {
+      throw new Error('Not a Camunda 8 BPMN file');
     }
 
     let rootElement, processes, linkedIds;

--- a/app/lib/file-context/processors/dmnProcessor.js
+++ b/app/lib/file-context/processors/dmnProcessor.js
@@ -14,6 +14,7 @@ const moddle = new DmnModdle();
 
 const {
   is,
+  isCamunda8DMN,
   traverse
 } = require('./util');
 
@@ -29,6 +30,10 @@ module.exports = {
         decisions: [],
         linkedIds: []
       };
+    }
+
+    if (!isCamunda8DMN(item.file.contents)) {
+      throw new Error('Not a Camunda 8 DMN file');
     }
 
     let rootElement, decisions;

--- a/app/lib/file-context/processors/formProcessor.js
+++ b/app/lib/file-context/processors/formProcessor.js
@@ -10,6 +10,8 @@
 
 const assert = require('node:assert');
 
+const { isCamunda8Form } = require('./util');
+
 module.exports = {
   id: 'form',
   extensions: [ '.form' ],
@@ -24,10 +26,15 @@ module.exports = {
       };
     }
 
+    if (!isCamunda8Form(item.file.contents)) {
+      throw new Error('Not a Camunda 8 Form file');
+    }
+
     let forms = [];
 
     try {
       const form = JSON.parse(item.file.contents);
+
       forms.push({
         id: form.id,
         name: form.name || form.id

--- a/app/package.json
+++ b/app/package.json
@@ -23,6 +23,7 @@
     "min-dash": "^4.1.1",
     "mri": "^1.1.6",
     "parents": "^1.0.1",
+    "saxen": "^10.0.0",
     "zeebe-bpmn-moddle": "^1.7.0"
   },
   "homepage": "https://github.com/camunda/camunda-modeler",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "min-dash": "^4.1.1",
         "mri": "^1.1.6",
         "parents": "^1.0.1",
+        "saxen": "^10.0.0",
         "zeebe-bpmn-moddle": "^1.7.0"
       },
       "optionalDependencies": {
@@ -116,6 +117,15 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "app/node_modules/saxen": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-10.0.0.tgz",
+      "integrity": "sha512-RXsmWok/SAWqOG/f5ADEz51DN9WtZEzqih3e08ranldcaXekxjx8NBKjGh/y5hlowjo0JH/LekBu6gtPFD1G6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "client": {
@@ -42514,6 +42524,7 @@
         "min-dash": "^4.1.1",
         "mri": "^1.1.6",
         "parents": "^1.0.1",
+        "saxen": "^10.0.0",
         "vscode-windows-ca-certs": "^0.3.0",
         "zeebe-bpmn-moddle": "^1.7.0"
       },
@@ -42544,6 +42555,11 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
           "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA=="
+        },
+        "saxen": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/saxen/-/saxen-10.0.0.tgz",
+          "integrity": "sha512-RXsmWok/SAWqOG/f5ADEz51DN9WtZEzqih3e08ranldcaXekxjx8NBKjGh/y5hlowjo0JH/LekBu6gtPFD1G6g=="
         }
       }
     },


### PR DESCRIPTION
Closes #4931

### Proposed Changes

* throws an error if BPMN, DMN or form has recognized file extension but isn't a Camunda 8 file
* file will show up as an error in process application overlay

![image](https://github.com/user-attachments/assets/8ae67d41-079d-4e26-98d8-c31dc2963222)

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
