### PR TITLE
fix: replace outline with border to keep border intact

### DIFF
--- a/client/src/app/side-panel/SidePanel.less
+++ b/client/src/app/side-panel/SidePanel.less
@@ -1,10 +1,9 @@
 :local(.SidePanel) {
   position: relative;
   flex: none;
-  outline: none;
 
   &.open {
-    outline: solid 1px var(--color-grey-225-10-75);
+    border-left: solid 1px var(--color-grey-225-10-75);
   }
 
   /* The ResizableContainer wraps children in an absolutely

--- a/client/src/app/tabs/cloud-bpmn/variables-side-panel/VariablesSidePanel.less
+++ b/client/src/app/tabs/cloud-bpmn/variables-side-panel/VariablesSidePanel.less
@@ -1,10 +1,9 @@
 :local(.VariablesSidePanel) {
   position: relative;
   flex: none;
-  outline: none;
 
   &.open {
-    outline: solid 1px var(--color-grey-225-10-75);
+    border-left: solid 1px var(--color-grey-225-10-75);
   }
 
   &:not(.open) .resizer {


### PR DESCRIPTION
Related to #5734

### Proposed Changes

This pull request aims to replace the `outline` with `border` as `outline` doesn't take up space and hence, z-index can eat it up. With `border`, it takes up space and thus, panels do not overlap with each other, but sit side-by-side.

<img width="475" height="677" alt="image" src="https://github.com/user-attachments/assets/cdf95c7d-a47a-41a5-974e-38768b1b81e8" />


<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
