### PR TITLE
chore: use consistent terminology for cluster URL

### DIFF
--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentConfigForm.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentConfigForm.js
@@ -37,7 +37,6 @@ const LABELS = {
   CLIENT_ID: 'Client ID',
   CLIENT_SECRET: 'Client secret',
   CLUSTER_URL: 'Cluster URL',
-  CONTACT_POINT: 'Cluster endpoint',
   OAUTH_AUDIENCE: 'OAuth audience',
   OAUTH_SCOPE: 'OAuth scope',
   OAUTH_URL: 'OAuth token URL',
@@ -48,7 +47,7 @@ const LABELS = {
 };
 
 const HINTS = {
-  CONTACT_POINT: 'http://localhost:26500'
+  CLUSTER_URL: 'http://localhost:26500'
 };
 
 export default function DeploymentConfigForm(props) {
@@ -115,10 +114,10 @@ export default function DeploymentConfigForm(props) {
                             <Field
                               name="endpoint.contactPoint"
                               component={ TextInput }
-                              label={ LABELS.CONTACT_POINT }
+                              label={ LABELS.CLUSTER_URL }
                               validate={ value => validateField('endpoint.contactPoint', value) }
                               fieldError={ getFieldError }
-                              hint={ HINTS.CONTACT_POINT }
+                              hint={ HINTS.CLUSTER_URL }
                               autoFocus
                             />
                             <Field

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentConfigValidator.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentConfigValidator.js
@@ -21,10 +21,10 @@ export const VALIDATION_ERROR_MESSAGES = {
   CLIENT_ID_MUST_NOT_BE_EMPTY: 'Client ID must not be empty.',
   CLIENT_SECRET_MUST_NOT_BE_EMPTY: 'Client Secret must not be empty.',
   CLUSTER_URL_MUST_BE_VALID_CLOUD_URL: 'Must be a valid Camunda 8 SaaS URL.',
-  CONTACT_POINT_MUST_BE_URL: 'Cluster endpoint must be a valid URL.',
-  CONTACT_POINT_MUST_NOT_BE_EMPTY: 'Cluster endpoint must not be empty.',
+  CONTACT_POINT_MUST_BE_URL: 'Cluster URL must be a valid URL.',
+  CONTACT_POINT_MUST_NOT_BE_EMPTY: 'Cluster URL must not be empty.',
   CLUSTER_URL_MUST_NOT_BE_EMPTY: 'Cluster URL must not be empty.',
-  CONTACT_POINT_MUST_START_WITH_PROTOCOL: 'Cluster endpoint must start with "http://", "grpc://", "https://", or "grpcs://".',
+  CONTACT_POINT_MUST_START_WITH_PROTOCOL: 'Cluster URL must start with "http://", "grpc://", "https://", or "grpcs://".',
   MUST_PROVIDE_A_VALUE: 'Must provide a value.',
   OAUTH_URL_MUST_NOT_BE_EMPTY: 'OAuth URL must not be empty.'
 };


### PR DESCRIPTION
Changes the label from __Cluster endpoint_ to _Cluster URL_ to use consistent terminology.

<img width="341" height="254" alt="image" src="https://github.com/user-attachments/assets/798ce242-7289-4942-bdbe-f2e1dc2a542b" />

Closes #5371

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. Ensure that any new additions or modifications are consistent with the
existing UI and UX patterns.
-->

### Checklist

Ensure you provided everything we need to review your contribution:

* [x] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [x] __Pull request description establishes context__:
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->