### PR TITLE
test: disable chrome prompt about keychain password while running tests on macOS

### DIFF
--- a/client/karma.config.js
+++ b/client/karma.config.js
@@ -34,7 +34,7 @@ process.env.CHROME_BIN = require('puppeteer').executablePath();
 
 // configures browsers to run test against
 // any of [ 'ChromeHeadless', 'Chrome', 'Firefox', 'IE', 'PhantomJS' ]
-var browsers = (process.env.TEST_BROWSERS || 'ChromeHeadless').split(/,/g);
+var browsers = (process.env.TEST_BROWSERS || 'ChromeHeadless_with_mock_keychain').split(/,/g);
 
 var suite = 'test/suite.js';
 
@@ -71,7 +71,15 @@ module.exports = function(karma) {
     },
 
     browsers: browsers,
-
+    customLaunchers: {
+      ChromeHeadless_with_mock_keychain: {
+        base: 'ChromeHeadless',
+        flags: [
+          '--use-mock-keychain',
+          '--password-store=basic'
+        ]
+      }
+    },
     browserNoActivityTimeout: 60000,
     browserDisconnectTolerance: 3,
     browserSocketTimeout: 60000,


### PR DESCRIPTION
### Proposed Changes
Previously, when I run `npm run test` locally, the following prompt would appear:
<img width="429" height="183" alt="image" src="https://github.com/user-attachments/assets/61feae56-e59a-47d0-bdbf-497ea0b0a7b5" />
The tests passed on their own, even if I clicked 'Deny' several times. At the same time my system password did't accepted.

This PR fixes this behavior by configuring ChromeHeadless in Karma to use a mocked keychain, preventing the password prompt from appearing.

Note: There is no option to pass these tags for the default ChromeHeadless, so we need to [customLaunchers](https://karma-runner.github.io/6.4/config/browsers.html#configured-launchers) for such case.

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
