### PR TITLE
Revert camundaBuiltins in linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+## 5.38.1
+
+* `DEPS`: update to `@camunda/linting@3.40.1`
+
+### General
+
+* `FIX`: revert inclusion of camunda builtin extensions due to performance issues ([camunda/bpmnlint-plugin-camunda-compat#215](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/215))
+* `FIX`: make `priority-definition` rule handle number value ([camunda/bpmnlint-plugin-camunda-compat#213](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/213))
+
 ## 5.38.0
 
 ### General

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
     "@camunda/form-linting": "^0.23.0",
     "@camunda/form-playground": "^0.22.0",
     "@camunda/improved-canvas": "^1.7.6",
-    "@camunda/linting": "^3.40.0",
+    "@camunda/linting": "^3.40.1",
     "@camunda/rpa-integration": "^1.1.4",
     "@carbon/icons-react": "^11.53.0",
     "@carbon/react": "^1.76.0",

--- a/client/src/plugins/version-info/ReleaseInfo.js
+++ b/client/src/plugins/version-info/ReleaseInfo.js
@@ -50,7 +50,6 @@ export function ReleaseInfo(props) {
         <li>
           <h4>Camunda FEEL editor intelligence</h4>
           Our FEEL editor now supports <a href="https://docs.camunda.io/docs/components/modeler/feel/language-guide/feel-variables/#escape-variable-names">escaping variable names with backticks</a>.
-          {" We've improved support for the Camunda dialect, ensuring that all built-in functions are now fully recognized."}
         </li>
         <li>
           <h4>Better linting for IO mapping</h4>

--- a/package-lock.json
+++ b/package-lock.json
@@ -145,7 +145,7 @@
         "@camunda/form-linting": "^0.23.0",
         "@camunda/form-playground": "^0.22.0",
         "@camunda/improved-canvas": "^1.7.6",
-        "@camunda/linting": "^3.40.0",
+        "@camunda/linting": "^3.40.1",
         "@camunda/rpa-integration": "^1.1.4",
         "@carbon/icons-react": "^11.53.0",
         "@carbon/react": "^1.76.0",
@@ -3031,15 +3031,15 @@
       "integrity": "sha512-to+unsToePnm7cUeR9TrMzFlETHd/UXmU+ELTRfWZj5XGT41KF6X3L233o3E/GdEs3sk2Tbw/lOLD1avmWkg8A=="
     },
     "node_modules/@camunda/linting": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-3.40.0.tgz",
-      "integrity": "sha512-3+1KE3TCXCcla/jp59uX3EXnMoC/by3jwyoZRi7dp1R9jOqTZR3pc8VXgUQgi+nM5c0qTBboAN+8hojubRsifw==",
+      "version": "3.40.1",
+      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-3.40.1.tgz",
+      "integrity": "sha512-2ZRL1hclv8uWdisj2V9YOFsdcbf8AZmZYG75Thz8qaD4TfMdDqxCXkU/KTd08DrsQbR7iDjOLZiv3veA9DjDew==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "bpmn-moddle": "^9.0.1",
         "bpmnlint": "^11.6.0",
-        "bpmnlint-plugin-camunda-compat": "^2.39.0",
+        "bpmnlint-plugin-camunda-compat": "^2.39.2",
         "bpmnlint-utils": "^1.0.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -12667,9 +12667,9 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat": {
-      "version": "2.39.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.39.0.tgz",
-      "integrity": "sha512-/d27Ll5rkhPQPFermkJeoqrT8nWRYWSZVg+TqRScC57XJdNxuimMCa3I9m8SHz5I61Nk7yOrKlhiur1iSZspyA==",
+      "version": "2.39.2",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.39.2.tgz",
+      "integrity": "sha512-Gomn0tem0Hk9YFOyp047K3DnDxMDNIvLfjrQNpUcZz9iz9CJuKxYg6GJZjCh5QZ9Llq9wwHTiuH92PGbrwyT1g==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/feel-lint": "^2.0.0",
@@ -12687,13 +12687,13 @@
       }
     },
     "node_modules/bpmnlint-plugin-camunda-compat/node_modules/@bpmn-io/feel-lint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-2.0.0.tgz",
-      "integrity": "sha512-8kY3AejcH/wjpAsN6LjbYB4SlIlZ6yEE4wYETjqwtF97RmH8dma9wsK9CyHYLuJ5xS/f0ueFiRNpJcrNuNGUJQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-2.0.1.tgz",
+      "integrity": "sha512-mvMzpckSxBjMDppyjXZyPDgjOKEwJJaWLUfV1dmDCWaJx/qyLiqSyPkRpSpmj+n51l06KHh8fpLBZxUF0zd2Lw==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.10.8",
-        "lezer-feel": "^1.7.0"
+        "lezer-feel": "^1.7.1"
       },
       "engines": {
         "node": "*"
@@ -22352,9 +22352,9 @@
       }
     },
     "node_modules/lezer-feel": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.7.0.tgz",
-      "integrity": "sha512-UC8h3Nu4llRPISEUhv+Ne7bNkdxjf4+/DcU4KfO8zKxycWxev8d2BoVnGlG17zbQDtQJBD39ZQvWtjCeTFm69g==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.8.1.tgz",
+      "integrity": "sha512-g0eGi7/INNPtPbtcz5ubInc3rSvXuJI5NfmS1hVU1FkaKNdBpwWdxXzrUb4wxr8DNXhXnUs1/a9rO4HaDzII7Q==",
       "license": "MIT",
       "dependencies": {
         "@lezer/highlight": "^1.2.1",
@@ -35889,14 +35889,14 @@
       }
     },
     "@camunda/linting": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-3.40.0.tgz",
