### PR TITLE
fix: resolve scrollbar issue in FEEL popup editor when close button o…

### DIFF
--- a/client/src/styles/_modal.less
+++ b/client/src/styles/_modal.less
@@ -68,6 +68,7 @@
 
 .modal-body {
   padding: 16px 20px 20px 20px;
+  padding-right: 40px;
 
   overflow-y: auto;
 


### PR DESCRIPTION
# Fix: FEEL Popup Editor Scrollbar Accessibility Issue

## Problem

The FEEL popup editor in Camunda Modeler had a UI bug where the scrollbar became inaccessible when it was positioned under the "Close" button. This made it difficult or impossible to scroll using the mouse from the left side of the scrollbar when the popup contained a large amount of text and was scrolled to the bottom.

**Steps to reproduce:**
1. Open a user task with a long FEEL expression.
2. Open the FEEL popup editor.
3. Scroll to the bottom.
4. Attempt to drag the scrollbar from the area under the "Close" button.

**Observed:**  
The scrollbar does not respond to mouse events under the "Close" button.

**Expected:**  
The scrollbar should be accessible and draggable from any position, regardless of the "Close" button.

---

## Solution

Added extra right padding to the `.modal-body` in the modal’s CSS.  
This ensures the scrollbar never appears under the "Close" button, making it fully accessible.

```less
.modal-body {
  // ...existing code...
  padding-right: 40px; // Ensures scrollbar is not under the close button
  // ...existing code...
}
```

---

## Testing

- Open the FEEL popup editor with a long expression.
- Scroll to the bottom.
- Drag the scrollbar from all sides, including the area previously under the "Close" button.
- Confirm that the scrollbar is now always accessible.

---

**Closes:** #5168  
**Related:** UI/UX, Accessibility, Camunda Modeler FEEL Editor