### PR TITLE
fix: store connection in memory for unsaved files

### DIFF
--- a/client/src/app/TabStorage.js
+++ b/client/src/app/TabStorage.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/**
+ * TabStorage - Generic in-memory storage for tab-based data
+ *
+ * Provides a simple key-value store per tab, using tab IDs as keys.
+ * Data is stored in memory only and cleared when tabs are closed.
+ *
+ * This class is generic and can be used for any tab-specific state,
+ * not just connection management.
+ */
+export default class TabStorage {
+  constructor() {
+    this._storage = new Map(); // tabId -> { key: value, ... }
+  }
+
+  /**
+   * Get a value from tab storage
+   *
+   * @param {Object} tab - The tab object with an id property
+   * @param {string} key - The storage key
+   * @param {*} defaultValue - Default value if not found
+   *
+   * @returns {*} The stored value or defaultValue
+   */
+  get(tab, key, defaultValue = null) {
+    const tabData = this._storage.get(tab.id);
+    if (!tabData) {
+      return defaultValue;
+    }
+    const value = tabData[key];
+    return value !== undefined ? value : defaultValue;
+  }
+
+  /**
+   * Set a value in tab storage
+   *
+   * @param {Object} tab - The tab object with an id property
+   * @param {string} key - The storage key
+   * @param {*} value - The value to store
+   */
+  set(tab, key, value) {
+    const tabId = tab.id;
+    if (!this._storage.has(tabId)) {
+      this._storage.set(tabId, {});
+    }
+    const tabData = this._storage.get(tabId);
+    tabData[key] = value;
+  }
+
+  /**
+   * Get all data for a tab
+   *
+   * @param {Object} tab - The tab object with an id property
+   *
+   * @returns {Object} All stored key-value pairs for the tab
+   */
+  getAll(tab) {
+    return this._storage.get(tab.id) || {};
+  }
+
+  /**
+   * Remove all data for a tab
+   *
+   * @param {string} tabId - The tab ID
+   */
+  removeTab(tabId) {
+    this._storage.delete(tabId);
+  }
+
+  /**
+   * Clear all data from storage
+   */
+  clear() {
+    this._storage.clear();
+  }
+}

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -32,6 +32,7 @@ import {
   StartInstance,
   SystemClipboard,
   TabsProvider,
+  TabStorage,
   Workspace,
   ZeebeAPI
 } from './mocks';
@@ -3733,6 +3734,7 @@ function createApp(options = {}) {
     settings: new Settings(),
     startInstance: new StartInstance(),
     systemClipboard: new SystemClipboard(),
+    tabStorage: new TabStorage(),
     workspace: new Workspace(),
     zeebeAPI: new ZeebeAPI()
   };

