### PR TITLE
fix: do not throw if a tab is already gone on `setTabGroup`

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -198,7 +198,7 @@ export class App extends PureComponent {
     const tab = this.state.tabs.find((tab) => tab.id === id);
 
     if (!tab) {
-      throw new Error(`Tab with ID ${id} not found`);
+      return;
     }
 
     this.setState(({ tabGroups }) => {


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/5684

### Proposed Changes

`setTabGroup` is called inside of a `useEffect` in Process Application Plugin. It can be called after the target tab is already closed. Let's relax the API and just silently continue, instead of throwing on empty tab in `setTabGroup`.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
