### PR TITLE
Make Tenant ID available for C8 self-managed deployment with basic auth

### DIFF
--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.js
@@ -294,14 +294,16 @@ export default class DeploymentPluginOverlay extends React.PureComponent {
                               />
                               {
                                 form.values.endpoint.targetType === SELF_HOSTED &&
-                                  form.values.endpoint.authType === AUTH_TYPES.OAUTH && (
-                                  <Field
-                                    name="deployment.tenantId"
-                                    component={ TextInput }
-                                    label={ TENANT_ID }
-                                    hint="Optional"
-                                  />
-                                )
+                                  (form.values.endpoint.authType === AUTH_TYPES.BASIC
+                                    || form.values.endpoint.authType === AUTH_TYPES.OAUTH)
+                                    && (
+                                      <Field
+                                        name="deployment.tenantId"
+                                        component={ TextInput }
+                                        label={ TENANT_ID }
+                                        hint="Optional"
+                                      />
+                                    )
                               }
                               <Field
                                 name="endpoint.authType"

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginOverlaySpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginOverlaySpec.js
@@ -107,7 +107,7 @@ describe('<DeploymentPluginModal> (Zeebe)', function() {
 
   describe('tenantId', function() {
 
-    it('should not show for self-managed without OAuth', function() {
+    it('should not show for self-managed with None', function() {
 
       // given
       const { wrapper } = createDeploymentPluginModal({
@@ -129,6 +129,32 @@ describe('<DeploymentPluginModal> (Zeebe)', function() {
 
       // then
       expect(tenantIdInput.exists()).to.be.false;
+    });
+
+
+    it('should show for self-managed with Basic', function() {
+
+      // given
+      const { wrapper } = createDeploymentPluginModal({
+        anchor,
+        config: {
+          endpoint: {
+            targetType: SELF_HOSTED,
+            authType: AUTH_TYPES.BASIC,
+            contactPoint: 'https://google.com'
+          },
+          deployment: {
+            tenantId: 'tenant-1'
+          }
+        }
+      });
+
+      // when
+      const tenantIdInput = wrapper.find('input[name="deployment.tenantId"]');
+
+      // then
+      expect(tenantIdInput.exists()).to.be.true;
+      expect(tenantIdInput.instance().value).to.eql('tenant-1');
     });
 
 
@@ -158,7 +184,7 @@ describe('<DeploymentPluginModal> (Zeebe)', function() {
     });
 
 
-    it('should not pass on deploy without OAuth', function(done) {
+    it('should not pass on deploy with None', function(done) {
 
       // given
       const { wrapper } = createDeploymentPluginModal({
@@ -184,6 +210,38 @@ describe('<DeploymentPluginModal> (Zeebe)', function() {
         const { deployment } = values;
 
         expect(deployment.tenantId).not.to.exist;
+
+        done();
+      }
+    });
+
+
+    it('should pass on deploy with Basic', function(done) {
+
+      // given
+      const { wrapper } = createDeploymentPluginModal({
+        anchor,
+        onDeploy,
+        config: {
+          endpoint: {
+            targetType: SELF_HOSTED,
+            authType: AUTH_TYPES.BASIC,
+            contactPoint: 'https://google.com'
+          },
+          deployment: {
+            tenantId: 'tenant-1'
+          }
+        }
+      });
+
+      // when deploy
+      wrapper.find('form').simulate('submit');
+
+      // then
+      function onDeploy(values) {
+        const { deployment } = values;
+
+        expect(deployment.tenantId).to.eql('tenant-1');
 
         done();
       }


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/4992

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

Tenant ID field is available for basic auth:

![image](https://github.com/user-attachments/assets/0ab472c4-d979-44bd-8124-a24b7e77b596)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
