### PR TITLE
fix: prevent use of canvas context menu in properties panel popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: prevent use of canvas context menu in properties panel popups ([#5803](https://github.com/camunda/camunda-modeler/issues/5803))
+
 ## 5.46.0
 
 ### General

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -779,6 +779,12 @@ export class BpmnEditor extends CachedComponent {
 
   handleContextMenu = (event) => {
 
+    // prevent diagram context menu in properties panel popups (e.g. FEEL editor)
+    // to allow native text editing context menu instead
+    if (event.target.closest('.bio-properties-panel-popup')) {
+      return;
+    }
+
     const {
       onContextMenu
     } = this.props;

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -828,6 +828,12 @@ export class BpmnEditor extends CachedComponent {
 
   handleContextMenu = (event) => {
 
+    // prevent diagram context menu in properties panel popups (e.g. FEEL editor)
+    // to allow native text editing context menu instead
+    if (event.target.closest('.bio-properties-panel-popup')) {
+      return;
+    }
+
     const {
       onContextMenu
     } = this.props;


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5803

### Proposed Changes

Prevent diagram context menu in properties panel popups (e.g. FEEL editor), instead native text selection context menu should be used.

**Before:**

https://github.com/user-attachments/assets/5ad00933-38de-4812-a4ff-7b5fb2768955

**After:**

https://github.com/user-attachments/assets/6cfa94ab-3f74-4c43-af97-6e4616ddb0a8



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
