### PR TITLE
docs(release-template): reorder merge to main

### DIFF
--- a/docs/.project/RELEASE_TEMPLATE.md
+++ b/docs/.project/RELEASE_TEMPLATE.md
@@ -41,12 +41,12 @@ _To be done after code freeze to prepare and test the release._
 * [ ] close all issues which are solved by dependency updates
 * [ ] ensure that the modeler is free of major security vulnerabilities via `npm audit`
 * [ ] smoke test to verify all diagrams can be created
+* [ ] merge to main: `git checkout main && git merge develop`
 * [ ] update [Release Info](https://github.com/camunda/camunda-modeler/blob/develop/client/src/plugins/version-info/ReleaseInfo.js)
   * [ ] create a draft following [our guidelines](https://github.com/bpmn-io/internal-docs/blob/main/releases/modeler/CAMUNDA_MODELER.md#whats-new-communication) and based on priorities which were aligned with the team (PM, UX, and Engineering side)
-  * [ ] create PR to merge the draft into `develop`. Assign to PM, UX and Engineering for review
+  * [ ] create PR to merge the draft into `main`. Assign to PM, UX and Engineering for review
 * [ ] update [`CHANGELOG`](https://github.com/camunda/camunda-modeler/blob/develop/CHANGELOG.md)
 * [ ] compile a list of blog worthy changes as input to [release blog](https://confluence.camunda.com/pages/viewpage.action?pageId=178590449)
-* [ ] merge to main: `git checkout main && git merge develop`
 * [ ] create release candidate (`npm run release:rc -- [preminor|premajor|prepatch]`), cf. [release schema](https://github.com/bpmn-io/internal-docs/blob/main/releases/RELEASE_SCHEMA.md)
   * [ ] wait for [release build](https://github.com/camunda/camunda-modeler/actions/workflows/RELEASE.yml) to create the [artifacts](https://github.com/camunda/camunda-modeler/releases)
   * [ ] (optional) to create further release candidates after the first one use `npm run release:rc -- prerelease`


### PR DESCRIPTION
### Proposed Changes

Related to slack discussion: https://camunda.slack.com/archives/GP70M0J6M/p1756306179392059
<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 
It's confusing either to target `main` or `develop` for release info. 

The proposed flow is 
1. merge to main 
2. RC and other activites (release notes) should be done in main then.
- `develop` will be free from code freeze and can be used to contribute for the next release during that period.

**Why pushing release info to develop is problematic**
- After code freeze, there’s a window between updating modeling dependencies and completing the release info.
- During this time, someone might push new changes intended for the next release into develop.
- This breaks the code freeze and risks pulling unintended changes into the release.

The git merge to main should be done as soon as possible.
### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
