### PR TITLE
fix: make only tooltip contents selectable

### DIFF
--- a/client/src/app/resizable-container/PropertiesPanelContainer.less
+++ b/client/src/app/resizable-container/PropertiesPanelContainer.less
@@ -23,7 +23,7 @@
   }
 
   // This makes the text inside of a tooltip selectable
-  .bio-properties-panel :has(.bio-properties-panel-tooltip-content) * {
+  .bio-properties-panel [role="tooltip"] * {
     user-select: text;
   }
 }


### PR DESCRIPTION
Closes #5443

### Proposed Changes

Only the tooltips contents can be selectable. Group name cannot be selected.

https://github.com/user-attachments/assets/74e77631-4ede-411b-932c-0d2b144c98c7

### Checklist

Ensure you provided everything we need to review your contribution:

* [x] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [x] __Pull request description establishes context__:
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->