### PR TITLE
Reduce number of rerenders cause by Task Testing

### DIFF
--- a/client/src/app/panel/tabs/task-testing/TaskTestingApi.js
+++ b/client/src/app/panel/tabs/task-testing/TaskTestingApi.js
@@ -59,7 +59,15 @@ export default class TaskTestingApi {
   }
 
   async deploy() {
-    this._onAction('save');
+
+    const saved = await this._onAction('save');
+
+    if (!saved) {
+      return {
+        success: false,
+        error: 'Failed to save the file before deployment'
+      };
+    }
 
     const config = await this.getDeploymentConfig();
 

--- a/client/src/app/panel/tabs/task-testing/TaskTestingApi.js
+++ b/client/src/app/panel/tabs/task-testing/TaskTestingApi.js
@@ -37,6 +37,11 @@ export default class TaskTestingApi {
   }
 
   async getDeploymentConfig() {
+
+    if (!this._file?.path) {
+      return {};
+    }
+
     const config = await this._deployment.getConfigForFile(this._file);
     return {
       ...config,

--- a/client/src/app/panel/tabs/task-testing/TaskTestingTab.js
+++ b/client/src/app/panel/tabs/task-testing/TaskTestingTab.js
@@ -8,7 +8,7 @@
  * except in compliance with the MIT License.
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 
 import semver from 'semver';
 
@@ -20,10 +20,10 @@ import { debounce } from '../../../../util';
 
 import ZeebeAPI from '../../../../remote/ZeebeAPI';
 
-import ConnectionChecker from '../../../../plugins/zeebe-plugin/deployment-plugin/ConnectionChecker';
-
 import TaskTestingStatusBarItem from './TaskTestingStatusBarItem';
 import TaskTestingApi from './TaskTestingApi';
+
+import { useConnectionChecker } from './hooks/useConnectionChecker';
 
 import * as css from './TaskTestingTab.less';
 
@@ -60,35 +60,22 @@ export default function TaskTestingTab(props) {
 
   const [ taskTestingConfig, setTaskTestingConfig ] = useState(DEFAULT_CONFIG);
 
-  const { current: zeebeApi } = useRef(new ZeebeAPI(backend));
-  const { current: taskTestingApi } = useRef(new TaskTestingApi(zeebeApi, config, file, onAction));
-  const { current: connectionChecker } = useRef(new ConnectionChecker(zeebeApi));
-
-  const [ connectionCheckResult, setConnectionCheckResult ] = useState(false);
-
+  const [ deployConfig, setDeployConfig ] = useState(null);
   const [ operateUrl, setOperateUrl ] = useState(null);
 
-  useEffect(() => {
-    if (connectionCheckResult) {
-      taskTestingApi.getOperateUrl().then(setOperateUrl);
-    }
-  }, [ connectionCheckResult, taskTestingApi ]);
+  const { current: zeebeApi } = useRef(new ZeebeAPI(backend));
 
-  const onConnectionCheck = async ({ success, response }) => {
+  const taskTestingApi = useMemo(() => {
 
-    // file is not saved
-    if (!file?.path) {
-      return;
-    }
+    const api = new TaskTestingApi(zeebeApi, config, file, onAction);
 
-    const config = await taskTestingApi.getDeploymentConfig();
+    api.getOperateUrl().then(setOperateUrl);
+    api.getDeploymentConfig().then(setDeployConfig);
 
-    connectionChecker.updateConfig(config);
+    return api.getApi();
+  }, [ zeebeApi, config, file, onAction ]);
 
-    setConnectionCheckResult({ success, response });
-  };
-
-  useConnectionChecker(connectionChecker, onConnectionCheck);
+  const { connectionSuccess, connectionError } = useConnectionChecker(zeebeApi, deployConfig);
 
   useEffect(() => {
     const loadConfig = async () => {
@@ -128,16 +115,16 @@ export default function TaskTestingTab(props) {
     }
   };
 
-  const handleTaskExecutionStarted = (element) => {
+  const handleTaskExecutionStarted = useCallback((element) => {
     onAction('emit-event', {
       type: 'taskTesting.started',
       payload: {
         element
       }
     });
-  };
+  }, [ onAction ]);
 
-  const handleTaskExecutionFinished = (element, output) => {
+  const handleTaskExecutionFinished = useCallback((element, output) => {
     onAction('emit-event', {
       type: 'taskTesting.finished',
       payload: {
@@ -145,17 +132,22 @@ export default function TaskTestingTab(props) {
         output
       }
     });
-  };
+  }, [ onAction ]);
 
-  const handleTaskExecutionInterrupted = () => {
+  const handleTaskExecutionInterrupted = useCallback(() => {
     onAction('display-notification', {
       type: 'warning',
       title: 'Task testing canceled',
     });
-  };
+  }, [ onAction ]);
 
-  const handleConfigureConnection = () => {
+  const handleConfigureConnection = useCallback(() => {
     onAction('open-deployment');
+  }, [ onAction ]);
+
+  const connectionCheckResult = {
+    success: connectionSuccess,
+    response: connectionError
   };
 
   const configureConnectionBannerTitle = getConnectionBannerTitle(connectionCheckResult);
@@ -180,7 +172,7 @@ export default function TaskTestingTab(props) {
           onTaskExecutionInterrupted={ handleTaskExecutionInterrupted }
           configureConnectionBannerTitle={ configureConnectionBannerTitle }
           configureConnectionBannerDescription={ configureConnectionBannerDescription }
-          api={ taskTestingApi.getApi() }
+          api={ taskTestingApi }
           documentationUrl={ DOCUMENTATION_URL }
         />
       </div>
@@ -212,18 +204,6 @@ function getConfigureConnectionBannerDescription(connectionCheckResult) {
     return UNSUPPORTED_EXECUTION_PLATFORM_VERSION_DESCRIPTION;
   }
   return null;
-}
-
-function useConnectionChecker(connectionChecker, onConnectionCheck) {
-  useEffect(() => {
-    connectionChecker.on('connectionCheck', onConnectionCheck);
-    connectionChecker.startChecking();
-
-    return () => {
-      connectionChecker.stopChecking();
-      connectionChecker.off('connectionCheck', onConnectionCheck);
-    };
-  }, [ connectionChecker ]);
 }
 
 function canConnectToCluster(connectionCheckResult) {

--- a/client/src/app/panel/tabs/task-testing/TaskTestingTab.js
+++ b/client/src/app/panel/tabs/task-testing/TaskTestingTab.js
@@ -178,7 +178,6 @@ export default function TaskTestingTab(props) {
       </div>
     </Fill>
     <TaskTestingStatusBarItem
-      injector={ injector }
       layout={ layout }
       onToggle={ onToggle } />
   </>;

--- a/client/src/app/panel/tabs/task-testing/hooks/useConnectionChecker.js
+++ b/client/src/app/panel/tabs/task-testing/hooks/useConnectionChecker.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+
+import ConnectionChecker from '../../../../../plugins/zeebe-plugin/deployment-plugin/ConnectionChecker';
+
+export function useConnectionChecker(zeebeApi, deployConfig) {
+
+  const { current: connectionChecker } = useRef(new ConnectionChecker(zeebeApi));
+
+  const [ result, setResult ] = useState({
+    success: false,
+    response: null
+  });
+
+  useEffect(() => {
+    connectionChecker.on('connectionCheck', checkConnection);
+    connectionChecker.startChecking();
+
+    return () => {
+      connectionChecker.stopChecking();
+      connectionChecker.off('connectionCheck', checkConnection);
+    };
+  }, []);
+
+  useEffect(() => {
+    connectionChecker.updateConfig(deployConfig);
+  }, [ deployConfig ]);
+
+  const checkConnection = async ({ success, response }) => {
+
+    if (success === result.success &&
+      response?.gatewayVersion === result.response?.gatewayVersion &&
+      response?.protocol === result.response?.protocol
+    ) {
+      return;
+    }
+
+    setResult({ success, response });
+  };
+
+  return {
+    connectionSuccess: result.success,
+    connectionError: result.response
+  };
+}


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

Related to [Slack discussion](https://camunda.slack.com/archives/GP70M0J6M/p1759158558147919).

Repetitive connection checking in task testing is causing unnecessary rerenders.

I extracted the connection checking logic out of the main component and made it only trigger a rerender if the connection result changed.

Additionally, I wrapped a bunch of callback functions into `useCallback` to prevent rerendering of ` <TaskTesting>`.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
