### PR TITLE
fix: infinite loop in findProcessApplicationFile

### DIFF
--- a/app/lib/file-context/processors/util.js
+++ b/app/lib/file-context/processors/util.js
@@ -73,7 +73,7 @@ module.exports.traverse = traverse;
 function findProcessApplicationFile(filePath) {
   let dirName = path.dirname(filePath);
 
-  while (dirName !== path.parse(dirName).root) {
+  while (dirName !== path.dirname(dirName)) {
     const fileNames = fs.readdirSync(dirName);
 
     const fileName = fileNames.find(fileName => {


### PR DESCRIPTION
### Proposed Changes

Fixes #5204

Whenever the event `file-context:file-opened` is fired, `findProcessApplicationFile` will be called. But the implementation of this function leads to an infinite loop whenever `filePath` is a relative path. This is because `path.parse(dirName).root` will return an empty string even though `path.dirname(dirName)` returns `'.'` and therefore the while loop will never exit.