### PR TITLE
Migrate connections to ZEEBE_GRPC_ADDRESS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: use `ZEEBE_GRPC_ADDRESS` in favor of deprecated `ZEEBE_ADDRESS` for cluster connections ([#5362](https://github.com/camunda/camunda-modeler/pull/5362))
+
 ## 5.40.1
 
 ### General

--- a/app/test/spec/zeebe-api/zeebe-api-grpc-spec.js
+++ b/app/test/spec/zeebe-api/zeebe-api-grpc-spec.js
@@ -1070,10 +1070,10 @@ describe('ZeebeAPI (gRPC)', function() {
         const [ config ] = configSpy.getCall(0).args;
 
         // ZBClient is invoked accordingly
-        expect(config.ZEEBE_ADDRESS).to.eql('localhost:26500');
+        expect(config.ZEEBE_GRPC_ADDRESS).to.eql('grpc://localhost:26500');
 
         expect(config).to.include.keys({
-          ZEEBE_ADDRESS: 'url',
+          ZEEBE_GRPC_ADDRESS: 'url',
           CAMUNDA_AUTH_STRATEGY: 'basic',
           CAMUNDA_BASIC_AUTH_USERNAME: 'username',
           CAMUNDA_BASIC_AUTH_PASSWORD: 'password'
@@ -1125,7 +1125,7 @@ describe('ZeebeAPI (gRPC)', function() {
         const config = configSpy.getCall(0).args[0];
 
         // ZBClient is invoked accordingly
-        expect(config.ZEEBE_ADDRESS).to.eql('localhost:26500');
+        expect(config.ZEEBE_GRPC_ADDRESS).to.eql('grpc://localhost:26500');
 
         expect(config).to.include.keys({
           CAMUNDA_AUTH_STRATEGY: 'OAUTH',
@@ -1654,7 +1654,7 @@ describe('ZeebeAPI (gRPC)', function() {
       await zeebeAPI.deploy(parameters);
 
       // then
-      expect(usedConfig.ZEEBE_ADDRESS).to.eql('localhost:26500');
+      expect(usedConfig.ZEEBE_GRPC_ADDRESS).to.eql('grpc://localhost:26500');
     });
 
 
@@ -1798,135 +1798,6 @@ describe('ZeebeAPI (gRPC)', function() {
 
       // then
       expect(closeSpy).to.have.been.calledOnce;
-    });
-
-
-    it('should set `CAMUNDA_SECURE_CONNECTION` to true for grpcs:// endpoint', async function() {
-
-      // given
-      let usedConfig;
-
-      const zeebeAPI = createZeebeAPI({
-        configSpy(config) {
-          usedConfig = config;
-        }
-      });
-
-      const parameters = {
-        endpoint: {
-          type: ENDPOINT_TYPES.SELF_HOSTED,
-          url: 'grpcs://camunda.com'
-        },
-        resourceConfigs: [
-          {
-            path: 'foo.bpmn',
-            type: 'bpmn'
-          }
-        ]
-      };
-
-      // when
-      await zeebeAPI.deploy(parameters);
-
-      // then
-      expect(usedConfig).to.have.property('CAMUNDA_SECURE_CONNECTION', true);
-    });
-
-
-    it('should set `CAMUNDA_SECURE_CONNECTION` to false for http:// endpoint (no auth)', async function() {
-
-      // given
-      let usedConfig;
-
-      const zeebeAPI = createZeebeAPI({
-        configSpy(config) {
-          usedConfig = config;
-        }
-      });
-
-      const parameters = {
-        endpoint: {
-          type: ENDPOINT_TYPES.SELF_HOSTED,
-          url: TEST_URL
-        },
-        resourceConfigs: [
-          {
-            path: 'foo.bpmn',
-            type: 'bpmn'
-          }
-        ]
-      };
-
-      // when
-      await zeebeAPI.deploy(parameters);
-
-      // then
-      expect(usedConfig).to.have.property('CAMUNDA_SECURE_CONNECTION', false);
-    });
-
-
-    it('should set `CAMUNDA_SECURE_CONNECTION` to false for grpc:// endpoint (oauth)', async function() {
-
-      // given
-      let usedConfig;
-
-      const zeebeAPI = createZeebeAPI({
-        configSpy(config) {
-          usedConfig = config;
-        }
-      });
-
-      const parameters = {
-        endpoint: {
-          type: ENDPOINT_TYPES.SELF_HOSTED,
-          authType: AUTH_TYPES.OAUTH,
-          url: 'grpc://camunda.com'
-        },
-        resourceConfigs: [
-          {
-            path: 'foo.bpmn',
-            type: 'bpmn'
-          }
-        ]
-      };
-
-      // when
-      await zeebeAPI.deploy(parameters);
-
-      // then
-      expect(usedConfig).to.have.property('CAMUNDA_SECURE_CONNECTION', false);
-    });
-
-
-    it('should set `CAMUNDA_SECURE_CONNECTION` to true for no protocol endpoint (cloud)', async function() {
-
-      // given
-      let usedConfig;
-
-      const zeebeAPI = createZeebeAPI({
-        configSpy(config) {
-          usedConfig = config;
-        }
-      });
-
-      const parameters = {
-        endpoint: {
-          type: ENDPOINT_TYPES.CAMUNDA_CLOUD,
-          url: 'camunda.com'
-        },
-        resourceConfigs: [
-          {
-            path: 'foo.bpmn',
-            type: 'bpmn'
-          }
-        ]
-      };
-
-      // when
-      await zeebeAPI.deploy(parameters);
-
-      // then
-      expect(usedConfig).to.have.property('CAMUNDA_SECURE_CONNECTION', true);
     });
 
 
@@ -2341,11 +2212,10 @@ describe('ZeebeAPI (gRPC)', function() {
           zeebeGrpcSettings: {
             ZEEBE_GRPC_CLIENT_RETRY: false
           },
-          ZEEBE_ADDRESS: 'localhost:26500',
+          ZEEBE_GRPC_ADDRESS: 'grpc://localhost:26500',
           CAMUNDA_AUTH_STRATEGY: 'BASIC',
           CAMUNDA_BASIC_AUTH_USERNAME: 'username',
           CAMUNDA_BASIC_AUTH_PASSWORD: '******',
-          CAMUNDA_SECURE_CONNECTION: false
         }
       });
 
@@ -2422,7 +2292,7 @@ describe('ZeebeAPI (gRPC)', function() {
           zeebeGrpcSettings: {
             ZEEBE_GRPC_CLIENT_RETRY: false
           },
-          ZEEBE_ADDRESS: 'localhost:26500',
+          ZEEBE_GRPC_ADDRESS: 'grpc://localhost:26500',
           CAMUNDA_AUTH_STRATEGY: 'OAUTH',
           CAMUNDA_TOKEN_DISK_CACHE_DISABLE: true,
           CAMUNDA_TOKEN_SCOPE: 'scope',
@@ -2430,7 +2300,6 @@ describe('ZeebeAPI (gRPC)', function() {
           ZEEBE_CLIENT_SECRET: '******',
           CAMUNDA_ZEEBE_OAUTH_AUDIENCE: 'audience',
           CAMUNDA_OAUTH_URL: 'oauthURL',
-          CAMUNDA_SECURE_CONNECTION: false
         }
       });
 

--- a/app/test/spec/zeebe-api/zeebe-api-rest-spec.js
+++ b/app/test/spec/zeebe-api/zeebe-api-rest-spec.js
@@ -1710,74 +1710,6 @@ describe('ZeebeAPI (REST)', function() {
     });
 
 
-
-
-
-    it('should set `CAMUNDA_SECURE_CONNECTION` to false for http:// endpoint (no auth)', async function() {
-
-      // given
-      let usedConfig;
-
-      const zeebeAPI = createZeebeAPI({
-        configSpy(config) {
-          usedConfig = config;
-        }
-      });
-
-      const parameters = {
-        endpoint: {
-          type: ENDPOINT_TYPES.SELF_HOSTED,
-          url: 'http://test'
-        },
-        resourceConfigs: [
-          {
-            path: 'foo.bpmn',
-            type: 'bpmn'
-          }
-        ]
-      };
-
-      // when
-      await zeebeAPI.deploy(parameters);
-
-      // then
-      expect(usedConfig).to.have.property('CAMUNDA_SECURE_CONNECTION', false);
-    });
-
-
-
-    it('should set `CAMUNDA_SECURE_CONNECTION` to true for no protocol endpoint (cloud)', async function() {
-
-      // given
-      let usedConfig;
-
-      const zeebeAPI = createZeebeAPI({
-        configSpy(config) {
-          usedConfig = config;
-        }
-      });
-
-      const parameters = {
-        endpoint: {
-          type: ENDPOINT_TYPES.CAMUNDA_CLOUD,
-          url: 'camunda.com'
-        },
-        resourceConfigs: [
-          {
-            path: 'foo.bpmn',
-            type: 'bpmn'
-          }
-        ]
-      };
-
-      // when
-      await zeebeAPI.deploy(parameters);
-
-      // then
-      expect(usedConfig).to.have.property('CAMUNDA_SECURE_CONNECTION', true);
-    });
-
-
     it('should accept port', async function() {
 
       // given
@@ -2097,7 +2029,6 @@ describe('ZeebeAPI (REST)', function() {
           CAMUNDA_AUTH_STRATEGY: 'BASIC',
           CAMUNDA_BASIC_AUTH_USERNAME: 'username',
           CAMUNDA_BASIC_AUTH_PASSWORD: '******',
-          CAMUNDA_SECURE_CONNECTION: true,
           port: '443'
         }
       });
@@ -2180,7 +2111,6 @@ describe('ZeebeAPI (REST)', function() {
           ZEEBE_CLIENT_SECRET: '******',
           CAMUNDA_ZEEBE_OAUTH_AUDIENCE: 'audience',
           CAMUNDA_OAUTH_URL: 'oauthURL',
-          CAMUNDA_SECURE_CONNECTION: true,
           port: '443',
         }
       });


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5356

### Proposed Changes

Usage of `ZEEBE_ADDRESS` + `CAMUNDA_SECURE_CONNECTION` was deprecated in favor of having a `ZEEBE_GRPC_ADDRESS` containing the protocol (`grpc` or `grpcs`) with [@camunda8/sdk@8.7.22](https://github.com/camunda/camunda-8-js-sdk/blob/main/CHANGELOG.md#8725-2025-07-29). Leading to deprecation warning logs polluting the output.

As we have quite a good guess wich protocol it should be we can use the stored information to build a proper `ZEEBE_GRPC_ADDRESS`

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. Ensure that any new additions or modifications are consistent with the
existing UI and UX patterns.
-->

### Checklist

Ensure you provided everything we need to review your contribution:

* [x] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [ ] __Pull request description establishes context__:
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->