### PR TITLE
fix: stop connection check on invalid tabs

### DIFF
--- a/client/src/app/panel/tabs/task-testing/hooks/useConnectionStatus.js
+++ b/client/src/app/panel/tabs/task-testing/hooks/useConnectionStatus.js
@@ -18,7 +18,7 @@ export function useConnectionStatus(subscribe) {
     });
 
     return () => subscription.cancel();
-  });
+  }, [ subscribe ]);
 
   return connectionCheckResult;
 }

--- a/client/src/app/zeebe/Deployment.js
+++ b/client/src/app/zeebe/Deployment.js
@@ -162,9 +162,11 @@ export default class Deployment extends EventEmitter {
    * @returns {Promise<{endpoint: Endpoint, connectionId: string}|null>}
    */
   async getConnectionForTab(tab) {
+    if (!tab || !tab.file) {
+      return NO_CONNECTION;
+    }
+
     let connectionId = null;
-
-
 
     if (tab.file.path) {
       const fileConfig = await this._config.getForFile(tab.file, CONFIG_KEYS.CONNECTION_MANAGER, {});

--- a/client/src/app/zeebe/__tests__/DeploymentSpec.js
+++ b/client/src/app/zeebe/__tests__/DeploymentSpec.js
@@ -539,6 +539,35 @@ describe('Deployment', function() {
       // then
       expect(endpoints).to.deep.equal(connections);
     });
+  });
+
+
+  describe('#getConnectionForTab', function() {
+
+    it('should return NO_CONNECTION without tab', async function() {
+
+      // given
+      const deployment = createDeployment();
+
+      // when
+      const result = await deployment.getConnectionForTab();
+
+      // then
+      expect(result.id).to.equal('NO_CONNECTION');
+    });
+
+
+    it('should return NO_CONNECTION without tab.file', async function() {
+
+      // given
+      const deployment = createDeployment();
+
+      // when
+      const result = await deployment.getConnectionForTab({ file: undefined });
+
+      // then
+      expect(result.id).to.equal('NO_CONNECTION');
+    });
 
   });
 

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerPlugin.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerPlugin.js
@@ -142,6 +142,7 @@ export default function ConnectionManagerPlugin(props) {
   // load connection from tab on tab change
   useEffect(() => {
     if (!activeTab) {
+      setActiveConnection(null);
       return;
     }
 


### PR DESCRIPTION
Fixes [CAMUNDA-MODELER-Z5E](https://camunda.sentry.io/issues/7151372496/?referrer=github_integration)

### Proposed Changes

Issue I want to fix:
- [Slack](https://camunda.slack.com/archives/GP70M0J6M/p1768559369283359?thread_ts=1768557078.744409&cid=GP70M0J6M)
- [Sentry](https://camunda.sentry.io/issues/7151372496/events/664e58c6be5e449eaefd5bacca597e21/?project=5223041&query=is%3Aunresolved&referrer=previous-event)

Reproduce Issue:
- open a c8 diagram with a connection
- close all tabs (you should see welcome tab)
- observe: exception in console, connection check continues running

<img width="2986" height="1652" alt="image" src="https://github.com/user-attachments/assets/90ce9346-df01-4c05-8864-2bacaad56a66" />

Aims to solve unhandled exception by preventing it:

- stop connection check on leaving a tab with connections (eg. closing all tabs/welcome page, or moving from a c8 to a c7 diagram). I choose not to abort, so one additional check might occur
- as an additional safeguard treat tabs unrelated to files as `NO_CONNECTION`

After fix: no exception, only one additional connection check

<img width="1494" height="833" alt="image" src="https://github.com/user-attachments/assets/b9d16ff0-f14d-4d65-a564-e64d598f2709" />

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
