### PR TITLE
feat: align variables and properties side panel styling

### DIFF
--- a/client/src/app/side-panel/SidePanelTitleBar.js
+++ b/client/src/app/side-panel/SidePanelTitleBar.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React from 'react';
+
+import TabCloseIcon from '../../../resources/icons/TabClose.svg';
+
+import * as css from './SidePanelTitleBar.less';
+
+
+export default function SidePanelTitleBar({ title, icon: Icon, onClose }) {
+  return (
+    <div className={ css.SidePanelTitleBar }>
+      <div className="side-panel-title-bar__title">
+        { Icon && <Icon className="side-panel-title-bar__title-icon" /> }
+        <span>{ title }</span>
+      </div>
+      { onClose && (
+        <div className="side-panel-title-bar__actions">
+          <button
+            className="side-panel-title-bar__action"
+            title="Close panel"
+            onClick={ onClose }
+          >
+            <TabCloseIcon />
+          </button>
+        </div>
+      ) }
+    </div>
+  );
+}

--- a/client/src/app/side-panel/SidePanelTitleBar.less
+++ b/client/src/app/side-panel/SidePanelTitleBar.less
@@ -1,0 +1,63 @@
+:local(.SidePanelTitleBar) {
+  background-color: var(--color-grey-225-10-95);
+  border-bottom: solid 1px var(--color-grey-225-10-75);
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  flex: none;
+  padding: 0 2px 0 12px;
+  min-height: 32px;
+
+  .side-panel-title-bar__title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--font-family);
+    font-size: 13px;
+    color: var(--color-grey-225-10-15);
+
+    .side-panel-title-bar__title-icon {
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+    }
+  }
+
+  .side-panel-title-bar__actions {
+    display: flex;
+    align-items: center;
+    margin-right: 6px;
+  }
+
+  .side-panel-title-bar__action {
+    font-family: var(--font-family);
+    font-size: 14px;
+    color: var(--color-grey-225-10-35);
+    background: none;
+    border: none;
+    outline: none;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+
+    &:hover {
+      background-color: var(--color-grey-225-10-85);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--focus-outline-color);
+      outline-offset: -2px;
+    }
+
+    svg {
+      width: 16px;
+      height: 16px;
+    }
+  }
+}

--- a/client/src/app/side-panel/__tests__/SidePanelSpec.js
+++ b/client/src/app/side-panel/__tests__/SidePanelSpec.js
@@ -15,6 +15,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 
 import SidePanel, { DEFAULT_WIDTH } from '../SidePanel';
+import SidePanelTitleBar from '../SidePanelTitleBar';
 
 const { spy } = sinon;
 
@@ -174,6 +175,22 @@ describe('<SidePanel>', function() {
 
     // then
     expect(container.querySelector('.custom-header')).to.exist;
+  });
+
+
+  it('should render title bar in header', function() {
+
+    // when
+    const { getByText, getByRole } = createSidePanel({
+      header: <SidePanelTitleBar title="Configuration" onClose={ noop } />,
+      tabs: [
+        { id: 'foo', label: 'Foo', children: <div>Foo</div> }
+      ]
+    });
+
+    // then
+    expect(getByText('Configuration')).to.exist;
+    expect(getByRole('button', { name: 'Close panel' })).to.exist;
   });
 
 

