### PR TITLE
chore: adjust link to latest stable docs

### DIFF
--- a/client/src/app/EmptyTab.js
+++ b/client/src/app/EmptyTab.js
@@ -112,7 +112,7 @@ export default class EmptyTab extends PureComponent {
           <h3>Learn more</h3>
           <div className="article top">
             <AiIcon />
-            <a href="https://docs.camunda.io/docs/8.8/guides/getting-started-agentic-orchestration?utm_source=modeler&utm_medium=referral">Build your first AI agent</a>
+            <a href="https://docs.camunda.io/docs/guides/getting-started-agentic-orchestration?utm_source=modeler&utm_medium=referral">Build your first AI agent</a>
           </div>
           <div className="article relative">
             <p>Introduction to Camunda 8</p>


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/5241

### Proposed Changes

Old link wasn't that bad as it already pointed to 8.8 and not next. but still fix it now for newer versions. 

https://docs.camunda.io/docs/guides/getting-started-agentic-orchestration?utm_source=modeler&utm_medium=referral

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
