### PR TITLE
Use latest stable as default engine version

### DIFF
--- a/client/src/plugins/settings/__tests__/useBuiltInSettingsSpec.js
+++ b/client/src/plugins/settings/__tests__/useBuiltInSettingsSpec.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { schema } from '../useBuiltInSettings';
+
+
+describe('useBuiltInSettings', function() {
+
+  it('should use latest stable versions', function() {
+
+    // then
+    expect(schema.properties['app.defaultC8Version'].default).to.equal('8.7.0');
+    expect(schema.properties['app.defaultC7Version'].default).to.equal('7.23.0');
+  });
+
+});

--- a/client/src/plugins/settings/useBuiltInSettings.js
+++ b/client/src/plugins/settings/useBuiltInSettings.js
@@ -12,7 +12,7 @@ import { useEffect } from 'react';
 
 import { find, map } from 'min-dash';
 
-import { ENGINES, ENGINE_PROFILES } from '../../util/Engines';
+import { ENGINES, ENGINE_PROFILES, getLatestStable } from '../../util/Engines';
 
 import { getAnnotatedVersion, toSemverMinor } from '../../app/tabs/EngineProfile';
 
@@ -27,7 +27,7 @@ export default function useBuiltInSettings(settings) {
   }, []);
 }
 
-const schema = {
+export const schema = {
   id: 'app',
   title: 'Global Settings',
   order: 0,
@@ -66,14 +66,14 @@ const schema = {
     'app.defaultC8Version': {
       type: 'select',
       options: getEngineOptions(ENGINES.CLOUD),
-      default: '8.6.0',
+      default: getLatestStable(ENGINES.CLOUD),
       flag: 'c8-engine-version',
       label: 'Default Camunda 8 version',
     },
     'app.defaultC7Version': {
       type: 'select',
       options: getEngineOptions(ENGINES.PLATFORM),
-      default: '7.23.0',
+      default: getLatestStable(ENGINES.PLATFORM),
       flag: 'c7-engine-version',
       label: 'Default Camunda 7 version',
     }


### PR DESCRIPTION
Closes #5041

### Proposed Changes

Use latest stable as the default version. No need to hard-code version number.

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/f728805b-b19a-49a0-b79f-513ee18ff77a" />

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
