### PR TITLE
docs(release): add smoke testing before publication

### DIFF
--- a/docs/.project/RELEASE_TEMPLATE.md
+++ b/docs/.project/RELEASE_TEMPLATE.md
@@ -61,7 +61,7 @@ _To be done to build the release after release testing completed._
 
 * [ ] create release (`npm run release`), cf. [release schema](https://github.com/bpmn-io/internal-docs/blob/main/releases/RELEASE_SCHEMA.md)
   * [ ] wait for [release build](https://github.com/camunda/camunda-modeler/actions/workflows/RELEASE.yml) to create the [artifacts](https://github.com/camunda/camunda-modeler/releases)
-  * [ ] smoke test the Windows, macOS, and Linux artifacts
+  * [ ] smoke test the Windows, Mac, and Linux artifacts
 
 _To be done once the release is built._
 


### PR DESCRIPTION
Documenting an unwritten expectation before publishing the artifacts.

To keep the task list concise, [I opened an internal docs PR](https://github.com/bpmn-io/internal-docs/pull/1285) to document the specific recommended tests.

I found the documentation gap while working on https://github.com/camunda/camunda-modeler/issues/5619

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
