### PR TITLE
Add visual distinction between different process applications to overlays

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -155,7 +155,7 @@ export class App extends PureComponent {
   }
 
   /**
-   * Set group for tab.
+   * Set group for tab. Also sets the className for the tab group to be used for styling.
    *
    * @param {string} id ID of the tab
    * @param {string} group Group name
@@ -168,12 +168,26 @@ export class App extends PureComponent {
     }
 
     this.setState(({ tabGroups }) => {
-      return {
-        tabGroups: {
-          ...tabGroups,
-          [ id ]: group
-        }
+      const newTabGroup = {
+        group
       };
+
+      const newTabGroups = {
+        ...tabGroups,
+        [id]: newTabGroup
+      };
+
+      for (const tabGroup of Object.values(newTabGroups)) {
+        tabGroup.className = getTabGroupClassName(tabGroup, newTabGroups);
+      }
+
+      return {
+        tabGroups: newTabGroups
+      };
+    }, () => {
+      this.emit('app.tabGroupsChanged', {
+        tabGroups: this.state.tabGroups
+      });
     });
   }
 
@@ -2557,4 +2571,22 @@ function getProcessor(type) {
   }
 
   return null;
+}
+
+function getTabGroupClassName(tabGroup, tabGroups) {
+  const index = Object.values(tabGroups).findIndex(({ group }) => group === tabGroup.group);
+
+  if (index === -1) {
+
+    // if the group is not found, we do not assign a color
+    return null;
+  }
+
+  if (index > 4) {
+
+    // if there are more than 5 groups, we do not assign a color
+    return null;
+  }
+
+  return `tab-group-${index}`;
 }

--- a/client/src/app/primitives/TabLinks.js
+++ b/client/src/app/primitives/TabLinks.js
@@ -12,8 +12,6 @@ import React, { PureComponent } from 'react';
 
 import classNames from 'classnames';
 
-import { groupBy, omit } from 'min-dash';
-
 import * as css from './Tabbed.less';
 
 import {
@@ -46,14 +44,6 @@ const MIDDLE_MOUSE_BUTTON = 1;
  */
 const SMALL_TAB_WIDTH = 90;
 const SMALLER_TAB_WIDTH = 45;
