### PR TITLE
chore: do not run lerna publish on dev build

### DIFF
--- a/app/util/get-version.js
+++ b/app/util/get-version.js
@@ -31,7 +31,7 @@ var pkg = require('../package.json');
  */
 module.exports = function getVersion() {
   var appVersion = pkg.version;
-  var increment = IS_NIGHTLY || IS_DEV;
+  var increment = IS_NIGHTLY;
 
   if (increment) {
     appVersion = semver.inc(appVersion, 'minor');

--- a/tasks/distro.js
+++ b/tasks/distro.js
@@ -19,6 +19,7 @@ const getVersion = require('../app/util/get-version');
 const pkg = require('../app/package');
 
 const nightly = process.env.NIGHTLY;
+const dev = process.env.NODE_ENV !== 'production';
 
 const {
   publish,
@@ -39,7 +40,7 @@ if (onDemand) {
 
 const version = getVersion();
 
-if (version !== pkg.version) {
+if (version !== pkg.version && !dev) {
 
   const lernaPublishArgs = [
     'version',
@@ -74,6 +75,8 @@ if (nightly) {
   replaceVersion = s => s.replace('${version}', 'nightly');
 } else if (onDemand) {
   replaceVersion = s => s.replace('${version}', buildName);
+} else if (dev) {
+  replaceVersion = s => s.replace('${version}', version);
 }
 
 const artifactOptions = [

--- a/tasks/test-distro.js
+++ b/tasks/test-distro.js
@@ -36,6 +36,7 @@ function currentPlatform() {
 }
 
 const nightly = process.env.NIGHTLY;
+const dev = process.env.NODE_ENV !== 'production';
 
 const {
   win,
@@ -103,6 +104,8 @@ if (nightly) {
   version = 'nightly';
 } else if (onDemand) {
   version = process.env.BUILD_NAME;
+} else if (dev) {
+  version = `${version}-dev`;
 }
 
 // execute tests


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/3922

### Proposed Changes

For dev builds, simply take current package version and add `-dev` to it without incrementing the minor part.

Skip lerna publish action for dev builds, which means no workspace changes after local build.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
