### PR TITLE
fix: notifications are always on top

### DIFF
--- a/client/src/app/notifications/Notification.less
+++ b/client/src/app/notifications/Notification.less
@@ -5,7 +5,7 @@
   --notification-title-font-color: var(--color-grey-225-10-15);
   --notification-link-color: var(--color-blue-205-100-50);
   --notification-font-color: var(--color-blue-205-100-35);
-  
+
   --notification-font-size: 14px;
   --notification-code-font-size: 13px;
 }
@@ -18,7 +18,7 @@
   border: 1px solid var(--notification-border-color);
   background-color: var(--notification-background-color);
   padding: 18px;
-  margin-bottom: 10px;
+  margin-bottom: 38px;
   margin-top: 10px;
 
   /* animation */
@@ -28,11 +28,11 @@
 
   @keyframes slidein {
     from {
-      margin-bottom: -140px;
+      margin-bottom: -112px;
     }
 
     to {
-      margin-bottom: 10px;
+      margin-bottom: 38px;
     }
   }
 

--- a/client/src/app/notifications/Notifications.less
+++ b/client/src/app/notifications/Notifications.less
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
 
-  z-index: 500;
+  z-index: 100000;
 
   position: absolute;
   bottom: 60px;

--- a/client/src/app/notifications/Notifications.less
+++ b/client/src/app/notifications/Notifications.less
@@ -1,15 +1,17 @@
 :local(.Notifications) {
   display: flex;
   flex-direction: column;
+  align-items: center;
+  overflow: hidden; // required so that the notification does not overlap status bar
 
   z-index: 100000;
 
   position: absolute;
-  bottom: 60px;
-  left: 40px;
+  bottom: 32px;
+  left: 0;
   margin-left: auto;
   margin-right: auto;
 
-  width: 300px;
+  width: 410px; // notification width + 40px on each side to maintain x position
   height: auto;
 }


### PR DESCRIPTION
Closes #4932

### Proposed Changes

* makes sure notifications are always on top including modals
<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

<img width="575" alt="electron_3ziJCRRG2H" src="https://github.com/user-attachments/assets/45ef2324-753e-4f61-abc6-ec957d6537ce" />

We don't really have a clear convention when it comes to `z-index` in the modeler but it appears that it is mostly 10^n so 10000 makes sure notifications are always on top.

![image](https://github.com/user-attachments/assets/7d054d5d-7dfd-4235-af4f-13133e917b84)

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
