### PR TITLE
test: mock `globals`

### DIFF
--- a/client/karma.config.js
+++ b/client/karma.config.js
@@ -150,7 +150,8 @@ module.exports = function(karma) {
           './editor/FormEditor': 'test/mocks/form-js',
           '@camunda/linting': 'test/mocks/linting',
           '@camunda/linting/modeler': 'test/mocks/linting/modeler',
-          'mixpanel-browser': 'test/mocks/mixpanel-browser'
+          'mixpanel-browser': 'test/mocks/mixpanel-browser',
+          '../../globals': 'test/mocks/globals'
         }
       },
       devtool: 'eval-cheap-module-source-map'

--- a/client/test/mocks/globals/index.js
+++ b/client/test/mocks/globals/index.js
@@ -1,0 +1,5 @@
+export const isMac = true;
+
+export const globals = {
+  isMac
+};


### PR DESCRIPTION
Related to https://camunda.slack.com/archives/GP70M0J6M/p1769004009147579

### Proposed Changes

We did not mock the globals module which caused `getAppPreload` and other constructors calls. This PR brings back the order.

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
