### PR TITLE
fix: highlight active side panel tab on initial start

### DIFF
--- a/client/src/app/side-panel/SidePanel.js
+++ b/client/src/app/side-panel/SidePanel.js
@@ -24,6 +24,7 @@ export const DEFAULT_WIDTH = MIN_WIDTH;
 
 export const DEFAULT_LAYOUT = {
   open: DEFAULT_OPEN,
+  tab: 'properties',
   width: DEFAULT_WIDTH
 };
 

--- a/client/src/app/side-panel/__tests__/SidePanelSpec.js
+++ b/client/src/app/side-panel/__tests__/SidePanelSpec.js
@@ -141,6 +141,9 @@ describe('<SidePanel>', function() {
     const onLayoutChanged = spy();
 
     const { container } = createSidePanel({
+      layout: {
+        sidePanel: { open: true, width: DEFAULT_WIDTH, tab: 'foo' }
+      },
       onLayoutChanged,
       tabs: [
         { id: 'foo', label: 'Foo', children: <div>Foo</div> },


### PR DESCRIPTION
### Proposed Changes

Closes #5829

By default, we show the sidepanel, but we do not provide `tab` property with the open sub-tab. So, this pull request sets it to `properties` as it's shown by default.

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
