### PR TITLE
Remember entered deployment config locally

### DIFF
--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.js
@@ -66,11 +66,11 @@ export default function DeploymentPluginOverlay(props) {
   };
 
   const onSubmit = async (values) => {
-    const config = values;
+    setConfig(values);
 
     const resourceConfigs = getResourceConfigs(activeTab);
 
-    const deploymentResponse = await deployment.deploy(resourceConfigs, config);
+    const deploymentResponse = await deployment.deploy(resourceConfigs, values);
 
     if (deploymentResponse.success) {
       displayNotification(getSuccessNotification(activeTab, config, deploymentResponse));
@@ -89,6 +89,8 @@ export default function DeploymentPluginOverlay(props) {
 
   const validateForm = async (values) => {
     const config = values;
+
+    setConfig(config);
 
     const configValidationErrors = deploymentConfigValidator.validateConfig(values);
 

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePluginOverlay.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePluginOverlay.js
@@ -93,8 +93,14 @@ export default function StartInstancePluginOverlay(props) {
     return null;
   };
 
-  const onSubmit = async (values) => {
-    const startInstanceConfig = values;
+  const onDeploymentSubmit = async (values) => {
+    setDeploymentConfig(values);
+
+    setShowDeploymentConfigForm(false);
+  };
+
+  const onStartInstanceSubmit = async (values) => {
+    setStartInstanceConfig(values);
 
     const resourceConfigs = getResourceConfigs(activeTab);
 
@@ -129,7 +135,7 @@ export default function StartInstancePluginOverlay(props) {
 
       const startInstanceResult = await startInstance.startInstance(processId, {
         ...deploymentConfig,
-        ...startInstanceConfig
+        ...values
       });
 
       if (startInstanceResult.success) {
@@ -151,7 +157,9 @@ export default function StartInstancePluginOverlay(props) {
   const validateDeploymentConfigForm = async (values) => {
     const config = values;
 
-    const configValidationErrors = deploymentConfigValidator.validateConfig(values);
+    setDeploymentConfig(config);
+
+    const configValidationErrors = deploymentConfigValidator.validateConfig(config);
 
     if (Object.keys(configValidationErrors).length > 0) {
       connectionChecker.updateConfig(null);
@@ -169,7 +177,9 @@ export default function StartInstancePluginOverlay(props) {
   const validateStartInstanceConfigForm = async (values) => {
     const config = values;
 
-    const configValidationErrors = startInstanceConfigValidator.validateConfig(values);
+    setStartInstanceConfig(config);
+
+    const configValidationErrors = startInstanceConfigValidator.validateConfig(config);
 
     if (!Object.keys(configValidationErrors).length) {
       const file = getConfigFile(activeTab);
@@ -252,7 +262,7 @@ export default function StartInstancePluginOverlay(props) {
               <DeploymentConfigForm
                 getFieldError={ getDeploymentFieldError }
                 initialFieldValues={ deploymentConfig }
-                onSubmit={ () => setShowDeploymentConfigForm(false) }
+                onSubmit={ onDeploymentSubmit }
                 renderDescription={ renderDeploymentDescription }
                 renderHeader={ renderDeploymentHeader }
                 renderSubmit={ renderDeploymentSubmit }
@@ -263,7 +273,7 @@ export default function StartInstancePluginOverlay(props) {
               <StartInstanceConfigForm
                 getFieldError={ getStartInstanceFieldError }
                 initialFieldValues={ startInstanceConfig }
-                onSubmit={ onSubmit }
+                onSubmit={ onStartInstanceSubmit }
                 renderDescription={ renderStartInstanceDescription }
                 renderHeader={ renderStartInstanceHeader }
                 renderSubmit={ renderStartInstanceSubmit }

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePluginOverlay.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePluginOverlay.js
@@ -198,6 +198,12 @@ export default function StartInstancePluginOverlay(props) {
 
       setDeploymentConfig(deploymentConfig);
 
+      const configValidationErrors = deploymentConfigValidator.validateConfig(deploymentConfig);
+
+      if (Object.keys(configValidationErrors).length > 0) {
+        setShowDeploymentConfigForm(true);
+      }
+
       connectionChecker.updateConfig(deploymentConfig);
 
       const startInstanceConfig = await startInstance.getConfigForFile(file);

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginOverlaySpec.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginOverlaySpec.js
@@ -45,7 +45,46 @@ describe('StartInstancePluginOverlay', function() {
   });
 
 
-  it('should render start instance config (no connection check result)', async function() {
+  it('should render deployment config (deployment config invalid)', async function() {
+
+    // when
+    const deploymentConfig = createMockDeploymentConfig({
+      endpoint: createMockEndpoint({
+        camundaCloudClientId: '',
+        camundaCloudClientSecret: ''
+      })
+    });
+
+    const deployment = new MockDeployment({
+      getConfigForFile: () => Promise.resolve(deploymentConfig)
+    });
+
+    const startInstanceConfig = createMockStartInstanceConfig();
+
+    const startInstance = new MockStartInstance({
+      getConfigForFile: () => Promise.resolve(startInstanceConfig)
+    });
+
+    createStartInstancePluginOverlay({
+      deployment,
+      deploymentConfigValidator: new MockConfigValidator({
+        validateConfig: () => ({
+          'endpoint.camundaCloudClientId': 'foo',
+          'endpoint.camundaCloudClientSecret': 'bar'
+        }),
+      }),
+      DeploymentConfigForm: createMockDeploymentConfigForm().Form,
+      startInstance
+    });
+
+    // then
+    await waitFor(() => {
+      expect(document.querySelector('form#deployment')).to.exist;
+    });
+  });
+
+
+  it('should render start instance config (deployment config valid, no connection check result)', async function() {
 
     // when
     const deploymentConfig = createMockDeploymentConfig();
@@ -73,7 +112,7 @@ describe('StartInstancePluginOverlay', function() {
   });
 
 
-  it('should render deployment config (connection check result, no success)', async function() {
+  it('should render deployment config (deployment config valid, connection check result, no success)', async function() {
 
     // when
     const connectionChecker = new MockConnectionChecker();

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginOverlaySpec.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginOverlaySpec.js
@@ -333,114 +333,301 @@ describe('StartInstancePluginOverlay', function() {
 
   describe('form submission', function() {
 
-    it('should submit form (success)', async function() {
+    describe('start instance config', function() {
 
-      // given
-      const deploymentConfig = createMockDeploymentConfig();
+      it('should submit form (success)', async function() {
 
-      const deployment = new MockDeployment({
-        deploy: sinon.spy(() => Promise.resolve(createMockDeploymentResult())),
-        getConfigForFile: () => Promise.resolve(deploymentConfig)
+        // given
+        const deploymentConfig = createMockDeploymentConfig();
+
+        const deployment = new MockDeployment({
+          deploy: sinon.spy(() => Promise.resolve(createMockDeploymentResult())),
+          getConfigForFile: () => Promise.resolve(deploymentConfig)
+        });
+
+        const displayNotificationSpy = sinon.spy();
+
+        const startInstanceConfig = createMockStartInstanceConfig();
+
+        const startInstance = new MockStartInstance({
+          getConfigForFile: () => Promise.resolve(startInstanceConfig),
+          startInstance: sinon.spy(() => Promise.resolve(createMockStartInstanceResult()))
+        });
+
+        const { Form, getProps: getFormProps } = createMockStartInstanceConfigForm();
+
+        createStartInstancePluginOverlay({
+          deployment,
+          displayNotification: displayNotificationSpy,
+          startInstance,
+          StartInstanceConfigForm: Form
+        });
+
+        await waitFor(() => {
+          expect(document.querySelector('.loading')).not.to.exist;
+        });
+
+        // when
+        getFormProps().onSubmit(startInstanceConfig);
+
+        // expect
+        await waitFor(() => {
+          expect(startInstance.startInstance).to.have.been.calledOnce;
+        });
+
+        expect(startInstance.startInstance).to.have.been.calledWith('foo', {
+          ...deploymentConfig,
+          ...startInstanceConfig
+        });
+
+        expect(displayNotificationSpy).to.have.been.calledOnce;
+        expect(displayNotificationSpy).to.have.been.calledWith(sinon.match({
+          title: 'Process instance started',
+          type: 'success'
+        }));
       });
 
-      const displayNotificationSpy = sinon.spy();
 
-      const startInstanceConfig = createMockStartInstanceConfig();
+      it('should submit form (no success)', async function() {
 
-      const startInstance = new MockStartInstance({
-        getConfigForFile: () => Promise.resolve(startInstanceConfig),
-        startInstance: sinon.spy(() => Promise.resolve(createMockStartInstanceResult()))
+        // given
+        const deploymentConfig = createMockDeploymentConfig();
+
+        const deployment = new MockDeployment({
+          deploy: sinon.spy(() => Promise.resolve(createMockDeploymentResult())),
+          getConfigForFile: () => Promise.resolve(deploymentConfig)
+        });
+
+        const displayNotificationSpy = sinon.spy();
+
+        const startInstanceConfig = createMockStartInstanceConfig();
+
+        const startInstance = new MockStartInstance({
+          getConfigForFile: () => Promise.resolve(startInstanceConfig),
+          startInstance: sinon.spy(() => Promise.resolve(createMockStartInstanceResult({
+            success: false,
+            response: {
+              details: 'foo'
+            }
+          })))
+        });
+
+        const { Form, getProps: getFormProps } = createMockStartInstanceConfigForm();
+
+        createStartInstancePluginOverlay({
+          deployment,
+          displayNotification: displayNotificationSpy,
+          startInstance,
+          StartInstanceConfigForm: Form
+        });
+
+        await waitFor(() => {
+          expect(document.querySelector('.loading')).not.to.exist;
+        });
+
+        // when
+        getFormProps().onSubmit(startInstanceConfig);
+
+        // expect
+        await waitFor(() => {
+          expect(startInstance.startInstance).to.have.been.calledOnce;
+        });
+
+        expect(startInstance.startInstance).to.have.been.calledWith('foo', {
+          ...deploymentConfig,
+          ...startInstanceConfig
+        });
+
+        expect(displayNotificationSpy).to.have.been.calledOnce;
+        expect(displayNotificationSpy).to.have.been.calledWith(sinon.match({
+          title: 'Process instance not started',
+          type: 'error'
+        }));
       });
 
-      const { Form, getProps: getFormProps } = createMockStartInstanceConfigForm();
-
-      createStartInstancePluginOverlay({
-        deployment,
-        displayNotification: displayNotificationSpy,
-        startInstance,
-        StartInstanceConfigForm: Form
-      });
-
-      await waitFor(() => {
-        expect(document.querySelector('.loading')).not.to.exist;
-      });
-
-      // when
-      getFormProps().onSubmit(startInstanceConfig);
-
-      // expect
-      await waitFor(() => {
-        expect(startInstance.startInstance).to.have.been.calledOnce;
-      });
-
-      expect(startInstance.startInstance).to.have.been.calledWith('foo', {
-        ...deploymentConfig,
-        ...startInstanceConfig
-      });
-
-      expect(displayNotificationSpy).to.have.been.calledOnce;
-      expect(displayNotificationSpy).to.have.been.calledWith(sinon.match({
-        title: 'Process instance started',
-        type: 'success'
-      }));
     });
 
 
-    it('should submit form (no success)', async function() {
+    describe('deployment and start instance config', function() {
 
-      // given
-      const deploymentConfig = createMockDeploymentConfig();
+      it('should submit form (success)', async function() {
 
-      const deployment = new MockDeployment({
-        deploy: sinon.spy(() => Promise.resolve(createMockDeploymentResult())),
-        getConfigForFile: () => Promise.resolve(deploymentConfig)
-      });
+        // given
+        const deploymentConfig = createMockDeploymentConfig({
+          endpoint: createMockEndpoint({
+            camundaCloudClientId: '',
+            camundaCloudClientSecret: ''
+          })
+        });
 
-      const displayNotificationSpy = sinon.spy();
+        const deployment = new MockDeployment({
+          deploy: sinon.spy(() => Promise.resolve(createMockDeploymentResult())),
+          getConfigForFile: () => Promise.resolve(deploymentConfig)
+        });
 
-      const startInstanceConfig = createMockStartInstanceConfig();
+        const { Form: DeploymentForm, getProps: getDeploymentFormProps } = createMockDeploymentConfigForm();
 
-      const startInstance = new MockStartInstance({
-        getConfigForFile: () => Promise.resolve(startInstanceConfig),
-        startInstance: sinon.spy(() => Promise.resolve(createMockStartInstanceResult({
-          success: false,
-          response: {
-            details: 'foo'
+        const displayNotificationSpy = sinon.spy();
+
+        const startInstanceConfig = createMockStartInstanceConfig();
+
+        const startInstance = new MockStartInstance({
+          getConfigForFile: () => Promise.resolve(startInstanceConfig),
+          startInstance: sinon.spy(() => Promise.resolve(createMockStartInstanceResult()))
+        });
+
+        const { Form: StartInstanceForm, getProps: getStartInstanceFormProps } = createMockStartInstanceConfigForm();
+
+        createStartInstancePluginOverlay({
+          deployment,
+          DeploymentConfigForm: DeploymentForm,
+          deploymentConfigValidator: new MockConfigValidator({
+            validateConfig: sinon.stub()
+              .onFirstCall().returns({
+                'camundaCloud.clientId': 'foo',
+                'camundaCloud.clientSecret': 'bar'
+              })
+              .onSecondCall().returns({}),
+          }),
+          displayNotification: displayNotificationSpy,
+          startInstance,
+          StartInstanceConfigForm: StartInstanceForm
+        });
+
+        await waitFor(() => {
+          expect(document.querySelector('form#deployment')).to.exist;
+        });
+
+        // when
+        const newDeploymentConfig = createMockDeploymentConfig();
+
+        getDeploymentFormProps().onSubmit(newDeploymentConfig);
+
+        // then
+        await waitFor(() => {
+          expect(document.querySelector('form#start-instance')).to.exist;
+        });
+
+        // when
+        getStartInstanceFormProps().onSubmit(startInstanceConfig);
+
+        // then
+        await waitFor(() => {
+          expect(deployment.deploy).to.have.been.calledOnce;
+          expect(startInstance.startInstance).to.have.been.calledOnce;
+        });
+
+        expect(deployment.deploy).to.have.been.calledWith([
+          {
+            path: 'foo.bpmn',
+            type: 'bpmn'
           }
-        })))
+        ], newDeploymentConfig);
+
+        expect(startInstance.startInstance).to.have.been.calledWith('foo', {
+          ...newDeploymentConfig,
+          ...startInstanceConfig
+        });
+
+        expect(displayNotificationSpy).to.have.been.calledOnce;
+        expect(displayNotificationSpy).to.have.been.calledWith(sinon.match({
+          title: 'Process instance started',
+          type: 'success'
+        }));
       });
 
-      const { Form, getProps: getFormProps } = createMockStartInstanceConfigForm();
 
-      createStartInstancePluginOverlay({
-        deployment,
-        displayNotification: displayNotificationSpy,
-        startInstance,
-        StartInstanceConfigForm: Form
+      it('should submit form (no success)', async function() {
+
+        // given
+        const deploymentConfig = createMockDeploymentConfig({
+          endpoint: createMockEndpoint({
+            camundaCloudClientId: '',
+            camundaCloudClientSecret: ''
+          })
+        });
+
+        const deployment = new MockDeployment({
+          deploy: sinon.spy(() => Promise.resolve(createMockDeploymentResult())),
+          getConfigForFile: () => Promise.resolve(deploymentConfig)
+        });
+
+        const { Form: DeploymentForm, getProps: getDeploymentFormProps } = createMockDeploymentConfigForm();
+
+        const displayNotificationSpy = sinon.spy();
+
+        const startInstanceConfig = createMockStartInstanceConfig();
+
+        const startInstance = new MockStartInstance({
+          getConfigForFile: () => Promise.resolve(startInstanceConfig),
+          startInstance: sinon.spy(() => Promise.resolve(createMockStartInstanceResult({
+            success: false,
+            response: {
+              details: 'foo'
+            }
+          })))
+        });
+
+        const { Form: StartInstanceForm, getProps: getStartInstanceFormProps } = createMockStartInstanceConfigForm();
+
+        createStartInstancePluginOverlay({
+          deployment,
+          DeploymentConfigForm: DeploymentForm,
+          deploymentConfigValidator: new MockConfigValidator({
+            validateConfig: sinon.stub()
+              .onFirstCall().returns({
+                'camundaCloud.clientId': 'foo',
+                'camundaCloud.clientSecret': 'bar'
+              })
+              .onSecondCall().returns({}),
+          }),
+          displayNotification: displayNotificationSpy,
+          startInstance,
+          StartInstanceConfigForm: StartInstanceForm
+        });
+
+        await waitFor(() => {
+          expect(document.querySelector('form#deployment')).to.exist;
+        });
+
+        // when
+        const newDeploymentConfig = createMockDeploymentConfig();
+
+        getDeploymentFormProps().onSubmit(newDeploymentConfig);
+
+        // then
+        await waitFor(() => {
+          expect(document.querySelector('form#start-instance')).to.exist;
+        });
+
+        // when
+        getStartInstanceFormProps().onSubmit(startInstanceConfig);
+
+        // then
+        await waitFor(() => {
+          expect(deployment.deploy).to.have.been.calledOnce;
+          expect(startInstance.startInstance).to.have.been.calledOnce;
+        });
+
+        expect(deployment.deploy).to.have.been.calledWith([
+          {
+            path: 'foo.bpmn',
+            type: 'bpmn'
+          }
+        ], newDeploymentConfig);
+
+        expect(startInstance.startInstance).to.have.been.calledWith('foo', {
+          ...newDeploymentConfig,
+          ...startInstanceConfig
+        });
+
+        expect(displayNotificationSpy).to.have.been.calledOnce;
+        expect(displayNotificationSpy).to.have.been.calledWith(sinon.match({
+          title: 'Process instance not started',
+          type: 'error'
+        }));
       });
 
-      await waitFor(() => {
-        expect(document.querySelector('.loading')).not.to.exist;
-      });
-
-      // when
-      getFormProps().onSubmit(startInstanceConfig);
-
-      // expect
-      await waitFor(() => {
-        expect(startInstance.startInstance).to.have.been.calledOnce;
-      });
-
-      expect(startInstance.startInstance).to.have.been.calledWith('foo', {
-        ...deploymentConfig,
-        ...startInstanceConfig
-      });
-
-      expect(displayNotificationSpy).to.have.been.calledOnce;
-      expect(displayNotificationSpy).to.have.been.calledWith(sinon.match({
-        title: 'Process instance not started',
-        type: 'error'
-      }));
     });
 
   });


### PR DESCRIPTION
### Proposed Changes

* remember entered deployment config locally
* go to deployment config form immediately if no valid deployment config

Closes #5083
Closes #5048

![electron_h7ODIztt7o](https://github.com/user-attachments/assets/a258b838-c57a-4d12-8a88-aa77176fe403)


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
