### PR TITLE
test: increase timeout for image generation

### DIFF
--- a/client/src/app/util/__tests__/generateImageSpec.js
+++ b/client/src/app/util/__tests__/generateImageSpec.js
@@ -23,6 +23,8 @@ const expectedImagesByType = {
 
 describe('util - generateImage', function() {
 
+  this.timeout(5000);
+
   const svg = require('./diagram.svg'),
         outOfBoundsSVG = require('./out_of_bounds_diagram.svg'),
         webhookSVG = require('./webhook.svg');


### PR DESCRIPTION
### Proposed Changes

The CI has been flaky for macOS. The tests would time out on the image generation, so I increased the timeout on that test suite, and it seems to help: https://github.com/camunda/camunda-modeler/actions/runs/19147777313

### Checklist

Ensure you provided everything we need to review your contribution:

* [x] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [x] __Pull request description establishes context__:
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->