### PR TITLE
fix: correct bug report link

### DIFF
--- a/client/src/app/tabs/ErrorTab.js
+++ b/client/src/app/tabs/ErrorTab.js
@@ -36,7 +36,7 @@ export default class ErrorTab extends PureComponent {
             This tab crashed due to an unexpected error.
           </p>
           <p>
-            <a href="https://github.com/camunda/camunda-modeler/issues/new?template=BUG_REPORT.md">
+            <a href="https://github.com/camunda/camunda-modeler/issues/new?template=BUG_REPORT.yml">
               Report bug
             </a>
           </p>


### PR DESCRIPTION
### Proposed Changes

During testing I managed to crash the editor tab once, there I noticed the broken link. But I couldn't find a way to reproduce the crash.

The template BUG_REPORT.yml was renamed to BUG_REPORT.md a few years ago, currently no template gets applied

Broken Link: https://github.com/camunda/camunda-modeler/issues/new?template=BUG_REPORT.md
Fixed Link: https://github.com/camunda/camunda-modeler/issues/new?template=BUG_REPORT.yml
<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
