### PR TITLE
Add adaptive modal style (used for settings) to increase usable space

### DIFF
--- a/client/src/plugins/settings/SettingsPlugin.js
+++ b/client/src/plugins/settings/SettingsPlugin.js
@@ -122,7 +122,7 @@ export default function SettingsPlugin(props) {
   }
 
   return (
-    <Modal onClose={ () => setOpen(false) }>
+    <Modal adaptive={ true } onClose={ () => setOpen(false) }>
       <div className="modal-header">
         <h2 className="modal-title">Settings</h2>
       </div>

--- a/client/src/plugins/settings/SettingsPlugin.less
+++ b/client/src/plugins/settings/SettingsPlugin.less
@@ -1,4 +1,6 @@
 :local(.SettingsPlugin) {
+  --input-width: 100%;
+
   .form-group {
     margin: 12px auto;
 

--- a/client/src/shared/ui/modal/Modal.js
+++ b/client/src/shared/ui/modal/Modal.js
@@ -64,13 +64,14 @@ export default class Modal extends PureComponent {
     const {
       className,
       children,
-      onClose
+      onClose,
+      adaptive
     } = this.props;
 
     return ReactDOM.createPortal(
       <KeyboardInteractionTrap>
         <div className="modal" tabIndex="-1" role="dialog">
-          <div className={ classNames('modal-dialog', className) } ref={ this.modalRef } role="document">
+          <div className={ classNames('modal-dialog', { 'modal-adaptive': adaptive }, className) } ref={ this.modalRef } role="document">
             <div className="modal-content">
               { children }
               { onClose && (<Close onClick={ this.close } />) }

--- a/client/src/styles/_modal.less
+++ b/client/src/styles/_modal.less
@@ -40,6 +40,32 @@
 
   background-color: var(--color-white);
   color: var(--color-grey-225-10-15);
+
+  &.modal-adaptive {
+    @height-breakpoint: 600px;
+    @width-breakpoint: 992px;
+
+    @margin-x: 10px;
+
+    @margin-y-min: 10px;
+    @margin-y-max: 40px;
+
+    margin-top: @margin-y-max;
+    margin-bottom: @margin-y-max;
+    height: calc(100% - (@margin-y-max * 2));
+    @media (max-height: @height-breakpoint) {
+      margin-top: @margin-y-min;
+      margin-bottom: @margin-y-min;
+      height: calc(100% - (@margin-y-min * 2));
+    }
+
+    width: @width-breakpoint - @margin-x * 2;
+    @media (max-width: @width-breakpoint) {
+      margin-left: @margin-x;
+      margin-right: @margin-x;
+      width: calc(100% - (@margin-x * 2));
+    }
+  }
 }
 
 .modal-content,
@@ -48,6 +74,11 @@
   flex: auto;
   flex-direction: column;
   max-height: 84vh;
+
+  .modal-adaptive & {
+    height: 100%;
+    max-height: 100%;
+  }
 }
 
 .modal-header {
@@ -67,6 +98,10 @@
 }
 
 .modal-body {
+  .modal-adaptive & {
+    height: 100%;
+  }
+
   padding: 16px 20px 20px 20px;
 
   overflow-y: auto;


### PR DESCRIPTION
### Proposed Changes

Give settings as much space as available/necessary. Some of my thoughts:
* if i have enough height I would like to see the top/bottom bars of the modeler in the background
* on ultrawide screens the width should still be reasonable, but its a bit wider than other modals
* on small screens I still have a small margin to visualize that we are in a modal (i found it looked weird without any margin
* by default it takes as much height as possible to reduce flickering due to expanding/collapsing/adding/deleting row elements

https://github.com/user-attachments/assets/aab3b90b-ac9b-4c86-8f0e-c4314638aba6

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. Ensure that any new additions or modifications are consistent with the
existing UI and UX patterns.
-->

### Try Out

```
npx @bpmn-io/sr camunda/camunda-modeler#increase-settings-modal-space
```

### Checklist

Ensure you provided everything we need to review your contribution:

* [x] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [ ] __Pull request description establishes context__:
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->