### PR TITLE
chore: run in strict mode

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -35,6 +35,8 @@ if (process.env.NODE_ENV !== 'production') {
   debug.enable('*,-sockjs-client:*');
 }
 
+const STRICT_MODE_ENABLED = process.env.REACT_STRICT_MODE_DISABLED !== 'true';
+
 Metadata.init(metadata);
 Flags.init(flags);
 
@@ -71,12 +73,23 @@ async function render() {
 
   const root = createRoot(rootElement);
   root.render(
-    <AppParent
-      keyboardBindings={ keyboardBindings }
-      globals={ globals }
-      tabsProvider={ tabsProvider }
-      onStarted={ onStarted }
-    />
+    STRICT_MODE_ENABLED ? (
+      <React.StrictMode>
+        <AppParent
+          keyboardBindings={ keyboardBindings }
+          globals={ globals }
+          tabsProvider={ tabsProvider }
+          onStarted={ onStarted }
+        />
+      </React.StrictMode>
+    ) : (
+      <AppParent
+        keyboardBindings={ keyboardBindings }
+        globals={ globals }
+        tabsProvider={ tabsProvider }
+        onStarted={ onStarted }
+      />
+    ),
   );
 }
 

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -16,6 +16,7 @@ const NODE_ENV = process.env.NODE_ENV || 'development';
 const SENTRY_DSN = process.env.SENTRY_DSN || null;
 const MIXPANEL_TOKEN = process.env.MIXPANEL_TOKEN || null;
 const MIXPANEL_STAGE = process.env.MIXPANEL_STAGE || null;
+const REACT_STRICT_MODE_DISABLED = process.env.REACT_STRICT_MODE_DISABLED || 'false';
 
 const DEV = NODE_ENV === 'development';
 const LICENSE_CHECK = process.env.LICENSE_CHECK;
@@ -121,6 +122,7 @@ module.exports = {
       'process.env.UPDATES_SERVER_PRODUCT_NAME': JSON.stringify(UPDATES_SERVER_PRODUCT_NAME),
       'process.env.MIXPANEL_TOKEN': JSON.stringify(MIXPANEL_TOKEN),
       'process.env.MIXPANEL_STAGE': JSON.stringify(MIXPANEL_STAGE),
+      'process.env.REACT_STRICT_MODE_DISABLED': JSON.stringify(REACT_STRICT_MODE_DISABLED)
     }),
     new CopyWebpackPlugin({
       patterns: [ copyPattern ]


### PR DESCRIPTION
### Proposed Changes

enable https://18.react.dev/reference/react/StrictMode to detect double renders. 

Strict Mode is only available in development builds, but I also made it configurable to disable it during normal dev (not sure about performance impact during development as it runs everything twice):

allows easier detection of too many state updates behavior: 

in case of issues can be overwritten by env variable `REACT_STRICT_MODE_DISABLED=true`

> [!WARNING] 
> Only merge once the strict issues are fixed

### to consider

- CI test run with strict mode
- manual strict testing of main as part of release activities

<img width="1492" height="821" alt="image" src="https://github.com/user-attachments/assets/097078f2-9cc7-4e06-bc08-7a77f0355bdb" />

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
