### PR TITLE
deps: update to `camunda-bpmn-js@5.9.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ ___Note:__ Yet to be released changes appear here._
 ## 5.35.0
 
 * `DEPS`: update to `bpmn-js@18.6.1` 
-* `DEPS`: update to `camunda-bpmn-js@5.8.0`
+* `DEPS`: update to `camunda-bpmn-js@5.9.0`
 * `DEPS`: update to `camunda-linting@3.37.0`
 * `DEPS`: update to `@camunda/rpa-integration@1.0.0`
 

--- a/client/package.json
+++ b/client/package.json
@@ -35,7 +35,7 @@
     "bpmn-js-properties-panel": "^5.35.0",
     "bpmn-js-tracking": "^0.6.0",
     "bpmn-moddle": "^9.0.1",
-    "camunda-bpmn-js": "^5.8.0",
+    "camunda-bpmn-js": "^5.9.0",
     "camunda-bpmn-moddle": "^7.0.1",
     "camunda-cmmn-moddle": "^1.0.0",
     "camunda-dmn-js": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,7 +162,7 @@
         "bpmn-js-properties-panel": "^5.35.0",
         "bpmn-js-tracking": "^0.6.0",
         "bpmn-moddle": "^9.0.1",
-        "camunda-bpmn-js": "^5.8.0",
+        "camunda-bpmn-js": "^5.9.0",
         "camunda-bpmn-moddle": "^7.0.1",
         "camunda-cmmn-moddle": "^1.0.0",
         "camunda-dmn-js": "^3.2.0",
@@ -12837,9 +12837,9 @@
       }
     },
     "node_modules/camunda-bpmn-js": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-5.8.0.tgz",
-      "integrity": "sha512-MRAyo1xRNadYVOlOYlw/FK/DwDSM4fOItcEwO52DW4SdHe0hEM9lxfQ3PdoJqrmLqKiUENOrb2FGTCxYc0Ot9A==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-5.9.0.tgz",
+      "integrity": "sha512-o4MqosqFjY7DNbf3E+WlH1D2X74uDkE7vm/NtnPN+NidxgB35WmxpIcE7+Fu88/M3wuHBuDgFOflGFmf8fW2xQ==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/align-to-origin": "^0.7.0",
@@ -12854,7 +12854,7 @@
         "bpmn-js-create-append-anything": "^1.0.0",
         "bpmn-js-element-templates": "^2.5.3",
         "bpmn-js-executable-fix": "^0.2.1",
-        "camunda-bpmn-js-behaviors": "^1.9.1",
+        "camunda-bpmn-js-behaviors": "^1.10.0",
         "camunda-bpmn-moddle": "^7.0.1",
         "diagram-js": "^15.3.0",
         "diagram-js-grid": "^1.1.0",
@@ -12869,9 +12869,9 @@
       }
     },
     "node_modules/camunda-bpmn-js-behaviors": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.9.1.tgz",
-      "integrity": "sha512-VHTJFgfsqn9C4ass4irNr9rQkrqBzNmw4+/l0yh8CW34XciIBDa754ZVmDpE5h86Ffl+yeiySbUaH/PqeoNWOw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.10.0.tgz",
+      "integrity": "sha512-WQ4S/IcNjtRSZrEzhI9r1mk+57y0PAAZ+Xz/a5srGaCWv8dNHyXk66YRZDaomFSc67jS6toFO2HpQX9S0ZdQFQ==",
       "license": "MIT",
       "dependencies": {
         "ids": "^1.0.0",
@@ -42308,9 +42308,9 @@
       }
     },
     "camunda-bpmn-js": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-5.8.0.tgz",
-      "integrity": "sha512-MRAyo1xRNadYVOlOYlw/FK/DwDSM4fOItcEwO52DW4SdHe0hEM9lxfQ3PdoJqrmLqKiUENOrb2FGTCxYc0Ot9A==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-5.9.0.tgz",
+      "integrity": "sha512-o4MqosqFjY7DNbf3E+WlH1D2X74uDkE7vm/NtnPN+NidxgB35WmxpIcE7+Fu88/M3wuHBuDgFOflGFmf8fW2xQ==",
       "requires": {
         "@bpmn-io/align-to-origin": "^0.7.0",
         "@bpmn-io/element-template-chooser": "^2.0.0",
@@ -42324,7 +42324,7 @@
         "bpmn-js-create-append-anything": "^1.0.0",
         "bpmn-js-element-templates": "^2.5.3",
         "bpmn-js-executable-fix": "^0.2.1",
-        "camunda-bpmn-js-behaviors": "^1.9.1",
+        "camunda-bpmn-js-behaviors": "^1.10.0",
         "camunda-bpmn-moddle": "^7.0.1",
         "diagram-js": "^15.3.0",
         "diagram-js-grid": "^1.1.0",
@@ -42349,9 +42349,9 @@
       }
     },
     "camunda-bpmn-js-behaviors": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.9.1.tgz",
-      "integrity": "sha512-VHTJFgfsqn9C4ass4irNr9rQkrqBzNmw4+/l0yh8CW34XciIBDa754ZVmDpE5h86Ffl+yeiySbUaH/PqeoNWOw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.10.0.tgz",
+      "integrity": "sha512-WQ4S/IcNjtRSZrEzhI9r1mk+57y0PAAZ+Xz/a5srGaCWv8dNHyXk66YRZDaomFSc67jS6toFO2HpQX9S0ZdQFQ==",
       "requires": {
         "ids": "^1.0.0",
         "min-dash": "^4.0.0"
@@ -42503,7 +42503,7 @@
         "bpmn-js-tracking": "^0.6.0",
         "bpmn-moddle": "^9.0.1",
         "bpmnlint-loader": "^0.1.6",
-        "camunda-bpmn-js": "^5.8.0",
+        "camunda-bpmn-js": "^5.9.0",
         "camunda-bpmn-moddle": "^7.0.1",
         "camunda-cmmn-moddle": "^1.0.0",
         "camunda-dmn-js": "^3.2.0",


### PR DESCRIPTION
### Proposed Changes

This PR updates camunda-bpmn-js to 5.9.0 which accounts for new message ref behavior in bpmn-js. In C8, we don't want to keep message ref in throw events as it's not supported, and cannot be removed via UI.

https://github.com/user-attachments/assets/da6239a5-6b77-4e4f-9ac7-c25b63f245fe

Closes #5003

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
