### PR TITLE
Allow setting NO_CONNECTION as lastUsedConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ___Note:__ Yet to be released changes appear here._
 
 ### General
 
+* `FIX`: persist offline connection as last used connection across restart ([#5746](https://github.com/camunda/camunda-modeler/pull/5746))
 * `FIX`: prevent cutting the tooltip if it couldn't fit to the bottom of the screen ([#5451](https://github.com/camunda/camunda-modeler/issues/5451))
 * `DEPS`: update to `@bpmn-io/properties-panel@3.40.1`
 * `DEPS`: update to `@bpmn-io/variable-resolver@2.0.0`

--- a/client/src/app/zeebe/Deployment.js
+++ b/client/src/app/zeebe/Deployment.js
@@ -185,6 +185,10 @@ export default class Deployment extends EventEmitter {
       }
     }
 
+    if (connectionId === NO_CONNECTION.id) {
+      return NO_CONNECTION;
+    }
+
     let endpoint = this.getEndpoint(connectionId);
 
     if (!endpoint) {

--- a/client/src/app/zeebe/__tests__/DeploymentSpec.js
+++ b/client/src/app/zeebe/__tests__/DeploymentSpec.js
@@ -726,9 +726,10 @@ describe('Deployment', function() {
         get: () => connections
       };
 
-      const config = new MockConfig();
-      config.getForFile = sinon.stub().resolves({});
-      config.get = sinon.stub().resolves(null);
+      const config = new MockConfig({
+        getForFile: () => Promise.resolve({}),
+        get: () => Promise.resolve(null)
+      });
 
       const deployment = createDeployment({ settings, config });
       sinon.spy(deployment, 'setConnectionIdForTab');
@@ -762,9 +763,10 @@ describe('Deployment', function() {
         get: () => connections
       };
 
-      const config = new MockConfig();
-      config.getForFile = sinon.stub().resolves({});
-      config.get = sinon.stub().resolves(null);
+      const config = new MockConfig({
+        getForFile: () => Promise.resolve({}),
+        get: () => Promise.resolve(null)
+      });
 
       const deployment = createDeployment({ settings, config });
       sinon.spy(deployment, 'setConnectionIdForTab');
@@ -780,6 +782,43 @@ describe('Deployment', function() {
       // then
       expect(result.id).to.equal('NO_CONNECTION');
       expect(deployment.setConnectionIdForTab).to.not.have.been.called;
+    });
+
+
+    it('should not overwrite NO_CONNECTION with default endpoint', async function() {
+
+      // given
+      const connections = [
+        {
+          id: 'c8run-local',
+          name: 'c8run (local)',
+          contactPoint: 'http://localhost:8080'
+        }
+      ];
+
+      const settings = {
+        get: () => connections
+      };
+
+      const config = new MockConfig({
+        getForFile: () => Promise.resolve({}),
+        get: () => Promise.resolve('NO_CONNECTION'),
+        set: sinon.spy()
+      });
+
+      const deployment = createDeployment({ settings, config });
+
+      const tab = {
+        id: 'tab-1',
+        file: createMockFile()
+      };
+
+      // when
+      const result = await deployment.getConnectionForTab(tab);
+
+      // then
+      expect(result.id).to.equal('NO_CONNECTION');
+      expect(config.set).to.not.have.been.calledWith('lastUsedConnection', 'c8run-local');
     });
 
   });


### PR DESCRIPTION
### Proposed Changes

Issue:
Even if you selected Disabled/No connection as the lastUsedConnection it would default to c8run (the default connection) the next time you start modeler

Reproduction Steps:
- clear config.json (optional, not sure if necessary)
- create new file in modeler
- select no connection
- close modeler
- open modeler
- create new file (either from homepage or if you have saved the earlier file)

Cause:
No connection is not a valid endpoint

Fix:
Don't check endpoint validity for no connection

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
