### PR TITLE
fix: use Desktop Modeler docs link

### DIFF
--- a/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
@@ -16,7 +16,7 @@ import { ResourcesProviderModule } from './ResourcesProvider';
 
 const processApplications = new ProcessApplications();
 
-const DOCUMENTATION_URL = 'https://docs.camunda.io/docs/components/modeler/web-modeler/process-applications/';
+const DOCUMENTATION_URL = 'https://docs.camunda.io/docs/components/modeler/desktop-modeler/process-applications/';
 
 export default function ProcessApplicationsPlugin(props) {
   const {


### PR DESCRIPTION
### Proposed Changes

This fixes the link to process applications docs to point to Desktop Modeler documentation.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
