### PR TITLE
deps: update to `electron@37.6.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+## 5.40.0
+
 ### General
 
 * `FEAT`: add task testing ([#5235](https://github.com/camunda/camunda-modeler/pull/5235))
@@ -18,6 +20,7 @@ ___Note:__ Yet to be released changes appear here._
 * `DEPS`: update to `bpmn-moddle@9.0.4`
 * `DEPS`: update to `camunda-bpmn-js@5.14.2`
 * `DEPS`: update to `diagram-js@15.4.0`
+* `DEPS`: update to `electron@37.6.0`
 * `DEPS`: update to `zeebe-bpmn-moddle@1.11.0`
 
 ### BPMN

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "del": "^8.0.0",
         "del-cli": "^7.0.0",
         "diff2html": "^3.4.48",
-        "electron": "^37.0.0",
+        "electron": "^37.6.0",
         "electron-builder": "^26.0.13",
         "electron-extension-installer": "^2.0.0",
         "electron-publisher-s3": "^20.17.2",
@@ -15280,9 +15280,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "37.5.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-37.5.1.tgz",
-      "integrity": "sha512-RqN3dl6I5yhmynkUc3pUzM6qFCvANau3VGRX9xQEh7FYdwmkqVxKXYM5enrE9LW7j7PzHomQQn6+J2xaF7BHsQ==",
+      "version": "37.6.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.6.0.tgz",
+      "integrity": "sha512-8AANcn6irYQ7cTAJRY7r0CovWckcGCHUniQecyGhw/jJ25vWwitVhF97skF+EyDztiEI6YBoF0G6tx1s37bO3g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -43862,9 +43862,9 @@
       }
     },
     "electron": {
-      "version": "37.5.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-37.5.1.tgz",
-      "integrity": "sha512-RqN3dl6I5yhmynkUc3pUzM6qFCvANau3VGRX9xQEh7FYdwmkqVxKXYM5enrE9LW7j7PzHomQQn6+J2xaF7BHsQ==",
+      "version": "37.6.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.6.0.tgz",
+      "integrity": "sha512-8AANcn6irYQ7cTAJRY7r0CovWckcGCHUniQecyGhw/jJ25vWwitVhF97skF+EyDztiEI6YBoF0G6tx1s37bO3g==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "del": "^8.0.0",
     "del-cli": "^7.0.0",
     "diff2html": "^3.4.48",
-    "electron": "^37.0.0",
+    "electron": "^37.6.0",
     "electron-builder": "^26.0.13",
     "electron-extension-installer": "^2.0.0",
     "electron-publisher-s3": "^20.17.2",


### PR DESCRIPTION
### Proposed Changes

We want to avoid the current release hanging users' computers, so that's why it's targeting `main`.

Related to https://github.com/electron/electron/pull/48376

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
