### PR TITLE
ci: use bash as default shell

### DIFF
--- a/.github/workflows/BUILD_ON_DEMAND.yml
+++ b/.github/workflows/BUILD_ON_DEMAND.yml
@@ -8,6 +8,11 @@ on:
       linkedDependencies:
         description: 'Dependencies to link from GitHub (format: bpmn-js#develop,dmn-js#9.0.0)'
         default: ''
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,10 @@
 name: CI
 on: [ push, pull_request ]
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/NIGHTLY.yml
+++ b/.github/workflows/NIGHTLY.yml
@@ -2,6 +2,11 @@ name: NIGHTLY
 on:
   schedule:
     - cron: '0 18 * * *'
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build_nightly:
     name: Build nightly

--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -3,6 +3,11 @@ on:
   push:
     tags:
       - 'v*'
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   pre_release:
     name: Prepare release


### PR DESCRIPTION
### Proposed Changes

This makes sure that we use the same shell across the multi-platform jobs. We should not fall into Windows-specific problems this way.

Related to https://github.com/npm/cli/issues/7375

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
