### PR TITLE
fix(client): indicate tab cut-off through ellipsis

### DIFF
--- a/client/src/app/primitives/Tabbed.less
+++ b/client/src/app/primitives/Tabbed.less
@@ -104,7 +104,7 @@
       font-size: var(--tab-font-size);
       white-space: nowrap;
       overflow: hidden;
-      text-overflow: clip;
+      text-overflow: ellipsis;
       margin: 0 28px 0 0;
     }
 


### PR DESCRIPTION
It is otherwise hard to see that tab name is not fully shown.

### Proposed Changes

Indicate that tab name is not fully shown through ellipsis `...`, it is otherwise not easy to understand that the tab name is not fully shown:

![capture lEVXfD_optimized](https://github.com/user-attachments/assets/2fd52434-5d0c-4374-a826-1ebff52f73a5)
 

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