--- a/client/src/app/__tests__/TabStorageSpec.js
+++ b/client/src/app/__tests__/TabStorageSpec.js
@@ -1,0 +1,548 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import TabStorage from '../TabStorage';
+
+describe('TabStorage', function() {
+
+  let tabStorage;
+
+  beforeEach(function() {
+    tabStorage = new TabStorage();
+  });
+
+
+  describe('constructor', function() {
+
+    it('should create an empty storage', function() {
+
+      // given
+      const storage = new TabStorage();
+
+      // when
+      const result = storage.getAll({ id: 'tab1' });
+
+      // then
+      expect(result).to.eql({});
+    });
+
+  });
+
+
+  describe('#set', function() {
+
+    it('should store a value for a tab', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+
+      // when
+      tabStorage.set(tab, 'key1', 'value1');
+
+      // then
+      expect(tabStorage.get(tab, 'key1')).to.equal('value1');
+    });
+
+
+    it('should store multiple values for the same tab', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+
+      // when
+      tabStorage.set(tab, 'key1', 'value1');
+      tabStorage.set(tab, 'key2', 'value2');
+
+      // then
+      expect(tabStorage.get(tab, 'key1')).to.equal('value1');
+      expect(tabStorage.get(tab, 'key2')).to.equal('value2');
+    });
+
+
+    it('should store values for different tabs independently', function() {
+
+      // given
+      const tab1 = { id: 'tab1' };
+      const tab2 = { id: 'tab2' };
+
+      // when
+      tabStorage.set(tab1, 'key1', 'value1');
+      tabStorage.set(tab2, 'key1', 'value2');
+
+      // then
+      expect(tabStorage.get(tab1, 'key1')).to.equal('value1');
+      expect(tabStorage.get(tab2, 'key1')).to.equal('value2');
+    });
+
+
+    it('should overwrite existing value', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+      tabStorage.set(tab, 'key1', 'value1');
+
+      // when
+      tabStorage.set(tab, 'key1', 'value2');
+
+      // then
+      expect(tabStorage.get(tab, 'key1')).to.equal('value2');
+    });
+
+
+    it('should store object values', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+      const obj = { foo: 'bar', nested: { a: 1 } };
+
+      // when
+      tabStorage.set(tab, 'key1', obj);
+
+      // then
+      expect(tabStorage.get(tab, 'key1')).to.equal(obj);
+    });
+
+
+    it('should store null values', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+
+      // when
+      tabStorage.set(tab, 'key1', null);
+
+      // then
+      expect(tabStorage.get(tab, 'key1')).to.be.null;
+    });
+
+
+    it('should store undefined values (returns default)', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+
+      // when
+      tabStorage.set(tab, 'key1', undefined);
+
+      // then
+      // Note: storing undefined is treated as non-existent, so returns default
+      expect(tabStorage.get(tab, 'key1')).to.be.null;
+      expect(tabStorage.get(tab, 'key1', 'default')).to.equal('default');
+    });
+
+
+    it('should store boolean values', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+
+      // when
+      tabStorage.set(tab, 'key1', false);
+      tabStorage.set(tab, 'key2', true);
+
+      // then
+      expect(tabStorage.get(tab, 'key1')).to.be.false;
+      expect(tabStorage.get(tab, 'key2')).to.be.true;
+    });
+
+
+    it('should store numeric values', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+
+      // when
+      tabStorage.set(tab, 'key1', 0);
+      tabStorage.set(tab, 'key2', 42);
+
+      // then
+      expect(tabStorage.get(tab, 'key1')).to.equal(0);
+      expect(tabStorage.get(tab, 'key2')).to.equal(42);
+    });
+
+  });
+
+
+  describe('#get', function() {
+
+    it('should return stored value', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+      tabStorage.set(tab, 'key1', 'value1');
+
+      // when
+      const result = tabStorage.get(tab, 'key1');
+
+      // then
+      expect(result).to.equal('value1');
+    });
+
+
+    it('should return null for non-existent key', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+
+      // when
+      const result = tabStorage.get(tab, 'key1');
+
+      // then
+      expect(result).to.be.null;
+    });
+
+
+    it('should return default value for non-existent key', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+
+      // when
+      const result = tabStorage.get(tab, 'key1', 'default');
+
+      // then
+      expect(result).to.equal('default');
+    });
+
+
+    it('should return null for non-existent tab', function() {
+
+      // given
+      const tab = { id: 'nonexistent' };
+
+      // when
+      const result = tabStorage.get(tab, 'key1');
+
+      // then
+      expect(result).to.be.null;
+    });
+
+
+    it('should return default value for non-existent tab', function() {
+
+      // given
+      const tab = { id: 'nonexistent' };
+
+      // when
+      const result = tabStorage.get(tab, 'key1', 'default');
+
+      // then
+      expect(result).to.equal('default');
+    });
+
+
+    it('should treat undefined as non-existent', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+      tabStorage.set(tab, 'key1', undefined);
+
+      // when
+      const result = tabStorage.get(tab, 'key1', 'default');
+
+      // then
+      // By design: storing undefined is same as not having the key
+      expect(result).to.equal('default');
+    });
+
+
+    it('should return falsy values correctly', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+      tabStorage.set(tab, 'key1', 0);
+      tabStorage.set(tab, 'key2', false);
+      tabStorage.set(tab, 'key3', '');
+
+      // when & then
+      expect(tabStorage.get(tab, 'key1')).to.equal(0);
+      expect(tabStorage.get(tab, 'key2')).to.be.false;
+      expect(tabStorage.get(tab, 'key3')).to.equal('');
+    });
+
+  });
+
+
+  describe('#getAll', function() {
+
+    it('should return all data for a tab', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+      tabStorage.set(tab, 'key1', 'value1');
+      tabStorage.set(tab, 'key2', 'value2');
+
+      // when
+      const result = tabStorage.getAll(tab);
+
+      // then
+      expect(result).to.eql({
+        key1: 'value1',
+        key2: 'value2'
+      });
+    });
+
+
+    it('should return empty object for non-existent tab', function() {
+
+      // given
+      const tab = { id: 'nonexistent' };
+
+      // when
+      const result = tabStorage.getAll(tab);
+
+      // then
+      expect(result).to.eql({});
+    });
+
+
+    it('should return empty object for tab with no data', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+
+      // when
+      const result = tabStorage.getAll(tab);
+
+      // then
+      expect(result).to.eql({});
+    });
+
+
+    it('should not affect other tabs', function() {
+
+      // given
+      const tab1 = { id: 'tab1' };
+      const tab2 = { id: 'tab2' };
+      tabStorage.set(tab1, 'key1', 'value1');
+      tabStorage.set(tab2, 'key2', 'value2');
+
+      // when
+      const result1 = tabStorage.getAll(tab1);
+      const result2 = tabStorage.getAll(tab2);
+
+      // then
+      expect(result1).to.eql({ key1: 'value1' });
+      expect(result2).to.eql({ key2: 'value2' });
+    });
+
+  });
+
+
+  describe('#removeTab', function() {
+
+    it('should remove all data for a tab', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+      tabStorage.set(tab, 'key1', 'value1');
+      tabStorage.set(tab, 'key2', 'value2');
+
+      // when
+      tabStorage.removeTab(tab.id);
+
+      // then
+      expect(tabStorage.get(tab, 'key1')).to.be.null;
+      expect(tabStorage.get(tab, 'key2')).to.be.null;
+      expect(tabStorage.getAll(tab)).to.eql({});
+    });
+
+
+    it('should not affect other tabs', function() {
+
+      // given
+      const tab1 = { id: 'tab1' };
+      const tab2 = { id: 'tab2' };
+      tabStorage.set(tab1, 'key1', 'value1');
+      tabStorage.set(tab2, 'key2', 'value2');
+
+      // when
+      tabStorage.removeTab(tab1.id);
+
+      // then
+      expect(tabStorage.get(tab1, 'key1')).to.be.null;
+      expect(tabStorage.get(tab2, 'key2')).to.equal('value2');
+    });
+
+
+    it('should handle removing non-existent tab', function() {
+
+      // when
+      tabStorage.removeTab('nonexistent');
+
+      // then
+      // should not throw error
+    });
+
+
+    it('should allow re-adding data after removal', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+      tabStorage.set(tab, 'key1', 'value1');
+      tabStorage.removeTab(tab.id);
+
+      // when
+      tabStorage.set(tab, 'key1', 'value2');
+
+      // then
+      expect(tabStorage.get(tab, 'key1')).to.equal('value2');
+    });
+
+  });
+
+
+  describe('#clear', function() {
+
+    it('should remove all data from all tabs', function() {
+
+      // given
+      const tab1 = { id: 'tab1' };
+      const tab2 = { id: 'tab2' };
+      tabStorage.set(tab1, 'key1', 'value1');
+      tabStorage.set(tab2, 'key2', 'value2');
+
+      // when
+      tabStorage.clear();
+
+      // then
+      expect(tabStorage.get(tab1, 'key1')).to.be.null;
+      expect(tabStorage.get(tab2, 'key2')).to.be.null;
+      expect(tabStorage.getAll(tab1)).to.eql({});
+      expect(tabStorage.getAll(tab2)).to.eql({});
+    });
+
+
+    it('should handle clearing empty storage', function() {
+
+      // when
+      tabStorage.clear();
+
+      // then
+      // should not throw error
+    });
+
+
+    it('should allow adding data after clear', function() {
+
+      // given
+      const tab = { id: 'tab1' };
+      tabStorage.set(tab, 'key1', 'value1');
+      tabStorage.clear();
+
+      // when
+      tabStorage.set(tab, 'key1', 'value2');
+
+      // then
+      expect(tabStorage.get(tab, 'key1')).to.equal('value2');
+    });
+
+  });
+
+
+  describe('integration scenarios', function() {
+
+    it('should handle complex workflow', function() {
+
+      // given
+      const tab1 = { id: 'tab1' };
+      const tab2 = { id: 'tab2' };
+      const tab3 = { id: 'tab3' };
+
+      // when - add data to multiple tabs
+      tabStorage.set(tab1, 'connection', { url: 'http://localhost:8080' });
+      tabStorage.set(tab1, 'auth', { token: 'abc123' });
+      tabStorage.set(tab2, 'connection', { url: 'http://localhost:9090' });
+      tabStorage.set(tab3, 'connection', { url: 'http://localhost:7070' });
+
+      // then - verify all data is stored correctly
+      expect(tabStorage.get(tab1, 'connection')).to.eql({ url: 'http://localhost:8080' });
+      expect(tabStorage.get(tab1, 'auth')).to.eql({ token: 'abc123' });
+      expect(tabStorage.get(tab2, 'connection')).to.eql({ url: 'http://localhost:9090' });
+
+      // when - remove one tab
+      tabStorage.removeTab(tab2.id);
+
+      // then - other tabs still have data
+      expect(tabStorage.get(tab1, 'connection')).to.eql({ url: 'http://localhost:8080' });
+      expect(tabStorage.get(tab3, 'connection')).to.eql({ url: 'http://localhost:7070' });
+      expect(tabStorage.get(tab2, 'connection')).to.be.null;
+
+      // when - update existing data
+      tabStorage.set(tab1, 'connection', { url: 'http://localhost:8888' });
+
+      // then - data is updated
+      expect(tabStorage.get(tab1, 'connection')).to.eql({ url: 'http://localhost:8888' });
+
+      // when - clear all
+      tabStorage.clear();
+
+      // then - all data is gone
+      expect(tabStorage.get(tab1, 'connection')).to.be.null;
+      expect(tabStorage.get(tab3, 'connection')).to.be.null;
+    });
+
+
+    it('should handle same key across multiple tabs', function() {
+
+      // given
+      const tabs = [
+        { id: 'tab1' },
+        { id: 'tab2' },
+        { id: 'tab3' }
+      ];
+
+      // when - set same key with different values
+      tabs.forEach((tab, index) => {
+        tabStorage.set(tab, 'index', index);
+      });
+
+      // then - each tab has its own value
+      tabs.forEach((tab, index) => {
+        expect(tabStorage.get(tab, 'index')).to.equal(index);
+      });
+    });
+
+
+    it('should handle rapid tab creation and deletion', function() {
+
+      // given
+      const tabs = Array.from({ length: 10 }, (_, i) => ({ id: `tab${i}` }));
+
+      // when - add data to all tabs
+      tabs.forEach((tab, i) => {
+        tabStorage.set(tab, 'data', `value${i}`);
+      });
+
+      // then - all data is stored
+      tabs.forEach((tab, i) => {
+        expect(tabStorage.get(tab, 'data')).to.equal(`value${i}`);
+      });
+
+      // when - remove every other tab
+      tabs.forEach((tab, i) => {
+        if (i % 2 === 0) {
+          tabStorage.removeTab(tab.id);
+        }
+      });
+
+      // then - only odd tabs have data
+      tabs.forEach((tab, i) => {
+        if (i % 2 === 0) {
+          expect(tabStorage.get(tab, 'data')).to.be.null;
+        } else {
+          expect(tabStorage.get(tab, 'data')).to.equal(`value${i}`);
+        }
+      });
+    });
+
+  });
+
+});