-      "integrity": "sha512-3+1KE3TCXCcla/jp59uX3EXnMoC/by3jwyoZRi7dp1R9jOqTZR3pc8VXgUQgi+nM5c0qTBboAN+8hojubRsifw==",
+      "version": "3.40.1",
+      "resolved": "https://registry.npmjs.org/@camunda/linting/-/linting-3.40.1.tgz",
+      "integrity": "sha512-2ZRL1hclv8uWdisj2V9YOFsdcbf8AZmZYG75Thz8qaD4TfMdDqxCXkU/KTd08DrsQbR7iDjOLZiv3veA9DjDew==",
       "requires": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "bpmn-moddle": "^9.0.1",
         "bpmnlint": "^11.6.0",
-        "bpmnlint-plugin-camunda-compat": "^2.39.0",
+        "bpmnlint-plugin-camunda-compat": "^2.39.2",
         "bpmnlint-utils": "^1.0.2",
         "camunda-bpmn-moddle": "^7.0.1",
         "clsx": "^2.0.0",
@@ -42664,9 +42664,9 @@
       "requires": {}
     },
     "bpmnlint-plugin-camunda-compat": {
-      "version": "2.39.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.39.0.tgz",
-      "integrity": "sha512-/d27Ll5rkhPQPFermkJeoqrT8nWRYWSZVg+TqRScC57XJdNxuimMCa3I9m8SHz5I61Nk7yOrKlhiur1iSZspyA==",
+      "version": "2.39.2",
+      "resolved": "https://registry.npmjs.org/bpmnlint-plugin-camunda-compat/-/bpmnlint-plugin-camunda-compat-2.39.2.tgz",
+      "integrity": "sha512-Gomn0tem0Hk9YFOyp047K3DnDxMDNIvLfjrQNpUcZz9iz9CJuKxYg6GJZjCh5QZ9Llq9wwHTiuH92PGbrwyT1g==",
       "requires": {
         "@bpmn-io/feel-lint": "^2.0.0",
         "@bpmn-io/moddle-utils": "^0.2.1",
@@ -42677,12 +42677,12 @@
       },
       "dependencies": {
         "@bpmn-io/feel-lint": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-2.0.0.tgz",
-          "integrity": "sha512-8kY3AejcH/wjpAsN6LjbYB4SlIlZ6yEE4wYETjqwtF97RmH8dma9wsK9CyHYLuJ5xS/f0ueFiRNpJcrNuNGUJQ==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-2.0.1.tgz",
+          "integrity": "sha512-mvMzpckSxBjMDppyjXZyPDgjOKEwJJaWLUfV1dmDCWaJx/qyLiqSyPkRpSpmj+n51l06KHh8fpLBZxUF0zd2Lw==",
           "requires": {
             "@codemirror/language": "^6.10.8",
-            "lezer-feel": "^1.7.0"
+            "lezer-feel": "^1.7.1"
           }
         },
         "min-dash": {
@@ -43239,7 +43239,7 @@
         "@camunda/form-linting": "^0.23.0",
         "@camunda/form-playground": "^0.22.0",
         "@camunda/improved-canvas": "^1.7.6",
-        "@camunda/linting": "^3.40.0",
+        "@camunda/linting": "^3.40.1",
         "@camunda/rpa-integration": "^1.1.4",
         "@carbon/icons-react": "^11.53.0",
         "@carbon/react": "^1.76.0",
@@ -50036,9 +50036,9 @@
       }
     },
     "lezer-feel": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.7.0.tgz",
-      "integrity": "sha512-UC8h3Nu4llRPISEUhv+Ne7bNkdxjf4+/DcU4KfO8zKxycWxev8d2BoVnGlG17zbQDtQJBD39ZQvWtjCeTFm69g==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.8.1.tgz",
+      "integrity": "sha512-g0eGi7/INNPtPbtcz5ubInc3rSvXuJI5NfmS1hVU1FkaKNdBpwWdxXzrUb4wxr8DNXhXnUs1/a9rO4HaDzII7Q==",
       "requires": {
         "@lezer/highlight": "^1.2.1",
         "@lezer/lr": "^1.4.2",


### PR DESCRIPTION
### Proposed Changes

Updating camunda/linting to revert inclusion of camunda feel builtins, also includes minor patch for priorityDefinition numbers.

I also removed camunda Builtins from the release notes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
