### PR TITLE
deps: downgrade to electron@39.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ ___Note:__ Yet to be released changes appear here._
 * `DEPS`: update to `bpmn-js-properties-panel@5.46.0`
 * `DEPS`: update to `camunda-bpmn-js@5.17.0`
 * `DEPS`: update to `diagram-js@15.5.0`
-* `DEPS`: update to `electron@40.0.0`
 * `DEPS`: update to `tiny-svg@4.1.4`
 * `DEPS`: update to `zeebe-bpmn-moddle@1.12.0`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "del": "^8.0.0",
         "del-cli": "^7.0.0",
         "diff2html": "^3.4.48",
-        "electron": "^40.0.0",
+        "electron": "^39.0.0",
         "electron-builder": "^26.0.13",
         "electron-extension-installer": "^2.0.0",
         "electron-publisher-s3": "^20.17.2",
@@ -16840,15 +16840,15 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.0.0.tgz",
-      "integrity": "sha512-UyBy5yJ0/wm4gNugCtNPjvddjAknMTuXR2aCHioXicH7aKRKGDBPp4xqTEi/doVcB3R+MN3wfU9o8d/9pwgK2A==",
+      "version": "39.0.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.0.0.tgz",
+      "integrity": "sha512-UejnuOK4jpRZUq7MkEAnR/szsRWLKBJAdvn6j3xdQLT57fVv13VSNdaUHHjSheaqGzNhCGIdkPsPJnGJVh5kiA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^24.9.0",
+        "@types/node": "^22.7.7",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -17497,19 +17497,19 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "24.10.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
-      "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
+      "version": "22.19.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
+      "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/electron/node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "del": "^8.0.0",
     "del-cli": "^7.0.0",
     "diff2html": "^3.4.48",
-    "electron": "^40.0.0",
+    "electron": "^39.0.0",
     "electron-builder": "^26.0.13",
     "electron-extension-installer": "^2.0.0",
     "electron-publisher-s3": "^20.17.2",


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5576

### Proposed Changes

Circumvent issue https://github.com/camunda/camunda-modeler/issues/5576 by staying on electron 39.0 for now

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
