### PR TITLE
Disable js typechecking by default and adjust tsconfig to be more performant and reduce common errors by configuration less strict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 .nyc_output
 .linked-dependencies
 tmp
+tsconfig.json

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,29 @@
+declare module "*.dmn" {
+  const content: string;
+  export default content;
+}
+
+declare module "*.bpmn" {
+  const content: string;
+  export default content;
+}
+
+declare module "*.svg" {
+  const content: JSX.IntrinsicElements.svg;
+  export default content;
+}
+
+declare module "*.css" {
+  const content: string;
+  export default content;
+}
+
+declare module "*.sass" {
+  const content: string;
+  export default content;
+}
+
+declare module "*.less" {
+  const content: string;
+  export default content;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,9 @@
       ],
       "devDependencies": {
         "@electron/notarize": "^3.0.1",
+        "@types/karma-sinon-chai": "^2.0.6",
+        "@types/mocha": "^10.0.10",
+        "@types/webpack-env": "^1.18.8",
         "archiver": "^7.0.1",
         "chai": "^4.5.0",
         "chai-subset": "^1.6.0",
@@ -30,6 +33,7 @@
         "eslint-plugin-bpmn-io": "^2.0.2",
         "eslint-plugin-camunda-licensed": "^1.0.0",
         "execa": "^1.0.0",
+        "karma-sinon-chai": "^2.0.2",
         "lerna": "~8.1.8",
         "license-webpack-plugin": "^4.0.2",
         "mocha": "^10.8.2",
@@ -9063,6 +9067,16 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
     "node_modules/@types/concat-stream": {
       "version": "2.0.0",
       "dev": true,
@@ -9108,6 +9122,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -9208,6 +9229,41 @@
         "jszip": "*"
       }
     },
+    "node_modules/@types/karma": {
+      "version": "6.3.9",
+      "resolved": "https://registry.npmjs.org/@types/karma/-/karma-6.3.9.tgz",
+      "integrity": "sha512-sjE/MHnoAZAQYAKRXAbjTOiBKyGGErEM725bruRcmDdMa2vp1bjWPhApI7/i564PTyHlzc3vIGXLL6TFIpAxFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "log4js": "^6.4.1"
+      }
+    },
+    "node_modules/@types/karma-sinon-chai": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/karma-sinon-chai/-/karma-sinon-chai-2.0.6.tgz",
+      "integrity": "sha512-7bfh0DuuFFd8OotzhARvekmBBSMwc+bzbiQjvS/Ja4T0WhhFo5ava9hMVL6Z7YZdDyeTlckHdCuWJhNXQrEpFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "*",
+        "@types/karma": "*",
+        "@types/sinon": "*",
+        "@types/sinon-chai": "^2"
+      }
+    },
+    "node_modules/@types/karma-sinon-chai/node_modules/@types/sinon-chai": {
+      "version": "2.7.42",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-2.7.42.tgz",
+      "integrity": "sha512-6M+l7agAuaS4iFwC9KtmcGznH4WYTcF3/Jq/m4jZ5/Gm1Rlufc7o7rl1Sb9++U81NliT+mV2Ri6UQziaJi6opw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
+      }
+    },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "license": "MIT",
@@ -9235,6 +9291,13 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -9369,6 +9432,23 @@
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
       "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
     },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/supports-color": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.3.tgz",
@@ -9420,6 +9500,13 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/webpack-env": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.8.tgz",
+      "integrity": "sha512-G9eAoJRMLjcvN4I08wB5I7YofOb/kaJNd5uoCMX+LbKXTPCF+ZIHuqTnFaK9Jz1rgs035f9JUPUhNFtqgucy/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
@@ -38663,6 +38750,15 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "requires": {
+        "@types/deep-eql": "*"
+      }
+    },
     "@types/concat-stream": {
       "version": "2.0.0",
       "dev": true,
@@ -38704,6 +38800,12 @@
       "requires": {
         "@types/ms": "*"
       }
+    },
+    "@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "@types/eslint": {
       "version": "9.6.1",
@@ -38794,6 +38896,40 @@
         "jszip": "*"
       }
     },
+    "@types/karma": {
+      "version": "6.3.9",
+      "resolved": "https://registry.npmjs.org/@types/karma/-/karma-6.3.9.tgz",
+      "integrity": "sha512-sjE/MHnoAZAQYAKRXAbjTOiBKyGGErEM725bruRcmDdMa2vp1bjWPhApI7/i564PTyHlzc3vIGXLL6TFIpAxFg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "log4js": "^6.4.1"
+      }
+    },
+    "@types/karma-sinon-chai": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/karma-sinon-chai/-/karma-sinon-chai-2.0.6.tgz",
+      "integrity": "sha512-7bfh0DuuFFd8OotzhARvekmBBSMwc+bzbiQjvS/Ja4T0WhhFo5ava9hMVL6Z7YZdDyeTlckHdCuWJhNXQrEpFQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*",
+        "@types/karma": "*",
+        "@types/sinon": "*",
+        "@types/sinon-chai": "^2"
+      },
+      "dependencies": {
+        "@types/sinon-chai": {
+          "version": "2.7.42",
+          "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-2.7.42.tgz",
+          "integrity": "sha512-6M+l7agAuaS4iFwC9KtmcGznH4WYTcF3/Jq/m4jZ5/Gm1Rlufc7o7rl1Sb9++U81NliT+mV2Ri6UQziaJi6opw==",
+          "dev": true,
+          "requires": {
+            "@types/chai": "*",
+            "@types/sinon": "*"
+          }
+        }
+      }
+    },
     "@types/keyv": {
       "version": "3.1.4",
       "requires": {
@@ -38819,6 +38955,12 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
       "dev": true
     },
     "@types/ms": {
@@ -38941,6 +39083,21 @@
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
       "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
     },
+    "@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true
+    },
     "@types/supports-color": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.3.tgz",
