### PR TITLE
feat: update properties sidebar title to "Details"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: update welcome screen to encourage creation ([#5716](https://github.com/camunda/camunda-modeler/pull/5716))
 * `FEAT`: mark Camunda 8.9 as latest stable engine profile ([#5740](https://github.com/camunda/camunda-modeler/issues/5740))
 * `FEAT`: remove icons in side panel title bars ([#5798](https://github.com/camunda/camunda-modeler/pull/5798))
+* `FEAT`: update properties sidebar title to "Details" ([#5795](https://github.com/camunda/camunda-modeler/pull/5795))
 * `FIX`: persist offline connection as last used connection across restart ([#5746](https://github.com/camunda/camunda-modeler/pull/5746))
 * `FIX`: use configured operate URL for linking also in Self-Managed ([#5669](https://github.com/camunda/camunda-modeler/pull/5669))
 * `FIX`: validate operate URL before using it ([#5708](https://github.com/camunda/camunda-modeler/issues/5708))

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -888,7 +888,7 @@ export class BpmnEditor extends CachedComponent {
           >
             <SidePanel.Header>
               <SidePanelTitleBar
-                title="Configuration"
+                title="Details"
                 onClose={ () => this.handleLayoutChange({
                   sidePanel: {
                     ...SIDE_PANEL_DEFAULT_LAYOUT,

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -1152,9 +1152,9 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
         });
 
         // when
-        const configurationTitle = getByText('Configuration');
-        const configurationSidePanel = configurationTitle.closest('.side-panel');
-        const closeButton = getByRole(configurationSidePanel, 'button', { name: 'Close panel' });
+        const detailsTitle = getByText('Details');
+        const detailsSidePanel = detailsTitle.closest('.side-panel');
+        const closeButton = getByRole(detailsSidePanel, 'button', { name: 'Close panel' });
 
         fireEvent.click(closeButton);
 


### PR DESCRIPTION
### Proposed Changes

This pull request updates the sidebar title to "Details" as "Configuration" was not found appropriate for the sidebar's responsibility.

<img width="556" height="337" alt="image" src="https://github.com/user-attachments/assets/cd8718c7-a5e0-4534-8218-7503c3dfbc4a" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
