### PR TITLE
Rename `Zeebe` to 'Orchestration cluster'

### DIFF
--- a/client/src/plugins/zeebe-plugin/deployment-plugin/ConnectionCheckErrors.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/ConnectionCheckErrors.js
@@ -29,13 +29,13 @@ export const CONNECTION_CHECK_ERROR_REASONS = {
 };
 
 export const CONNECTION_CHECK_ERROR_MESSAGES = {
-  [ CONNECTION_CHECK_ERROR_REASONS.CONTACT_POINT_UNAVAILABLE ]: 'Cannot connect to Zeebe cluster.',
-  [ CONNECTION_CHECK_ERROR_REASONS.CLUSTER_UNAVAILABLE ]: 'Cannot connect to Zeebe cluster.',
+  [ CONNECTION_CHECK_ERROR_REASONS.CONTACT_POINT_UNAVAILABLE ]: 'Cannot connect to Orchestration cluster.',
+  [ CONNECTION_CHECK_ERROR_REASONS.CLUSTER_UNAVAILABLE ]: 'Cannot connect to Orchestration cluster.',
   [ CONNECTION_CHECK_ERROR_REASONS.UNAUTHORIZED ]: 'Credentials rejected by server.',
   [ CONNECTION_CHECK_ERROR_REASONS.FORBIDDEN ]: 'This user is not permitted to deploy. Please use different credentials or get this user enabled to deploy.',
   [ CONNECTION_CHECK_ERROR_REASONS.OAUTH_URL ]: 'Cannot connect to OAuth token endpoint.',
-  [ CONNECTION_CHECK_ERROR_REASONS.UNKNOWN ]: 'Unknown error. Please check Zeebe cluster status.',
-  [ CONNECTION_CHECK_ERROR_REASONS.UNSUPPORTED_ENGINE ]: 'Unsupported Zeebe version.',
+  [ CONNECTION_CHECK_ERROR_REASONS.UNKNOWN ]: 'Unknown error. Please check Orchestration cluster status.',
+  [ CONNECTION_CHECK_ERROR_REASONS.UNSUPPORTED_ENGINE ]: 'Unsupported Orchestration cluster version.',
   [ CONNECTION_CHECK_ERROR_REASONS.INVALID_CLIENT_ID ]: 'Invalid Client ID.',
   [ CONNECTION_CHECK_ERROR_REASONS.INVALID_CREDENTIALS ]: 'The client secret is not valid for the client ID provided.'
 };


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/5110

Related to https://github.com/camunda/camunda-docs/pull/6106

### Proposed Changes

Renaming `zeebe` to `Orchestration cluster` in deployment tab. Links to docs did not change yet. 

<img width="304" alt="image" src="https://github.com/user-attachments/assets/58a9dae1-0454-4e88-ba14-92b7532b5407" />

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
