### PR TITLE
Use `monospace` font in code editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: support all Camunda FEEL builtins ([#3983](https://github.com/camunda/camunda-modeler/issues/3983))
 * `FIX`: use uniform GTK symbols on Linux ([#5095](https://github.com/camunda/camunda-modeler/issues/5095))
 * `FIX`: display tooltip on number fields ([#5102](https://github.com/camunda/camunda-modeler/issues/5102))
+* `FIX`: use `monospace` font in code editors ([#5140](https://github.com/camunda-modeler/issues/5140))
 * `DEPS`: update to `electron@37`
 * `DEPS`: update to `dmn-js@17.3.0`
 * `DEPS`: update to `camunda-bpmn-js@5.11.0`

--- a/client/src/app/tabs/json/CodeMirror.js
+++ b/client/src/app/tabs/json/CodeMirror.js
@@ -65,7 +65,7 @@ export default function create() {
         vscodeLight,
         EditorView.theme({
           '.cm-content': {
-            fontFamily: 'Consolas, "Courier New", monospace'
+            fontFamily: 'monospace'
           }
         }),
         ...extensions

--- a/client/src/app/tabs/xml/CodeMirror.js
+++ b/client/src/app/tabs/xml/CodeMirror.js
@@ -65,7 +65,7 @@ export default function create() {
         vscodeLight,
         EditorView.theme({
           '.cm-content': {
-            fontFamily: 'Consolas, "Courier New", monospace'
+            fontFamily: 'monospace'
           }
         }),
         ...extensions

--- a/client/src/shared/ui/form/JSONInput.js
+++ b/client/src/shared/ui/form/JSONInput.js
@@ -134,7 +134,7 @@ function create() {
             fontSize: '13px'
           },
           '.cm-content': {
-            fontFamily: 'Consolas, "Courier New", monospace'
+            fontFamily: 'monospace'
           }
         }),
         ...extensions


### PR DESCRIPTION
### Proposed Changes

This PR fixes the contrast issue by setting `monospace` as the font for code editors.

Closes #5140

Built on top of https://github.com/camunda/camunda-modeler/pull/5175 which needs to be merged first.

https://github.com/user-attachments/assets/a679c607-9796-4c6d-8dd1-4070013f1bed

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
