### PR TITLE
fix: scroll height limited sections

### DIFF
--- a/client/src/shared/ui/Section.js
+++ b/client/src/shared/ui/Section.js
@@ -36,7 +36,8 @@ export function Section(props) {
       };
     } else {
       style = {
-        '--section-max-height': isString(maxHeight) ? maxHeight : `${maxHeight}px`
+        '--section-max-height': isString(maxHeight) ? maxHeight : `${maxHeight}px`,
+        'overflowY': 'auto'
       };
     }
   }

--- a/client/src/shared/ui/__tests__/SectionSpec.js
+++ b/client/src/shared/ui/__tests__/SectionSpec.js
@@ -75,7 +75,8 @@ describe('<Section>', function() {
 
       // then
       expectStyle(container, {
-        '--section-max-height': '100vh'
+        '--section-max-height': '100vh',
+        'overflowY': 'auto'
       });
 
     });
@@ -88,7 +89,8 @@ describe('<Section>', function() {
 
       // then
       expectStyle(container, {
-        '--section-max-height': '100px'
+        '--section-max-height': '100px',
+        'overflowY': 'auto'
       });
 
     });


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/5807

### Proposed Changes

Use scrolling if content doesn't fix in max height of section. mainly fixes release info issue. 

Now:

<img width="938" height="583" alt="image" src="https://github.com/user-attachments/assets/08fd81e9-6478-4473-9637-0e205e7538c4" />

Before:

<img width="427" height="568" alt="image" src="https://github.com/user-attachments/assets/554891e7-89d5-475a-81bc-c0f58d49e9e6" />

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
