### PR TITLE
chore: use `eval-source-map` in dev mode

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -132,7 +132,7 @@ module.exports = {
   devServer: {
     writeToDisk: true
   },
-  devtool: DEV ? 'cheap-module-source-map' : 'source-map'
+  devtool: DEV ? 'eval-source-map' : 'source-map'
 };
 
 


### PR DESCRIPTION
### Proposed Changes

This PR changes the dev mode sourcemaps. Currently, at least on my machine, I cannot access the variables in the scope. This hinders debugging a lot. The change fixes the problem. I did not notice significant performance drop.

Before:

<img width="612" height="958" alt="image" src="https://github.com/user-attachments/assets/e24e425a-53e3-4af7-825b-9220fe67c279" />

After:

<img width="616" height="961" alt="image" src="https://github.com/user-attachments/assets/36164aee-4e01-4e9a-bf8f-91d55e057ee4" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
