### PR TITLE
fix: separate control labels from option labels

### DIFF
--- a/client/src/plugins/privacy-preferences/PrivacyPreferencesView.js
+++ b/client/src/plugins/privacy-preferences/PrivacyPreferencesView.js
@@ -75,7 +75,7 @@ class PrivacyPreferencesView extends PureComponent {
                 onChange={ (event) => {
                   this.setState({ [item.key]: event.target.checked });
                 } } />
-              <label className="custom-control-label" htmlFor={ item.key }> </label>
+              <label className="custom-control-option" htmlFor={ item.key }> </label>
             </div>
           </div>
         </div>

--- a/client/src/plugins/privacy-preferences/PrivacyPreferencesView.less
+++ b/client/src/plugins/privacy-preferences/PrivacyPreferencesView.less
@@ -30,8 +30,4 @@
     color: var(--color-grey-225-10-35);;
   }
 
-  .privacyPreferencesCheckbox {
-    margin-top: -5px;
-  }
-
 }

--- a/client/src/shared/ui/form/CheckBox.js
+++ b/client/src/shared/ui/form/CheckBox.js
@@ -55,7 +55,7 @@ export default function CheckBox(props) {
             { ...restProps }
           />
           <label
-            className={ classNames('custom-control-label', {
+            className={ classNames('custom-control-option', {
               'is-invalid': !!error
             }) }
             htmlFor={ fieldName }

--- a/client/src/shared/ui/form/Radio.js
+++ b/client/src/shared/ui/form/Radio.js
@@ -77,7 +77,7 @@ export default function Radio(props) {
                       { ...restProps } />
                     <label
                       htmlFor={ id }
-                      className={ classNames('custom-control-label', {
+                      className={ classNames('custom-control-option', {
                         'is-invalid': !!error
                       }) }
                     >

--- a/client/src/styles/_forms.less
+++ b/client/src/styles/_forms.less
@@ -102,9 +102,9 @@
   textarea.form-control.is-invalid,
   input[type=text].form-control.is-invalid,
   select.form-control.is-invalid,
-  .custom-radio .custom-control-input.is-invalid:checked + .custom-control-label:before,
-  .custom-checkbox .custom-control-input.is-invalid:checked+ .custom-control-label:before, 
-  .custom-checkbox .custom-control-input.is-invalid:not(:checked) + .custom-control-label:before {
+  .custom-radio .custom-control-input.is-invalid:checked + .custom-control-option:before,
+  .custom-checkbox .custom-control-input.is-invalid:checked+ .custom-control-option:before, 
+  .custom-checkbox .custom-control-input.is-invalid:not(:checked) + .custom-control-option:before {
     border: solid 1px var(--color-red-360-100-45);
   }
 
@@ -112,9 +112,9 @@
   textarea.form-control.is-invalid:focus,
   input[type=text].form-control.is-invalid:focus,
   select.form-control.is-invalid:focus,
-  .custom-radio .custom-control-input.is-invalid:checked:focus + .custom-control-label:before,
-  .custom-checkbox .custom-control-input.is-invalid:checked:focus + .custom-control-label:before, 
-  .custom-checkbox .custom-control-input.is-invalid:not(:checked):focus + .custom-control-label:before {
+  .custom-radio .custom-control-input.is-invalid:checked:focus + .custom-control-option:before,
+  .custom-checkbox .custom-control-input.is-invalid:checked:focus + .custom-control-option:before, 
+  .custom-checkbox .custom-control-input.is-invalid:not(:checked):focus + .custom-control-option:before {
     outline: none;
     box-shadow: 0 0 0 1px var(--color-red-360-100-92), 0 0 0 1px var(--color-grey-225-10-75) inset;
     border: solid 1px var(--color-red-360-100-45) !important;
@@ -130,6 +130,9 @@
     line-height: normal;
     letter-spacing: normal;
     color: var(--color-grey-225-10-15);
+    &.custom-control-option{
+      margin-bottom: 0px;
+    }
   }
 
   .form-check-inline {
@@ -158,27 +161,26 @@
     }
 
     // the text
-    .custom-control-input:checked + .custom-control-label,
-    .custom-control-input:not(:checked) + .custom-control-label {
+    .custom-control-input:checked + .custom-control-option,
+    .custom-control-input:not(:checked) + .custom-control-option {
         position: relative;
         padding-left: 26px;
         line-height: 20px;
-        margin-bottom: 0; // overwriting `.form-group label`
     }
 
     // radio control
-    .custom-control-input:not(:checked) + .custom-control-label:after {
+    .custom-control-input:not(:checked) + .custom-control-option:after {
         opacity: 0;
     }
-    .custom-control-input:checked + .custom-control-label:after {
+    .custom-control-input:checked + .custom-control-option:after {
         opacity: 1;
     }
 
-    .custom-control-label:focus {
+    .custom-control-option:focus {
       outline: none;
     }
 
-    .custom-control-input:focus + .custom-control-label:before {
+    .custom-control-input:focus + .custom-control-option:before {
       box-shadow: 0 0 0 1px var(--color-blue-205-100-50), 0 0 0 1px var(--color-grey-225-10-75) inset;
       border: solid 1px var(--color-blue-205-100-50) !important;
     }
@@ -187,8 +189,8 @@
   .custom-checkbox {
 
     // border of the radio
-    .custom-control-input:checked + .custom-control-label:before,
-    .custom-control-input:not(:checked) + .custom-control-label:before {
+    .custom-control-input:checked + .custom-control-option:before,
+    .custom-control-input:not(:checked) + .custom-control-option:before {
       content: '';
       position: absolute;
       left: 0;
@@ -202,8 +204,8 @@
     }
 
     // inside the checkbox
-    .custom-control-input:checked + .custom-control-label:after,
-    .custom-control-input:not(:checked) + .custom-control-label:after {
+    .custom-control-input:checked + .custom-control-option:after,
+    .custom-control-input:not(:checked) + .custom-control-option:after {
       position: absolute;
       left: 1px;
       width: 16px;
@@ -213,7 +215,7 @@
       box-sizing: content-box;
     }
 
-    .custom-control-input:disabled + label {
+    .custom-control-input:disabled + .custom-control-label {
       color: var(--color-grey-225-10-35);
     }
   }
@@ -221,8 +223,8 @@
   .custom-radio {
 
     // border of the radio
-    .custom-control-input:checked + .custom-control-label:before,
-    .custom-control-input:not(:checked) + .custom-control-label:before {
+    .custom-control-input:checked + .custom-control-option:before,
+    .custom-control-input:not(:checked) + .custom-control-option:before {
       content: '';
       position: absolute;
       left: 0;
@@ -236,8 +238,8 @@
     }
 
     // inside the radio
-    .custom-control-input:checked + .custom-control-label:after,
-    .custom-control-input:not(:checked) + .custom-control-label:after {
+    .custom-control-input:checked + .custom-control-option:after,
+    .custom-control-input:not(:checked) + .custom-control-option:after {
       content: '';
       width: 8px;
       height: 8px;
@@ -250,18 +252,18 @@
     }
 
     // radio control
-    .custom-control-input:not(:checked) + .custom-control-label:after {
+    .custom-control-input:not(:checked) + .custom-control-option:after {
       opacity: 0;
     }
-    .custom-control-input:checked + .custom-control-label:after {
+    .custom-control-input:checked + .custom-control-option:after {
       opacity: 1;
     }
 
-    .custom-control-label:focus {
+    .custom-control-option:focus {
       outline: none;
     }
 
-    .custom-control-input:focus + .custom-control-label:before {
+    .custom-control-input:focus + .custom-control-option:before {
       box-shadow: 0 0 0 1px var(--color-blue-205-100-50), 0 0 0 1px var(--color-grey-225-10-75) inset;
       border: solid 1px var(--color-blue-205-100-50) !important;
     }


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/5486

### Proposed Changes

**Problem**: Label (custom control label) is normally used on top of the input field, but for checkbox & control we are using the same class to describe the options (probably because they also use the label element)

**Proposal**: split describing labels and option labels. allowing more individual control over spacing (cf privacy preferences)

before (custom control label twice as options in radio and in checkbox): 
<img width="917" height="281" alt="image" src="https://github.com/user-attachments/assets/74771ff0-a419-4a03-8942-5991c05c7737" />

<img width="720" height="192" alt="image" src="https://github.com/user-attachments/assets/eb9d892e-1a2d-4ea7-802a-1110add4f370" />


after (custom control label only on top of controls, inside controls only custom control option
<img width="910" height="267" alt="image" src="https://github.com/user-attachments/assets/e13faba1-db69-49eb-817c-c3f393e17ef1" />

<img width="525" height="105" alt="image" src="https://github.com/user-attachments/assets/541fdd79-5d7d-4eed-ab6d-c62806c647c6" />

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
