### PR TITLE
fix(RPA): open fallback editor on invalid JSON

### DIFF
--- a/client/src/app/tabs/rpa/RPAEditor.js
+++ b/client/src/app/tabs/rpa/RPAEditor.js
@@ -63,30 +63,41 @@ export class RPAEditor extends CachedComponent {
   };
 
 
-  componentDidMount() {
+  async componentDidMount() {
 
     const {
-      editorContainer, propertiesContainer, editor
+      editorContainer,
+      propertiesContainer,
+      editor
     } = this.getCached();
 
     this.modelerRef.current.appendChild(editorContainer);
     this.propertiesPanelRef.current.appendChild(propertiesContainer);
 
-    if (!editor) {
+    let currentEditor = editor;
 
-      // Create editor if not present
-      this.createEditor().then(() => {
-        this.handleChanged();
-      });
-    } else {
+    try {
+      if (!currentEditor) {
 
-      // or reimport if config changed
-      this.checkImport();
-      this.handleListeners(editor);
-      this.setState({
-        loading: false
-      });
+        // Create editor if not present
+        currentEditor = await this.createEditor();
+      } else {
+
+        // or reimport if config changed
+        currentEditor = await this.checkImport();
+      }
+
+    } catch (e) {
+      this.handleError(e);
+      return;
     }
+
+    this.handleChanged();
+    this.handleListeners(currentEditor);
+    this.setState({
+      loading: false
+    });
+    this.props.onImport();
   }
 
   async createEditor() {
@@ -134,6 +145,17 @@ export class RPAEditor extends CachedComponent {
     return editor;
   }
 
+  handleError(error) {
+    this.setCached({
+      editor: null,
+      lastXML: null,
+    });
+
+    console.log(error);
+
+    this.props.onImport(error);
+  }
+
   componentWillUnmount() {
     const {
       editorContainer,
@@ -143,6 +165,10 @@ export class RPAEditor extends CachedComponent {
 
     editorContainer.remove();
     propertiesContainer.remove();
+
+    if (!editor) {
+      return;
+    }
 
     this.handleListeners(editor, true);
   }
@@ -201,16 +227,16 @@ export class RPAEditor extends CachedComponent {
     } = this.getCached();
 
     if (isXMLChange(lastXML, xml)) {
-      this.createEditor();
-      return;
+      return this.createEditor();
     }
 
     const rpaConfig = await this.props.getConfig('rpa', {});
     if (isWorkerConfigChange(rpaConfig.workerConfig, lastWorkerConfig)) {
       editor.workerConfig = rpaConfig.workerConfig;
       editor.eventBus.fire('config.changed', rpaConfig.workerConfig);
-      return;
     }
+
+    return editor;
   }
 
   isDirty() {
@@ -231,6 +257,10 @@ export class RPAEditor extends CachedComponent {
     const {
       editor: monaco
     } = this.getCached();
+
+    if (!monaco) {
+      return;
+    }
 
     const undoState = {
       redo: monaco.editor.getModel().canRedo(),

--- a/client/src/app/tabs/rpa/RPAEditor.js
+++ b/client/src/app/tabs/rpa/RPAEditor.js
@@ -151,8 +151,6 @@ export class RPAEditor extends CachedComponent {
       lastXML: null,
     });
 
-    console.log(error);
-
     this.props.onImport(error);
   }
 


### PR DESCRIPTION
### Proposed Changes
Gracefully handle broken `JSON` in RPA editor

[screencap-2025-03-27-13-11-40.webm](https://github.com/user-attachments/assets/03ae3cc3-eb06-4cb1-80ad-5a7f906efcb2)

closes https://github.com/camunda/camunda-modeler/issues/4929
### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
