### PR TITLE
fix: depend on @vs-code/windows-ca-certs

### DIFF
--- a/app/lib/zeebe-api/get-system-certificates.js
+++ b/app/lib/zeebe-api/get-system-certificates.js
@@ -72,7 +72,7 @@ async function readCaCertificates() {
 }
 
 async function readWindowsCaCertificates() {
-  const winCA = require('vscode-windows-ca-certs');
+  const winCA = require('@vscode/windows-ca-certs');
 
   let ders = [];
   const store = new winCA.Crypt32();

--- a/app/package.json
+++ b/app/package.json
@@ -33,6 +33,6 @@
     "url": "https://github.com/camunda/camunda-modeler"
   },
   "optionalDependencies": {
-    "vscode-windows-ca-certs": "^0.3.0"
+    "@vscode/windows-ca-certs": "^0.3.4"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "zeebe-bpmn-moddle": "^1.12.0"
       },
       "optionalDependencies": {
-        "vscode-windows-ca-certs": "^0.3.0"
+        "@vscode/windows-ca-certs": "^0.3.4"
       }
     },
     "app/node_modules/chokidar": {
@@ -10939,6 +10939,30 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vscode/windows-ca-certs": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@vscode/windows-ca-certs/-/windows-ca-certs-0.3.4.tgz",
+      "integrity": "sha512-DcDLjBpu8srh6wUiZqEMyhXHzNDO81ecZOttL3+1u3Iht4CS6Qtxy5WkTPX/aDgbheASO/MK8yg6uLq58RzEWg==",
+      "hasInstallScript": true,
+      "license": "BSD",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "node-addon-api": "^8.2.0"
+      }
+    },
+    "node_modules/@vscode/windows-ca-certs/node_modules/node-addon-api": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
+      "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -34771,27 +34795,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/vscode-windows-ca-certs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/vscode-windows-ca-certs/-/vscode-windows-ca-certs-0.3.0.tgz",
-      "integrity": "sha512-CYrpCEKmAFQJoZNReOrelNL+VKyebOVRCqL9evrBlVcpWQDliliJgU5RggGS8FPGtQ3jAKLQt9frF0qlxYYPKA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "hasInstallScript": true,
-      "license": "ISC",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "dependencies": {
-        "node-addon-api": "^3.0.2"
-      }
-    },
-    "node_modules/vscode-windows-ca-certs/node_modules/node-addon-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
-      "optional": true
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.6",


### PR DESCRIPTION
### Proposed Changes

* vscode-windows-ca-certs is deprecated, newer versions (>0.3.0) of the package are released as @vs-code/windows-ca-certs
<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

Closes https://github.com/camunda/camunda-modeler/issues/5702

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
