### PR TITLE
chore(ci): add FOSSA release job to generate attribution/SBOM reports

### DIFF
--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -224,8 +224,7 @@ jobs:
 
   # This job waits for the FOSSA scan (triggered by CHECK_LICENSES.yml on tag push)
   # to complete, then creates releases in FOSSA and generates attribution/SBOM reports.
-  # It only runs for stable releases (skips release candidates) and depends on successful
-  # completion of the build_release job to ensure the release artifacts are ready.
+  # It depends on successful completion of the build_release job to ensure the release artifacts are ready.
   fossa_release:
     name: Create FOSSA releases and generate attribution/SBOM reports
     needs:
@@ -233,11 +232,8 @@ jobs:
       - build_release
     runs-on: ubuntu-latest
 
-    # skip for release candidates
-    if: contains(needs.pre_release.outputs.tag, 'rc') == false
-
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Import Secrets
         id: secrets
         uses: hashicorp/vault-action@v3.4.0


### PR DESCRIPTION
### Proposed Changes

Add a new job to the release workflow that creates FOSSA releases and generates attribution and SBOM reports. The job waits for the FOSSA scan (triggered by CHECK_LICENSES.yml) to complete, then publishes the reports to designated release groups. Only runs for stable releases, skipping release candidates.

Related to https://github.com/camunda/team-infrastructure/issues/854

As the release groups have to be created only once, and the process needs an API token with access rights that the machine accounts don't have, I created the release groups manually, using the recent `v5.40.0` as the initial release:
```
fossa release-group create \
    -t camunda-modeler-attribution \
    -r v5.40.0 \
    --project-locator custom+50756/camunda/camunda-modeler \
    --project-branch main \
    --project-revision d6b3afe0eb670bb538a594d5f331d445f9dc47b3 \
    --license-policy "Camunda8 Distribution" \
    --security-policy "Default Camunda" \
    --quality-policy "Major - 3 Policy" \
    --team "Modeler-bpmn.io Team"

----> Created release group with id: 4917
----> and a new release with id: 21618

fossa release-group create \
    -t camunda-modeler-sbom \
    -r v5.40.0 \
    --project-locator custom+50756/camunda/camunda-modeler \
    --project-branch main \
    --project-revision d6b3afe0eb670bb538a594d5f331d445f9dc47b3 \
    --license-policy "Camunda8 Distribution" \
    --security-policy "Default Camunda" \
    --quality-policy "Major - 3 Policy" \
    --team "Modeler-bpmn.io Team"

----> Created release group with id: 4918
----> and a new release with id: 21619
```
- On the FOSSA UI I did set the release groups' FOSSA portal settings to "public"
- Then, using the Desktop Modeler's FOSSA machine account's API key, I published the attribution and SBOM reports to the FOSSA portal:
```
curl \
    --request POST \
    --header "accept: application/json" \
    --header "Authorization: Bearer $FOSSA_API_KEY" \
    --url "https://app.fossa.com/api/project_group/4917/release/21618/attribution/TXT"\
"?includeDeepDependencies=true"\
"&includeDirectDependencies=true"\
"&includeLicenseList=true"\
"&includeLicenseScan=true"\
"&includeProjectLicense=true"\
"&includeCopyrightList=true"\
"&includeFileMatches=true"\
"&includeOpenVulnerabilities=true"\
"&includeClosedVulnerabilities=true"\
"&includeDependencySummary=true"\
"&includeLicenseHeaders=true"\
"&isPublishing=true"

curl \
    --request POST \
    --header "accept: application/json" \
    --header "Authorization: Bearer $FOSSA_API_KEY" \
    --url "https://app.fossa.com/api/project_group/4918/release/21619/attribution/CYCLONEDX_JSON"\
"?includeDeepDependencies=true"\
"&includeDirectDependencies=true"\
"&includeLicenseList=true"\
"&includeLicenseScan=true"\
"&includeProjectLicense=true"\
"&includeCopyrightList=true"\
"&includeFileMatches=true"\
"&includeOpenVulnerabilities=true"\
"&includeClosedVulnerabilities=true"\
"&includeDependencySummary=true"\
"&includeLicenseHeaders=true"\
"&isPublishing=true"
```
The reports can be checked below

- [Attribution TXT](https://portal.fossa.com/p/camunda/release/4917/21618)
- [SBOM](https://portal.fossa.com/p/camunda/release/4918/21619)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
