### PR TITLE
test:  increase the timeout for the image generation test which failed on CI

### DIFF
--- a/client/src/app/util/__tests__/generateImageSpec.js
+++ b/client/src/app/util/__tests__/generateImageSpec.js
@@ -44,7 +44,7 @@ describe('util - generateImage', function() {
       const image = await generateImage(type, outOfBoundsSVG);
 
       expectToBeAnImage(image);
-    }).timeout(10000); // downscaling may exceed the default timeout 2000ms.
+    }).timeout(15000); // downscaling may exceed the default timeout 2000ms.
 
 
     it('should generate expected images <' + type + '>', async function() {


### PR DESCRIPTION
### Proposed Changes
test: increase the timeout for the image generation test which failed on CI with the previous(10000ms) timeout
<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
