### PR TITLE
Support `saveAs` for config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: migrate configs when file path changes ([#5464](https://github.com/camunda/camunda-modeler/pull/5464/))
+
 ## 5.42.0
 
 * `DEPS`: update to `@bpmn-io/properties-panel@3.34.0`

--- a/client/src/remote/Config.js
+++ b/client/src/remote/Config.js
@@ -59,10 +59,10 @@ export default class Config {
   }
 
   /**
-   * Get configuration value for file.
+   * Get configuration or value for file.
    *
    * @param {File} file
-   * @param {string} [key]
+   * @param {string} [key] if no key is provided returns the whole config for file
    * @param {*} [defaultValue]
    *
    * @returns {Promise<*>}
@@ -92,10 +92,10 @@ export default class Config {
   }
 
   /**
-   * Set configuration value for file.
+   * Set configuration or value for file.
    *
    * @param {File} file
-   * @param {string} key
+   * @param {string} [key] if no key is provided sets the whole config
    * @param {*} value
    *
    * @returns {Promise<*>}
@@ -107,18 +107,22 @@ export default class Config {
 
     const configForFile = files[ path ] = files[ path ] || {};
 
-    configForFile[ key ] = value;
+    if (key) {
+      configForFile[ key ] = value;
+    } else {
+      files[ path ] = value;
+    }
 
     await this.set('files', files);
 
-    return configForFile;
+    return files[ path ];
   }
 
   /**
-   * Get configuration value for plugin.
+   * Get configuration or value for plugin.
    *
    * @param {string} name
-   * @param {string} [key]
+   * @param {string} [key] if no key is provided returns the whole config for plugin
    * @param {*} [defaultValue]
    *
    * @returns {Promise<*>}

--- a/client/src/remote/__tests__/ConfigSpec.js
+++ b/client/src/remote/__tests__/ConfigSpec.js
@@ -27,7 +27,7 @@ describe('config', function() {
 
   describe('#getForFile', function() {
 
-    it('should get', async function() {
+    it('should get config value (key provided)', async function() {
 
       // given
       const file = {
@@ -48,7 +48,30 @@ describe('config', function() {
     });
 
 
-    it('should return default value (no config for file)', async function() {
+    it('should get entire config (no key provided)', async function() {
+
+      // given
+      const file = {
+        path: 'foo.bpmn'
+      };
+
+      backend.setSendResponse({
+        'foo.bpmn': {
+          foo: 42
+        }
+      });
+
+      // when
+      const value = await config.getForFile(file);
+
+      // then
+      expect(value).to.eql({
+        foo: 42
+      });
+    });
+
+
+    it('should return default value (key provided, no config for file, default value provided)', async function() {
 
       // given
       const file = {
@@ -65,7 +88,7 @@ describe('config', function() {
     });
 
 
-    it('should return null (no config for file, no default value)', async function() {
+    it('should return null (key provided, no config for file, no default value provided)', async function() {
 
       // given
       const file = {
@@ -82,7 +105,7 @@ describe('config', function() {
     });
 
 
-    it('should return default value (no config value)', async function() {
+    it('should return default value (key provided, no config value, default value provided)', async function() {
 
       // given
       const file = {
@@ -101,7 +124,7 @@ describe('config', function() {
     });
 
 
-    it('should return null (no config value, no default value)', async function() {
+    it('should return null (key provided, no config value, no default value provided)', async function() {
 
       // given
       const file = {
@@ -141,7 +164,7 @@ describe('config', function() {
 
   describe('#setForFile', function() {
 
-    it('should set', async function() {
+    it('should set config value (key provided)', async function() {
 
       // given
       const file = {
@@ -155,16 +178,16 @@ describe('config', function() {
       });
 
       // when
-      const value = await config.setForFile(file, 'foo', 42);
+      const value = await config.setForFile(file, 'foo', 43);
 
       // then
       expect(value).to.eql({
-        foo: 42
+        foo: 43
       });
     });
 
 
-    it('should set (no config)', async function() {
+    it('should set config value (key provided, no config)', async function() {
 
       // given
       const file = {
@@ -179,6 +202,29 @@ describe('config', function() {
       // then
       expect(value).to.eql({
         foo: 42
+      });
+    });
+
+
+    it('should set entire config (no key provided)', async function() {
+
+      // given
+      const file = {
+        path: 'foo.bpmn'
+      };
+
+      backend.setSendResponse({
+        'foo.bpmn': {
+          foo: 42
+        }
+      });
+
+      // when
+      const value = await config.setForFile(file, undefined, { bar: 'baz' });
+
+      // then
+      expect(value).to.eql({
+        bar: 'baz'
       });
     });
 


### PR DESCRIPTION
Alternative for https://github.com/camunda/camunda-modeler/pull/5461

### Proposed Changes

- migrate configs if the path changes (only for saved files)(ie saveas triggered from within modeler)
  - the old config is not deleted
  - but the new one is completely overwritten (as save as confirms overwriting existing files)

Caveat: Path changes outside of modeler (ie. moving file in explorer) will still not be catched, ie losing config.

<img width="585" height="749" alt="image" src="https://github.com/user-attachments/assets/eddabcda-f2ab-4270-9ddf-f7e7d83688e1" />

### Alternatives considered

- Problem: connection information is linked to the filepath, all unsaved file share that information (previously key was null, currently separate config key)
- First approach: Connection manager listens on tab saved and rewrites connection information. Works for deploy and start instance but not task testing due to asynchrosity
- Second: let the deployment tool handle the save logic and ensure connection is set. works in most cases but not if the user changes the file path (save as)
- Third: only migrate specific config keys as we wouldn't know otherwise their default
- Another: explicitly set default values (would be on top of this)
<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
