### PR TITLE
fix: add IDs for initial DMN diagrams

### DIFF
--- a/client/src/app/tabs/cloud-dmn/diagram.dmn
+++ b/client/src/app/tabs/cloud-dmn/diagram.dmn
@@ -12,7 +12,7 @@
   </decision>
   <dmndi:DMNDI>
     <dmndi:DMNDiagram>
-      <dmndi:DMNShape dmnElementRef="Decision_{{ ID:decision }}">
+      <dmndi:DMNShape id="Decision_{{ ID:decision }}_di" dmnElementRef="Decision_{{ ID:decision }}">
         <dc:Bounds height="80" width="180" x="160" y="100" />
       </dmndi:DMNShape>
     </dmndi:DMNDiagram>

--- a/client/src/app/tabs/dmn/diagram.dmn
+++ b/client/src/app/tabs/dmn/diagram.dmn
@@ -12,7 +12,7 @@
   </decision>
   <dmndi:DMNDI>
     <dmndi:DMNDiagram>
-      <dmndi:DMNShape dmnElementRef="Decision_{{ ID:decision }}">
+      <dmndi:DMNShape id="Decision_{{ ID:decision }}_di" dmnElementRef="Decision_{{ ID:decision }}">
         <dc:Bounds height="80" width="180" x="160" y="100" />
       </dmndi:DMNShape>
     </dmndi:DMNDiagram>


### PR DESCRIPTION
### Proposed Changes

Small adjustment of the initial DMN diagrams. Any DI shape that is created has an ID. The ones in the initial diagrams don't have one for some reason.

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. Ensure that any new additions or modifications are consistent with the
existing UI and UX patterns.
-->

### Checklist

Ensure you provided everything we need to review your contribution:

* [x] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [ ] __Pull request description establishes context__:
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->