### PR TITLE
chore: increase karma and mocha timeouts

### DIFF
--- a/client/.mocharc.js
+++ b/client/.mocharc.js
@@ -1,3 +1,0 @@
-module.exports = {
-  timeout: 10000,
-};

--- a/client/karma.config.js
+++ b/client/karma.config.js
@@ -81,6 +81,12 @@ module.exports = function(karma) {
     singleRun: true,
     autoWatch: false,
 
+    client: {
+      mocha: {
+        timeout: 10000
+      }
+    },
+
     webpack: {
       mode: 'none',
       module: {


### PR DESCRIPTION
### Proposed Changes

This PR attempts to fix our utterly annoying failing macOS CI tests by dumping a bunch of random configuration options in.

I've been running the macOS job for a while and it hasn't failed yet. 🤞

Stuff in `karma` config is related to Karma's `Disconnected reconnect failed before timeout of 2000ms` error.

Stuff in `mocha` config is related to Mocha's `Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.` error.

### Checklist

Ensure you provided everything we need to review your contribution:

* [ ] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [ ] __Pull request description establishes context__:
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->