### PR TITLE
fix: do not call `onDrag` when `dragging` is canceled

### DIFF
--- a/client/src/app/util/dragger.js
+++ b/client/src/app/util/dragger.js
@@ -12,14 +12,14 @@ import dragTabs from 'drag-tabs';
 
 const noop = () => {};
 
-export function addDragger(node, options, onDrag, onStart = noop) {
+export function addDragger(node, options, onDrag, onStart = noop, onCancel = noop) {
 
   const dragger = dragTabs(node, options);
 
   dragger.on('drag', onDrag);
   dragger.on('start', onStart);
 
-  dragger.on('cancel', onDrag);
+  dragger.on('cancel', onCancel);
 
   return dragger;
 }


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/5681

### Proposed Changes

`dragTabs` emits `onCancel` when the dragging is over. This calls `onDrag` with the initial tab index, reverting the tabs move.

It probably worked "by accident" with React 16, as the order of App tabs changed with every `onDrag` call, but with React 18 the last `onCancel` call is made with the index the tab had before the dragging.

![tabs-arrange-fix](https://github.com/user-attachments/assets/749bfacb-2209-4e0b-8c9a-57d529aff039)


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
