### PR TITLE
fix: enable edit shortcuts in nested inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 ___Note:__ Yet to be released changes appear here._
 
 ### General
+
+* `FIX`: enable undo/redo actions in settings modal ([#5306](https://github.com/camunda/camunda-modeler/issues/5306))
 * `DEPS`: update to `@bpmn-io/properties-panel@3.37.0`
 
 ### BPMN
+
 * `FIX`: change the tooltip content for the message property to be specific depending on the event/task type ([#4864](https://github.com/camunda/camunda-modeler/issues/4864))
 * `FEAT`: add support of FEEL expressions for 'Form ID' field ([#5231](https://github.com/camunda/camunda-modeler/issues/5231))
 * `FIX`: fix unexpected close or resize of a properties panel by toggling groups inside ([#5526](https://github.com/camunda/camunda-modeler/issues/5526))

--- a/client/src/shared/ui/__tests__/KeyboardInteractionTrapSpec.js
+++ b/client/src/shared/ui/__tests__/KeyboardInteractionTrapSpec.js
@@ -54,4 +54,166 @@ describe('<KeyboardInteractionTrap>', function() {
     // then
     expect(container).to.exist;
   });
+
+
+  it('should update menu when input receives focus', function() {
+
+    // given
+    const triggerAction = sinon.spy();
+
+    const { container } = render(
+      <KeyboardInteractionTrapContext.Provider value={ triggerAction }>
+        <KeyboardInteractionTrap>
+          <input type="text" />
+        </KeyboardInteractionTrap>
+      </KeyboardInteractionTrapContext.Provider>
+    );
+
+    const input = container.querySelector('input');
+
+    // when
+    input.focus();
+
+    // then
+    expect(triggerAction).to.have.been.calledWith('update-menu', {
+      editMenu: [
+        [
+          {
+            role: 'undo',
+            enabled: true
+          },
+          {
+            role: 'redo',
+            enabled: true
+          }
+        ],
+        [
+          {
+            role: 'copy',
+            enabled: true
+          },
+          {
+            role: 'cut',
+            enabled: true
+          },
+          {
+            role: 'paste',
+            enabled: true
+          },
+          {
+            role: 'selectAll',
+            enabled: true
+          }
+        ]
+      ]
+    });
+  });
+
+
+  it('should update menu when textarea receives focus', function() {
+
+    // given
+    const triggerAction = sinon.spy();
+
+    const { container } = render(
+      <KeyboardInteractionTrapContext.Provider value={ triggerAction }>
+        <KeyboardInteractionTrap>
+          <textarea />
+        </KeyboardInteractionTrap>
+      </KeyboardInteractionTrapContext.Provider>
+    );
+
+    const textarea = container.querySelector('textarea');
+
+    // when
+    textarea.focus();
+
+    // then
+    expect(triggerAction).to.have.been.calledWith('update-menu', {
+      editMenu: [
+        [
+          {
+            role: 'undo',
+            enabled: true
+          },
+          {
+            role: 'redo',
+            enabled: true
+          }
+        ],
+        [
+          {
+            role: 'copy',
+            enabled: true
+          },
+          {
+            role: 'cut',
+            enabled: true
+          },
+          {
+            role: 'paste',
+            enabled: true
+          },
+          {
+            role: 'selectAll',
+            enabled: true
+          }
+        ]
+      ]
+    });
+  });
+
+
+  it('should disable menu when non-input element receives focus', function() {
+
+    // given
+    const triggerAction = sinon.spy();
+
+    const { container } = render(
+      <KeyboardInteractionTrapContext.Provider value={ triggerAction }>
+        <KeyboardInteractionTrap>
+          <button>Click me</button>
+        </KeyboardInteractionTrap>
+      </KeyboardInteractionTrapContext.Provider>
+    );
+
+    const button = container.querySelector('button');
+
+    // when
+    button.focus();
+
+    // then
+    expect(triggerAction).to.have.been.calledWith('update-menu', {
+      editMenu: [
+        [
+          {
+            role: 'undo',
+            enabled: false
+          },
+          {
+            role: 'redo',
+            enabled: false
+          }
+        ],
+        [
+          {
+            role: 'copy',
+            enabled: false
+          },
+          {
+            role: 'cut',
+            enabled: false
+          },
+          {
+            role: 'paste',
+            enabled: false
+          },
+          {
+            role: 'selectAll',
+            enabled: false
+          }
+        ]
+      ]
+    });
+  });
 });

--- a/client/src/shared/ui/trap/KeyboardInteractionTrap.js
+++ b/client/src/shared/ui/trap/KeyboardInteractionTrap.js
@@ -81,13 +81,13 @@ class KeyboardInteractionTrapComponent extends PureComponent {
   }
 
   componentDidMount() {
-    window.addEventListener('focus', this.handleFocus);
+    window.addEventListener('focusin', this.handleFocus);
 
     this.updateMenu(document.activeElement);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('focus', this.handleFocus);
+    window.removeEventListener('focusin', this.handleFocus);
   }
 
   render() {


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/5306

### Proposed Changes

instead of the non-bubbling focus event I'm now using the bubbling focusin event to detect if we should trap keyboard shortcuts (cf https://developer.mozilla.org/en-US/docs/Web/API/Element/focusin_event). this enables the input detection also to work in nested inputs enabling use of select all (other commands already worked) (eg. input fields/connections in settings modal)

@nikku @philippfromme @barinali could you test this specifically for windows & linux

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
