### PR TITLE
fix: infer port 443 for grpcs endpoints

### DIFF
--- a/app/lib/zeebe-api/zeebe-api.js
+++ b/app/lib/zeebe-api/zeebe-api.js
@@ -459,7 +459,7 @@ class ZeebeAPI {
 
     return {
       ...options,
-      port: parsedUrl.protocol === 'https:' ? '443' : '80'
+      port: parsedUrl.protocol === 'https:' || parsedUrl.protocol === 'grpcs:' ? '443' : '80'
     };
   }
 

--- a/app/test/spec/zeebe-api/zeebe-api-spec.js
+++ b/app/test/spec/zeebe-api/zeebe-api-spec.js
@@ -1989,6 +1989,38 @@ describe('ZeebeAPI', function() {
     });
 
 
+    it('should infer port=443 for grpcs:// endpoint', async function() {
+
+      // given
+      let usedConfig;
+
+      const zeebeAPI = createZeebeAPI({
+        configSpy(config) {
+          usedConfig = config;
+        }
+      });
+
+      const parameters = {
+        endpoint: {
+          type: ENDPOINT_TYPES.SELF_HOSTED,
+          url: 'grpcs://camunda.com'
+        },
+        resourceConfigs: [
+          {
+            path: 'foo.bpmn',
+            type: 'bpmn'
+          }
+        ]
+      };
+
+      // when
+      await zeebeAPI.deploy(parameters);
+
+      // then
+      expect(usedConfig).to.have.property('port', '443');
+    });
+
+
     describe('custom certificate', function() {
 
       function setup(certificate) {


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/pull/5180

### Proposed Changes

During testing of rest deployments I noticed missing port inference for grpcs

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
