### PR TITLE
chore: update package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -535,6 +535,7 @@
       "version": "3.9.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array.prototype.flat": "^1.2.1",
         "cheerio": "^1.0.0-rc.2",
@@ -886,6 +887,7 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1364,6 +1366,7 @@
       "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -2688,6 +2691,7 @@
       "resolved": "https://registry.npmjs.org/@bpmn-io/form-js/-/form-js-1.18.0.tgz",
       "integrity": "sha512-RLH2y2M39uYUKf+6XsV55DMm4w0RxlEqAm5/wvvRZr7fwTH4wTW5Dl1AgJVcq/rji9YrnTlX9eM8wX9GdEjHpQ==",
       "license": "SEE LICENSE IN LICENSE",
+      "peer": true,
       "dependencies": {
         "@bpmn-io/form-js-carbon-styles": "^1.18.0",
         "@bpmn-io/form-js-editor": "^1.18.0",
@@ -2895,6 +2899,7 @@
       "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.34.0.tgz",
       "integrity": "sha512-BkY3JYVDtmuUox4U/B5Mxis0UzW+uY9cZvKEUMKQeW+4IyOZ6yF07/fsabS1koaQV19YxF8im3PX5fibSNxphg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bpmn-io/feel-editor": "^1.12.0",
         "@carbon/icons": "^11.69.0",
@@ -2953,6 +2958,7 @@
       "resolved": "https://registry.npmjs.org/@bpmn-io/variable-resolver/-/variable-resolver-1.3.6.tgz",
       "integrity": "sha512-u3dzPB0DYNJld9sHu9GsqwqyV3XNfAQJ0qzXlxPGLYnL10Q7iOlsNHeCvGQ4TehfwpCT4YUarHfB5Ggkhptojg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bpmn-io/extract-process-variables": "^1.0.1",
         "@lezer/common": "^1.2.3",
@@ -4438,7 +4444,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -4460,7 +4465,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -8331,6 +8335,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -8483,6 +8488,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -8502,6 +8508,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.0.1.tgz",
       "integrity": "sha512-XuY23lSI3d4PEqKA+7SLtAgwqIfc6E/E9eAQWLN1vlpC53ybO3o6jW4BsXo1xvz9lYyyWItfQDDLzezER01mCw==",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -8513,6 +8520,7 @@
       "version": "0.203.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.203.0.tgz",
       "integrity": "sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.203.0",
         "import-in-the-middle": "^1.8.1",
@@ -9165,6 +9173,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
       "integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -9202,6 +9211,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
       "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/resources": "2.0.1",
@@ -9937,6 +9947,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
       "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -9951,6 +9962,7 @@
       "version": "1.36.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.36.0.tgz",
       "integrity": "sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -11221,6 +11233,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11306,6 +11319,7 @@
       "version": "6.12.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -12621,6 +12635,7 @@
       "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.9.1.tgz",
       "integrity": "sha512-hpTwvid74iHLdqBW/ZOverBzWboXFY1sMtGsizrbcaftXc7T9STdQ5Ny5++LOw1lAv/AQZiDxgk5JjaRGwKVPw==",
       "license": "SEE LICENSE IN LICENSE",
+      "peer": true,
       "dependencies": {
         "bpmn-moddle": "^9.0.4",
         "diagram-js": "^15.4.0",
@@ -12652,6 +12667,7 @@
       "resolved": "https://registry.npmjs.org/bpmn-js-create-append-anything/-/bpmn-js-create-append-anything-1.0.1.tgz",
       "integrity": "sha512-TYGvkX4tbLd1gqMguhqYdQ0Iy+bsAfd0hThp6rmpeUoA06hg9qdeuunYsmYnYMR4cbAm8u35G17PR0BJ/NwuFQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "diagram-js": ">= 15.3.0"
       }
@@ -12757,6 +12773,7 @@
       "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.43.0.tgz",
       "integrity": "sha512-y8/wNMqaOAerDXgvyEJBYGuYtnjaxXr1u84Ob3R6iw1w0G0Qc79phqtGl5/WbgQHnFcyX5Yr6MjIU2SoaQiriA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bpmn-io/extract-process-variables": "^1.0.1",
         "array-move": "^4.0.0",
@@ -12874,6 +12891,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/moddle/-/moddle-7.0.0.tgz",
       "integrity": "sha512-Hpte2hfKDwoZWPvDngsEHjloPnO+sKMUVkAPc0r9PrpnVLqsyPUTV0ZQU8CAp87YmRZ9QzeQMJxdKbaP9vEIKA==",
+      "peer": true,
       "dependencies": {
         "min-dash": "^4.2.1"
       }
@@ -12898,6 +12916,7 @@
       "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-11.7.1.tgz",
       "integrity": "sha512-SyMrm9KSPLqS5s2kyplg+7DIAt+E+gD8SfUX3u2GNx+Vd34P0y31fh5TlHu1DMpXmEbHThMnOB1an2pc2Lf3Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bpmn-io/moddle-utils": "^0.2.1",
         "ansi-colors": "^4.1.3",
@@ -13022,6 +13041,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -13537,6 +13557,7 @@
       "resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-5.15.0.tgz",
       "integrity": "sha512-/pHrG92MUArOxhwYuOij9UxGue3GBYrZbVoOAbWkeY8ZoW++qz5Cn0XaaxbaxySzshSb9gGnF/0v1pTLEwyuQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bpmn-io/align-to-origin": "^0.7.0",
         "@bpmn-io/element-template-chooser": "^2.0.0",
@@ -13569,6 +13590,7 @@
       "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.11.3.tgz",
       "integrity": "sha512-9cj9hnwmP9+PDgLQHjXMQkHNgu+me0DrFsOBw/AmbS64s8WWzoGdam27l/ua7ar+7FpP4WZhoopQrhCy4Md99g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ids": "^1.0.0",
         "min-dash": "^4.2.3"
@@ -13603,7 +13625,8 @@
     },
     "node_modules/camunda-bpmn-moddle": {
       "version": "7.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/camunda-dmn-js": {
       "version": "3.5.0",
@@ -13711,6 +13734,7 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
       "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -15143,8 +15167,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-env": {
       "version": "10.0.0",
@@ -15860,7 +15883,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
       "integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/di": {
       "version": "0.0.1",
@@ -15872,6 +15896,7 @@
       "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.4.0.tgz",
       "integrity": "sha512-rpwDLA/w55wPfiZgp/z2T6cFdCXU3bARGdjhUpEOoh673K18OJ4ruEu3+/94ALRIIyEvJ0XHUk9sgZrzzE79ng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.0",
@@ -16048,6 +16073,7 @@
       "integrity": "sha512-RXbDCcrPw2B0q2HIcPI2H7pIFeQiDsLW+ykRVKkW2ke2H3pTgI36r86xLmQZ6397uFCNUjpegRFv6bB+BCWJIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.0.15",
         "builder-util": "26.0.13",
@@ -16092,6 +16118,7 @@
       "resolved": "https://registry.npmjs.org/dmn-js/-/dmn-js-17.4.0.tgz",
       "integrity": "sha512-QEo8Sdu0EGCP9lMB0O3/pxDCGsCInz86SrNLGBsTOQjPxOfYskvWAPsnj3gMf6aBFQJgs9OhbORdxHmILkQw1A==",
       "license": "SEE LICENSE IN LICENSE",
+      "peer": true,
       "dependencies": {
         "dmn-js-boxed-expression": "^17.4.0",
         "dmn-js-decision-table": "^17.4.0",
@@ -16293,6 +16320,7 @@
       "resolved": "https://registry.npmjs.org/dmn-js-properties-panel/-/dmn-js-properties-panel-3.8.2.tgz",
       "integrity": "sha512-qFexoUySPavhtDg5ouqz5uHUPa5EzoZ5KEJ0bUR30g/A3/W6Y0Ihe+i2cY/lQjBRC29sftpBmGGnRoxxwBjiUg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "min-dash": "^4.2.1",
         "min-dom": "^4.1.0"
@@ -16390,6 +16418,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/moddle/-/moddle-7.2.0.tgz",
       "integrity": "sha512-x1+JREThy7JBOBR3g2hbOnOfrlC/YAWXX9RzrSZS5HhqeuBly9H/PCtOBtcQs+Y2sjRAXF+WTNSgHvn8Uq+6Yw==",
+      "peer": true,
       "dependencies": {
         "min-dash": "^4.2.1"
       }
@@ -17230,7 +17259,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -17251,7 +17279,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -17267,7 +17294,6 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -17278,7 +17304,6 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -17711,6 +17736,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -19975,8 +20001,7 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
       "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -20064,6 +20089,7 @@
       "integrity": "sha512-2m7bEo/6D+pbxFkFKY/2QOVdknxxXyrXyDdVFobJcQyvfv3985MY+VVwyRZoVJylQG+mzPY5/uDNuXygp8jObA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inferno-shared": "5.6.3",
         "inferno-vnode-flags": "5.6.3",
@@ -25470,7 +25496,8 @@
     },
     "node_modules/modeler-moddle": {
       "version": "0.2.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/modify-values": {
       "version": "1.0.1",
@@ -25496,7 +25523,8 @@
       "version": "0.51.0",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.51.0.tgz",
       "integrity": "sha512-xaGwVV1fq343cM7aOYB6lVE4Ugf0UyimdD/x5PWcWBMKENwectaEu77FAN7c5sFiyumqeJdX1RPTh1ocioyDjw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/monaco-editor-webpack-plugin": {
       "version": "7.1.0",
@@ -26667,6 +26695,7 @@
       "integrity": "sha512-yaKvr1MogUv3uh4s8VhSQh1l8mhtupclxVTTAua6bSaUYeuUT0qYn52w+Zf5ALg0YCtfzrNUeBgZK2l83HlkgA==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -28757,6 +28786,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -28886,7 +28916,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -28904,7 +28933,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -28912,6 +28940,7 @@
     "node_modules/preact": {
       "version": "10.11.3",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -29458,6 +29487,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -29471,6 +29501,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
       "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -32057,7 +32088,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
       "integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -32078,7 +32108,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -32094,7 +32123,6 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -32152,6 +32180,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -32438,6 +32467,7 @@
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
       "integrity": "sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0",
         "@sinonjs/fake-timers": "^11.2.2",
@@ -32455,6 +32485,7 @@
       "version": "3.7.0",
       "dev": true,
       "license": "(BSD-2-Clause OR WTFPL)",
+      "peer": true,
       "peerDependencies": {
         "chai": "^4.0.0",
         "sinon": ">=4.0.0"
@@ -33398,7 +33429,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -33433,7 +33463,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -33686,6 +33715,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -35083,6 +35113,7 @@
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -35132,6 +35163,7 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -35868,7 +35900,8 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.11.0.tgz",
       "integrity": "sha512-v2PkIAjyZEnzuFHrm9ZhpbEGMgNjYZkUw+H17JxkA7Da+dcbPHbD7fWuBWSbPzNSCOyYYmrH+PL6wp9407ptMg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/zeebe-dmn-moddle": {
       "version": "1.0.0",
@@ -36015,6 +36048,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -36337,6 +36371,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
       "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.25.9"
       }
@@ -37214,6 +37249,7 @@
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/form-js/-/form-js-1.18.0.tgz",
       "integrity": "sha512-RLH2y2M39uYUKf+6XsV55DMm4w0RxlEqAm5/wvvRZr7fwTH4wTW5Dl1AgJVcq/rji9YrnTlX9eM8wX9GdEjHpQ==",
+      "peer": true,
       "requires": {
         "@bpmn-io/form-js-carbon-styles": "^1.18.0",
         "@bpmn-io/form-js-editor": "^1.18.0",
@@ -37387,6 +37423,7 @@
       "version": "3.34.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.34.0.tgz",
       "integrity": "sha512-BkY3JYVDtmuUox4U/B5Mxis0UzW+uY9cZvKEUMKQeW+4IyOZ6yF07/fsabS1koaQV19YxF8im3PX5fibSNxphg==",
+      "peer": true,
       "requires": {
         "@bpmn-io/feel-editor": "^1.12.0",
         "@carbon/icons": "^11.69.0",
@@ -37436,6 +37473,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/@bpmn-io/variable-resolver/-/variable-resolver-1.3.6.tgz",
       "integrity": "sha512-u3dzPB0DYNJld9sHu9GsqwqyV3XNfAQJ0qzXlxPGLYnL10Q7iOlsNHeCvGQ4TehfwpCT4YUarHfB5Ggkhptojg==",
+      "peer": true,
       "requires": {
         "@bpmn-io/extract-process-variables": "^1.0.1",
         "@lezer/common": "^1.2.3",
@@ -38538,7 +38576,6 @@
       "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -38553,7 +38590,6 @@
           "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
           "dev": true,
           "optional": true,
-          "peer": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
@@ -41228,6 +41264,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -41343,7 +41380,8 @@
     "@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "peer": true
     },
     "@opentelemetry/api-logs": {
       "version": "0.203.0",
@@ -41357,12 +41395,14 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.0.1.tgz",
       "integrity": "sha512-XuY23lSI3d4PEqKA+7SLtAgwqIfc6E/E9eAQWLN1vlpC53ybO3o6jW4BsXo1xvz9lYyyWItfQDDLzezER01mCw==",
+      "peer": true,
       "requires": {}
     },
     "@opentelemetry/instrumentation": {
       "version": "0.203.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.203.0.tgz",
       "integrity": "sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==",
+      "peer": true,
       "requires": {
         "@opentelemetry/api-logs": "0.203.0",
         "import-in-the-middle": "^1.8.1",
@@ -41796,6 +41836,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.1.tgz",
       "integrity": "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==",
+      "peer": true,
       "requires": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -41820,6 +41861,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.1.tgz",
       "integrity": "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==",
+      "peer": true,
       "requires": {
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/resources": "2.0.1",
@@ -42333,6 +42375,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
           "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+          "peer": true,
           "requires": {
             "@opentelemetry/semantic-conventions": "^1.29.0"
           }
@@ -42340,7 +42383,8 @@
         "@opentelemetry/semantic-conventions": {
           "version": "1.36.0",
           "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.36.0.tgz",
-          "integrity": "sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ=="
+          "integrity": "sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==",
+          "peer": true
         },
         "@sentry/core": {
           "version": "10.8.0",
@@ -43353,7 +43397,8 @@
     "acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "peer": true
     },
     "acorn-import-attributes": {
       "version": "1.9.5",
@@ -43408,6 +43453,7 @@
     "ajv": {
       "version": "6.12.6",
       "dev": true,
+      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -44309,6 +44355,7 @@
       "version": "18.9.1",
       "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.9.1.tgz",
       "integrity": "sha512-hpTwvid74iHLdqBW/ZOverBzWboXFY1sMtGsizrbcaftXc7T9STdQ5Ny5++LOw1lAv/AQZiDxgk5JjaRGwKVPw==",
+      "peer": true,
       "requires": {
         "bpmn-moddle": "^9.0.4",
         "diagram-js": "^15.4.0",
@@ -44366,6 +44413,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bpmn-js-create-append-anything/-/bpmn-js-create-append-anything-1.0.1.tgz",
       "integrity": "sha512-TYGvkX4tbLd1gqMguhqYdQ0Iy+bsAfd0hThp6rmpeUoA06hg9qdeuunYsmYnYMR4cbAm8u35G17PR0BJ/NwuFQ==",
+      "peer": true,
       "requires": {}
     },
     "bpmn-js-element-templates": {
@@ -44433,6 +44481,7 @@
       "version": "5.43.0",
       "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.43.0.tgz",
       "integrity": "sha512-y8/wNMqaOAerDXgvyEJBYGuYtnjaxXr1u84Ob3R6iw1w0G0Qc79phqtGl5/WbgQHnFcyX5Yr6MjIU2SoaQiriA==",
+      "peer": true,
       "requires": {
         "@bpmn-io/extract-process-variables": "^1.0.1",
         "array-move": "^4.0.0",
@@ -44486,6 +44535,7 @@
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/moddle/-/moddle-7.0.0.tgz",
           "integrity": "sha512-Hpte2hfKDwoZWPvDngsEHjloPnO+sKMUVkAPc0r9PrpnVLqsyPUTV0ZQU8CAp87YmRZ9QzeQMJxdKbaP9vEIKA==",
+          "peer": true,
           "requires": {
             "min-dash": "^4.2.1"
           }
@@ -44505,6 +44555,7 @@
       "version": "11.7.1",
       "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-11.7.1.tgz",
       "integrity": "sha512-SyMrm9KSPLqS5s2kyplg+7DIAt+E+gD8SfUX3u2GNx+Vd34P0y31fh5TlHu1DMpXmEbHThMnOB1an2pc2Lf3Pw==",
+      "peer": true,
       "requires": {
         "@bpmn-io/moddle-utils": "^0.2.1",
         "ansi-colors": "^4.1.3",
@@ -44591,6 +44642,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
       "integrity": "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -44937,6 +44989,7 @@
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/camunda-bpmn-js/-/camunda-bpmn-js-5.15.0.tgz",
       "integrity": "sha512-/pHrG92MUArOxhwYuOij9UxGue3GBYrZbVoOAbWkeY8ZoW++qz5Cn0XaaxbaxySzshSb9gGnF/0v1pTLEwyuQA==",
+      "peer": true,
       "requires": {
         "@bpmn-io/align-to-origin": "^0.7.0",
         "@bpmn-io/element-template-chooser": "^2.0.0",
@@ -44978,6 +45031,7 @@
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.11.3.tgz",
       "integrity": "sha512-9cj9hnwmP9+PDgLQHjXMQkHNgu+me0DrFsOBw/AmbS64s8WWzoGdam27l/ua7ar+7FpP4WZhoopQrhCy4Md99g==",
+      "peer": true,
       "requires": {
         "ids": "^1.0.0",
         "min-dash": "^4.2.3"
@@ -44991,7 +45045,8 @@
       }
     },
     "camunda-bpmn-moddle": {
-      "version": "7.0.1"
+      "version": "7.0.1",
+      "peer": true
     },
     "camunda-dmn-js": {
       "version": "3.5.0",
@@ -45391,6 +45446,7 @@
         "enzyme": {
           "version": "3.9.0",
           "dev": true,
+          "peer": true,
           "requires": {
             "array.prototype.flat": "^1.2.1",
             "cheerio": "^1.0.0-rc.2",
@@ -45650,6 +45706,7 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
       "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -46638,8 +46695,7 @@
       "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "cross-env": {
       "version": "10.0.0",
@@ -47097,7 +47153,8 @@
       "version": "0.0.1521046",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
       "integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "di": {
       "version": "0.0.1",
@@ -47107,6 +47164,7 @@
       "version": "15.4.0",
       "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.4.0.tgz",
       "integrity": "sha512-rpwDLA/w55wPfiZgp/z2T6cFdCXU3bARGdjhUpEOoh673K18OJ4ruEu3+/94ALRIIyEvJ0XHUk9sgZrzzE79ng==",
+      "peer": true,
       "requires": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.0",
@@ -47257,6 +47315,7 @@
       "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.0.15.tgz",
       "integrity": "sha512-RXbDCcrPw2B0q2HIcPI2H7pIFeQiDsLW+ykRVKkW2ke2H3pTgI36r86xLmQZ6397uFCNUjpegRFv6bB+BCWJIA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "app-builder-lib": "26.0.15",
         "builder-util": "26.0.13",
@@ -47288,6 +47347,7 @@
       "version": "17.4.0",
       "resolved": "https://registry.npmjs.org/dmn-js/-/dmn-js-17.4.0.tgz",
       "integrity": "sha512-QEo8Sdu0EGCP9lMB0O3/pxDCGsCInz86SrNLGBsTOQjPxOfYskvWAPsnj3gMf6aBFQJgs9OhbORdxHmILkQw1A==",
+      "peer": true,
       "requires": {
         "dmn-js-boxed-expression": "^17.4.0",
         "dmn-js-decision-table": "^17.4.0",
@@ -47468,6 +47528,7 @@
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/dmn-js-properties-panel/-/dmn-js-properties-panel-3.8.2.tgz",
       "integrity": "sha512-qFexoUySPavhtDg5ouqz5uHUPa5EzoZ5KEJ0bUR30g/A3/W6Y0Ihe+i2cY/lQjBRC29sftpBmGGnRoxxwBjiUg==",
+      "peer": true,
       "requires": {
         "min-dash": "^4.2.1",
         "min-dom": "^4.1.0"
@@ -47554,6 +47615,7 @@
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/moddle/-/moddle-7.2.0.tgz",
           "integrity": "sha512-x1+JREThy7JBOBR3g2hbOnOfrlC/YAWXX9RzrSZS5HhqeuBly9H/PCtOBtcQs+Y2sjRAXF+WTNSgHvn8Uq+6Yw==",
+          "peer": true,
           "requires": {
             "min-dash": "^4.2.1"
           }
@@ -48204,7 +48266,6 @@
       "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
       "integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@electron/asar": "^3.2.1",
         "@electron/windows-sign": "^1.1.2",
@@ -48219,7 +48280,6 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
           "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
           "dev": true,
-          "peer": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
@@ -48231,7 +48291,6 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
           "dev": true,
-          "peer": true,
           "requires": {
             "graceful-fs": "^4.1.6"
           }
@@ -48240,8 +48299,7 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -48548,6 +48606,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -50080,8 +50139,7 @@
     "immutable": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
-      "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
-      "peer": true
+      "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -50137,6 +50195,7 @@
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/inferno/-/inferno-5.6.3.tgz",
       "integrity": "sha512-2m7bEo/6D+pbxFkFKY/2QOVdknxxXyrXyDdVFobJcQyvfv3985MY+VVwyRZoVJylQG+mzPY5/uDNuXygp8jObA==",
+      "peer": true,
       "requires": {
         "inferno-shared": "5.6.3",
         "inferno-vnode-flags": "5.6.3",
@@ -53848,7 +53907,8 @@
       }
     },
     "modeler-moddle": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "peer": true
     },
     "modify-values": {
       "version": "1.0.1",
@@ -53868,7 +53928,8 @@
     "monaco-editor": {
       "version": "0.51.0",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.51.0.tgz",
-      "integrity": "sha512-xaGwVV1fq343cM7aOYB6lVE4Ugf0UyimdD/x5PWcWBMKENwectaEu77FAN7c5sFiyumqeJdX1RPTh1ocioyDjw=="
+      "integrity": "sha512-xaGwVV1fq343cM7aOYB6lVE4Ugf0UyimdD/x5PWcWBMKENwectaEu77FAN7c5sFiyumqeJdX1RPTh1ocioyDjw==",
+      "peer": true
     },
     "monaco-editor-webpack-plugin": {
       "version": "7.1.0",
@@ -54698,6 +54759,7 @@
       "resolved": "https://registry.npmjs.org/nx/-/nx-22.0.4.tgz",
       "integrity": "sha512-yaKvr1MogUv3uh4s8VhSQh1l8mhtupclxVTTAua6bSaUYeuUT0qYn52w+Zf5ALg0YCtfzrNUeBgZK2l83HlkgA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@nx/nx-darwin-arm64": "22.0.4",
@@ -56165,6 +56227,7 @@
       "version": "8.4.47",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
       "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -56252,7 +56315,6 @@
       "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "commander": "^9.4.0"
       },
@@ -56262,13 +56324,13 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
           "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
           "dev": true,
-          "optional": true,
-          "peer": true
+          "optional": true
         }
       }
     },
     "preact": {
-      "version": "10.11.3"
+      "version": "10.11.3",
+      "peer": true
     },
     "preact-markup": {
       "version": "2.1.1",
@@ -56643,6 +56705,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -56653,6 +56716,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
       "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -58621,7 +58685,6 @@
       "version": "1.89.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
       "integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
-      "peer": true,
       "requires": {
         "@parcel/watcher": "^2.4.1",
         "chokidar": "^4.0.0",
@@ -58633,7 +58696,6 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
           "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-          "peer": true,
           "requires": {
             "readdirp": "^4.0.1"
           }
@@ -58641,8 +58703,7 @@
         "readdirp": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-          "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-          "peer": true
+          "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="
         }
       }
     },
@@ -58681,6 +58742,7 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
           "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
           "dev": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
             "fast-uri": "^3.0.1",
@@ -58901,6 +58963,7 @@
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
       "integrity": "sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@sinonjs/commons": "^3.0.0",
         "@sinonjs/fake-timers": "^11.2.2",
@@ -58948,6 +59011,7 @@
     "sinon-chai": {
       "version": "3.7.0",
       "dev": true,
+      "peer": true,
       "requires": {}
     },
     "slash": {
@@ -59601,7 +59665,6 @@
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -59612,7 +59675,6 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
-          "peer": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -59811,7 +59873,8 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
           "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -60774,6 +60837,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.1.tgz",
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -60813,6 +60877,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -61317,7 +61382,8 @@
     "zeebe-bpmn-moddle": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.11.0.tgz",
-      "integrity": "sha512-v2PkIAjyZEnzuFHrm9ZhpbEGMgNjYZkUw+H17JxkA7Da+dcbPHbD7fWuBWSbPzNSCOyYYmrH+PL6wp9407ptMg=="
+      "integrity": "sha512-v2PkIAjyZEnzuFHrm9ZhpbEGMgNjYZkUw+H17JxkA7Da+dcbPHbD7fWuBWSbPzNSCOyYYmrH+PL6wp9407ptMg==",
+      "peer": true
     },
     "zeebe-dmn-moddle": {
       "version": "1.0.0",


### PR DESCRIPTION
### Proposed Changes

- https://github.com/camunda/camunda-modeler/pull/5475 against main

- https://github.com/camunda/camunda-modeler/pull/5448 against develop

led to a diverged package lock. this pr fixes that (npm i on develop)

To be verified: is renovate bot using node 24 to update deps?

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