--- a/client/src/app/__tests__/mocks/index.js
+++ b/client/src/app/__tests__/mocks/index.js
@@ -597,7 +597,7 @@ export class SystemClipboard extends Mock {
 }
 
 export class Deployment extends Mock {
-  getConfigForFile() {}
+  getConnectionForTab() {}
 
   deploy() {
     return { success: true };
@@ -607,12 +607,51 @@ export class Deployment extends Mock {
 
   off() {}
 
+  onTabSaved() {}
+
   registerResourcesProvider() {}
 
   unregisterResourcesProvider() {}
 }
 
 export class StartInstance extends Mock {}
+
+export class TabStorage extends Mock {
+  constructor(overrides) {
+    super(overrides);
+    this._storage = new Map();
+  }
+
+  get(tab, key, defaultValue = null) {
+    const tabData = this._storage.get(tab.id);
+    if (!tabData) {
+      return defaultValue;
+    }
+    const value = tabData[key];
+    return value !== undefined ? value : defaultValue;
+  }
+
+  set(tab, key, value) {
+    const tabId = tab.id;
+    if (!this._storage.has(tabId)) {
+      this._storage.set(tabId, {});
+    }
+    const tabData = this._storage.get(tabId);
+    tabData[key] = value;
+  }
+
+  getAll(tab) {
+    return this._storage.get(tab.id) || {};
+  }
+
+  removeTab(tabId) {
+    this._storage.delete(tabId);
+  }
+
+  clear() {
+    this._storage.clear();
+  }
+}
 
 function without(arr, toRemove) {
   return arr.filter(item => item !== toRemove);

--- a/client/src/app/panel/tabs/task-testing/TaskTestingTab.js
+++ b/client/src/app/panel/tabs/task-testing/TaskTestingTab.js
@@ -56,6 +56,7 @@ export default function TaskTestingTab(props) {
     deployment,
     injector,
     file,
+    id,
     layout = {},
     onAction,
     startInstance,
@@ -68,14 +69,19 @@ export default function TaskTestingTab(props) {
 
   const [ operateUrl, setOperateUrl ] = useState(null);
 
+  const tab = useMemo(() => ({
+    id: id?.includes('-') ? id.split('-')[0] : id,
+    file
+  }), [ id, file ]);
+
   const taskTestingApi = useMemo(() => {
 
-    const api = new TaskTestingApi(deployment, startInstance, zeebeApi, file, onAction);
+    const api = new TaskTestingApi(deployment, startInstance, zeebeApi, tab, onAction);
 
     api.getOperateUrl().then(setOperateUrl);
 
     return api.getApi();
-  }, [ zeebeApi, config, file, onAction ]);
+  }, [ zeebeApi, config, tab, onAction ]);
 
   const connectionStatus = useConnectionStatus(subscribe);
 

--- a/client/src/app/panel/tabs/task-testing/__tests__/TaskTestingApiSpec.js
+++ b/client/src/app/panel/tabs/task-testing/__tests__/TaskTestingApiSpec.js
@@ -24,13 +24,10 @@ describe('<TaskTestingApi>', function() {
       // given
       const api = new TaskTestingApi(
         new Deployment({
-          getConfigForFile: async () => {
+          getConnectionForTab: async () => {
             return {
-              deployment: {},
-              endpoint: {
-                targetType: 'camundaCloud',
-                camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
-              }
+              targetType: 'camundaCloud',
+              camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
             };
           }
         }),
@@ -56,13 +53,10 @@ describe('<TaskTestingApi>', function() {
       // given
       const api = new TaskTestingApi(
         new Deployment({
-          getConfigForFile: async () => {
+          getConnectionForTab: async () => {
             return {
-              deployment: {},
-              endpoint: {
-                targetType: 'selfHosted',
-                operateUrl: 'https://operate.example.com'
-              }
+              targetType: 'selfHosted',
+              operateUrl: 'https://operate.example.com'
             };
           }
         }),
@@ -83,18 +77,15 @@ describe('<TaskTestingApi>', function() {
     });
 
 
-    it('should return no URL for unsaved file', async function() {
+    it('should return URL for unsaved file', async function() {
 
       // given
       const api = new TaskTestingApi(
         new Deployment({
-          getConfigForFile: async () => {
+          getConnectionForTab: async () => {
             return {
-              deployment: {},
-              endpoint: {
-                targetType: 'selfHosted',
-                operateUrl: 'https://operate.example.com'
-              }
+              targetType: 'selfHosted',
+              operateUrl: 'https://operate.example.com'
             };
           }
         }),
@@ -111,7 +102,7 @@ describe('<TaskTestingApi>', function() {
       const operateUrl = await api.getOperateUrl();
 
       // then
-      expect(operateUrl).not.to.exist;
+      expect(operateUrl).to.equal('https://operate.example.com');
     });
   });
 
@@ -130,17 +121,10 @@ describe('<TaskTestingApi>', function() {
       const api = new TaskTestingApi(
         new Deployment({
           deploy: deploySpy,
-          getConfigForFile: async file => {
-            if (!file.path) {
-              throw new Error('File not saved');
-            }
-
+          getConnectionForTab: async file => {
             return {
-              deployment: {},
-              endpoint: {
-                targetType: 'camundaCloud',
-                camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
-              }
+              targetType: 'camundaCloud',
+              camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
             };
           },
           once: () => {}

--- a/client/src/app/panel/tabs/task-testing/__tests__/TaskTestingTabSpec.js
+++ b/client/src/app/panel/tabs/task-testing/__tests__/TaskTestingTabSpec.js
@@ -77,12 +77,10 @@ describe('<TaskTestingTab>', function() {
         }
       }),
       deployment: new Deployment({
-        getConfigForFile: async () => {
+        getConnectionForTab: async () => {
           return {
-            endpoint: {
-              targetType: 'camundaCloud',
-              camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
-            }
+            targetType: 'camundaCloud',
+            camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
           };
         }
       }),
@@ -137,12 +135,10 @@ describe('<TaskTestingTab>', function() {
           }
         }),
         deployment: new Deployment({
-          getConfigForFile: async () => {
+          getConnectionForTab: async () => {
             return {
-              endpoint: {
-                targetType: 'camundaCloud',
-                camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
-              }
+              targetType: 'camundaCloud',
+              camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
             };
           }
         }),
@@ -194,12 +190,10 @@ describe('<TaskTestingTab>', function() {
           }
         }),
         deployment: new Deployment({
-          getConfigForFile: async () => {
+          getConnectionForTab: async () => {
             return {
-              endpoint: {
-                targetType: 'camundaCloud',
-                camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
-              }
+              targetType: 'camundaCloud',
+              camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
             };
           }
         }),
@@ -248,12 +242,10 @@ describe('<TaskTestingTab>', function() {
           }
         }),
         deployment: new Deployment({
-          getConfigForFile: async () => {
+          getConnectionForTab: async () => {
             return {
-              endpoint: {
-                targetType: 'camundaCloud',
-                camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
-              }
+              targetType: 'camundaCloud',
+              camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
             };
           }
         }),
@@ -314,12 +306,10 @@ describe('<TaskTestingTab>', function() {
           }
         }),
         deployment: new Deployment({
-          getConfigForFile: async () => {
+          getConnectionForTab: async () => {
             return {
-              endpoint: {
-                targetType: 'camundaCloud',
-                camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
-              }
+              targetType: 'camundaCloud',
+              camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
             };
           }
         }),
@@ -377,12 +367,10 @@ describe('<TaskTestingTab>', function() {
           }
         }),
         deployment: new Deployment({
-          getConfigForFile: async () => {
+          getConnectionForTab: async () => {
             return {
-              endpoint: {
-                targetType: 'camundaCloud',
-                camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
-              }
+              targetType: 'camundaCloud',
+              camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
             };
           }
         }),

--- a/client/src/app/zeebe/__tests__/DeploymentSpec.js
+++ b/client/src/app/zeebe/__tests__/DeploymentSpec.js
@@ -439,13 +439,52 @@ class MockZeebeAPI extends Mock {
   }
 }
 
+class MockTabStorage extends Mock {
+  constructor() {
+    super();
+    this._storage = new Map();
+  }
+
+  get(tab, key, defaultValue = null) {
+    const tabData = this._storage.get(tab.id);
+    if (!tabData) {
+      return defaultValue;
+    }
+    const value = tabData[key];
+    return value !== undefined ? value : defaultValue;
+  }
+
+  set(tab, key, value) {
+    const tabId = tab.id;
+    if (!this._storage.has(tabId)) {
+      this._storage.set(tabId, {});
+    }
+    const tabData = this._storage.get(tabId);
+    tabData[key] = value;
+  }
+
+  getAll(tab) {
+    return this._storage.get(tab.id) || {};
+  }
+
+  removeTab(tabId) {
+    this._storage.delete(tabId);
+  }
+
+  clear() {
+    this._storage.clear();
+  }
+}
+
+
 function createDeployment(options = {}) {
   const {
+    tabStorage = new MockTabStorage(),
     config = new MockConfig(),
     zeebeAPI = new MockZeebeAPI()
   } = options;
 
-  return new Deployment(config, zeebeAPI);
+  return new Deployment(tabStorage, config, zeebeAPI);
 }
 
 function createMockFile(overrides = {}) {

--- a/client/src/app/zeebe/__tests__/StartInstanceSpec.js
+++ b/client/src/app/zeebe/__tests__/StartInstanceSpec.js
@@ -99,14 +99,14 @@ describe('StartInstance', function() {
     it('should get default config for file', async function() {
 
       // given
-      const deployment = createStartInstance({
+      const startInstance = createStartInstance({
         config: new MockConfig({
-          getForFile: sinon.stub().resolves(JSON.stringify({}))
+          getConfigForFile: sinon.stub().resolves(JSON.stringify({}))
         })
       });
 
       // when
-      const config = await deployment.getConfigForFile(createMockFile());
+      const config = await startInstance.getConfigForFile(createMockFile());
 
       // then
       expect(config).to.eql({

--- a/client/src/globals.js
+++ b/client/src/globals.js
@@ -18,6 +18,7 @@ import Workspace from './remote/Workspace';
 import ZeebeAPI from './remote/ZeebeAPI';
 
 import Settings from './app/Settings';
+import TabStorage from './app/TabStorage';
 import StartInstance from './app/zeebe/StartInstance';
 import Deployment from './app/zeebe/Deployment';
 
@@ -50,7 +51,9 @@ export const workspace = new Workspace(backend);
 
 export const zeebeAPI = new ZeebeAPI(backend);
 
-export const deployment = new Deployment(config, zeebeAPI, settings);
+export const tabStorage = new TabStorage();
+
+export const deployment = new Deployment(tabStorage, config, zeebeAPI, settings);
 
 export const startInstance = new StartInstance(config, zeebeAPI);
 
@@ -73,6 +76,7 @@ export const globals = {
   settings,
   startInstance,
   systemClipboard,
+  tabStorage,
   workspace,
   zeebeAPI
 };

--- a/client/src/plugins/process-applications/ProcessApplicationsDeploymentPlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsDeploymentPlugin.js
@@ -111,7 +111,6 @@ export default function ProcessApplicationsDeploymentPlugin(props) {
         anchor={ anchorRef.current }
         connectionCheckResult={ connectionCheckResult }
         deployment={ deployment }
-        getConfigFile={ () => processApplication.file }
         getSuccessNotification={ (...args) => getSuccessNotification(...args, resourceConfigs) }
         log={ log }
         onClose={ () => setOverlayOpen(false) }

--- a/client/src/plugins/process-applications/ProcessApplicationsStartInstancePlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsStartInstancePlugin.js
@@ -97,7 +97,6 @@ export default function ProcessApplicationsStartInstancePlugin(props) {
         anchor={ anchorRef.current }
         connectionCheckResult={ connectionCheckResult }
         deployment={ deployment }
-        getConfigFile={ () => processApplication.file }
         getResourceConfigs={ () => resourceConfigs }
         getSuccessNotification={ (...args) => getSuccessNotification(...args, resourceConfigs) }
         log={ log }

--- a/client/src/plugins/process-applications/__tests__/ProcessApplicationsDeploymentPluginSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ProcessApplicationsDeploymentPluginSpec.js
@@ -215,11 +215,8 @@ describe('ProcessApplicationsDeploymentPlugin', function() {
     const getGlobal = (name) => {
       if (name === 'deployment') {
         return new Deployment({
-          async getConfigForFile(file) {
-            return {
-              deployment: {},
-              endpoint: DEFAULT_ENDPOINT
-            };
+          async getConnectionForTab(file) {
+            return DEFAULT_ENDPOINT;
           },
           registerResourcesProvider,
           unregisterResourcesProvider
@@ -305,11 +302,8 @@ function createProcessApplicationsDeploymentPlugin(props = {}) {
     _getGlobal = (name) => {
       if (name === 'deployment') {
         return new Deployment({
-          async getConfigForFile(file) {
-            return {
-              deployment: {},
-              endpoint: DEFAULT_ENDPOINT
-            };
+          async getConnectionForTab(file) {
+            return DEFAULT_ENDPOINT;
           },
           registerResourcesProvider() {},
           unregisterResourcesProvider() {}

--- a/client/src/plugins/process-applications/__tests__/ProcessApplicationsStartInstancePluginSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ProcessApplicationsStartInstancePluginSpec.js
@@ -155,16 +155,13 @@ function createProcessApplicationsStartInstancePlugin(props = {}) {
     _getGlobal = (name) => {
       if (name === 'deployment') {
         return new Deployment({
-          async getConfigForFile(file) {
-            return {
-              deployment: {},
-              endpoint: DEFAULT_ENDPOINT
-            };
+          async getConnectionForTab(file) {
+            return DEFAULT_ENDPOINT;
           }
         });
       } else if (name === 'startInstance') {
         return new StartInstance({
-          async getConfigForFile(file) {
+          async getConnectionForTab(file) {
             return {};
           }
         });

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerOverlay.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerOverlay.js
@@ -16,6 +16,7 @@ import { Section, Select } from '../../../shared/ui';
 import { getMessageForReason } from '../../zeebe-plugin/shared/util';
 import { CONNECTION_CHECK_ERROR_REASONS } from '../deployment-plugin/ConnectionCheckErrors';
 import { utmTag } from '../../../util/utmTag';
+import { NO_CONNECTION } from './ConnectionManagerPlugin';
 
 export function ConnectionManagerOverlay({
   connections = [],
@@ -49,7 +50,7 @@ export function ConnectionManagerOverlay({
       label: connection.name ? connection.name : `Unnamed (${getUrl(connection)})`
     })),
     { separator: true },
-    { value: 'NO_CONNECTION', label: 'Disabled (offline mode)' }
+    { value: NO_CONNECTION.id, label: 'Disabled (offline mode)' }
   ];
 
   const getConnectionFieldError = () => {
@@ -64,6 +65,11 @@ export function ConnectionManagerOverlay({
     return undefined;
   };
 
+  function handleConnectionIdChange(connectionId) {
+    const connection = connections.find(c => c.id === connectionId) || NO_CONNECTION;
+    handleConnectionChange(connection);
+  }
+
   return (
     <Section>
       <Section.Header className="form-header">
@@ -76,7 +82,7 @@ export function ConnectionManagerOverlay({
               <Select
                 field={ {
                   name: 'connection',
-                  onChange: (event) => handleConnectionChange(event.target.value)
+                  onChange: (event) => handleConnectionIdChange(event.target.value)
                 } }
                 className="form-control"
                 name="connection"

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionManagerOverlaySpec.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionManagerOverlaySpec.js
@@ -118,7 +118,7 @@ describe('ConnectionManagerOverlay', function() {
 
       // then
       expect(handleConnectionChange).to.have.been.calledOnce;
-      expect(handleConnectionChange).to.have.been.calledWith('connection-2');
+      expect(handleConnectionChange).to.have.been.calledWith(connections[1]);
     });
 
 

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.js
@@ -32,6 +32,28 @@ import { ENGINES } from '../../../util/Engines';
 
 import * as css from './DeploymentPluginOverlay.less';
 
+/**
+ * @typedef {Object} DeploymentPluginOverlayProps
+ * @property {Object} activeTab - The currently active tab
+ * @property {HTMLElement} anchor - The anchor element for positioning the overlay
+ * @property {Object} connectionCheckResult - Result of the connection check
+ * @property {import('../../../app/zeebe/Deployment').default} deployment - The deployment instance
+ * @property {Function} displayNotification - Function to display notifications
+ * @property {React.ComponentType} [DeploymentConfigForm] - Custom deployment configuration form component
+ * @property {Function} [getErrorNotification] - Function to generate error notifications
+ * @property {Function} [getResourceConfigs] - Function to get resource configurations
+ * @property {Function} [getSuccessNotification] - Function to generate success notifications
+ * @property {Function} log - Logging function
+ * @property {Function} onClose - Callback function when overlay is closed
+ * @property {Function|null} [renderDescription] - Function to render description or null
+ * @property {string} [renderHeader] - Header text for the overlay
+ * @property {string} [renderSubmit] - Submit button text
+ * @property {Function} triggerAction - Function to trigger actions
+ */
+
+/**
+ * @param {DeploymentPluginOverlayProps} props
+ */
 export default function DeploymentPluginOverlay(props) {
   const {
     activeTab,
@@ -40,7 +62,6 @@ export default function DeploymentPluginOverlay(props) {
     deployment,
     displayNotification,
     DeploymentConfigForm = DefaultDeploymentConfigForm,
-    getConfigFile = defaultGetConfigFile,
     getErrorNotification = defaultGetErrorNotification,
     getResourceConfigs = defaultGetResourceConfigs,
     getSuccessNotification = defaultGetSuccessNotification,
@@ -68,9 +89,12 @@ export default function DeploymentPluginOverlay(props) {
 
   const onSubmit = async () => {
     setIsSubmitting(true);
-    const file = getConfigFile(activeTab);
-    const config = await deployment.getConfigForFile(file);
+    const connection = await deployment.getConnectionForTab(activeTab);
 
+    const config = {
+      context: 'deploymentTool',
+      endpoint: connection
+    };
     const resourceConfigs = getResourceConfigs(activeTab);
 
     const deploymentResponse = await deployment.deploy(resourceConfigs, config);
@@ -145,12 +169,6 @@ export default function DeploymentPluginOverlay(props) {
       />
     </Overlay>
   );
-}
-
-function defaultGetConfigFile(activeTab) {
-  const { file } = activeTab;
-
-  return file;
 }
 
 function defaultGetResourceConfigs(activeTab) {

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginOverlaySpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginOverlaySpec.js
@@ -38,11 +38,11 @@ describe('DeploymentPluginOverlay', function() {
     it('should submit form (success)', async function() {
 
       // given
-      const config = createMockConfig();
+      const endpoint = createMockEndpoint();
 
       const deployment = new MockDeployment({
         deploy: sinon.spy(() => Promise.resolve(createMockDeploymentResult())),
-        getConfigForFile: () => Promise.resolve(config)
+        getConnectionForTab: () => Promise.resolve(endpoint)
       });
 
       const displayNotificationSpy = sinon.spy();
@@ -60,7 +60,7 @@ describe('DeploymentPluginOverlay', function() {
       });
 
       // when
-      getFormProps().onSubmit(config);
+      getFormProps().onSubmit({});
 
       // expect
       await waitFor(() => {
@@ -72,7 +72,7 @@ describe('DeploymentPluginOverlay', function() {
           path: 'foo.bpmn',
           type: 'bpmn'
         }
-      ], config);
+      ], { endpoint, context: 'deploymentTool' });
 
       expect(displayNotificationSpy).to.have.been.calledOnce;
       expect(displayNotificationSpy).to.have.been.calledWith(sinon.match({
@@ -85,7 +85,7 @@ describe('DeploymentPluginOverlay', function() {
     it('should submit form (no success)', async function() {
 
       // given
-      const config = createMockConfig();
+      const endpoint = createMockEndpoint();
 
       const deployment = new MockDeployment({
         deploy: sinon.spy(() => Promise.resolve(createMockDeploymentResult({
@@ -94,7 +94,7 @@ describe('DeploymentPluginOverlay', function() {
             details: 'foo'
           }
         }))),
-        getConfigForFile: () => Promise.resolve(config)
+        getConnectionForTab: () => Promise.resolve(endpoint)
       });
 
       const displayNotificationSpy = sinon.spy();
@@ -115,7 +115,7 @@ describe('DeploymentPluginOverlay', function() {
       });
 
       // when
-      getFormProps().onSubmit(config);
+      getFormProps().onSubmit({});
 
       // expect
       await waitFor(() => {
@@ -127,7 +127,7 @@ describe('DeploymentPluginOverlay', function() {
           path: 'foo.bpmn',
           type: 'bpmn'
         }
-      ], config);
+      ], { endpoint, context: 'deploymentTool' });
 
       expect(displayNotificationSpy).to.have.been.calledOnce;
       expect(displayNotificationSpy).to.have.been.calledWith(sinon.match({
@@ -151,14 +151,14 @@ describe('DeploymentPluginOverlay', function() {
     it('should emit event (success)', async function() {
 
       // given
-      const config = createMockConfig();
+      const endpoint = createMockEndpoint();
 
       const mockDeploymentResult = createMockDeploymentResult();
 
       const deployment = new MockDeployment({
         deploy: sinon.spy(() => Promise.resolve(mockDeploymentResult)),
         on: sinon.spy(),
-        getConfigForFile: () => Promise.resolve(config)
+        getConnectionForTab: () => Promise.resolve(endpoint)
       });
 
       const triggerActionSpy = sinon.spy();
@@ -178,7 +178,7 @@ describe('DeploymentPluginOverlay', function() {
       // when
       deployment.on.getCall(0).args[1]({
         deploymentResult: mockDeploymentResult,
-        endpoint: config.endpoint,
+        endpoint: endpoint,
         gatewayVersion: '7.0.0'
       });
 
@@ -202,7 +202,7 @@ describe('DeploymentPluginOverlay', function() {
     it('should emit event (error)', async function() {
 
       // given
-      const config = createMockConfig();
+      const endpoint = createMockEndpoint();
 
       const mockDeploymentResult = createMockDeploymentResult({
         success: false,
@@ -212,7 +212,7 @@ describe('DeploymentPluginOverlay', function() {
       const deployment = new MockDeployment({
         deploy: sinon.spy(() => Promise.resolve(mockDeploymentResult)),
         on: sinon.spy(),
-        getConfigForFile: () => Promise.resolve(config)
+        getConnectionForTab: () => Promise.resolve(endpoint)
       });
 
       const triggerActionSpy = sinon.spy();
@@ -232,7 +232,7 @@ describe('DeploymentPluginOverlay', function() {
       // when
       deployment.on.getCall(0).args[1]({
         deploymentResult: mockDeploymentResult,
-        endpoint: config.endpoint,
+        endpoint: endpoint,
         gatewayVersion: '7.0.0'
       });
 
@@ -255,58 +255,6 @@ describe('DeploymentPluginOverlay', function() {
       }));
     });
 
-
-    it('should emit event (custom context)', async function() {
-
-      // given
-      const config = createMockConfig({ context: 'testSuite' });
-
-      const mockDeploymentResult = createMockDeploymentResult();
-
-      const deployment = new MockDeployment({
-        deploy: sinon.spy(() => Promise.resolve(mockDeploymentResult)),
-        on: sinon.spy(),
-        getConfigForFile: () => Promise.resolve(config)
-      });
-
-      const triggerActionSpy = sinon.spy();
-
-      createDeploymentPluginOverlay({
-        deployment,
-        triggerAction: triggerActionSpy
-      });
-
-      await waitFor(() => {
-        expect(document.querySelector('.loading')).not.to.exist;
-      });
-
-      expect(deployment.on).to.have.been.calledOnce;
-      expect(deployment.on).to.have.been.calledWith('deployed', sinon.match.func);
-
-      // when
-      deployment.on.getCall(0).args[1]({
-        deploymentResult: mockDeploymentResult,
-        endpoint: config.endpoint,
-        gatewayVersion: '7.0.0',
-        context: 'testSuite'
-      });
-
-      // then
-      expect(triggerActionSpy).to.have.been.calledOnce;
-      expect(triggerActionSpy).to.have.been.calledWith('emit-event', sinon.match({
-        type: 'deployment.done',
-        payload: {
-          deployment: mockDeploymentResult.response,
-          context: 'testSuite',
-          targetType: 'camundaCloud',
-          deployedTo: {
-            executionPlatformVersion: '7.0.0',
-            executionPlatform: 'Camunda Cloud'
-          }
-        }
-      }));
-    });
-
   });
 
 
@@ -315,10 +263,10 @@ describe('DeploymentPluginOverlay', function() {
     it('should render custom header', async function() {
 
       // when
-      const config = createMockConfig();
+      const endpoint = createMockEndpoint();
 
       const deployment = new MockDeployment({
-        getConfigForFile: () => Promise.resolve(config)
+        getConnectionForTab: () => Promise.resolve(endpoint)
       });
 
       createDeploymentPluginOverlay({
@@ -338,10 +286,10 @@ describe('DeploymentPluginOverlay', function() {
     it('should render custom submit', async function() {
 
       // when
-      const config = createMockConfig();
+      const endpoint = createMockEndpoint();
 
       const deployment = new MockDeployment({
-        getConfigForFile: () => Promise.resolve(config)
+        getConnectionForTab: () => Promise.resolve(endpoint)
       });
 
       createDeploymentPluginOverlay({
@@ -361,11 +309,11 @@ describe('DeploymentPluginOverlay', function() {
     it('should deploy custom resources', async function() {
 
       // given
-      const config = createMockConfig();
+      const endpoint = createMockEndpoint();
 
       const deployment = new MockDeployment({
         deploy: sinon.spy(() => Promise.resolve(createMockDeploymentResult())),
-        getConfigForFile: () => Promise.resolve(config)
+        getConnectionForTab: () => Promise.resolve(endpoint)
       });
 
       const displayNotificationSpy = sinon.spy();
@@ -391,7 +339,7 @@ describe('DeploymentPluginOverlay', function() {
       });
 
       // when
-      getFormProps().onSubmit(config);
+      getFormProps().onSubmit();
 
       // expect
       await waitFor(() => {
@@ -403,7 +351,7 @@ describe('DeploymentPluginOverlay', function() {
           path: 'bar.bpmn',
           type: 'bpmn'
         }
-      ], config);
+      ], { endpoint, context: 'deploymentTool' });
 
       expect(displayNotificationSpy).to.have.been.calledOnce;
       expect(displayNotificationSpy).to.have.been.calledWith(sinon.match({
@@ -416,11 +364,11 @@ describe('DeploymentPluginOverlay', function() {
     it('should display custom success notification', async function() {
 
       // given
-      const config = createMockConfig();
+      const endpoint = createMockEndpoint();
 
       const deployment = new MockDeployment({
         deploy: sinon.spy(() => Promise.resolve(createMockDeploymentResult())),
-        getConfigForFile: () => Promise.resolve(config)
+        getConnectionForTab: () => Promise.resolve(endpoint)
       });
 
       const displayNotificationSpy = sinon.spy();
@@ -442,7 +390,7 @@ describe('DeploymentPluginOverlay', function() {
       });
 
       // when
-      getFormProps().onSubmit(config);
+      getFormProps().onSubmit();
 
       // expect
       await waitFor(() => {
@@ -454,7 +402,7 @@ describe('DeploymentPluginOverlay', function() {
           path: 'foo.bpmn',
           type: 'bpmn'
         }
-      ], config);
+      ], { endpoint, context: 'deploymentTool' });
 
       expect(displayNotificationSpy).to.have.been.calledOnce;
       expect(displayNotificationSpy).to.have.been.calledWith(sinon.match({
@@ -467,7 +415,7 @@ describe('DeploymentPluginOverlay', function() {
     it('should display custom error notification', async function() {
 
       // given
-      const config = createMockConfig();
+      const endpoint = createMockEndpoint();
 
       const deployment = new MockDeployment({
         deploy: sinon.spy(() => Promise.resolve(createMockDeploymentResult({
@@ -476,7 +424,7 @@ describe('DeploymentPluginOverlay', function() {
             details: 'foo'
           }
         }))),
-        getConfigForFile: () => Promise.resolve(config)
+        getConnectionForTab: () => Promise.resolve(endpoint)
       });
 
       const displayNotificationSpy = sinon.spy();
@@ -498,7 +446,7 @@ describe('DeploymentPluginOverlay', function() {
       });
 
       // when
-      getFormProps().onSubmit(config);
+      getFormProps().onSubmit();
 
       // expect
       await waitFor(() => {
@@ -510,7 +458,7 @@ describe('DeploymentPluginOverlay', function() {
           path: 'foo.bpmn',
           type: 'bpmn'
         }
-      ], config);
+      ], { endpoint, context: 'deploymentTool' });
 
       expect(displayNotificationSpy).to.have.been.calledOnce;
       expect(displayNotificationSpy).to.have.been.calledWith(sinon.match({
@@ -558,13 +506,9 @@ class MockConnectionChecker extends Mock {
 class MockDeployment extends Mock {
   deploy() {}
 
-  getConfigForFile() {}
-
   off() {}
 
   on() {}
-
-  setConfigForFile() {}
 }
 
 class MockConfigValidator extends Mock {
@@ -651,14 +595,6 @@ function createMockEndpoint(overrides = {}) {
     camundaCloudClientId: 'bar',
     camundaCloudClientSecret: 'baz',
     camundaCloudClusterUrl: 'https://xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.yyy-1.zeebe.example.io:443',
-    ...overrides
-  };
-}
-
-function createMockConfig(overrides = {}) {
-  return {
-    deployment: {},
-    endpoint: createMockEndpoint(),
     ...overrides
   };
 }

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
@@ -148,7 +148,7 @@ function createDeploymentPlugin(props = {}) {
     _getGlobal = (name) => {
       if (name === 'deployment') {
         return new Deployment({
-          async getConfigForFile(file) {
+          async getConnectionForTab(file) {
             return {
               deployment: {},
               endpoint: DEFAULT_ENDPOINT

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePluginOverlay.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePluginOverlay.js
@@ -153,12 +153,11 @@ export default function StartInstancePluginOverlay(props) {
 
   useEffect(() => {
     (async () => {
+      const connection = await deployment.getConnectionForTab(activeTab);
+
+      setDeploymentConfig({ endpoint: connection, context: 'startInstancePlugin' });
+
       const file = getConfigFile(activeTab);
-
-      const deploymentConfig = await deployment.getConfigForFile(file);
-
-      setDeploymentConfig(deploymentConfig);
-
       const startInstanceConfig = await startInstance.getConfigForFile(file);
 
       setStartInstanceConfig(startInstanceConfig);
@@ -166,7 +165,7 @@ export default function StartInstancePluginOverlay(props) {
 
 
 
-  }, [ deployment, setDeploymentConfig, setStartInstanceConfig, startInstance ]);
+  }, [ deployment, activeTab, setDeploymentConfig, setStartInstanceConfig, startInstance ]);
 
   useEffect(() => {
     const onDeployed = ({ deploymentResult, endpoint, gatewayVersion }) => {

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginOverlaySpec.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginOverlaySpec.js
@@ -46,10 +46,10 @@ describe('StartInstancePluginOverlay', function() {
   it('should render start instance config (deployment config valid, no connection check result)', async function() {
 
     // when
-    const deploymentConfig = createMockDeploymentConfig();
+    const deploymentConfig = createMockEndpoint();
 
     const deployment = new MockDeployment({
-      getConfigForFile: () => Promise.resolve(deploymentConfig)
+      getConnectionForTab: () => Promise.resolve(deploymentConfig)
     });
 
     const startInstanceConfig = createMockStartInstanceConfig();
@@ -78,11 +78,11 @@ describe('StartInstancePluginOverlay', function() {
       it('should submit form (success)', async function() {
 
         // given
-        const deploymentConfig = createMockDeploymentConfig();
+        const endpoint = createMockEndpoint();
 
         const deployment = new MockDeployment({
           deploy: sinon.spy(() => Promise.resolve(createMockDeploymentResult())),
-          getConfigForFile: () => Promise.resolve(deploymentConfig)
+          getConnectionForTab: () => Promise.resolve(endpoint)
         });
 
         const displayNotificationSpy = sinon.spy();
@@ -116,7 +116,8 @@ describe('StartInstancePluginOverlay', function() {
         });
 
         expect(startInstance.startInstance).to.have.been.calledWith('foo', {
-          ...deploymentConfig,
+          endpoint,
+          context: 'startInstancePlugin',
           ...startInstanceConfig
         });
 
@@ -131,11 +132,11 @@ describe('StartInstancePluginOverlay', function() {
       it('should submit form (no success)', async function() {
 
         // given
-        const deploymentConfig = createMockDeploymentConfig();
+        const endpoint = createMockEndpoint();
 
         const deployment = new MockDeployment({
           deploy: sinon.spy(() => Promise.resolve(createMockDeploymentResult())),
-          getConfigForFile: () => Promise.resolve(deploymentConfig)
+          getConnectionForTab: () => Promise.resolve(endpoint)
         });
 
         const displayNotificationSpy = sinon.spy();
@@ -174,7 +175,8 @@ describe('StartInstancePluginOverlay', function() {
         });
 
         expect(startInstance.startInstance).to.have.been.calledWith('foo', {
-          ...deploymentConfig,
+          endpoint,
+          context: 'startInstancePlugin',
           ...startInstanceConfig
         });
 
@@ -195,14 +197,14 @@ describe('StartInstancePluginOverlay', function() {
     it('should emit event (success)', async function() {
 
       // given
-      const deploymentConfig = createMockDeploymentConfig();
+      const endpoint = createMockEndpoint();
 
       const mockDeploymentResult = createMockDeploymentResult();
 
       const deployment = new MockDeployment({
         deploy: sinon.spy(() => Promise.resolve(mockDeploymentResult)),
         on: sinon.spy(),
-        getConfigForFile: () => Promise.resolve(deploymentConfig)
+        getConnectionForTab: () => Promise.resolve(endpoint)
       });
 
       const startInstanceConfig = createMockStartInstanceConfig();
@@ -230,7 +232,7 @@ describe('StartInstancePluginOverlay', function() {
       // when
       deployment.on.getCall(0).args[1]({
         deploymentResult: mockDeploymentResult,
-        endpoint: deploymentConfig.endpoint,
+        endpoint: endpoint,
         gatewayVersion: '7.0.0'
       });
 
@@ -254,7 +256,7 @@ describe('StartInstancePluginOverlay', function() {
     it('should emit event (error)', async function() {
 
       // given
-      const deploymentConfig = createMockDeploymentConfig();
+      const endpoint = createMockEndpoint();
 
       const mockDeploymentResult = createMockDeploymentResult({
         success: false,
@@ -264,7 +266,7 @@ describe('StartInstancePluginOverlay', function() {
       const deployment = new MockDeployment({
         deploy: sinon.spy(() => Promise.resolve(mockDeploymentResult)),
         on: sinon.spy(),
-        getConfigForFile: () => Promise.resolve(deploymentConfig)
+        getConnectionForTab: () => Promise.resolve(endpoint)
       });
 
       const startInstanceConfig = createMockStartInstanceConfig();
@@ -292,7 +294,7 @@ describe('StartInstancePluginOverlay', function() {
       // when
       deployment.on.getCall(0).args[1]({
         deploymentResult: mockDeploymentResult,
-        endpoint: deploymentConfig.endpoint,
+        endpoint: endpoint,
         gatewayVersion: '7.0.0'
       });
 
@@ -323,10 +325,10 @@ describe('StartInstancePluginOverlay', function() {
     it('should render custom start instance header', async function() {
 
       // when
-      const deploymentConfig = createMockDeploymentConfig();
+      const deploymentConfig = createMockEndpoint();
 
       const deployment = new MockDeployment({
-        getConfigForFile: () => Promise.resolve(deploymentConfig)
+        getConnectionForTab: () => Promise.resolve(deploymentConfig)
       });
 
       const startInstanceConfig = createMockStartInstanceConfig();
@@ -353,10 +355,10 @@ describe('StartInstancePluginOverlay', function() {
     it('should render custom start instance submit', async function() {
 
       // when
-      const deploymentConfig = createMockDeploymentConfig();
+      const deploymentConfig = createMockEndpoint();
 
       const deployment = new MockDeployment({
-        getConfigForFile: () => Promise.resolve(deploymentConfig)
+        getConnectionForTab: () => Promise.resolve(deploymentConfig)
       });
 
       const startInstanceConfig = createMockStartInstanceConfig();
@@ -383,7 +385,7 @@ describe('StartInstancePluginOverlay', function() {
     it('should deploy custom resources', async function() {
 
       // given
-      const deploymentConfig = createMockDeploymentConfig();
+      const endpoint = createMockEndpoint();
 
       const deployment = new MockDeployment({
         deploy: sinon.spy(() => Promise.resolve(createMockDeploymentResult({
@@ -404,7 +406,7 @@ describe('StartInstancePluginOverlay', function() {
             ]
           }
         }))),
-        getConfigForFile: () => Promise.resolve(deploymentConfig)
+        getConnectionForTab: () => Promise.resolve(endpoint)
       });
 
       const displayNotificationSpy = sinon.spy();
@@ -459,10 +461,11 @@ describe('StartInstancePluginOverlay', function() {
           path: 'bar.bpmn',
           type: 'bpmn'
         }
-      ], deploymentConfig);
+      ], { endpoint, context: 'startInstancePlugin' });
 
       expect(startInstance.startInstance).to.have.been.calledWith('foo', {
-        ...deploymentConfig,
+        endpoint,
+        context: 'startInstancePlugin',
         ...startInstanceConfig
       });
 
@@ -477,11 +480,11 @@ describe('StartInstancePluginOverlay', function() {
     it('should display custom success notification', async function() {
 
       // given
-      const deploymentConfig = createMockDeploymentConfig();
+      const endpoint = createMockEndpoint();
 
       const deployment = new MockDeployment({
         deploy: sinon.spy(() => Promise.resolve(createMockDeploymentResult())),
-        getConfigForFile: () => Promise.resolve(deploymentConfig)
+        getConnectionForTab: () => Promise.resolve(endpoint)
       });
 
       const displayNotificationSpy = sinon.spy();
@@ -519,7 +522,8 @@ describe('StartInstancePluginOverlay', function() {
       });
 
       expect(startInstance.startInstance).to.have.been.calledWith('foo', {
-        ...deploymentConfig,
+        endpoint,
+        context: 'startInstancePlugin',
         ...startInstanceConfig
       });
 
@@ -534,11 +538,11 @@ describe('StartInstancePluginOverlay', function() {
     it('should display custom error notification', async function() {
 
       // given
-      const deploymentConfig = createMockDeploymentConfig();
+      const endpoint = createMockEndpoint();
 
       const deployment = new MockDeployment({
         deploy: sinon.spy(() => Promise.resolve(createMockDeploymentResult())),
-        getConfigForFile: () => Promise.resolve(deploymentConfig)
+        getConnectionForTab: () => Promise.resolve(endpoint)
       });
 
       const displayNotificationSpy = sinon.spy();
@@ -581,7 +585,8 @@ describe('StartInstancePluginOverlay', function() {
       });
 
       expect(startInstance.startInstance).to.have.been.calledWith('foo', {
-        ...deploymentConfig,
+        endpoint,
+        context: 'startInstancePlugin',
         ...startInstanceConfig
       });
 
@@ -631,7 +636,7 @@ class MockConnectionChecker extends Mock {
 class MockDeployment extends Mock {
   deploy() {}
 
-  getConfigForFile() {}
+  getConnectionForTab() {}
 
   off() {}
 
@@ -747,13 +752,6 @@ function createMockEndpoint(overrides = {}) {
   };
 }
 
-function createMockDeploymentConfig(overrides = {}) {
-  return {
-    deployment: {},
-    endpoint: createMockEndpoint(),
-    ...overrides
-  };
-}
 
 function createMockStartInstanceConfig(overrides = {}) {
   return {

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginSpec.js
@@ -186,7 +186,7 @@ function createStartInstancePlugin(props = {}) {
     _getGlobal = (name) => {
       if (name === 'deployment') {
         return new Deployment({
-          async getConfigForFile(file) {
+          async getConnectionForTab(file) {
             return {
               deployment: {},
               endpoint: DEFAULT_ENDPOINT
@@ -195,7 +195,7 @@ function createStartInstancePlugin(props = {}) {
         });
       } else if (name === 'startInstance') {
         return new StartInstance({
-          async getConfigForFile(file) {
+          async getConnectionForTab(file) {
             return {};
           }
         });


### PR DESCRIPTION
### Proposed Changes

- add tab storage which can be used to store configs per tabId

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
