### PR TITLE
chore: remove C7 from new alpha workflow

### DIFF
--- a/.github/workflows/NEW_ALPHA_ISSUE.yml
+++ b/.github/workflows/NEW_ALPHA_ISSUE.yml
@@ -15,8 +15,8 @@ jobs:
           ISSUE_BODY: |
             ### What should we do?
             Add a new Alpha Version to the version select.
-            - [ ] Update the version select (C7, C8)
-            - [ ] Update linting profiles (C7, C8)
+            - [ ] Update the version select (C8)
+            - [ ] Update linting profile (C8)
 
             ### Why should we do it?
             To support the next alpha release of the engine.


### PR DESCRIPTION
Related to https://camunda.com/blog/2025/02/camunda-7-enterprise-end-of-life-extension/

### Proposed Changes

Since there will be no minor releases of C7 after 7.24, we don't need to mention C7 in the workflow.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
