### PR TITLE
chore: new github workflow for license analysis with FOSSA

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,12 @@
+version: 3
+
+project:
+  id: camunda/camunda-modeler
+  labels:
+  - camunda-modeler
+  policy: Camunda8 Distribution
+  url: https://github.com/camunda/camunda-modeler
+
+paths:
+  exclude:
+  - ./resources

--- a/.github/workflows/CHECK_LICENSES.yml
+++ b/.github/workflows/CHECK_LICENSES.yml
@@ -1,0 +1,35 @@
+name: CHECK_LICENSES
+
+on:
+  push:    
+    branches:
+    - main
+    - develop
+
+jobs:
+  analyze:
+    name: Analyze dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v4
+    # Import FOSSA_API_KEY from Vault
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v3.0.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        exportEnv: false
+        secrets: |
+          secret/data/products/desktop-modeler/ci/fossa FOSSA_API_KEY;
+    - name: Setup fossa-cli
+      uses: camunda/infra-global-github-actions/fossa/setup@32470949e549396aa5f2c5def890de831b8ca107
+    - name: Analyze project
+      uses: camunda/infra-global-github-actions/fossa/analyze@32470949e549396aa5f2c5def890de831b8ca107
+      with:
+        api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
+        branch: ${{ github.ref_name }}
+        revision-id: ${{ github.sha }}


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/camunda/team-infrastructure/issues/751.

Add a new workflow to analyze licenses using FOSSA.

This workflow uploads only a dependency graph to FOSSA, the source code itself is not uploaded; The file-level scan of the dependencies is performed by the FOSSA platform asynchronously, making/keeping this workflow fast (execution time).

It currently analyzes licenses without enforcing any blocking checks and targets the main branch. Tag analysis will be added later, along with PR checks.

Configuration (`.fossa.yml`) has been set up to exclude `npm` projects in the `./resources` directory, focusing the scan on the top-level project and the `app` and `client` workspaces. This ensures that the same dependencies used to generate the licensing book (cf. `license-book.js`) are targeted. NPM `devDependencies` are ignored by default.

Test workflow run: https://github.com/camunda/camunda-modeler/actions/runs/14079389139/job/39428665013

Before merging:
- [x] check that https://github.com/camunda/infra-global-github-actions/pull/373 is merged (github composite actions)
    - [x]  replace the @main ref by a commit hash (best practice followed by the Modeler team)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
