### PR TITLE
Use `gh` to comment on PR 

### DIFF
--- a/.github/workflows/COMMENT_DEVELOP_FIX.yml
+++ b/.github/workflows/COMMENT_DEVELOP_FIX.yml
@@ -11,6 +11,8 @@ jobs:
   comment:
     name: Comment on fix to develop
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Check for fix commits
         env:
@@ -26,10 +28,12 @@ jobs:
           fi
       - name: Create comment
         if: ${{ env.FIX_COMMITS_PRESENT == 'true' }}
-        uses: peter-evans/create-or-update-comment@9561a839eec9e21b71c79137fd8cc4732293862d
-        with:
-          issue-number: ${{ github.event.number }}
-          body: |
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}
+          BODY: |
             This Pull Request targets `develop` branch, but contains `fix` commits.
 
             Consider targeting `main` instead.
+        run: gh issue comment "$NUMBER" --body "$BODY"


### PR DESCRIPTION
### Proposed Changes

This removes the peter-evans action from the workflow which should save us some time updating the action. We don't use the `update` section of the action anyway.

Solution based on https://docs.github.com/en/actions/use-cases-and-examples/project-management/commenting-on-an-issue-when-a-label-is-added

I used `fix` in the initial comment to test the new workflow in action.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