--- a/client/src/app/side-panel/__tests__/SidePanelTitleBarSpec.js
+++ b/client/src/app/side-panel/__tests__/SidePanelTitleBarSpec.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/* global sinon */
+
+import React from 'react';
+
+import { render, fireEvent, screen } from '@testing-library/react';
+
+import SidePanelTitleBar from '../SidePanelTitleBar';
+
+const { spy } = sinon;
+
+const DummyIcon = (props) => <svg { ...props } aria-label="dummy icon" />;
+
+
+describe('<SidePanelTitleBar>', function() {
+
+  it('should render', function() {
+
+    // when
+    createSidePanelTitleBar();
+
+    // then
+    expect(screen.getByText('Test')).to.exist;
+  });
+
+
+  it('should render title', function() {
+
+    // when
+    createSidePanelTitleBar({ title: 'Variables' });
+
+    // then
+    expect(screen.getByText('Variables')).to.exist;
+  });
+
+
+  it('should render icon', function() {
+
+    // when
+    createSidePanelTitleBar({ icon: DummyIcon });
+
+    // then
+    expect(screen.getByLabelText('dummy icon')).to.exist;
+  });
+
+
+  it('should NOT render icon when not provided', function() {
+
+    // when
+    createSidePanelTitleBar();
+
+    // then
+    expect(screen.queryByLabelText('dummy icon')).not.to.exist;
+  });
+
+
+  it('should render close button', function() {
+
+    // when
+    createSidePanelTitleBar({ onClose: () => {} });
+
+    // then
+    expect(screen.getByRole('button', { name: 'Close panel' })).to.exist;
+  });
+
+
+  it('should NOT render close button when onClose not provided', function() {
+
+    // when
+    createSidePanelTitleBar();
+
+    // then
+    expect(screen.queryByRole('button', { name: 'Close panel' })).not.to.exist;
+  });
+
+
+  it('should call onClose when close button is clicked', function() {
+
+    // given
+    const onClose = spy();
+
+    createSidePanelTitleBar({ onClose });
+
+    // when
+    fireEvent.click(screen.getByRole('button', { name: 'Close panel' }));
+
+    // then
+    expect(onClose).to.have.been.calledOnce;
+  });
+
+});
+
+
+// helpers //////////
+
+function createSidePanelTitleBar(options = {}) {
+  const {
+    title = 'Test',
+    icon,
+    onClose
+  } = options;
+
+  return render(
+    <SidePanelTitleBar title={ title } icon={ icon } onClose={ onClose } />
+  );
+}

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -29,6 +29,7 @@ import {
 import { Settings } from '@carbon/icons-react';
 
 import SidePanel, { DEFAULT_LAYOUT as SIDE_PANEL_DEFAULT_LAYOUT } from '../../side-panel/SidePanel';
+import SidePanelTitleBar from '../../side-panel/SidePanelTitleBar';
 import PropertiesTab from '../../side-panel/tabs/PropertiesTab';
 import PropertiesPanelStatusBarItem from '../../resizable-container/PropertiesPanelStatusBarItem';
 import TaskTestingStatusBarItem from './side-panel/tabs/task-testing/TaskTestingStatusBarItem';
@@ -885,6 +886,19 @@ export class BpmnEditor extends CachedComponent {
             layout={ layout }
             onLayoutChanged={ this.handleLayoutChange }
           >
+            <SidePanel.Header>
+              <SidePanelTitleBar
+                title="Configuration"
+                icon={ Settings }
+                onClose={ () => this.handleLayoutChange({
+                  sidePanel: {
+                    ...SIDE_PANEL_DEFAULT_LAYOUT,
+                    ...layout.sidePanel,
+                    open: false
+                  }
+                }) }
+              />
+            </SidePanel.Header>
             <SidePanel.Header>
               <SidePanelHeader injector={ injector } />
             </SidePanel.Header>

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -10,7 +10,7 @@
 
 /* global sinon */
 
-import { waitFor, fireEvent } from '@testing-library/react';
+import { waitFor, fireEvent, getByRole } from '@testing-library/react';
 
 import { find } from 'min-dash';
 
@@ -1132,6 +1132,40 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
             width: 280
           }
         });
+      });
+
+
+      it('should close via title bar close button', async function() {
+
+        // given
+        const layout = {
+          sidePanel: {
+            open: true
+          }
+        };
+
+        const onLayoutChanged = sinon.spy();
+
+        const { getByText } = await renderEditor(diagramXML, {
+          layout,
+          onLayoutChanged
+        });
+
+        // when
+        const configurationTitle = getByText('Configuration');
+        const configurationSidePanel = configurationTitle.closest('.side-panel');
+        const closeButton = getByRole(configurationSidePanel, 'button', { name: 'Close panel' });
+
+        fireEvent.click(closeButton);
+
+        // then
+        await waitFor(() => {
+          expect(onLayoutChanged).to.have.been.calledOnce;
+        });
+
+        const callArg = onLayoutChanged.getCall(0).args[0];
+
+        expect(callArg.sidePanel.open).to.be.false;
       });
 
     });

--- a/client/src/app/tabs/cloud-bpmn/variables-side-panel/VariablesSidePanel.js
+++ b/client/src/app/tabs/cloud-bpmn/variables-side-panel/VariablesSidePanel.js
@@ -19,7 +19,7 @@ import '@bpmn-io/variable-outline/dist/variable-outline.css';
 
 import { utmTag } from '../../../../util/utmTag';
 import ResizableContainer from '../../../resizable-container/ResizableContainer';
-import TabCloseIcon from '../../../../../resources/icons/TabClose.svg';
+import SidePanelTitleBar from '../../../side-panel/SidePanelTitleBar';
 
 import * as css from './VariablesSidePanel.less';
 