-
-const COLORS = [
-  'rgb(30, 136, 229)',
-  'rgb(251, 140, 0)',
-  'rgb(67, 160, 71)',
-  'rgb(229, 57, 53)',
-  'rgb(142, 36, 170)'
-];
 
 export default class TabLinks extends PureComponent {
   constructor(props) {
@@ -108,14 +98,6 @@ export default class TabLinks extends PureComponent {
       isDirty = () => false
     } = this.props;
 
-    const tabsByGroup = omit(groupBy(tabs, tab => tabGroups[ tab.id ]), '_');
-
-    const colors = {};
-
-    Object.keys(tabsByGroup).forEach((key, index) => {
-      colors[ key ] = COLORS[ index % COLORS.length ];
-    });
-
     return (
       <div
         className={ classNames(css.LinksContainer, className) }
@@ -126,7 +108,7 @@ export default class TabLinks extends PureComponent {
               const dirty = isDirty(tab);
               const active = tab === activeTab;
 
-              const color = tabGroups[ tab.id ] && colors[ tabGroups[ tab.id ] ];
+              const tabGroup = tabGroups[ tab.id ];
 
               return (
                 <Tab
@@ -138,7 +120,7 @@ export default class TabLinks extends PureComponent {
                   onClose={ onClose }
                   onContextMenu={ onContextMenu }
                   onSelect={ onSelect }
-                  color={ color }
+                  tabGroup={ tabGroup }
                 />
               );
             })
@@ -175,7 +157,7 @@ function Tab(props) {
     onContextMenu,
     onSelect,
     tab,
-    color
+    tabGroup
   } = props;
 
   const tabRef = React.useRef(0);
@@ -199,29 +181,19 @@ function Tab(props) {
     return () => resizeObserver.disconnect();
   }, [ tabNode ]);
 
-  let style = {};
-
-  if (color) {
-    style = {
-      ...style,
-      '--tab-line-group-background-color': color
-    };
-  }
-
   return (
     <div
       tabIndex="0"
       ref={ tabRef }
       data-tab-id={ tab.id }
       title={ getTitleTag(tab, dirty) }
-      className={ classNames('tab', {
+      className={ classNames('tab', tabGroup?.className, {
         'tab--active': active,
         'tab--dirty': dirty,
         'tab--small': small,
         'tab--smaller': smaller,
-        'tab--group': !!color
+        'tab--group': tabGroup
       }) }
-      style={ style }
       onClick={ (event) => onSelect(tab, event) }
       onAuxClick={ (event) => {
         if (event.button === MIDDLE_MOUSE_BUTTON) {

--- a/client/src/app/primitives/Tabbed.less
+++ b/client/src/app/primitives/Tabbed.less
@@ -209,7 +209,26 @@
       left: 0px;
       right: 0px;
       height: 2px;
-      background-color: var(--tab-line-group-background-color);
+    }
+
+    &.tab--group.tab-group-0:after {
+      background-color: var(--color-tab-group-1);
+    }
+
+    &.tab--group.tab-group-1:after {
+      background-color: var(--color-tab-group-2);
+    }
+
+    &.tab--group.tab-group-2:after {
+      background-color: var(--color-tab-group-3);
+    }
+
+    &.tab--group.tab-group-3:after {
+      background-color: var(--color-tab-group-4);
+    }
+
+    &.tab--group.tab-group-4:after {
+      background-color: var(--color-tab-group-5);
     }
   }
 }

--- a/client/src/app/primitives/__tests__/TabLinksSpec.js
+++ b/client/src/app/primitives/__tests__/TabLinksSpec.js
@@ -183,21 +183,18 @@ describe('<TabLinks>', function() {
       // then
       expect(tab1.exists()).to.be.true;
       expect(tab1.hasClass('tab--group')).to.be.true;
-      expect(tab1.getDOMNode().style.getPropertyValue('--tab-line-group-background-color')).to.exist;
+      expect(tab1.hasClass('tab-group-1')).to.be.true;
 
       expect(tab2.exists()).to.be.true;
       expect(tab2.hasClass('tab--group')).to.be.true;
-      expect(tab2.getDOMNode().style.getPropertyValue('--tab-line-group-background-color')).to.exist;
-      expect(tab2.getDOMNode().style.getPropertyValue('--tab-line-group-background-color')).to.equal(tab1.getDOMNode().style.getPropertyValue('--tab-line-group-background-color'));
+      expect(tab2.hasClass('tab-group-1')).to.be.true;
 
       expect(tab3.exists()).to.be.true;
       expect(tab3.hasClass('tab--group')).to.be.true;
-      expect(tab3.getDOMNode().style.getPropertyValue('--tab-line-group-background-color')).to.exist;
-      expect(tab3.getDOMNode().style.getPropertyValue('--tab-line-group-background-color')).not.to.equal(tab1.getDOMNode().style.getPropertyValue('--tab-line-group-background-color'));
+      expect(tab3.hasClass('tab-group-2')).to.be.true;
 
       expect(tab4.exists()).to.be.true;
       expect(tab4.hasClass('tab--group')).to.be.false;
-      expect(tab4.getDOMNode().style.getPropertyValue('--tab-line-group-background-color')).to.equal('');
     });
 
   });

--- a/client/src/app/primitives/__tests__/mocks/index.js
+++ b/client/src/app/primitives/__tests__/mocks/index.js
@@ -31,7 +31,16 @@ export const defaultTabs = [
 ];
 
 export const defaultTabGroups = {
-  tab1: 'group1',
-  tab2: 'group1',
-  tab3: 'group2'
+  tab1: {
+    group: 'group1',
+    className: 'tab-group-1'
+  },
+  tab2: {
+    group: 'group1',
+    className: 'tab-group-1'
+  },
+  tab3: {
+    group: 'group2',
+    className: 'tab-group-2'
+  }
 };

--- a/client/src/plugins/process-applications/ProcessApplicationsDeploymentPlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsDeploymentPlugin.js
@@ -10,7 +10,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import { Fill } from '../../app/slot-fill';
 
@@ -29,6 +29,7 @@ export default function ProcessApplicationsDeploymentPlugin(props) {
   const {
     _getGlobal,
     activeTab,
+    tabGroup,
     displayNotification,
     log,
     processApplication,
@@ -110,7 +111,7 @@ export default function ProcessApplicationsDeploymentPlugin(props) {
         <button
           onClick={ onClick }
           title="Open process application deployment"
-          className={ classNames('btn', css.ProcessApplicationsDeploymentPlugin, { 'btn--active': overlayOpen }) }
+          className={ classnames('btn', css.ProcessApplicationsDeploymentPlugin, { 'btn--active': overlayOpen }) }
           ref={ anchorRef }
         >
           <DeployIcon className="icon" />
@@ -121,6 +122,7 @@ export default function ProcessApplicationsDeploymentPlugin(props) {
       <DeploymentPluginOverlay
         activeTab={ activeTab }
         anchor={ anchorRef.current }
+        className={ classnames(tabGroup?.className) }
         connectionChecker={ connectionChecker }
         deployment={ deployment }
         deploymentConfigValidator={ deploymentConfigValidator }

--- a/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
@@ -31,6 +31,8 @@ export default function ProcessApplicationsPlugin(props) {
   } = props;
 
   const [ activeTab, setActiveTab ] = useState(null);
+  const [ tabGroup, setTabGroup ] = useState(null);
+  const [ tabGroups, setTabGroups ] = useState(null);
   const [ tabs, setTabs ] = useState([]);
   const [ items, setItems ] = useState([]);
   const [ processApplication, setProcessApplication ] = useState(null);
@@ -45,6 +47,12 @@ export default function ProcessApplicationsPlugin(props) {
 
     subscribe('app.tabsChanged', (event) => {
       setTabs(event.tabs);
+    });
+
+    subscribe('app.tabGroupsChanged', (event) => {
+      const { tabGroups } = event;
+
+      setTabGroups(tabGroups);
     });
 
     subscribe('create-process-application', async () => {
@@ -173,6 +181,20 @@ export default function ProcessApplicationsPlugin(props) {
     }
   }, [ items, tabs ]);
 
+  useEffect(() => {
+    if (!activeTab || !tabGroups) {
+      return;
+    }
+
+    const tabGroup = tabGroups[activeTab.id];
+
+    if (tabGroup) {
+      setTabGroup(tabGroup);
+    } else {
+      setTabGroup(null);
+    }
+  }, [ activeTab, tabGroups ]);
+
   return <>
     <ProcessApplicationsStatusBar
       activeTab={ activeTab }
@@ -180,6 +202,7 @@ export default function ProcessApplicationsPlugin(props) {
       processApplicationItems={ processApplicationItems }
       onOpen={ (path) => triggerAction('open-diagram', { path }) }
       onRevealInFileExplorer={ (filePath) => triggerAction('reveal-in-file-explorer', { filePath }) }
+      tabGroup={ tabGroup }
       tabsProvider={ _getFromApp('props').tabsProvider }
     />
     <ProcessApplicationsDeploymentPlugin
@@ -189,6 +212,7 @@ export default function ProcessApplicationsPlugin(props) {
       log={ log }
       processApplication={ processApplication }
       processApplicationItems={ processApplicationItems }
+      tabGroup={ tabGroup }
       triggerAction={ triggerAction } />
     <ProcessApplicationsStartInstancePlugin
       _getGlobal={ _getGlobal }
@@ -197,6 +221,7 @@ export default function ProcessApplicationsPlugin(props) {
       log={ log }
       processApplication={ processApplication }
       processApplicationItems={ processApplicationItems }
+      tabGroup={ tabGroup }
       triggerAction={ triggerAction } />
   </>;
 }

--- a/client/src/plugins/process-applications/ProcessApplicationsStartInstancePlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsStartInstancePlugin.js
@@ -10,7 +10,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import { Fill } from '../../app/slot-fill';
 
@@ -36,6 +36,7 @@ export default function ProcessApplicationsStartInstancePlugin(props) {
     log,
     processApplication,
     processApplicationItems,
+    tabGroup,
     triggerAction
   } = props;
 
@@ -124,7 +125,7 @@ export default function ProcessApplicationsStartInstancePlugin(props) {
         <button
           onClick={ onClick }
           title="Open process application start instance"
-          className={ classNames('btn', css.ProcessApplicationsStartInstancePlugin, { 'btn--active': overlayOpen }) }
+          className={ classnames('btn', css.ProcessApplicationsStartInstancePlugin, { 'btn--active': overlayOpen }) }
           ref={ anchorRef }
         >
           <StartInstanceIcon className="icon" />
@@ -135,6 +136,7 @@ export default function ProcessApplicationsStartInstancePlugin(props) {
       <StartInstancePluginOverlay
         activeTab={ activeTab }
         anchor={ anchorRef.current }
+        className={ classnames(tabGroup?.className) }
         connectionChecker={ connectionChecker }
         deployment={ deployment }
         deploymentConfigValidator={ deploymentConfigValidator }

--- a/client/src/plugins/process-applications/ProcessApplicationsStatusBar.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsStatusBar.js
@@ -34,6 +34,7 @@ export default function ProcessApplicationsStatusBar(props) {
     onRevealInFileExplorer,
     processApplication,
     processApplicationItems,
+    tabGroup,
     tabsProvider
   } = props;
 
@@ -60,7 +61,7 @@ export default function ProcessApplicationsStatusBar(props) {
       </button>
     </Fill>
     {
-      isOpen && <Overlay className={ css.ProcessApplicationsOverlay } id="process-application-overlay" anchor={ ref.current } onClose={ () => setIsOpen(false) }>
+      isOpen && <Overlay className={ classnames(css.ProcessApplicationsOverlay, tabGroup?.className) } id="process-application-overlay" anchor={ ref.current } onClose={ () => setIsOpen(false) }>
         <Section>
           <Section.Header>
             Process application

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.js
@@ -15,6 +15,8 @@
 
 import React, { useEffect, useState } from 'react';
 
+import classnames from 'classnames';
+
 import { Overlay } from '../../../shared/ui';
 
 import { default as DefaultDeploymentConfigForm } from './DeploymentConfigForm';
@@ -38,6 +40,7 @@ export default function DeploymentPluginOverlay(props) {
   const {
     activeTab,
     anchor,
+    className,
     connectionChecker,
     deployment,
     deploymentConfigValidator,
@@ -167,7 +170,7 @@ export default function DeploymentPluginOverlay(props) {
   }, [ deployment, triggerAction ]);
 
   return (
-    <Overlay className={ css.DeploymentPluginOverlay } onClose={ onClose } anchor={ anchor }>
+    <Overlay className={ classnames(css.DeploymentPluginOverlay, className) } onClose={ onClose } anchor={ anchor }>
       { config
         ? (
           <DeploymentConfigForm

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePluginOverlay.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePluginOverlay.js
@@ -16,6 +16,8 @@
 
 import React, { useEffect, useState } from 'react';
 
+import classnames from 'classnames';
+
 import { Overlay } from '../../../shared/ui';
 
 import { default as DefaultDeploymentConfigForm } from '../deployment-plugin/DeploymentConfigForm';
@@ -45,6 +47,7 @@ export default function StartInstancePluginOverlay(props) {
   const {
     activeTab,
     anchor,
+    className,
     connectionChecker,
     deployment,
     DeploymentConfigForm = DefaultDeploymentConfigForm,
@@ -260,7 +263,7 @@ export default function StartInstancePluginOverlay(props) {
   }, [ deployment, triggerAction ]);
 
   return (
-    <Overlay className={ css.StartInstancePluginOverlay } onClose={ onClose } anchor={ anchor }>
+    <Overlay className={ classnames(css.StartInstancePluginOverlay, className) } onClose={ onClose } anchor={ anchor }>
       { deploymentConfig && startInstanceConfig
         ? (
           showDeploymentConfigForm

--- a/client/src/shared/ui/overlay/Overlay.less
+++ b/client/src/shared/ui/overlay/Overlay.less
@@ -131,4 +131,24 @@
       font-weight: 500;
     }
   }
+
+  &.tab-group-0 {
+    border-top: solid 2px var(--color-tab-group-1);
+  }
+
+  &.tab-group-1 {
+    border-top: solid 2px var(--color-tab-group-2);
+  }
+
+  &.tab-group-2 {
+    border-top: solid 2px var(--color-tab-group-3);
+  }
+
+  &.tab-group-3 {
+    border-top: solid 2px var(--color-tab-group-4);
+  }
+
+  &.tab-group-4 {
+    border-top: solid 2px var(--color-tab-group-5);
+  }
 }

--- a/client/src/styles/_colors.less
+++ b/client/src/styles/_colors.less
@@ -34,4 +34,10 @@
   --color-black-opacity-30: hsla(0, 0%, 0%, 30%);
 
   --link-color: var(--color-blue-205-100-50);
+
+  --color-tab-group-1: rgb(30, 136, 229);
+  --color-tab-group-2: rgb(251, 140, 0);
+  --color-tab-group-3: rgb(67, 160, 71);
+  --color-tab-group-4: rgb(229, 57, 53);
+  --color-tab-group-5: rgb(142, 36, 170); 
 }


### PR DESCRIPTION
### Proposed Changes

Adds top border to overlays if file is part of process application. Border color corresponds with tab link bottom border color. Number of groups is limited to 5 (5 open process applications), after that no color will be assigned until number of process applications is down to 5 again.

![electron_9RGFT0zetd](https://github.com/user-attachments/assets/f56a2340-6d66-4030-bee4-32ecf94fb6d1)

Closes #4930 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
