### PR TITLE
Use own implementation of connection checking for task testing

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -83,6 +83,7 @@
     "@bpmn-io/variable-resolver": "^1.3.6",
     "@sentry/webpack-plugin": "^4.0.0",
     "@testing-library/react": "^12.0.0",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.6.1",
     "babel-loader": "^10.0.0",
     "babel-plugin-istanbul": "^7.0.0",

--- a/client/src/app/panel/tabs/task-testing/TaskTestingTab.js
+++ b/client/src/app/panel/tabs/task-testing/TaskTestingTab.js
@@ -75,7 +75,7 @@ export default function TaskTestingTab(props) {
     return api.getApi();
   }, [ zeebeApi, config, file, onAction ]);
 
-  const { connectionSuccess, connectionError } = useConnectionChecker(zeebeApi, deployConfig);
+  const connectionCheckResult = useConnectionChecker(zeebeApi, deployConfig);
 
   useEffect(() => {
     const loadConfig = async () => {
@@ -144,11 +144,6 @@ export default function TaskTestingTab(props) {
   const handleConfigureConnection = useCallback(() => {
     onAction('open-deployment');
   }, [ onAction ]);
-
-  const connectionCheckResult = {
-    success: connectionSuccess,
-    response: connectionError
-  };
 
   const configureConnectionBannerTitle = getConnectionBannerTitle(connectionCheckResult);
   const configureConnectionBannerDescription = getConfigureConnectionBannerDescription(connectionCheckResult);

--- a/client/src/app/panel/tabs/task-testing/__tests__/useConnectionCheckerSpec.js
+++ b/client/src/app/panel/tabs/task-testing/__tests__/useConnectionCheckerSpec.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/* global sinon */
+
+import { waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks/dom';
+
+import { useConnectionChecker } from '../hooks/useConnectionChecker';
+
+describe('useConnectionChecker', function() {
+
+  const successResponse = {
+    success: true,
+    response: {
+      protocol: 'rest',
+      gatewayVersion: '8.8.0',
+    }
+  };
+
+  const errorResponse = {
+    success: false,
+    response: 'Some error'
+  };
+
+  it('should handle successful connection', async function() {
+
+    // given
+    const zeebeApi = {
+      checkConnection: sinon.stub().resolves(successResponse)
+    };
+
+    // when
+    const { result } = renderHook(() => useConnectionChecker(zeebeApi, { endpoint: true }));
+
+    // then
+    await waitFor(() => {
+      expect(result.current).to.deep.equal(successResponse);
+    });
+  });
+
+
+  it('should handle connection error', async function() {
+
+    // given
+    const zeebeApi = {
+      checkConnection: sinon.stub().resolves(errorResponse)
+    };
+
+    // when
+    const { result } = renderHook(() => useConnectionChecker(zeebeApi, { endpoint: true }));
+
+    // then
+    await waitFor(() => {
+      expect(result.current).to.deep.equal(errorResponse);
+    });
+  });
+
+
+  it('should handle missing deployment config', async function() {
+
+    // given
+    const zeebeApi = {
+      checkConnection: sinon.stub().resolves(successResponse)
+    };
+
+    // when
+    const { result } = renderHook(() => useConnectionChecker(zeebeApi, null));
+
+    // then
+    await waitFor(() => {
+      expect(result.current).to.deep.equal({
+        success: false,
+        response: "Cannot destructure property 'endpoint' of 'deployConfig' as it is null."
+      });
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -210,6 +210,7 @@
         "@bpmn-io/variable-resolver": "^1.3.6",
         "@sentry/webpack-plugin": "^4.0.0",
         "@testing-library/react": "^12.0.0",
+        "@testing-library/react-hooks": "^8.0.1",
         "@testing-library/user-event": "^14.6.1",
         "babel-loader": "^10.0.0",
         "babel-plugin-istanbul": "^7.0.0",
@@ -8952,6 +8953,37 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/react-hooks": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
+      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0",
+        "react-test-renderer": "^16.9.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-test-renderer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@testing-library/user-event": {
@@ -26599,6 +26631,23 @@
         "react": "^16.14.0"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-fast-compare": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
@@ -38708,6 +38757,16 @@
         }
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
+      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
+      }
+    },
     "@testing-library/user-event": {
       "version": "14.6.1",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
@@ -41150,6 +41209,7 @@
         "@sentry/integrations": "^7.108.0",
         "@sentry/webpack-plugin": "^4.0.0",
         "@testing-library/react": "^12.0.0",
+        "@testing-library/react-hooks": "^8.0.1",
         "@testing-library/user-event": "^14.6.1",
         "@uiw/codemirror-theme-vscode": "^4.23.12",
         "babel-loader": "^10.0.0",
@@ -51629,6 +51689,15 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-fast-compare": {


### PR DESCRIPTION
### Proposed Changes

Use a custom implementation of connection checking, drop the dependency on `ConnectionChecker`.

The `ConnectionChecker` utility we used is not really fit for the purpose of task testing - it implements a delay which is helpful for checking in the deployment overlay, but we want it to be rapid for task testing.

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
