### PR TITLE
fix: target only settings section with fontsize increase

### DIFF
--- a/client/src/plugins/settings/SettingsPlugin.less
+++ b/client/src/plugins/settings/SettingsPlugin.less
@@ -1,5 +1,9 @@
 :local(.SettingsPlugin) {
   --input-width: 100%;
+ 
+  .section__header{
+    font-size:  20px;
+  }
 
   .form-group {
     margin: 12px auto;

--- a/client/src/shared/ui/Section.less
+++ b/client/src/shared/ui/Section.less
@@ -20,7 +20,6 @@
     margin: 0;
     font-size: inherit;
     font-weight: 500;
-    font-size: 20px;
     color: var(--overlay-title-color);
   }
 


### PR DESCRIPTION
### Proposed Changes

fix of issue caused by https://github.com/camunda/camunda-modeler/pull/5492

revert global section change and only use large section headers in settings. ie deployment section header is normal again, while keeping settings large as desired.

<img width="2047" height="1662" alt="image" src="https://github.com/user-attachments/assets/e5d1cbd3-4e56-4120-9eb5-9460784b046a" />


<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
