### PR TITLE
fix: migrate configs when file path changes

### DIFF
--- a/client/src/app/zeebe/Deployment.js
+++ b/client/src/app/zeebe/Deployment.js
@@ -146,7 +146,9 @@ export default class Deployment extends EventEmitter {
   async getConfigForFile(file) {
     const {
       connectionId = null
-    } = await this._config.getForFile(file, CONFIG_KEYS.CONNECTION_MANAGER, {});
+    } = await (file.path
+      ? this._config.getForFile(file, CONFIG_KEYS.CONNECTION_MANAGER, {})
+      : this._config.get(CONFIG_KEYS.CONNECTION_MANAGER, {}));
 
     const endpoint = await this.getEndpoint(connectionId);
     if (!endpoint) {


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/5360

### Proposed Changes

- align reading configs to the same set behavior for unsaved files
- migrate configs if the path changes (eg. unsaved `null` -> `new.bpmn` or saveAs `old.bpmn` -> `new.bpmn`

Once task testing is also no longer using null as a config key they can be added to the migration keys

Solves issues were connections were not loaded for unsaved or "renamed" (saveAs) files


https://github.com/user-attachments/assets/0410505a-c89e-41ea-bf8e-61bf810c93f7

### Alternatives considered

- Problem: connection information is linked to the filepath, all unsaved file share that information (previously key was null, currently separate config key)
- First approach: Connection manager listens on tab saved and rewrites connection information. Works for deploy and start instance but not task testing due to asynchrosity
- Second: let the deployment tool handle the save logic and ensure connection is set. works in most cases but not if the user changes the file path (save as)

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. Ensure that any new additions or modifications are consistent with the
existing UI and UX patterns.
-->

### Checklist

Ensure you provided everything we need to review your contribution:

* [x] Your __contribution meets the [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Any new additions or modifications are __consistent with the existing UI and UX patterns__
* [ ] __Pull request description establishes context__:
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--
Thanks for creating this pull request! ❤️
-->