### PR TITLE
chore: increase max bottom panel height

### DIFF
--- a/client/src/app/resizable-container/PanelContainer.js
+++ b/client/src/app/resizable-container/PanelContainer.js
@@ -13,7 +13,7 @@ import React, { useCallback } from 'react';
 import ResizableContainer from './ResizableContainer';
 
 export const MIN_HEIGHT = 200;
-export const MAX_HEIGHT = 400;
+export const MAX_HEIGHT = 600;
 
 export const DEFAULT_OPEN = false;
 export const DEFAULT_HEIGHT = 200;


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

We use the bottom panel to show more complex stuff (e.g. task testing), so we can allow users to expand it more.

<img width="1412" height="974" alt="Screenshot 2025-09-15 at 14 42 42" src="https://github.com/user-attachments/assets/de80a8b2-d72d-44dd-b4d1-cee7cbf79c43" />

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
