### PR TITLE
feat(SidePanelTitleBar): remove icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: implement side panel for variables and task testing ([#5633](https://github.com/camunda/camunda-modeler/issues/5633))
 * `FEAT`: update welcome screen to encourage creation ([#5716](https://github.com/camunda/camunda-modeler/pull/5716))
 * `FEAT`: mark Camunda 8.9 as latest stable engine profile ([#5740](https://github.com/camunda/camunda-modeler/issues/5740))
+* `FEAT`: remove icons in side panel title bars ([#5798](https://github.com/camunda/camunda-modeler/pull/5798))
 * `FIX`: persist offline connection as last used connection across restart ([#5746](https://github.com/camunda/camunda-modeler/pull/5746))
 * `FIX`: use configured operate URL for linking also in Self-Managed ([#5669](https://github.com/camunda/camunda-modeler/pull/5669))
 * `FIX`: validate operate URL before using it ([#5708](https://github.com/camunda/camunda-modeler/issues/5708))

--- a/client/src/app/side-panel/SidePanelTitleBar.js
+++ b/client/src/app/side-panel/SidePanelTitleBar.js
@@ -15,11 +15,10 @@ import TabCloseIcon from '../../../resources/icons/TabClose.svg';
 import * as css from './SidePanelTitleBar.less';
 
 
-export default function SidePanelTitleBar({ title, icon: Icon, onClose }) {
+export default function SidePanelTitleBar({ title, onClose }) {
   return (
     <div className={ css.SidePanelTitleBar }>
       <div className="side-panel-title-bar__title">
-        { Icon && <Icon className="side-panel-title-bar__title-icon" /> }
         <span>{ title }</span>
       </div>
       { onClose && (

--- a/client/src/app/side-panel/SidePanelTitleBar.less
+++ b/client/src/app/side-panel/SidePanelTitleBar.less
@@ -12,16 +12,9 @@
   .side-panel-title-bar__title {
     display: flex;
     align-items: center;
-    gap: 6px;
     font-family: var(--font-family);
     font-size: 13px;
     color: var(--color-grey-225-10-15);
-
-    .side-panel-title-bar__title-icon {
-      width: 16px;
-      height: 16px;
-      flex-shrink: 0;
-    }
   }
 
   .side-panel-title-bar__actions {

--- a/client/src/app/side-panel/__tests__/SidePanelTitleBarSpec.js
+++ b/client/src/app/side-panel/__tests__/SidePanelTitleBarSpec.js
@@ -18,8 +18,6 @@ import SidePanelTitleBar from '../SidePanelTitleBar';
 
 const { spy } = sinon;
 
-const DummyIcon = (props) => <svg { ...props } aria-label="dummy icon" />;
-
 
 describe('<SidePanelTitleBar>', function() {
 
@@ -40,26 +38,6 @@ describe('<SidePanelTitleBar>', function() {
 
     // then
     expect(screen.getByText('Variables')).to.exist;
-  });
-
-
-  it('should render icon', function() {
-
-    // when
-    createSidePanelTitleBar({ icon: DummyIcon });
-
-    // then
-    expect(screen.getByLabelText('dummy icon')).to.exist;
-  });
-
-
-  it('should NOT render icon when not provided', function() {
-
-    // when
-    createSidePanelTitleBar();
-
-    // then
-    expect(screen.queryByLabelText('dummy icon')).not.to.exist;
   });
 
 
@@ -105,11 +83,10 @@ describe('<SidePanelTitleBar>', function() {
 function createSidePanelTitleBar(options = {}) {
   const {
     title = 'Test',
-    icon,
     onClose
   } = options;
 
   return render(
-    <SidePanelTitleBar title={ title } icon={ icon } onClose={ onClose } />
+    <SidePanelTitleBar title={ title } onClose={ onClose } />
   );
 }

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -889,7 +889,6 @@ export class BpmnEditor extends CachedComponent {
             <SidePanel.Header>
               <SidePanelTitleBar
                 title="Configuration"
-                icon={ Settings }
                 onClose={ () => this.handleLayoutChange({
                   sidePanel: {
                     ...SIDE_PANEL_DEFAULT_LAYOUT,

--- a/client/src/app/tabs/cloud-bpmn/variables-side-panel/VariablesSidePanel.js
+++ b/client/src/app/tabs/cloud-bpmn/variables-side-panel/VariablesSidePanel.js
@@ -10,8 +10,6 @@
 
 import React, { useCallback } from 'react';
 
-import { ValueVariableAlt } from '@carbon/icons-react';
-
 import classNames from 'classnames';
 
 import VariableOutline from '@bpmn-io/variable-outline';
@@ -81,7 +79,7 @@ export default function VariablesSidePanel(props) {
       maxWidth={ MAX_WIDTH }
       onResized={ onResized }
     >
-      <SidePanelTitleBar title="Variables" icon={ ValueVariableAlt } onClose={ onClose } />
+      <SidePanelTitleBar title="Variables" onClose={ onClose } />
 
       <div className="variables-side-panel__body">
         <VariableOutline


### PR DESCRIPTION
### Proposed Changes

This pull request removes the icons in the side panel title bars to bring DM and WM closer in look.

<img width="857" height="295" alt="image" src="https://github.com/user-attachments/assets/c47ff10c-7220-4f05-bd1d-215f624106b5" />


<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