@@ -81,21 +81,7 @@ export default function VariablesSidePanel(props) {
       maxWidth={ MAX_WIDTH }
       onResized={ onResized }
     >
-      <div className="variables-side-panel__header">
-        <div className="variables-side-panel__title">
-          <ValueVariableAlt className="variables-side-panel__title-icon" />
-          <span>Variables</span>
-        </div>
-        <div className="variables-side-panel__actions">
-          <button
-            className="variables-side-panel__action"
-            title="Close panel"
-            onClick={ onClose }
-          >
-            <TabCloseIcon />
-          </button>
-        </div>
-      </div>
+      <SidePanelTitleBar title="Variables" icon={ ValueVariableAlt } onClose={ onClose } />
 
       <div className="variables-side-panel__body">
         <VariableOutline

--- a/client/src/app/tabs/cloud-bpmn/variables-side-panel/VariablesSidePanel.less
+++ b/client/src/app/tabs/cloud-bpmn/variables-side-panel/VariablesSidePanel.less
@@ -17,70 +17,6 @@
     flex-direction: column;
   }
 
-  .variables-side-panel__header {
-    background-color: var(--color-grey-225-10-95);
-    border-bottom: solid 1px var(--color-grey-225-10-75);
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    flex: none;
-    padding: 0 2px 0 12px;
-    min-height: 32px;
-  }
-
-  .variables-side-panel__title {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-family: var(--font-family);
-    font-size: 13px;
-    color: var(--color-grey-225-10-15);
-
-    .variables-side-panel__title-icon {
-      width: 16px;
-      height: 16px;
-      flex-shrink: 0;
-    }
-  }
-
-  .variables-side-panel__actions {
-    display: flex;
-    align-items: center;
-    margin-right: 6px;
-  }
-
-  .variables-side-panel__action {
-    font-family: var(--font-family);
-    font-size: 14px;
-    color: var(--color-grey-225-10-35);
-    background: none;
-    border: none;
-    outline: none;
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0;
-
-    &:hover {
-      background-color: var(--color-grey-225-10-85);
-    }
-
-    &:focus-visible {
-      outline: 2px solid var(--focus-outline-color);
-      outline-offset: -2px;
-    }
-
-    svg {
-      width: 16px;
-      height: 16px;
-    }
-  }
-
   .variables-side-panel__body {
     flex: 1;
     position: relative;
@@ -94,8 +30,5 @@
       left: 0;
     }
 
-    .bio-vo-search-container {
-      height: 64px;
-    }
   }
 }

--- a/client/src/app/tabs/cloud-bpmn/variables-side-panel/__tests__/VariablesSidePanelSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/variables-side-panel/__tests__/VariablesSidePanelSpec.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+/* global sinon */
+
+import React from 'react';
+
+import { render, fireEvent, screen } from '@testing-library/react';
+
+import VariablesSidePanel from '../VariablesSidePanel';
+
+const { spy } = sinon;
+
+const noop = () => {};
+
+
+describe('<VariablesSidePanel>', function() {
+
+  it('should render title bar', function() {
+
+    // when
+    createVariablesSidePanel();
+
+    // then
+    expect(screen.getByText('Variables')).to.exist;
+    expect(screen.getByRole('button', { name: 'Close panel' })).to.exist;
+  });
+
+
+  it('should close on title bar close button click', function() {
+
+    // given
+    const onLayoutChanged = spy();
+
+    createVariablesSidePanel({ onLayoutChanged });
+
+    // when
+    fireEvent.click(screen.getByRole('button', { name: 'Close panel' }));
+
+    // then
+    expect(onLayoutChanged).to.have.been.calledOnce;
+
+    const layoutArg = onLayoutChanged.firstCall.args[0];
+
+    expect(layoutArg.variablesSidePanel.open).to.be.false;
+  });
+
+});
+
+
+// helpers //////////
+
+function createMockInjector() {
+  const services = {
+    bpmnjs: {
+      getDefinitions: () => null
+    },
+    variableResolver: {},
+    eventBus: {
+      on: noop,
+      off: noop,
+      fire: noop
+    },
+    selection: {
+      get: () => []
+    }
+  };
+
+  return {
+    get: (name) => services[name] || {}
+  };
+}
+
+
+function createVariablesSidePanel(options = {}) {
+  const {
+    layout = {
+      variablesSidePanel: { open: true, width: 280 }
+    },
+    onLayoutChanged = noop,
+    injector = createMockInjector()
+  } = options;
+
+  return render(
+    <VariablesSidePanel
+      injector={ injector }
+      layout={ layout }
+      onLayoutChanged={ onLayoutChanged }
+    />
+  );
+}


### PR DESCRIPTION
Introduces a shared SidePanelTitleBar component used by both the variables and properties side panels, ensuring consistent title headers with close buttons.

Closes #5773

<img width="853" height="269" alt="image" src="https://github.com/user-attachments/assets/bba1de1b-8d4b-4c39-ae43-c5fadd6e39d4" />


I was hoping `npx @bpmn-io/sr camunda/camunda-modeler#issue-5773 -l bpmn-io/variable-outline#issue-5773 -c 'npm run dev'` to enable us test the changes, but the modeler it runs does not seem healthy. However, if you open the modeler folder this command creates, you can run `npm run dev` and test the changes there.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
