### PR TITLE
fix: correct 'Save File As' ellipsis to three periods

### DIFF
--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -249,7 +249,7 @@ class MenuBuilder {
 
   appendSaveAsFile() {
     this.menu.append(new MenuItem({
-      label: 'Save File As..',
+      label: 'Save File As...',
       accelerator: 'CommandOrControl+Shift+S',
       enabled: this.options.state.save,
       click: function() {


### PR DESCRIPTION
## Description

Fixes a typo in the menu where "Save File As.." should be "Save File As..." (three periods, not two).

## Related Issues

Closes #5711