### PR TITLE
deps: update to `bpmn-js-properties-panel@5.48.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ___Note:__ Yet to be released changes appear here._
 
 ### BPMN
 * `FIX`: change the tooltip content for the message property to be specific depending on the event/task type ([#4864](https://github.com/camunda/camunda-modeler/issues/4864))
+* `FEAT`: add support of FEEL expressions for 'Form ID' field ([#5231](https://github.com/camunda/camunda-modeler/issues/5231))
 
 ## 5.44.0
 

--- a/client/package.json
+++ b/client/package.json
@@ -35,7 +35,7 @@
     "@uiw/codemirror-theme-vscode": "^4.23.12",
     "bpmn-js": "^18.10.1",
     "bpmn-js-element-templates": "^2.18.0",
-    "bpmn-js-properties-panel": "^5.47.0",
+    "bpmn-js-properties-panel": "^5.48.0",
     "bpmn-js-tracking": "^0.6.0",
     "bpmn-moddle": "^9.0.4",
     "camunda-bpmn-js": "^5.17.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,7 +187,7 @@
         "@uiw/codemirror-theme-vscode": "^4.23.12",
         "bpmn-js": "^18.10.1",
         "bpmn-js-element-templates": "^2.18.0",
-        "bpmn-js-properties-panel": "^5.47.0",
+        "bpmn-js-properties-panel": "^5.48.0",
         "bpmn-js-tracking": "^0.6.0",
         "bpmn-moddle": "^9.0.4",
         "camunda-bpmn-js": "^5.17.0",
@@ -13002,9 +13002,9 @@
       "license": "MIT"
     },
     "node_modules/bpmn-js-properties-panel": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.47.0.tgz",
-      "integrity": "sha512-dWMm0zmj11EpBpQJ50dhuanpe9zli31kMkBQvELpD8hAVLJZWoFGwdnH8PMx531zASQxsDCTWdNDYg9L3CGUlg==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.48.0.tgz",
+      "integrity": "sha512-WR89IQ682tgnjdXVvI6P+DbgyrRybPuDxC/EFYv9rNbyNLBJ3AnXXyBhl/hIgj+Dji6jgBTnL+rysrCU+3dQ5g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {


### PR DESCRIPTION
### Proposed Changes

Closes https://github.com/camunda/camunda-modeler/issues/4864, https://github.com/camunda/camunda-modeler/issues/5231

Update `bpmn-js-properties-panel` to `5.47.0` and then to `5.48.0` which introduced:

- `5.47.0`: new tooltip content for the message property depends on the event/task type(fixed upstream by https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1181)
- `5.48.0`: add support of FEEL expressions for 'Form ID' field ( fixed upstream by https://github.com/bpmn-io/bpmn-js-properties-panel/pull/1183))

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
