### PR TITLE
Add `.rpa` file association

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -72,6 +72,13 @@
       "description": "FORM file",
       "role": "Editor",
       "mimeType": "application/camunda-form"
+    },
+    {
+      "ext": "rpa",
+      "name": "CamundaModeler.RPA",
+      "description": "RPA file",
+      "role": "Editor",
+      "mimeType": "application/rpa"
     }
   ],
   "npmArgs": "--workspaces=false"

--- a/resources/platform/linux/support/mime-types.xml
+++ b/resources/platform/linux/support/mime-types.xml
@@ -44,4 +44,5 @@
     <glob pattern="*.rpa"/>
     <sub-class-of type="application/json"/>
     <generic-icon name="application-json"/>
+  </mime-type>
 </mime-info>

--- a/resources/platform/linux/support/mime-types.xml
+++ b/resources/platform/linux/support/mime-types.xml
@@ -37,4 +37,11 @@
     <sub-class-of type="application/json"/>
     <generic-icon name="application-json"/>
   </mime-type>
+  <mime-type type="application/rpa">
+    <comment>RPA script</comment>
+    <acronym>RPA</acronym>
+    <expanded-acronym>Robotic Process Automation</expanded-acronym>
+    <glob pattern="*.rpa"/>
+    <sub-class-of type="application/json"/>
+    <generic-icon name="application-json"/>
 </mime-info>

--- a/resources/platform/linux/support/xdg_register.sh
+++ b/resources/platform/linux/support/xdg_register.sh
@@ -31,7 +31,7 @@ cat << EOF > $DESKTOP_FILE
 Version=1.0
 Encoding=UTF-8
 Name=Camunda Modeler
-Keywords=bpmn;cmmn;dmn;form;modeler;camunda
+Keywords=bpmn;cmmn;dmn;form;rpa;modeler;camunda
 GenericName=Process Modeling Tool
 Type=Application
 Categories=Development
@@ -39,7 +39,7 @@ Terminal=false
 StartupNotify=true
 Path=$CAMUNDA_MODELER_BIN
 Exec="$CAMUNDA_MODELER_BIN/camunda-modeler" %F
-MimeType=application/bpmn;application/cmmn;application/dmn;application/camunda-form
+MimeType=application/bpmn;application/cmmn;application/dmn;application/camunda-form;application/rpa
 Icon=$ICON_NAME.png
 X-Ayatana-Desktop-Shortcuts=NewWindow;RepositoryBrowser
 EOF

--- a/resources/platform/win32/support/fileassoc.reg
+++ b/resources/platform/win32/support/fileassoc.reg
@@ -14,6 +14,9 @@ Windows Registry Editor Version 5.00
 [HKEY_CURRENT_USER\Software\Classes\.form]
 @="CamundaModeler.FORM"
 
+[HKEY_CURRENT_USER\Software\Classes\.rpa]
+@="CamundaModeler.RPA"
+
 [HKEY_CURRENT_USER\Software\Classes\CamundaModeler.BPMN]
 @="BPMN file"
 
@@ -73,3 +76,19 @@ Windows Registry Editor Version 5.00
 
 [HKEY_CURRENT_USER\Software\Classes\CamundaModeler.FORM\shell\open\command]
 @="__CWD__ \"%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\CamundaModeler.RPA]
+@="RPA file"
+
+[HKEY_CURRENT_USER\Software\Classes\CamundaModeler.RPA\DefaultIcon]
+@="__CWD__,0"
+
+[HKEY_CURRENT_USER\Software\Classes\CamundaModeler.RPA\shell]
+@="open"
+
+[HKEY_CURRENT_USER\Software\Classes\CamundaModeler.RPA\shell\open]
+@="Open with Camunda Modeler"
+
+[HKEY_CURRENT_USER\Software\Classes\CamundaModeler.RPA\shell\open\command]
+@="__CWD__ \"%1\""
+


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/4963

### Proposed Changes

Add rpa file association for macOS, windows, and linux. For windows and linux the file association needs to be [rewired](https://docs.camunda.io/docs/components/modeler/desktop-modeler/install-the-modeler/#wire-file-associations) manually. On macOS a relaunch of finder should be enough and `.rpa` files should be linked with camunda modeler.

As I can only test it for macOS, someone with a matching OS please verify its working on others OSs:

* [x] macOS (tested by @Buckwich)
* [x] linux (maybe @nikku?)
* [x] windows (maybe @philippfromme?)

<img width="825" alt="image" src="https://github.com/user-attachments/assets/087dc0cb-ebc1-46a7-949c-6648092d60b8" />

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
