### PR TITLE
fix: ensure connection ID is always stored in tab storage

### DIFF
--- a/client/src/app/zeebe/Deployment.js
+++ b/client/src/app/zeebe/Deployment.js
@@ -60,6 +60,7 @@ const log = debug('Deployment');
 export default class Deployment extends EventEmitter {
 
   /**
+   * @param {import('../../app/TabStorage.js').default} tabStorage
    * @param {import('../../remote/Config').default} config
    * @param {import('../../remote/ZeebeAPI').default} zeebeAPI
    * @param {import('../../app/Settings').default} settings
@@ -200,9 +201,8 @@ export default class Deployment extends EventEmitter {
 
     if (tab.file?.path) {
       await this._config.setForFile(tab.file, CONFIG_KEYS.CONNECTION_MANAGER, { connectionId });
-    } else {
-      this._tabStorage.set(tab, STORAGE_KEY, connectionId);
     }
+    this._tabStorage.set(tab, STORAGE_KEY, connectionId);
 
     if (connectionId) {
       await this._config.set(CONFIG_KEYS.LAST_USED_CONNECTION, connectionId);


### PR DESCRIPTION
### Proposed Changes

Problem:

Current behaviours:
- never saved files use tab storage for used connection
- saved files use config for used connection
- saving a file copies used connection from tab storage to config
- opening deployment modal triggers save (even for unsaved)

Meaning: initially a connection is written to tab storage, after the first save connections are written to config, but triggering a save (eg via opening deploy) overwrites the config with the value of tab storage

Solution options: 
1 always store connection in tab storage (confirmed, works)
2 remove tab from tabstorage after save , preventing overwrites (confirmed, works)
3 only do migrations for unsaved files (problem: save event doesn't contain info if it was a new file)

Proposal: go with solution 1 for now (always using tab storage and config for persistence), after refactoring with a common service option 2 might be good 

Problem visualized:

https://github.com/user-attachments/assets/dc9c8e74-95ae-43bb-bc9a-1cc7cb9ac869

With fix (always storing in tab storage)

https://github.com/user-attachments/assets/690f2195-ffac-4294-b5a6-885c88653bb3


<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
