### PR TITLE
fix: prevent task testing freeze for unsaved file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: prevent task testing freeze for unsaved file ([#5341](https://github.com/camunda/camunda-modeler/issues/5341))
+
 ## 5.40.0
 
 ### General

--- a/client/src/app/__tests__/mocks/index.js
+++ b/client/src/app/__tests__/mocks/index.js
@@ -605,6 +605,10 @@ export class SystemClipboard extends Mock {
 export class Deployment extends Mock {
   getConfigForFile() {}
 
+  deploy() {
+    return { success: true };
+  }
+
   on() {}
 
   off() {}

--- a/client/src/app/panel/tabs/task-testing/TaskTestingApi.js
+++ b/client/src/app/panel/tabs/task-testing/TaskTestingApi.js
@@ -49,6 +49,10 @@ export default class TaskTestingApi {
   async getOperateUrl() {
     const { endpoint } = await this.getDeploymentConfig();
 
+    if (!endpoint) {
+      return;
+    }
+
     if (endpoint.targetType === 'camundaCloud') {
       const { href } = getOperateUrl(endpoint) || {};
       return href;
@@ -70,6 +74,9 @@ export default class TaskTestingApi {
         error: 'Failed to save the file before deployment'
       };
     }
+
+    // saved file overrides the unsaved one; noop if same
+    this._file = saved.file;
 
     const config = await this.getDeploymentConfig();
 

--- a/client/src/app/panel/tabs/task-testing/__tests__/TaskTestingApiSpec.js
+++ b/client/src/app/panel/tabs/task-testing/__tests__/TaskTestingApiSpec.js
@@ -1,0 +1,171 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/* global sinon */
+
+import TaskTestingApi from '../TaskTestingApi';
+
+import { Deployment } from '../../../../__tests__/mocks';
+
+
+describe('<TaskTestingApi>', function() {
+
+  describe('#getOperateUrl', function() {
+
+    it('should return Operate URL for SaaS', async function() {
+
+      // given
+      const api = new TaskTestingApi(
+        new Deployment({
+          getConfigForFile: async () => {
+            return {
+              deployment: {},
+              endpoint: {
+                targetType: 'camundaCloud',
+                camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+              }
+            };
+          }
+        }),
+        null,
+        null,
+        {
+          path: 'path/to/file.bpmn'
+        },
+        null
+      );
+
+
+      // when
+      const operateUrl = await api.getOperateUrl();
+
+      // then
+      expect(operateUrl).to.equal('https://yyy-1.operate.camunda.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
+    });
+
+
+    it('should return Operate URL for SM', async function() {
+
+      // given
+      const api = new TaskTestingApi(
+        new Deployment({
+          getConfigForFile: async () => {
+            return {
+              deployment: {},
+              endpoint: {
+                targetType: 'selfHosted',
+                operateUrl: 'https://operate.example.com'
+              }
+            };
+          }
+        }),
+        null,
+        null,
+        {
+          path: 'path/to/file.bpmn'
+        },
+        null
+      );
+
+
+      // when
+      const operateUrl = await api.getOperateUrl();
+
+      // then
+      expect(operateUrl).to.equal('https://operate.example.com');
+    });
+
+
+    it('should return no URL for unsaved file', async function() {
+
+      // given
+      const api = new TaskTestingApi(
+        new Deployment({
+          getConfigForFile: async () => {
+            return {
+              deployment: {},
+              endpoint: {
+                targetType: 'selfHosted',
+                operateUrl: 'https://operate.example.com'
+              }
+            };
+          }
+        }),
+        null,
+        null,
+        {
+          path: null
+        },
+        null
+      );
+
+
+      // when
+      const operateUrl = await api.getOperateUrl();
+
+      // then
+      expect(operateUrl).not.to.exist;
+    });
+  });
+
+
+  describe('#deploy', function() {
+
+    it('should save and deploy an unsaved file', async function() {
+
+      // given
+      const deploySpy = sinon.spy(() => {
+        return { success: true };
+      });
+      const savedFile = {
+        path: 'path/to/file.bpmn'
+      };
+      const api = new TaskTestingApi(
+        new Deployment({
+          deploy: deploySpy,
+          getConfigForFile: async file => {
+            if (!file.path) {
+              throw new Error('File not saved');
+            }
+
+            return {
+              deployment: {},
+              endpoint: {
+                targetType: 'camundaCloud',
+                camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+              }
+            };
+          }
+        }),
+        null,
+        null,
+        {
+          path: null
+        },
+        actionName => {
+          return actionName === 'save' && {
+            file: savedFile
+          };
+        }
+      );
+
+      // when
+      await api.deploy();
+
+      // then
+      expect(deploySpy).to.have.been.calledWith([
+        {
+          path: savedFile.path,
+          type: 'bpmn'
+        }
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #5341

### Proposed Changes

In case the file is not saved, we won't be able to retrieve its configured endpoint. Task testing should not fail in that case.
Alternatively, we could let the deployment handle the case of an unsaved file. However, that means we add a new case to the deployment module.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
