### PR TITLE
Add support for pasting diagram selection into new tab using CTRL/CMD…

### DIFF
--- a/app/lib/clipboard-read-text.js
+++ b/app/lib/clipboard-read-text.js
@@ -1,0 +1,5 @@
+const { clipboard } = require('electron');
+
+module.exports = function clipboardReadText() {
+  return clipboard.readText();
+}; 

--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -55,6 +55,7 @@ const {
 const browserOpen = require('./util/browser-open');
 const fileExplorerOpen = require('./util/file-explorer-open');
 const clipboardWriteText = require('./util/clipboard-write-text');
+const clipboardReadText = require('./util/clipboard-read-text');
 const renderer = require('./util/renderer');
 
 const errorTracking = require('./util/error-tracking');
@@ -219,6 +220,11 @@ renderer.on('system-clipboard:write-text', function(options, done) {
   clipboardWriteText(text);
 
   done(null, undefined);
+});
+
+renderer.on('system-clipboard:read-text', function(options, done) {
+  const text = clipboardReadText();
+  done(null, text);
 });
 
 // file context //////////

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1984,6 +1984,37 @@ export class App extends PureComponent {
       return this.emit('app.settings-open');
     }
 
+    if (action === 'paste-into-new-tab') {
+      // Read clipboard and open as new diagram tab
+      const systemClipboard = this.getGlobal('systemClipboard');
+      systemClipboard.readText().then(text => {
+        if (text && text.trim().startsWith('<?xml')) {
+          // Try to detect diagram type (bpmn, dmn, etc.)
+          const type = this.detectDiagramType(text);
+          if (type) {
+            const file = {
+              name: `Pasted Diagram.${type}`,
+              contents: text
+            };
+            this.openFiles([file]);
+          } else {
+            this.displayNotification({
+              type: 'error',
+              title: 'Paste into New Tab',
+              content: 'Clipboard does not contain a supported diagram type.'
+            });
+          }
+        } else {
+          this.displayNotification({
+            type: 'error',
+            title: 'Paste into New Tab',
+            content: 'Clipboard does not contain diagram XML.'
+          });
+        }
+      });
+      return;
+    }
+
     const tab = this.tabRef.current;
 
     return tab.triggerAction(action, options);
@@ -2294,6 +2325,15 @@ export class App extends PureComponent {
 
     return tabsProvider.getTabIcon(type);
   };
+
+  // Add a helper to detect diagram type from XML
+  detectDiagramType(xml) {
+    if (/bpmn:definitions|<definitions[\s>]/.test(xml)) return 'bpmn';
+    if (/dmn:definitions|<dmn:definitions[\s>]/.test(xml)) return 'dmn';
+    if (/cmmn:definitions|<cmmn:definitions[\s>]/.test(xml)) return 'cmmn';
+    if (/form:form|<form[\s>]/.test(xml)) return 'form';
+    return null;
+  }
 }
 
 

--- a/client/src/app/__tests__/KeyboardBindingsSpec.js
+++ b/client/src/app/__tests__/KeyboardBindingsSpec.js
@@ -173,6 +173,28 @@ describe('KeyboardBindings', function() {
   });
 
 
+  it('paste-into-new-tab (Ctrl+Shift+V)', function() {
+    // given
+    event = createKeyEvent('V', { ctrlKey: true, shiftKey: true });
+
+    keyboardBindings.update([ {
+      custom: {
+        key: 'V',
+        keydown: 'paste-into-new-tab',
+        shiftKey: true,
+        ctrlKey: true,
+        metaKey: true // for Mac
+      }
+    } ]);
+
+    // when
+    keyboardBindings._keyDownHandler(event);
+
+    // then
+    expect(actionSpy).to.have.been.calledWith('paste-into-new-tab', event);
+  });
+
+
   it('undo', function() {
 
     // given

--- a/client/src/app/tabs/getEditMenu.js
+++ b/client/src/app/tabs/getEditMenu.js
@@ -197,6 +197,17 @@ export function getCopyCutPasteEntries({
     accelerator: 'CommandOrControl + V',
     enabled: paste,
     action: 'paste'
+  }, {
+    label: 'Paste into New Tab',
+    accelerator: 'CommandOrControl + Shift + V',
+    enabled: paste,
+    custom: {
+      key: 'V',
+      keydown: 'paste-into-new-tab',
+      shiftKey: true,
+      ctrlKey: true,
+      metaKey: true // for Mac
+    }
   } ];
 }
 

--- a/client/src/remote/SystemClipboard.js
+++ b/client/src/remote/SystemClipboard.js
@@ -26,4 +26,13 @@ export default class SystemClipboard {
     return this.backend.send('system-clipboard:write-text', options);
   }
 
+  /**
+   * Read text from system clipboard.
+   *
+   * @returns {Promise<string>} Clipboard text
+   */
+  readText() {
+    return this.backend.send('system-clipboard:read-text', {});
+  }
+
 }


### PR DESCRIPTION
### Summary

This PR implements the feature to allow users to paste a diagram selection into a newly created tab using `CTRL/CMD+SHIFT+V`.

### Changes

- Detects the shortcut `CTRL/CMD+SHIFT+V`
- Automatically creates a new tab
- Pastes the previously copied diagram selection into that tab

### Issue Reference

Closes #277 