### PR TITLE
fix: display settings in application menu only on macOS

### DIFF
--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -62,6 +62,8 @@ class MenuBuilder {
   }
 
   build() {
+    const MenuBuilder = this.constructor;
+
     this.appendFileMenu(
       new MenuBuilder(this.options)
         .appendNewFile()
@@ -76,7 +78,7 @@ class MenuBuilder {
         .appendExportAs()
         .appendCloseTab()
         .appendSeparator()
-        .appendSettings(this)
+        .appendSettings()
         .appendSeparator()
         .appendQuit()
         .get()


### PR DESCRIPTION
### Proposed Changes

On macOS, Settings should be present in the application menu. On other platforms, they should be displayed in File menu.

https://github.com/user-attachments/assets/db6e94cb-0991-46a7-a63a-649ff05f0a5a

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
