### PR TITLE
ci: make slack role update failure visible

### DIFF
--- a/.github/workflows/RELEASE_ISSUE.yml
+++ b/.github/workflows/RELEASE_ISSUE.yml
@@ -78,7 +78,9 @@ jobs:
         # User ID is either the assignee from the newly created issue or the new assigned from the `assigned` trigger
         USER_ID: ${{ fromJSON(steps.secrets.outputs.TEAM_MEMBER_IDS)[ needs.create_release_issue.outputs.assignee || github.event.issue.assignee.login ] }}
       run: |
-        curl --fail-with-body -X POST -H "application/x-www-form-urlencoded" -d "token=${SLACK_BOT_TOKEN}&usergroup=${GROUP_ID}&users=${USER_ID}" https://slack.com/api/usergroups.users.update
+        RESPONSE="$(curl --fail-with-body -X POST -H "application/x-www-form-urlencoded" -d "token=${SLACK_BOT_TOKEN}&usergroup=${GROUP_ID}&users=${USER_ID}" https://slack.com/api/usergroups.users.update)"
+        echo "$RESPONSE"
+        echo "$RESPONSE" | jq -e '.ok == true' > /dev/null
 
   notify_on_slack:
     name: Notify new release manager on Slack


### PR DESCRIPTION
### Proposed Changes

This makes sure that the job fails in case slack api returns `ok: false`.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
