### PR TITLE
chore: fix changelog by moving not related to 5.45.0 release changes to 'Unreleased' section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+### General
+
+* `DEPS`: update to `@bpmn-io/properties-panel@3.40.1`
+* `FIX`: prevent cutting the tooltip if it couldn't fit to the bottom of the screen ([#5451](https://github.com/camunda/camunda-modeler/issues/5451))
+
 ## 5.45.0
 
 ### General
@@ -15,9 +20,8 @@ ___Note:__ Yet to be released changes appear here._
 * `FIX`: enable undo/redo and select all actions in settings modal ([#5306](https://github.com/camunda/camunda-modeler/issues/5306))
 * `FIX`: deduplicate open file filters ([#4503](https://github.com/camunda/camunda-modeler/issues/4503))
 * `FIX`: fix dragging elements out from the append menu ([#5513](https://github.com/camunda/camunda-modeler/issues/5513))
-* `FIX`: prevent cutting the tooltip if it couldn't fit to the bottom of the screen ([#5451](https://github.com/camunda/camunda-modeler/issues/5451))
 * `DEPS`: update to `@bpmn-io/svg-to-image@1.0.1`
-* `DEPS`: update to `@bpmn-io/properties-panel@3.40.1`
+* `DEPS`: update to `@bpmn-io/properties-panel@3.40.0`
 * `DEPS`: update to `@camunda/linting@3.48.1`
 * `DEPS`: update to `@bpmn-io/variable-resolver@1.6.1`
 * `DEPS`: update to `@bpmn-io/extract-process-variables@2.1.0`


### PR DESCRIPTION
### Proposed Changes

Fix changelog by moving not related to 5.45.0 release changes from [PR](https://github.com/camunda/camunda-modeler/pull/5674) to 'Unreleased' section, based on discussion [here](https://github.com/camunda/camunda-modeler/pull/5695#discussion_r2871646583).

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
