### PR TITLE
fix(client/App): de-curry tab callback handlers

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -86,6 +86,8 @@ const FILTER_ALL_EXTENSIONS = {
   extensions: [ '*' ]
 };
 
+const EMPTY_LINTING_STATE = [];
+
 const INITIAL_STATE = {
   activeTab: EMPTY_TAB,
   dirtyTabs: {},
@@ -951,13 +953,14 @@ export class App extends PureComponent {
 
 
   /**
-   * Mark a tab as shown.
+   * Mark tab as shown if it's active tab, otherwise ignore.
    *
-   * @param {Object} tab descriptor
-   *
-   * @return {Function} tab shown callback
+   * @param {Tab} tab
    */
-  handleTabShown = (tab) => () => {
+  handleTabShown = (tab) => {
+    if (tab !== this.state.activeTab) {
+      return;
+    }
 
     const {
       openedTabs,
@@ -965,11 +968,7 @@ export class App extends PureComponent {
       tabShown
     } = this.state;
 
-    if (tab === activeTab) {
-      tabShown.resolve();
-    } else {
-      tabShown.reject(new Error('tab miss-match'));
-    }
+    tabShown.resolve();
 
     this.setState({
       openedTabs: {
@@ -981,44 +980,53 @@ export class App extends PureComponent {
   };
 
   /**
-   * Handle tab error.
+   * Handle tab error if it is active tab, otherwise ignore.
    *
-   * @param {Object} tab descriptor
-   *
-   * @return {Function} tab error callback
+   * @param {Tab} tab
+   * @param {Error} error
    */
-  handleTabError = (tab) => (error) => {
-    this.handleError(error, tab);
+  handleTabError = (tab, error) => {
+    if (tab !== this.state.activeTab) {
+      return;
+    }
+
+    this.handleError(error, this.state.activeTab);
   };
 
   /**
-   * Handle tab warning.
+   * Handle tab warning if it is active tab, otherwise ignore.
    *
-   * @param {Object} tab descriptor
-   *
-   * @return {Function} tab warning callback
+   * @param {Tab} tab
+   * @param {Error|{ message: string }} warning
    */
-  handleTabWarning = (tab) => (warning) => {
-    this.handleWarning(warning, tab);
+  handleTabWarning = (tab, warning) => {
+    if (tab !== this.state.activeTab) {
+      return;
+    }
+
+    this.handleWarning(warning, this.state.activeTab);
   };
 
   /**
-   * Handle tab changed.
+   * Handle tab changed if it is active tab, otherwise ignore.
    *
-   * @param {Object} tab descriptor
-   *
-   * @return {Function} tab changed callback
+   * @param {Tab} tab
+   * @param {Object} properties
    */
-  handleTabChanged = (tab) => (properties = {}) => {
+  handleTabChanged = (tab, properties = {}) => {
+    if (tab !== this.state.activeTab) {
+      return;
+    }
 
-    let {
+    const {
+      activeTab,
       tabState
     } = this.state;
 
     let dirtyState = {};
 
     if ('dirty' in properties) {
-      dirtyState = this.setDirty(tab, properties.dirty);
+      dirtyState = this.setDirty(activeTab, properties.dirty);
     }
 
     this.setState({
@@ -1055,7 +1063,7 @@ export class App extends PureComponent {
   };
 
   getLintingState = (tab) => {
-    return this.state.lintingState[ tab.id ] || [];
+    return this.state.lintingState[ tab.id ] || EMPTY_LINTING_STATE;
   };
 
   setLintingState = (tab, results) => {
@@ -2409,10 +2417,10 @@ export class App extends PureComponent {
                         tab={ activeTab }
                         layout={ layout }
                         linting={ this.getLintingState(activeTab) }
-                        onChanged={ this.handleTabChanged(activeTab) }
-                        onError={ this.handleTabError(activeTab) }
-                        onWarning={ this.handleTabWarning(activeTab) }
-                        onShown={ this.handleTabShown(activeTab) }
+                        onChanged={ this.handleTabChanged }
+                        onError={ this.handleTabError }
+                        onWarning={ this.handleTabWarning }
+                        onShown={ this.handleTabShown }
                         onLayoutChanged={ this.handleLayoutChanged }
                         onContextMenu={ this.openTabMenu }
                         onAction={ this.triggerAction }
@@ -2537,7 +2545,7 @@ function missingProvider(providerType) {
   class MissingProviderTab extends PureComponent {
 
     componentDidMount() {
-      this.props.onShown();
+      this.props.onShown(this.props.tab);
     }
 
     render() {

--- a/client/src/app/EmptyTab.js
+++ b/client/src/app/EmptyTab.js
@@ -28,7 +28,7 @@ import Flags, { DISABLE_ZEEBE, DISABLE_PLATFORM } from '../util/Flags';
 export default class EmptyTab extends PureComponent {
 
   componentDidMount() {
-    this.props.onShown();
+    this.props.onShown(this.props.tab);
   }
 
   triggerAction() { }

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -108,7 +108,7 @@ describe('<App>', function() {
         });
 
         // when
-        app.handleTabChanged()();
+        app.handleTabChanged(app.state.activeTab);
 
         // then
         // 1 - tab render
@@ -1752,7 +1752,7 @@ describe('<App>', function() {
       const onTabChanged = spy(function(tab, oldTab) {
         events.push([ 'tab-changed', tab ]);
 
-        app.handleTabShown(tab)();
+        app.handleTabShown();
       });
 
       const onTabShown = spy(function(tab) {
@@ -2798,7 +2798,7 @@ describe('<App>', function() {
     class CustomEmptyTab extends Component {
 
       componentDidMount() {
-        this.props.onShown();
+        this.props.onShown(this.props.tab);
       }
 
       render() {

--- a/client/src/app/__tests__/mocks/index.js
+++ b/client/src/app/__tests__/mocks/index.js
@@ -51,10 +51,11 @@ class FakeTab extends Component {
 
   componentDidMount() {
     const {
-      onShown
+      onShown,
+      tab
     } = this.props;
 
-    onShown();
+    onShown(tab);
   }
 
   componentDidUpdate() {
@@ -79,11 +80,11 @@ class FakeTab extends Component {
     }
 
     if (action === 'error') {
-      this.props.onError(options);
+      this.props.onError(this.props.tab, options);
     }
 
     if (action === 'warning') {
-      this.props.onWarning(options);
+      this.props.onWarning(this.props.tab, options);
     }
 
     if (action === 'errorThrow') {

--- a/client/src/app/tabs/EditorTab.js
+++ b/client/src/app/tabs/EditorTab.js
@@ -37,11 +37,11 @@ export function createTab(tabName, providers) {
     }
 
     componentDidCatch(error, info) {
-      this.props.onError(error, info);
+      this.props.onError(this.props.tab, error, info);
     }
 
     componentDidMount() {
-      this.props.onShown();
+      this.props.onShown(this.props.tab);
     }
 
     render() {

--- a/client/src/app/tabs/MultiSheetTab.js
+++ b/client/src/app/tabs/MultiSheetTab.js
@@ -88,12 +88,13 @@ export class MultiSheetTab extends CachedComponent {
 
   handleChanged = (newState = {}) => {
     const {
-      onChanged
+      onChanged,
+      tab
     } = this.props;
 
     const dirty = this.isDirty(newState);
 
-    onChanged({
+    onChanged(tab, {
       ...newState,
       dirty
     });
@@ -101,18 +102,20 @@ export class MultiSheetTab extends CachedComponent {
 
   handleError = (error) => {
     const {
-      onError
+      onError,
+      tab
     } = this.props;
 
-    onError(error);
+    onError(tab, error);
   };
 
   handleWarning = (warning) => {
     const {
-      onWarning
+      onWarning,
+      tab
     } = this.props;
 
-    onWarning(warning);
+    onWarning(tab, warning);
   };
 
   /**

--- a/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
+++ b/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
@@ -115,7 +115,7 @@ describe('<MultiSheetTab>', function() {
       // then
       expect(errorSpy).not.to.have.been.called;
       expect(warningSpy).to.have.been.calledTwice;
-      expect(warningSpy.alwaysCalledWith('warning')).to.be.true;
+      expect(warningSpy.alwaysCalledWith(defaultTab, 'warning')).to.be.true;
     });
 
 
@@ -154,7 +154,7 @@ describe('<MultiSheetTab>', function() {
       instance.handleImport(error);
 
       // then
-      expect(errorSpy).to.have.been.calledWith(error);
+      expect(errorSpy).to.have.been.calledWith(defaultTab, error);
       expect(warningSpy).not.to.have.been.called;
       expect(showImportErrorDialogSpy).to.have.been.called;
     });
@@ -180,10 +180,10 @@ describe('<MultiSheetTab>', function() {
       instance.handleImport(error, warnings);
 
       // then
-      expect(errorSpy).to.have.been.calledWith(error);
+      expect(errorSpy).to.have.been.calledWith(defaultTab, error);
 
       expect(warningSpy).to.have.been.calledTwice;
-      expect(warningSpy.alwaysCalledWith('warning')).to.be.true;
+      expect(warningSpy.alwaysCalledWith(defaultTab, 'warning')).to.be.true;
 
       expect(showImportErrorDialogSpy).to.have.been.called;
       expect(displayWarningsNotificationSpy).not.to.have.been.called;


### PR DESCRIPTION
### Proposed Changes

Removes unnecessary currying from handleTabChanged, handleTabError, handleTabWarning, handleTabShown to ensure stable function references across renders.

Currying was introduced here: https://github.com/camunda/camunda-modeler/commit/ec0b1d1b6523f9ef406820306b8a5a0279607028

Fixes infinite re-render loop when opening files via OS double-click after React 18 migration.

Closes #5748
<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
