### PR TITLE
chore: remove checkbox for Windows signing

### DIFF
--- a/docs/.project/PATCH_RELEASE_TEMPLATE.md
+++ b/docs/.project/PATCH_RELEASE_TEMPLATE.md
@@ -24,7 +24,6 @@ _To be done to prepare and build the release._
 * [ ] update [`CHANGELOG`](https://github.com/camunda/camunda-modeler/blob/master/CHANGELOG.md)
 * [ ] create release (`npm run release`), cf. [release schema](https://github.com/bpmn-io/internal-docs/blob/main/releases/RELEASE_SCHEMA.md)
   * [ ] wait for [release build](https://github.com/camunda/camunda-modeler/actions/workflows/RELEASE.yml) to create the [artifacts](https://github.com/camunda/camunda-modeler/releases)
-* [ ] make sure Windows artifacts are signed
 * [ ] prepare a list of what was changed or needs to be tested
 * [ ] execute integration test, verifying fixed things are actually fixed
 * [ ] (optional) trigger QA for testing

--- a/docs/.project/RELEASE_TEMPLATE.md
+++ b/docs/.project/RELEASE_TEMPLATE.md
@@ -64,7 +64,6 @@ _To be done to build the release after release testing completed._
 _To be done once the release is built._
 
 * [ ] communicate release with closed support-related issues to [#ask-support](https://camunda.slack.com/archives/CHAC0L80M) (automated)
-* [ ] make sure Windows artifacts are signed
 * [ ] publish release on [Github Releases](https://github.com/camunda/camunda-modeler/releases)
 * [ ] close [current milestone](https://github.com/camunda/camunda-modeler/milestones)
 


### PR DESCRIPTION
### Proposed Changes

We don't need to additionally ensure that artifacts are signed. We will notice if they are not signed once we open the Modeler.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
