### PR TITLE
chore: import `@carbon/react` styles without `sass`

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -109,8 +109,6 @@
     "puppeteer": "^24.4.0",
     "react-svg-loader": "^3.0.3",
     "react-test-renderer": "^16.14.0",
-    "sass": "^1.83.4",
-    "sass-loader": "^16.0.4",
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "style-loader": "^4.0.0",

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -8,7 +8,6 @@
  * except in compliance with the MIT License.
  */
 
-import './styles/carbon.scss';
 import './styles/style.less';
 
 import {

--- a/client/src/styles/_carbon.less
+++ b/client/src/styles/_carbon.less
@@ -1,0 +1,1 @@
+@import '@carbon/styles/css/styles.css';

--- a/client/src/styles/carbon.scss
+++ b/client/src/styles/carbon.scss
@@ -1,4 +1,0 @@
-// Enables Carbon themes
-@use '@carbon/styles/scss/zone';
-
-@use '@carbon/react/scss/components';

--- a/client/src/styles/style.less
+++ b/client/src/styles/style.less
@@ -1,3 +1,5 @@
+@import "_carbon";
+
 @import "_colors";
 @import "_font";
 

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -101,14 +101,6 @@ module.exports = {
             ]
           },
           {
-            test: /\.s[ac]ss$/i,
-            use: [
-              'style-loader',
-              cssLoader(),
-              'sass-loader',
-            ],
-          },
-          {
 
             // exclude files served otherwise
             exclude: [ /\.(js|jsx|cjs|mjs|bpmnlintrc)$/, /\.html$/, /\.json$/ ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -235,8 +235,6 @@
         "puppeteer": "^24.4.0",
         "react-svg-loader": "^3.0.3",
         "react-test-renderer": "^16.14.0",
-        "sass": "^1.83.4",
-        "sass-loader": "^16.0.4",
         "sinon": "^17.0.1",
         "sinon-chai": "^3.7.0",
         "style-loader": "^4.0.0",
@@ -8733,6 +8731,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
         "is-glob": "^4.0.3",
@@ -8774,6 +8773,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8794,6 +8794,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8814,6 +8815,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8834,6 +8836,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8854,6 +8857,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8874,6 +8878,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8894,6 +8899,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8914,6 +8920,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8934,6 +8941,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8954,6 +8962,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8974,6 +8983,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8994,6 +9004,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -9014,6 +9025,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -9028,6 +9040,7 @@
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -9040,7 +9053,8 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -19786,7 +19800,8 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
       "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -30355,6 +30370,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
       "integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -30370,52 +30386,12 @@
         "@parcel/watcher": "^2.4.1"
       }
     },
-    "node_modules/sass-loader": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.5.tgz",
-      "integrity": "sha512-oL+CMBXrj6BZ/zOq4os+UECPL+bWqt6OAC6DWS8Ln8GZRcMDjlJ4JC3FBDuHJdYaFWIdKNIBYmtZtK2MaMkNIw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "neo-async": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
-        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
-        "sass": "^1.3.0",
-        "sass-embedded": "*",
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@rspack/core": {
-          "optional": true
-        },
-        "node-sass": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/sass/node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -30431,6 +30407,7 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -39814,6 +39791,7 @@
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@parcel/watcher-android-arm64": "2.5.1",
         "@parcel/watcher-darwin-arm64": "2.5.1",
@@ -39838,13 +39816,15 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
           "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-          "optional": true
+          "optional": true,
+          "peer": true
         },
         "node-addon-api": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
           "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-          "optional": true
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -39852,79 +39832,92 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
       "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@parcel/watcher-darwin-arm64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
       "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@parcel/watcher-darwin-x64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
       "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@parcel/watcher-freebsd-x64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
       "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@parcel/watcher-linux-arm-glibc": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
       "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@parcel/watcher-linux-arm-musl": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
       "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@parcel/watcher-linux-arm64-glibc": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
       "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@parcel/watcher-linux-arm64-musl": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
       "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@parcel/watcher-linux-x64-glibc": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
       "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@parcel/watcher-linux-x64-musl": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
       "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@parcel/watcher-win32-arm64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
       "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@parcel/watcher-win32-ia32": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
       "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@parcel/watcher-win32-x64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
       "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -43194,8 +43187,6 @@
         "react-dom": "^16.14.0",
         "react-svg-loader": "^3.0.3",
         "react-test-renderer": "^16.14.0",
-        "sass": "^1.83.4",
-        "sass-loader": "^16.0.4",
         "scroll-tabs": "^1.0.1",
         "semver-compare": "^1.0.0",
         "sinon": "^17.0.1",
@@ -48207,7 +48198,8 @@
     "immutable": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
-      "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg=="
+      "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
+      "peer": true
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -55612,6 +55604,7 @@
       "version": "1.89.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
       "integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
+      "peer": true,
       "requires": {
         "@parcel/watcher": "^2.4.1",
         "chokidar": "^4.0.0",
@@ -55623,6 +55616,7 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
           "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+          "peer": true,
           "requires": {
             "readdirp": "^4.0.1"
           }
@@ -55630,17 +55624,9 @@
         "readdirp": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-          "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="
+          "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+          "peer": true
         }
-      }
-    },
-    "sass-loader": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.5.tgz",
-      "integrity": "sha512-oL+CMBXrj6BZ/zOq4os+UECPL+bWqt6OAC6DWS8Ln8GZRcMDjlJ4JC3FBDuHJdYaFWIdKNIBYmtZtK2MaMkNIw==",
-      "dev": true,
-      "requires": {
-        "neo-async": "^2.6.2"
       }
     },
     "sax": {


### PR DESCRIPTION
### Proposed Changes

Drop the dependency on `sass` and simply import Carbon `styles.css`.

`_carbon.less` is where we can do our "Carbon theming" in the future.

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
