### PR TITLE
fix(FormEditor): do not update `previewOpen` on `handleChanged`

### DIFF
--- a/client/src/app/tabs/form/FormEditor.js
+++ b/client/src/app/tabs/form/FormEditor.js
@@ -373,8 +373,6 @@ export class FormEditor extends CachedComponent {
 
     const { onChanged } = this.props;
 
-    const { previewOpen } = this.state;
-
     const { form } = this.getCached();
 
     const commandStack = form.getEditor().get('commandStack');
@@ -385,7 +383,6 @@ export class FormEditor extends CachedComponent {
       defaultUndoRedo: inputActive,
       dirty: this.isDirty(),
       inputActive,
-      previewOpen,
       redo: commandStack.canRedo(),
       removeSelected: inputActive,
       save: true,


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/5679

### Proposed Changes

Do not update `previewOpen` flag in the general `handleChanged` handler. It's explicitly handled in `handlePlaygroundLayoutChanged`.

![form-preview](https://github.com/user-attachments/assets/ab206072-37a4-4117-bf8f-465f2790f8c2)


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
