### PR TITLE
fix: use correct remeasureFonts call

### DIFF
--- a/client/src/app/tabs/rpa/RPAEditor.js
+++ b/client/src/app/tabs/rpa/RPAEditor.js
@@ -9,6 +9,7 @@
  */
 
 import React from 'react';
+import Monaco from 'monaco-editor';
 
 import {
   WithCache,
@@ -218,7 +219,7 @@ export class RPAEditor extends CachedComponent {
     });
 
     document.fonts.ready.then(() => {
-      editor.editor.remeasureFonts();
+      Monaco.editor.remeasureFonts();
     });
 
     this.setCached({


### PR DESCRIPTION
### Proposed Changes

This PR ensures that the font size is actually measured correctly. Currently, the Font size might be wrong, leading to incorrect Cursor placement. An error is shown in the console.

[screencap-2025-09-23-11-21-31.webm](https://github.com/user-attachments/assets/dbfd3c3f-1c1d-4187-9e85-362cf7bd5bd0)

Fix:
`remeasureFonts` is not a function on the monaco instance, but on the editor constructor.

You can try out the artifacts here:
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/actually-remeasure-fonts/camunda-modeler-actually-remeasure-fonts-linux-x64.tar.gz
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/actually-remeasure-fonts/camunda-modeler-actually-remeasure-fonts-mac-x64.dmg
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/actually-remeasure-fonts/camunda-modeler-actually-remeasure-fonts-mac-x64.zip
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/actually-remeasure-fonts/camunda-modeler-actually-remeasure-fonts-mac-arm64.dmg
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/actually-remeasure-fonts/camunda-modeler-actually-remeasure-fonts-mac-arm64.zip
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/actually-remeasure-fonts/camunda-modeler-actually-remeasure-fonts-win-ia32.zip
https://camunda-modeler-on-demand.s3.eu-central-1.amazonaws.com/actually-remeasure-fonts/camunda-modeler-actually-remeasure-fonts-win-x64.zip

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [x] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
