### PR TITLE
fix: use singular in deployment notification

### DIFF
--- a/client/src/plugins/process-applications/ProcessApplicationsDeploymentNotifications.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsDeploymentNotifications.js
@@ -39,7 +39,7 @@ export function getSuccessNotification(tab, config, deploymentResult, resourceCo
     content: (
       <div className={ css.ProcessApplicationsDeploymentNotification }>
         <div>
-          <code>{ tab.file.name }</code> and { resourceConfigs.length - 1} additional files deployed.
+          <code>{ tab.file.name }</code> and { resourceConfigs.length - 1} additional { resourceConfigs.length - 1 === 1 ? 'file' : 'files' } deployed.
         </div>
         {
           urls.length


### PR DESCRIPTION
Fixes singluar/plural in the deployment notification for process applications.

Related to https://github.com/camunda/camunda-modeler/pull/5062

### Proposed Changes

![image](https://github.com/user-attachments/assets/aa1ec258-a8a6-4119-9d9f-b1e794e3f1da)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
