### PR TITLE
fix: highlight active side panel tab on initial start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FIX`: use configured operate URL for linking also in Self-Managed ([#5669](https://github.com/camunda/camunda-modeler/pull/5669))
 * `FIX`: enable right click context menu for editable elements and selected text ([#5801](https://github.com/camunda/camunda-modeler/pull/5801))
 * `FIX`: validate operate URL before using it ([#5708](https://github.com/camunda/camunda-modeler/issues/5708))
+* `FIX`: highlight active side panel tab on initial start ([#5826](https://github.com/camunda/camunda-modeler/issues/5826))
 * `DEPS`: update to `@bpmn-io/extract-process-variables@2.2.1`
 * `DEPS`: update to `@bpmn-io/form-js@1.21.1`
 * `DEPS`: update to `@bpmn-io/properties-panel@3.40.5`

--- a/client/src/app/resizable-container/PropertiesPanelTabActionItem.js
+++ b/client/src/app/resizable-container/PropertiesPanelTabActionItem.js
@@ -32,7 +32,7 @@ export default function PropertiesPanelTabActionItem(props) {
     onLayoutChanged({
       sidePanel: {
         ...sidePanelLayout,
-        open: !sidePanelLayout.open || sidePanelLayout.tab !== 'properties',
+        open: !sidePanelLayout.open || (sidePanelLayout.tab ?? 'properties') !== 'properties',
         tab: 'properties'
       }
     });
@@ -42,7 +42,7 @@ export default function PropertiesPanelTabActionItem(props) {
     <button
       className={ classnames(
         'btn--tab-action',
-        { 'btn--active': sidePanelLayout.open && sidePanelLayout.tab === 'properties' }
+        { 'btn--active': sidePanelLayout.open && (sidePanelLayout.tab ?? 'properties') === 'properties' }
       ) }
       onClick={ onClick }
       title="Properties"

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -717,7 +717,7 @@ export class BpmnEditor extends CachedComponent {
       const newLayout = {
         sidePanel: {
           ...sidePanelLayout,
-          open: sidePanelLayout.tab === 'properties' ? !sidePanelLayout.open : true,
+          open: (sidePanelLayout.tab ?? 'properties') === 'properties' ? !sidePanelLayout.open : true,
           tab: 'properties'
         }
       };

--- a/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/TaskTestingTabActionItem.js
+++ b/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/TaskTestingTabActionItem.js
@@ -32,7 +32,7 @@ export default function TaskTestingTabActionItem(props) {
     onLayoutChanged({
       sidePanel: {
         ...sidePanelLayout,
-        open: !sidePanelLayout.open || sidePanelLayout.tab !== 'test',
+        open: !sidePanelLayout.open || (sidePanelLayout.tab ?? 'properties') !== 'test',
         tab: 'test'
       }
     });
@@ -43,7 +43,7 @@ export default function TaskTestingTabActionItem(props) {
       className={ classnames(
         'btn--tab-action',
         {
-          'btn--active': sidePanelLayout.open && sidePanelLayout.tab === 'test'
+          'btn--active': sidePanelLayout.open && (sidePanelLayout.tab ?? 'properties') === 'test'
         }
       ) }
       onClick={ onClick }


### PR DESCRIPTION
Treat undefined tab as 'properties' (the default) in consumer components so that on fresh config the properties button is correctly shown as active.

Closes #5826

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
