### PR TITLE
Fix crash when call activity without extension elements is used in Camunda 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+## 5.43.1
+
+* `DEPS`: update to `camunda-bpmn-js-behaviors@1.12.1`
+
+### BPMN
+
+* `FIX`: fix crash when call activity without extension elements is used in Camunda 7 ([#5541](https://github.com/camunda/camunda-modeler/issues/5541))
+
 ## 5.43.0
 
 * `DEPS`: update to `@bpmn-io/properties-panel@3.35.1`

--- a/package-lock.json
+++ b/package-lock.json
@@ -13717,9 +13717,9 @@
       }
     },
     "node_modules/camunda-bpmn-js-behaviors": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.12.0.tgz",
-      "integrity": "sha512-0lZbDt2tfSR6CNYrI5szes17JLHv7SXbUlSpG5wDgbsm4EXz2OWJdBTV6IgL4A/D3kONMd1rtxFlmfnyptymLw==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.12.1.tgz",
+      "integrity": "sha512-xbWID2riHTpCnr4t7Y4SSeUY07Ep6/EQZwxm4DJNmGfrYE1flaHNw5VWhIWoN7dXuh01lyFDrO0prKDmsd74HQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {


### PR DESCRIPTION
Closes #5541

### Proposed Changes

Just a simple deps update with the fix. I want to build a patch release afterwords.


https://github.com/user-attachments/assets/55ff41d3-348d-4a9a-8005-d746855ba9d1



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