@@ -38988,6 +39145,12 @@
       "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
       "dev": true,
       "optional": true
+    },
+    "@types/webpack-env": {
+      "version": "1.18.8",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.8.tgz",
+      "integrity": "sha512-G9eAoJRMLjcvN4I08wB5I7YofOb/kaJNd5uoCMX+LbKXTPCF+ZIHuqTnFaK9Jz1rgs035f9JUPUhNFtqgucy/A==",
+      "dev": true
     },
     "@types/yauzl": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
   },
   "devDependencies": {
     "@electron/notarize": "^3.0.1",
+    "@types/karma-sinon-chai": "^2.0.6",
+    "@types/mocha": "^10.0.10",
+    "@types/webpack-env": "^1.18.8",
     "archiver": "^7.0.1",
     "chai": "^4.5.0",
     "chai-subset": "^1.6.0",
@@ -63,6 +66,7 @@
     "eslint-plugin-bpmn-io": "^2.0.2",
     "eslint-plugin-camunda-licensed": "^1.0.0",
     "execa": "^1.0.0",
+    "karma-sinon-chai": "^2.0.2",
     "lerna": "~8.1.8",
     "license-webpack-plugin": "^4.0.2",
     "mocha": "^10.8.2",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,46 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "lib": [
+      "ES2018"
+    ],
+    "paths": {
+      "src/app/*": [ "./client/src/app/*" ],
+      "test/*": [ "./client/test/*" ]
+    },
+    "types": [
+      "mocha",
+      "karma-sinon-chai",
+      "node",
+      "webpack-env"
+    ],
+
+    "checkJs": false,
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowUmdGlobalAccess": true,
+    "resolveJsonModule": true,
+    "allowArbitraryExtensions": true,
+    "strict": true,
+    // strict overwrites to reduce initial error overload
+    "noImplicitAny": false,
+    "noImplicitOverride": false,
+    "useUnknownInCatchVariables": false,
+    "strictNullChecks": false,
+  },
+  "typeAcquisition": {
+    "enable": true
+  },
+  "include": [
+    "client",
+    "app",
+    "globals.d.ts"
+  ],
+  "exclude": [
+    "*/node_modules/**",
+    "*/build/**",
+    "*/public/**"
+  ]
+}

--- a/tsconfig.enable.json
+++ b/tsconfig.enable.json
@@ -1,0 +1,7 @@
+{
+  // If you want to enable type checking for JS files copy this file to `tsconfig.json`
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "checkJs": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "compilerOptions": {
-    "lib": [
-      "ES2018"
-    ],
-    "strict": true,
-    "checkJS": true
-  }
-}


### PR DESCRIPTION
### Proposed Changes

> Discussion basis for HOC

In https://github.com/camunda/camunda-modeler/commit/5bd8d9ed5776ea997ea65d40e07f6e12bcbf1b19 a tsconfig was added with invalid keys, this PR fixes that but I want to make the team aware of the implications. 
To remove some errors i also added jsx parsing and other configurations to make tsc behave as much as our js codebase as possible. (its still not perfect)

With https://www.typescriptlang.org/tsconfig/#checkJs a lot of ts error will be shown in vscode, due to the strict config also a lot of complaints of implicit any 
<img width="583" height="135" alt="image" src="https://github.com/user-attachments/assets/04eef99a-e3f8-4644-aae7-710c9b7076b5" />

Until we have improved our type safety I would suggest to be not as strict. Disabling the following strict checks:  
```
"noImplicitAny": false,
"useUnknownInCatchVariables": false,
"strictNullChecks": false,
```

As discussed in HOC we don't want to force a wave of errors to our developers and make it an opt-in option. With this PR we don't ship with a default tsconfig (same behavior as previous / before https://github.com/camunda/camunda-modeler/commit/5bd8d9ed5776ea997ea65d40e07f6e12bcbf1b19). but have a simple way to enable it for those who like it: Copy `tsconfig.enable.json` to `tsconfig.json` (which is now gitignored)

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Try out

Copy `tsconfig.enable.json` to `tsconfig.json`

Open a file in an IDE with TS support. To get a full list of errors just run tsc, its configured to not emit:
```
npx tsc
```

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [x] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
