### PR TITLE
Limit shown connection name length

### DIFF
--- a/client/src/app/status-bar/StatusBar.less
+++ b/client/src/app/status-bar/StatusBar.less
@@ -22,6 +22,7 @@
   z-index: 1000;
   height: 32px;
   padding: 0;
+  white-space: nowrap;
 
   background-color: var(--status-bar-background-color);
   border-top: 1px solid var(--status-bar-border-color);

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerPlugin.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerPlugin.js
@@ -208,11 +208,11 @@ export default function ConnectionManagerPlugin(props) {
   const statusBarText = activeConnection ? activeConnection.name || 'Unnamed connection' : 'No connection';
   return <>
     { tabNeedsConnection(activeTab) &&
-      <Fill name="connection-manager" className slot="status-bar__file" group="8_deploy" priority={ 2 }>
+      <Fill name="connection-manager" slot="status-bar__file" group="8_deploy" priority={ 2 }>
         <button
           onClick={ () => setOverlayOpen(!overlayOpen) }
           title="Configure Camunda 8 connection"
-          className={ classNames('btn', { 'btn--active': overlayOpen }) }
+          className={ classNames(css.ConnectionSelector, 'btn', { 'btn--active': overlayOpen }) }
           ref={ statusBarButtonRef }
         >
           <StatusIndicator status={ statusBarConnectionStatus } text={ statusBarText }></StatusIndicator>

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerPlugin.less
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerPlugin.less
@@ -17,4 +17,16 @@
     float: right;
   }
 
+  select#connection{
+    text-overflow: ellipsis;
+  }
+}
+
+:local(.ConnectionSelector) {
+  span {
+    // non linear scaling with min and max values
+    max-width: clamp(5rem, calc(25vw - 5rem), 30rem);
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5504

### Proposed Changes

- sets max width (if content fits thats the size) of status bar connection selector (responsive with min/max values) (roughly 10-30 em)

Note: at least on macOS i was not able to limit the native select options length, but the OS limits it at some point

https://github.com/user-attachments/assets/14ad4f62-fae7-4ec8-895d-16d8e23e07a2


<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
