### PR TITLE
test: run auto-cleanup before instead of after test

### DIFF
--- a/client/karma.config.js
+++ b/client/karma.config.js
@@ -36,6 +36,8 @@ process.env.CHROME_BIN = require('puppeteer').executablePath();
 // any of [ 'ChromeHeadless', 'Chrome', 'Firefox', 'IE', 'PhantomJS' ]
 var browsers = (process.env.TEST_BROWSERS || 'ChromeHeadless').split(/,/g);
 
+var autocleanup = 'test/helper/autocleanup.js';
+
 var suite = 'test/suite.js';
 
 if (modelers) {
@@ -55,10 +57,12 @@ module.exports = function(karma) {
     ],
 
     files: [
+      autocleanup,
       suite
     ],
 
     preprocessors: {
+      [autocleanup]: [ 'webpack' ],
       [suite]: [ 'webpack', 'env' ]
     },
 
@@ -149,9 +153,11 @@ module.exports = function(karma) {
       },
       plugins: [
         new DefinePlugin({
-          'process.env': {
-            NODE_ENV: JSON.stringify('test'),
-            WINDOWS: JSON.stringify(windows)
+          'process.env.NODE_ENV': JSON.stringify('test'),
+          'process.env.WINDOWS': JSON.stringify(windows),
+          'process.env.RTL_SKIP_AUTO_CLEANUP': JSON.stringify('true'), // auto-cleanup is configured as beforeEach hook
+          'process': { // must be present to prevent short-circuit in RTL auto-cleanup
+            env: {} // mocks variables set at build time
           }
         }),
         new MonacoWebpackPlugin({

--- a/client/test/helper/autocleanup.js
+++ b/client/test/helper/autocleanup.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { cleanup } from '@testing-library/react';
+
+// eslint-disable-next-line mocha/no-top-level-hooks
+beforeEach(function() {
+  cleanup();
+});


### PR DESCRIPTION
### Proposed Changes

This PR changes our test setup so that one can run a single test, and examine the result without debugger statement.

<img width="1396" height="948" alt="image" src="https://github.com/user-attachments/assets/da10a067-7638-4e32-94fb-75ce703a084b" />

Related to https://camunda.slack.com/archives/GP70M0J6M/p1771519537319059

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
