### PR TITLE
fix: fix connections migration to restore c8run predefined connection

### DIFF
--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettings.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettings.js
@@ -27,8 +27,7 @@ export async function initializeSettings({ settings, connectionChecker }) {
       [SETTINGS_KEY_CONNECTIONS]: {
         type: 'custom',
         component: (props) => ConnectionManagerSettingsComponent({ ...props, connectionChecker }),
-        description: 'Manage Camunda 8 Orchestration Cluster connections.',
-        default: []
+        description: 'Manage Camunda 8 Orchestration Cluster connections.'
       },
 
     }


### PR DESCRIPTION
Closes #5593

### Proposed Changes

**Problem**

The `c8run (local)` has disappeared in the connection manager as the migration for the connections stop functioning. The introduced default value (`[]`) was preventing the migration from seeding the missing c8run connection.
  
Associated Slack thread: https://camunda.slack.com/archives/GP70M0J6M/p1770117433496659?thread_ts=1768913143.210289&cid=GP70M0J6M

**Solution**

As @Buckwich suggested, I have removed the default value for the connections as that is the way how we recognize if the connections are actually migrated over to Settings, or not.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
