### PR TITLE
Settings: return values from `register` and handle non-existing key on `get`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ ___Note:__ Yet to be released changes appear here._
 ### General
 
 * `FEAT`: make Camunda 8 start instance variables input a code editor ([#4976](https://github.com/camunda/camunda-modeler/issues/4976))
+* `FEAT`: return registered settings values ([#5069](https://github.com/camunda/camunda-modeler/pull/5069))
+* `FEAT`: allow to subscribe prior to settings registration ([#5069](https://github.com/camunda/camunda-modeler/pull/5069))
+* `FIX`: handle missing setting registration on `settings.get` ([#5069](https://github.com/camunda/camunda-modeler/pull/5069))
 
 ## 5.36.1
 

--- a/client/src/app/Settings.js
+++ b/client/src/app/Settings.js
@@ -176,7 +176,7 @@ export default class Settings {
    * If a setting is controlled by a flag and the flag is set,
    * the value of the flag is returned.
    *
-   * @param { string|undefined } key
+   * @param { string } [key]
    * @returns { Object.<string, string|boolean>|string|boolean }
    */
   get(key) {
@@ -188,8 +188,13 @@ export default class Settings {
   }
 
   _get(key) {
+    const schema = this.getSchema(key);
 
-    const { flag } = this.getSchema(key);
+    if (!schema) {
+      throw new Error(`Setting with key ${key} is not registered`);
+    }
+
+    const { flag } = schema;
 
     if (flag && Flags.get(flag) !== undefined) {
       return Flags.get(flag);
@@ -201,12 +206,12 @@ export default class Settings {
   /**
    * Get the metadata for the specified setting or all settings if no key is provided.
    *
-   * @param { string|undefined } key
+   * @param { string } [key]
    * @returns { SettingsGroup }
    */
   getSchema(key) {
     const prefix = key ? key.split('.')[0] : null;
-    return key ? this._settings[prefix].properties[key] : this._settings;
+    return key ? this._settings[prefix]?.properties[key] : this._settings;
   }
 
   /**

--- a/client/src/app/Settings.js
+++ b/client/src/app/Settings.js
@@ -22,7 +22,7 @@ import { Flags } from '../util';
  * @property {string} id - unique identifier for the settings group
  * @property {string} title - title of the section on the settings page
  * @property {number} [order] - index of the section on the settings page
- * @property {Object.<string, SettingsProperty>} properties - property key must be prefixed with
+ * @property {Record<string, SettingsProperty>} properties - property key must be prefixed with
  * the group `id` e.g `bpmn.enabled`
  */
 
@@ -69,14 +69,14 @@ export default class Settings {
      * Dictionary of all the provided settings metadata.
      * Key is the `id` of the settings group.
      *
-     * @type { Object.<string, SettingsGroup> }
+     * @type { Record<string, SettingsGroup> }
      */
     this._settings = {};
 
     /**
      * Dictionary of setting keys and their default values, if provided.
      *
-     * @type { Object.<string, string|boolean> }
+     * @type { Record<string, string|boolean> }
      */
     this._defaults = {};
 
@@ -84,7 +84,7 @@ export default class Settings {
      * Dictionary of all the settings keys and their values.
      * This is stored in the `settings.json` file.
      *
-     * @type { Object.<string, string|boolean>}
+     * @type { Record<string, string|boolean>}
      */
     this._values = {};
 
@@ -92,7 +92,7 @@ export default class Settings {
      * Dictionary of setting keys and their listeners.
      * Listeners are called when the setting value changes.
      *
-     * @type { Object.<string, Array<function>> }
+     * @type { Record<string, Array<function>> }
      */
     this._listeners = {};
 
@@ -112,7 +112,7 @@ export default class Settings {
    *
    * @param { SettingsGroup } settings
    *
-   * @returns { Object.<string, string|boolean> } Dictionary of setting keys and their values.
+   * @returns { Record<string, string|boolean> } Dictionary of setting keys and their values.
   */
   register(settings) {
     const {
@@ -177,7 +177,7 @@ export default class Settings {
    * the value of the flag is returned.
    *
    * @param { string } [key]
-   * @returns { Object.<string, string|boolean>|string|boolean }
+   * @returns { Record<string, string|boolean>|string|boolean }
    */
   get(key) {
     if (key) {
@@ -219,7 +219,7 @@ export default class Settings {
    *
    * Calls the listeners for each setting that has changed. Saves the file.
    *
-   * @param {Object.<string, string|boolean} settings - Dictionary of setting keys and their values.
+   * @param {Record<string, string|boolean} settings - Dictionary of setting keys and their values.
    */
   set(settings) {
 

--- a/client/src/app/Settings.js
+++ b/client/src/app/Settings.js
@@ -8,7 +8,7 @@
  * except in compliance with the MIT License.
  */
 
-import { forEach } from 'min-dash';
+import { forEach, reduce } from 'min-dash';
 
 import { mapValues } from 'lodash';
 
@@ -111,6 +111,8 @@ export default class Settings {
    * @see Refere to {@link SettingsGroup} and {@link SettingsProperty} types for more details.
    *
    * @param { SettingsGroup } settings
+   *
+   * @returns { Object.<string, string|boolean> } Dictionary of setting keys and their values.
   */
   register(settings) {
     const {
@@ -139,7 +141,14 @@ export default class Settings {
 
       // Set the default value if provided
       this._defaults[key] = property.default;
+
+      // Notify listeners if they subscribed before the setting was registered
+      this._notify(key);
     });
+
+    return reduce(properties, (acc, _, key) => {
+      return { ...acc, [key]: this.get(key) };
+    }, {});
   }
 
   _validate(settings) {
@@ -238,7 +247,7 @@ export default class Settings {
    */
   _notify(key) {
     forEach(this._listeners[key], listener => {
-      listener({ value: this._values[key] });
+      listener({ value: this._get(key) });
     });
   }
 

--- a/client/src/app/__tests__/SettingsSpec.js
+++ b/client/src/app/__tests__/SettingsSpec.js
@@ -52,6 +52,23 @@ describe('Settings', function() {
     });
   });
 
+  describe('register', function() {
+
+    it('should register and return values', function() {
+
+      // when
+      const values = settings.register(settingsMock);
+
+      // then
+      expect(values).to.deep.equal({
+        'test.enabled': true,
+        'test.name': 'test',
+        'test.flag': false
+      });
+    });
+  });
+
+
   describe('schema', function() {
 
     it('should return the registered schema for all settings', function() {
@@ -226,6 +243,20 @@ describe('Settings', function() {
 
       // then
       expect(listener).to.have.been.calledWith({ value: 'foo' });
+    });
+
+
+    it('should call the listener when the setting is registered', function() {
+
+      // given
+      const listener = sinon.spy();
+      settings.subscribe('test.name', listener);
+
+      // when
+      settings.register(settingsMock);
+
+      // then
+      expect(listener).to.have.been.calledWith({ value: 'test' });
     });
 
   });

--- a/client/src/app/__tests__/SettingsSpec.js
+++ b/client/src/app/__tests__/SettingsSpec.js
@@ -225,6 +225,22 @@ describe('Settings', function() {
       // then
       expect(value).to.equal('foo');
     });
+
+
+    it('should throw when key does not exist', function() {
+
+      // given
+      const key = 'test.invalid';
+
+      // when
+      settings.register(settingsMock);
+
+      // then
+      const get = () => settings.get(key);
+
+      // expect error to contain the invalid key
+      expect(get).to.throw(key);
+    });
   });
 
 


### PR DESCRIPTION
### Proposed Changes

The following changes are related to my findings when rewriting the auto-save plugin to use settings instead of a custom overlay.

Related to https://github.com/jarekdanielak/camunda-modeler-autosave-plugin/pull/1

#### Return current settings values and notify subscribers on `Settings#register`

Quality of life feature - no need to `get` the setting value right after registration. 

#### Handle `Settings#get` when `key` does not exist

More gently handle a case when `Settings#get` is called with a key which doesn't exist.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
