### PR TITLE
feat: accept trailing `v2` or `/` for REST endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 ___Note:__ Yet to be released changes appear here._
 
 * `FIX`: use `ZEEBE_GRPC_ADDRESS` in favor of deprecated `ZEEBE_ADDRESS` for cluster connections ([#5362](https://github.com/camunda/camunda-modeler/pull/5362))
+* `FEAT`: accept trailing `v2` or `/` for REST cluster URLs ([#5345](https://github.com/camunda/camunda-modeler/issues/5345))
 
 ## 5.40.1
 

--- a/app/lib/zeebe-api/camunda-client-factory.js
+++ b/app/lib/zeebe-api/camunda-client-factory.js
@@ -23,7 +23,8 @@ const {
 const {
   sanitizeCamundaClientOptions,
   isGrpcSaasUrl,
-  isRestSaasUrl
+  isRestSaasUrl,
+  removeV2OrSlashes
 } = require('./utils');
 
 /**
@@ -269,7 +270,7 @@ class CamundaClientFactory {
     case 'http':
     case 'https':
     default:
-      clientConfig.ZEEBE_REST_ADDRESS = url;
+      clientConfig.ZEEBE_REST_ADDRESS = removeV2OrSlashes(url);
       break;
     }
 

--- a/app/lib/zeebe-api/utils.js
+++ b/app/lib/zeebe-api/utils.js
@@ -138,3 +138,39 @@ function isRestSaasUrl(url) {
   return /^https:\/\/[a-z]+-\d+\.zeebe\.camunda\.io(:443|)\/[a-z\d-]+\/?/.test(url);
 }
 module.exports.isRestSaasUrl = isRestSaasUrl;
+
+/**
+ * Remove trailing slashes and '/v2' from a URL. This is mainly used for Camunda 8 REST API endpoints as we are inconsistent if we add /v2 or not.
+ *
+ * @param {string} url
+ *
+ * @returns {string}
+ *
+ * @examples
+ * removeV2OrSlashes('https://example.com') // returns 'https://example.com'
+ * removeV2OrSlashes('https://example.com/') // returns 'https://example.com'
+ * removeV2OrSlashes('https://example.com/v2') // returns 'https://example.com'
+ * removeV2OrSlashes('https://example.com/v2/') // returns 'https://example.com'
+ * removeV2OrSlashes('https://example.com/v2/v2') // returns 'https://example.com/v2' (super edge case, they have to specify v2 explicitly twice)
+ */
+module.exports.removeV2OrSlashes = function(url) {
+
+  if (!url) {
+    return url;
+  }
+  const parsed = new URL(url);
+
+  let pathname = parsed.pathname || '';
+
+  while (pathname.endsWith('/')) {
+    pathname = pathname.slice(0, -1);
+  }
+
+  if (pathname.endsWith('/v2')) {
+    pathname = pathname.slice(0, -3);
+  }
+
+  parsed.pathname = pathname || '/';
+
+  return parsed.href.replace(/\/(\?|#|$)/, '$1');
+};

--- a/app/test/spec/zeebe-api/utils-spec.js
+++ b/app/test/spec/zeebe-api/utils-spec.js
@@ -3,7 +3,8 @@ const {
   isRestSaasUrl,
   isSaasUrl,
   sanitizeCamundaClientOptions,
-  sanitizeConfigWithEndpoint
+  sanitizeConfigWithEndpoint,
+  removeV2OrSlashes
 } = require('../../../lib/zeebe-api/utils');
 
 describe('utils', function() {
@@ -157,6 +158,64 @@ describe('utils', function() {
         },
         tenantId: 'tenant-id'
       });
+    });
+
+  });
+
+
+  describe('#removeV2OrSlashes', function() {
+    function validateRemoveV2OrSlashes(url, expected) {
+      expect(removeV2OrSlashes(url)).to.equal(expected);
+    }
+
+
+    it('should keep base URL (no trailing slash)', function() {
+      validateRemoveV2OrSlashes('https://example.com', 'https://example.com');
+    });
+
+
+    it('should remove single trailing slash from base URL', function() {
+      validateRemoveV2OrSlashes('https://example.com/', 'https://example.com');
+    });
+
+
+    it('should remove trailing /v2', function() {
+      validateRemoveV2OrSlashes('https://example.com/v2', 'https://example.com');
+    });
+
+
+    it('should remove trailing /v2/', function() {
+      validateRemoveV2OrSlashes('https://example.com/v2/', 'https://example.com');
+    });
+
+
+    it('should keep first /v2 if double specified', function() {
+      validateRemoveV2OrSlashes('https://example.com/v2/v2', 'https://example.com/v2');
+    });
+
+
+    it('should preserve query string and hash', function() {
+      validateRemoveV2OrSlashes('https://example.com/v2?a=1#top', 'https://example.com?a=1#top');
+    });
+
+
+    it('should not remove mid-path v2', function() {
+      validateRemoveV2OrSlashes('https://example.com/api/v2/resources', 'https://example.com/api/v2/resources');
+    });
+
+
+    it('should remove trailing slashes', function() {
+      validateRemoveV2OrSlashes('https://example.com/api/', 'https://example.com/api');
+    });
+
+
+    it('should preserve port', function() {
+      validateRemoveV2OrSlashes('https://example.com:8080/v2', 'https://example.com:8080');
+    });
+
+
+    it('should support localhost', function() {
+      validateRemoveV2OrSlashes('https://localhost:8080/v2', 'https://localhost:8080');
     });
 
   });

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentConfigValidator.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentConfigValidator.js
@@ -24,7 +24,7 @@ export const VALIDATION_ERROR_MESSAGES = {
   CONTACT_POINT_MUST_BE_URL: 'Cluster endpoint must be a valid URL.',
   CONTACT_POINT_MUST_NOT_BE_EMPTY: 'Cluster endpoint must not be empty.',
   CLUSTER_URL_MUST_NOT_BE_EMPTY: 'Cluster URL must not be empty.',
-  CONTACT_POINT_MUST_START_WITH_PROTOCOL: 'Cluster endpoint must start with "http://", "grpc://", "https://", or "grpcs", .',
+  CONTACT_POINT_MUST_START_WITH_PROTOCOL: 'Cluster endpoint must start with "http://", "grpc://", "https://", or "grpcs://".',
   MUST_PROVIDE_A_VALUE: 'Must provide a value.',
   OAUTH_URL_MUST_NOT_BE_EMPTY: 'OAuth URL must not be empty.'
 };

--- a/client/src/plugins/zeebe-plugin/shared/__tests__/utilSpec.js
+++ b/client/src/plugins/zeebe-plugin/shared/__tests__/utilSpec.js
@@ -52,6 +52,21 @@ describe('util', function() {
     });
 
 
+    it('should get Camunda Operate URL (REST v2)', function() {
+
+      // given
+      const endpoint = {
+        camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/v2/'
+      };
+
+      // when
+      const url = getOperateUrl(endpoint);
+
+      // then
+      expect(url.toString()).to.eql('https://yyy-1.operate.camunda.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
+    });
+
+
     it('should not get Camunda Operate URL', function() {
 
       // given


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/5345

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. Ensure that any new additions or modifications are consistent with the
existing UI and UX patterns.
-->

Remove any trailing `/` or `v2` from REST URLs, while preserving other parts of the URL. Examples:
```
'https://example.com'        -> 'https://example.com'
'https://example.com/'       -> 'https://example.com'
'https://example.com/v2'     -> 'https://example.com'
'https://example.com/v2/'    -> 'https://example.com'
'https://example.com/v2/v2/' -> 'https://example.com/v2' (super edge case, they have to specify v2 explicitly twice)
```

should work for SaaS (`https://yyy-1.zeebe.camunda.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/v2`), SM, and c8run (8.8) (`http://localhost:8080/v2`)

Note: This is not applied to grpc URLs as they cannot contain any paths (`/`) anyway

### Checklist

Ensure you provided everything we need to review your contribution:

* [x] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [x] __Pull request description establishes context__:
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->