### PR TITLE
Improve file dialog when working with process applications

### DIFF
--- a/app/lib/dialog.js
+++ b/app/lib/dialog.js
@@ -95,7 +95,7 @@ class Dialog {
       } = response;
 
       if (filePath) {
-        this.setDefaultPath(filePath);
+        this.setDefaultPath(path.dirname(filePath));
       }
 
       return filePath;
@@ -105,7 +105,7 @@ class Dialog {
   showOpenDialog(options) {
     const {
       filters,
-      properties,
+      properties = [ 'openFile', 'multiSelections' ],
       title
     } = options;
 
@@ -118,7 +118,7 @@ class Dialog {
     return this.electronDialog.showOpenDialog(this.browserWindow, {
       defaultPath,
       filters,
-      properties: properties || [ 'openFile', 'multiSelections' ],
+      properties,
       title: title || 'Open File'
     }).then(response => {
 
@@ -126,8 +126,12 @@ class Dialog {
         filePaths
       } = response;
 
-      if (filePaths && filePaths[0]) {
-        this.setDefaultPath(filePaths);
+      const defaultPath = filePaths && filePaths[0];
+
+      if (defaultPath) {
+        this.setDefaultPath(
+          properties.includes('openFile') ? path.dirname(defaultPath) : defaultPath
+        );
       }
 
       return filePaths || [];
@@ -167,24 +171,16 @@ class Dialog {
     });
   }
 
-  setDefaultPath(filePaths) {
-    let defaultPath;
+  /**
+   * Set the default path for file dialogs.
+   *
+   * @param {string} defaultPath - path to be used for open / save dialogs
+   */
+  setDefaultPath(defaultPath) {
 
-    if (Array.isArray(filePaths)) {
-      defaultPath = filePaths[0];
-    } else {
-      defaultPath = filePaths;
-    }
+    this.config.set('defaultPath', defaultPath);
 
-    if (this.defaultPath && this.defaultPath === defaultPath) {
-      return this.defaultPath;
-    }
-
-    const dirname = path.dirname(defaultPath);
-
-    this.config.set('defaultPath', dirname);
-
-    this.defaultPath = dirname;
+    this.defaultPath = defaultPath;
   }
 
   setActiveWindow(browserWindow) {

--- a/app/lib/dialog.js
+++ b/app/lib/dialog.js
@@ -19,17 +19,21 @@ const { assign } = require('min-dash');
 const log = require('./log')('app:dialog');
 
 /**
- * Dialogs.
+ * @typedef { import('electron').Dialog } ElectronDialog
+ * @typedef { import('./config') } Config
+ */
+
+/**
+ * A dialog utility
  */
 class Dialog {
 
   /**
-   * Constructor.
-   *
-   * @param {Object} options - Options.
-   * @param {Object} options.electronDialog - Electron dialog.
-   * @param {Object} options.config - Config.
-   * @param {Object} options.userDesktopPath - User desktop path.
+   * @param { {
+   *   electronDialog: ElectronDialog,
+   *   config: Config,
+   *   userDesktopPath: string
+   * } } options
    */
   constructor(options) {
     ensureOptions([ 'electronDialog', 'config', 'userDesktopPath' ], options);

--- a/app/lib/dialog.js
+++ b/app/lib/dialog.js
@@ -16,6 +16,7 @@ const ensureOptions = require('./util/ensure-opts');
 
 const { assign } = require('min-dash');
 
+const log = require('./log')('app:dialog');
 
 /**
  * Dialogs.
@@ -177,6 +178,8 @@ class Dialog {
    * @param {string} defaultPath - path to be used for open / save dialogs
    */
   setDefaultPath(defaultPath) {
+
+    log.debug('set', { defaultPath });
 
     this.config.set('defaultPath', defaultPath);
 

--- a/app/lib/log/log.js
+++ b/app/lib/log/log.js
@@ -10,6 +10,11 @@
 
 const { format } = require('util');
 
+/**
+ * @param {string} namespace
+ *
+ * @return {Log}
+ */
 function createLog(namespace) {
   return new Log(namespace);
 }

--- a/app/test/spec/dialog-spec.js
+++ b/app/test/spec/dialog-spec.js
@@ -351,6 +351,27 @@ describe('Dialog', function() {
         expect(config.get('defaultPath')).to.equal(defaultPath);
       });
 
+
+      it('should set defaultPath when opening directory', async function() {
+
+        // given
+        const fooPath = path.join(USER_PATH, 'foo', 'bar'),
+              defaultPath = fooPath;
+
+        const filePaths = [ fooPath ];
+
+        electronDialog.setResponse({ filePaths });
+
+        // when
+        await dialog.showOpenDialog({
+          ...options,
+          properties: [ 'openDirectory' ]
+        });
+
+        // then
+        expect(config.get('defaultPath')).to.equal(defaultPath);
+      });
+
     });
 
   });
@@ -511,6 +532,23 @@ describe('Dialog', function() {
       expect(dialogArgs.title).to.equal('File Open Error');
       expect(dialogArgs.message).to.equal('Unable to open "foo.txt"');
       expect(dialogArgs.detail).not.to.exist;
+    });
+
+  });
+
+
+  describe('setDefaultPath', function() {
+
+    it('should set defaultPath', function() {
+
+      // given
+      const defaultPath = '/foo/bar';
+
+      // when
+      dialog.setDefaultPath(defaultPath);
+
+      // then
+      expect(config.get('defaultPath')).to.equal(defaultPath);
     });
 
   });

--- a/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
@@ -51,7 +51,10 @@ export default function ProcessApplicationsPlugin(props) {
       const dialog = _getGlobal('dialog');
 
       const [ directoryPath ] = await dialog.showOpenFilesDialog({
-        properties: [ 'openDirectory' ],
+        properties: [
+          'createDirectory', // Allow creating new directories from dialog on macOS
+          'openDirectory'
+        ],
         title: 'Create Process Application'
       });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "ES2018"
+    ],
+    "strict": true,
+    "checkJS": true
+  }
+}


### PR DESCRIPTION
### Proposed Changes

This PR addresses two issues identified in https://github.com/camunda/camunda-modeler/issues/4923 and https://github.com/camunda/camunda-modeler/issues/4928:

* saving the correct default path when creating a process application file
  * we previously didn't account for the possibility of directory paths when setting the default path
  * we would always `dirname` so if it's a directory path we'd accidentally set the parent directory path as the default path

Closes https://github.com/camunda/camunda-modeler/issues/4928
Related to https://github.com/camunda/camunda-modeler/issues/4923

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
