### PR TITLE
Added UTM params to the download center link in the desktop modeler u…

### DIFF
--- a/client/src/plugins/update-checks/UpdateChecks.js
+++ b/client/src/plugins/update-checks/UpdateChecks.js
@@ -363,7 +363,18 @@ export default class UpdateChecks extends PureComponent {
       _getGlobal
     } = this.props;
 
-    _getGlobal('backend').send('external:open-url', { url: latestVersionInfo.downloadURL });
+    let downloadURL = latestVersionInfo.downloadURL;
+
+    // Check if UTM tags are already present
+    if (!downloadURL.includes('utm_source') && !downloadURL.includes('utm_medium') && !downloadURL.includes('utm_campaign')) {
+      const url = new URL(downloadURL);
+      url.searchParams.append('utm_source', 'desktop-modeler');
+      url.searchParams.append('utm_medium', 'product');
+      url.searchParams.append('utm_campaign', 'update-check');
+      downloadURL = url.toString();
+    }
+
+    _getGlobal('backend').send('external:open-url', { url: downloadURL });
 
     this.closeNewVersionInfoView();
   };


### PR DESCRIPTION
…pdate button.

### Proposed Changes

The update button from the desktop modeler now has UTM links.

Steps to try out:
- Modify the package.json in the app folder to simulate an older version. I tried with 5.36.1
- Click check for updates.

<img width="1196" height="968" alt="image" src="https://github.com/user-attachments/assets/a717e9bd-b324-467e-9b7d-1d0796faba1e" />

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
