### PR TITLE
chore(fossa): check PRs for newly introduced license issues

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -4,6 +4,7 @@ project:
   id: camunda/camunda-modeler
   labels:
   - camunda-modeler
+  - modeler
   policy: Camunda8 Distribution
   url: https://github.com/camunda/camunda-modeler
 

--- a/.github/workflows/CHECK_LICENSES.yml
+++ b/.github/workflows/CHECK_LICENSES.yml
@@ -1,12 +1,16 @@
 name: CHECK_LICENSES
 
 on:
-  push:    
+  push:
     branches:
     - main
     - develop
     tags:
     - '*'
+  pull_request:
+    types:
+    - opened
+    - synchronize
 
 jobs:
   analyze:
@@ -29,9 +33,23 @@ jobs:
           secret/data/products/desktop-modeler/ci/fossa FOSSA_API_KEY;
     - name: Setup fossa-cli
       uses: camunda/infra-global-github-actions/fossa/setup@476d338fe2f3cf81fff0c3b4f78ebce8e008d745
+    - name: Get context info
+      id: info
+      uses: camunda/infra-global-github-actions/fossa/info@476d338fe2f3cf81fff0c3b4f78ebce8e008d745
     - name: Analyze project
       uses: camunda/infra-global-github-actions/fossa/analyze@476d338fe2f3cf81fff0c3b4f78ebce8e008d745
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
-        branch: ${{ github.ref_name }}
-        revision-id: ${{ github.sha }}
+        branch: ${{  steps.info.outputs.head-ref }}
+        revision-id: ${{ steps.info.outputs.head-revision }}
+    # PR-only: Check for newly introduced license issues
+    # This step only fails if the PR introduces new license violations.
+    # It does not fail for pre-existing issues already present in the base branch.
+    - name: Check Pull Request for new License Issues
+      if: steps.info.outputs.is-pull-request == 'true'
+      uses: camunda/infra-global-github-actions/fossa/pr-check@24523caae329d9322538632a9b385c690c3dcc96
+      with:
+        api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
+        base-ref: ${{ steps.info.outputs.base-ref }}
+        base-revision: ${{ steps.info.outputs.base-revision }}
+        revision: ${{ steps.info.outputs.head-revision }}


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/camunda/team-infrastructure/issues/752.

This PR introduces a new job step in `CHECK_LICENSES.yml` workflow that runs only on pull requests, and checks for newly introduced license policy violations, such as those from new dependencies or updated versions:
- if license issues are found, they are listed in the logs with actionable links to the FOSSA dashboard and Confluence [page](https://confluence.camunda.com/spaces/HAN/pages/277024795/FOSSA#FOSSA-Handlelicenseissues)
- a job annotation is added for visibility, showing `License Check: X issues found. Please check the logs and resolve before merging`
- the step does not fail for pre-existing license issues in the base branch

The job waits for the FOSSA analysis to complete, which typically takes under a minute. If additional dependency scans (at file-level) are required (if results for a new dependency/version are not already in FOSSA's shared database), it may take an extra 3–4 minutes.

Scans for references like `main`, `develop`, and `tags` are not affected by this change.

TL;DR; FOSSA License analyses (file-level scan) are currently run only on `main`, `develop`, and tags. This change adds analysis for pull requests, including a policy violation check. It helps support shift-left license compliance (via FOSSA) by catching issues directly at the PR level.

Test (introducing a temporary issue):
- Added the dual [licensed](https://github.com/Stuk/jszip/blob/main/package.json#L66) (`MIT OR GPL-3.0-or-later`) `jszip` NPM package
- Workflow run: https://github.com/camunda/camunda-modeler/actions/runs/14968536975
    - direct link to commit [scan](https://app.fossa.com/projects/custom%2B50756%2Fcamunda%2Fcamunda-modeler/refs/branch/fossa-integration/1b3e4f1dfd4ce43dddaa370e3046095a7f6c4ace/issues/licensing?page=1&count=20&sort=issue_count_desc&grouping=revision&status=active&revisionScanId=82897042) (displayed in logs)
- Notes:
    - this package is used by the Desktop Modeler under the MIT license, so `GPL-3.0-or-later` can be safely ignored. Such decision can be document via an ignore/resolution note
    - the `GPL-3.0-only` finding in the `README.markdown` is a false positive and can be curated (removed via `Edit Package`)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
