### PR TITLE
Apply engine profile change immediately

### DIFF
--- a/client/src/app/tabs/EngineProfile.js
+++ b/client/src/app/tabs/EngineProfile.js
@@ -113,7 +113,7 @@ function EngineProfileOverlay(props) {
 function EditableVersionSection(props) {
 
   const {
-    engineProfile: _engineProfile,
+    engineProfile,
     engineProfileVersions,
     onChange
   } = props;
@@ -122,7 +122,7 @@ function EditableVersionSection(props) {
     throw new Error('<onChange> required');
   }
 
-  if (!_engineProfile) {
+  if (!engineProfile) {
     throw new Error('<engineProfile> required');
   }
 
@@ -130,21 +130,13 @@ function EditableVersionSection(props) {
     throw new Error('<engineProfileVersions> required');
   }
 
-  const [ engineProfile, setEngineProfile ] = useState(_engineProfile);
-
   const handleVersionChanged = event => {
     const executionPlatformVersion = toSemver(event.target.value);
 
-    setEngineProfile({
+    onChange({
       executionPlatform: engineProfile.executionPlatform,
       executionPlatformVersion: executionPlatformVersion || undefined
     });
-  };
-
-  const handleApply = (e) => {
-    onChange(engineProfile);
-
-    e.preventDefault();
   };
 
   const {
@@ -165,7 +157,7 @@ function EditableVersionSection(props) {
         Select the { engineLabel } version
       </Section.Header>
       <Section.Body>
-        <form onSubmit={ handleApply } className="fields">
+        <form className="fields">
           <div className="form-group">
             <label htmlFor={ name }>Version</label>
 
@@ -196,10 +188,6 @@ function EditableVersionSection(props) {
             <PlatformHint className="form-group form-description" executionPlatform={ executionPlatform } displayLabel={ engineLabel } /> :
             <UnknownVersionHint className="form-group form-description" executionPlatform={ executionPlatform } executionPlatformVersion={ engineProfile.executionPlatformVersion } displayLabel={ engineLabel } />
           }
-
-          <Section.Actions>
-            <button className="btn btn-primary" type="submit">Apply</button>
-          </Section.Actions>
         </form>
       </Section.Body>
     </Section>

--- a/client/src/app/tabs/__tests__/EngineProfileSpec.js
+++ b/client/src/app/tabs/__tests__/EngineProfileSpec.js
@@ -463,9 +463,6 @@ function selectVersion(select, version) {
   if (select.value !== version) {
     fireEvent.change(select, { target: { value: toSemverMinor(version) || '' } });
   }
-
-  const form = select.closest('form');
-  fireEvent.submit(form);
 }
 
 function expectVersion(select, version) {


### PR DESCRIPTION
### Proposed Changes

Ensures there is no additional button click needed when applying the engine profile:

![capture YlsEnQ_optimized](https://github.com/user-attachments/assets/e3b54a13-c95a-4c9b-a8cf-92cf979c9014)

Closes https://github.com/camunda/camunda-modeler/issues/5211

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
