### PR TITLE
fix: show default context menu for text inputs in diagram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: show default context menu for text inputs in diagram ([#5803](https://github.com/camunda/camunda-modeler/issues/5803))
+
 ## 5.46.0
 
 ### General

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -34,7 +34,7 @@ import PropertiesPanelTabActionItem from '../../resizable-container/PropertiesPa
 
 import BpmnModeler from './modeler';
 
-import { active as isInputActive } from '../../../util/dom/isInput';
+import { active as isInputActive, isTextInput } from '../../../util/dom/isInput';
 
 import getBpmnContextMenu from './getBpmnContextMenu';
 
@@ -779,6 +779,12 @@ export class BpmnEditor extends CachedComponent {
   };
 
   handleContextMenu = (event) => {
+
+    // allow default context menu for text inputs,
+    // e.g. FEEL popup or direct editing
+    if (isTextInput(event.target)) {
+      return;
+    }
 
     const {
       onContextMenu

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -948,6 +948,71 @@ describe('<BpmnEditor>', function() {
   });
 
 
+  describe('#handleContextMenu', function() {
+
+    it('should call onContextMenu for non-input elements', async function() {
+
+      // given
+      const onContextMenuSpy = spy();
+
+      const { instance } = await renderEditor(diagramXML, {
+        onContextMenu: onContextMenuSpy
+      });
+
+      const div = document.createElement('div');
+      const event = { target: div };
+
+      // when
+      instance.handleContextMenu(event);
+
+      // then
+      expect(onContextMenuSpy).to.have.been.calledOnceWith(event);
+    });
+
+
+    it('should NOT call onContextMenu for text inputs', async function() {
+
+      // given
+      const onContextMenuSpy = spy();
+
+      const { instance } = await renderEditor(diagramXML, {
+        onContextMenu: onContextMenuSpy
+      });
+
+      const textarea = document.createElement('textarea');
+      const event = { target: textarea };
+
+      // when
+      instance.handleContextMenu(event);
+
+      // then
+      expect(onContextMenuSpy).to.not.have.been.called;
+    });
+
+
+    it('should NOT call onContextMenu for contentEditable elements', async function() {
+
+      // given
+      const onContextMenuSpy = spy();
+
+      const { instance } = await renderEditor(diagramXML, {
+        onContextMenu: onContextMenuSpy
+      });
+
+      const div = document.createElement('div');
+      div.setAttribute('contenteditable', 'true');
+      const event = { target: div };
+
+      // when
+      instance.handleContextMenu(event);
+
+      // then
+      expect(onContextMenuSpy).to.not.have.been.called;
+    });
+
+  });
+
+
   describe('#handleNamespace', function() {
 
     it('should replace namespace', async function() {

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -43,7 +43,7 @@ import VariablesTabActionItem from './variables-side-panel/VariablesTabActionIte
 
 import BpmnModeler from './modeler';
 
-import { active as isInputActive } from '../../../util/dom/isInput';
+import { active as isInputActive, isTextInput } from '../../../util/dom/isInput';
 
 import getBpmnContextMenu from '../bpmn/getBpmnContextMenu';
 
@@ -828,6 +828,12 @@ export class BpmnEditor extends CachedComponent {
   };
 
   handleContextMenu = (event) => {
+
+    // allow default context menu for text inputs,
+    // e.g. FEEL popup or direct editing
+    if (isTextInput(event.target)) {
+      return;
+    }
 
     const {
       onContextMenu

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -937,6 +937,71 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
   });
 
 
+  describe('#handleContextMenu', function() {
+
+    it('should call onContextMenu for non-input elements', async function() {
+
+      // given
+      const onContextMenuSpy = spy();
+
+      const { instance } = await renderEditor(diagramXML, {
+        onContextMenu: onContextMenuSpy
+      });
+
+      const div = document.createElement('div');
+      const event = { target: div };
+
+      // when
+      instance.handleContextMenu(event);
+
+      // then
+      expect(onContextMenuSpy).to.have.been.calledOnceWith(event);
+    });
+
+
+    it('should NOT call onContextMenu for text inputs', async function() {
+
+      // given
+      const onContextMenuSpy = spy();
+
+      const { instance } = await renderEditor(diagramXML, {
+        onContextMenu: onContextMenuSpy
+      });
+
+      const textarea = document.createElement('textarea');
+      const event = { target: textarea };
+
+      // when
+      instance.handleContextMenu(event);
+
+      // then
+      expect(onContextMenuSpy).to.not.have.been.called;
+    });
+
+
+    it('should NOT call onContextMenu for contentEditable elements', async function() {
+
+      // given
+      const onContextMenuSpy = spy();
+
+      const { instance } = await renderEditor(diagramXML, {
+        onContextMenu: onContextMenuSpy
+      });
+
+      const div = document.createElement('div');
+      div.setAttribute('contenteditable', 'true');
+      const event = { target: div };
+
+      // when
+      instance.handleContextMenu(event);
+
+      // then
+      expect(onContextMenuSpy).to.not.have.been.called;
+    });
+
+  });
+
+
   describe('#triggerAction', function() {
 
     it('should return value of editor action', async function() {

--- a/client/src/util/dom/__tests__/isInputSpec.js
+++ b/client/src/util/dom/__tests__/isInputSpec.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { isTextInput } from '../isInput';
+
+
+describe('util/dom/isInput', function() {
+
+  describe('isTextInput', function() {
+
+    it('should detect <textarea>', function() {
+
+      // given
+      const textarea = document.createElement('textarea');
+
+      // then
+      expect(isTextInput(textarea)).to.be.true;
+    });
+
+
+    it('should detect <input>', function() {
+
+      // given
+      const input = document.createElement('input');
+
+      // then
+      expect(isTextInput(input)).to.be.true;
+    });
+
+
+    it('should detect contentEditable element', function() {
+
+      // given
+      const div = document.createElement('div');
+      div.setAttribute('contenteditable', 'true');
+
+      // then
+      expect(isTextInput(div)).to.be.true;
+    });
+
+
+    it('should detect child of contentEditable element', function() {
+
+      // given
+      const container = document.createElement('div');
+      container.setAttribute('contenteditable', 'true');
+
+      const span = document.createElement('span');
+      container.appendChild(span);
+
+      // then
+      expect(isTextInput(span)).to.be.true;
+    });
+
+
+    it('should not detect non-input element', function() {
+
+      // given
+      const div = document.createElement('div');
+
+      // then
+      expect(isTextInput(div)).to.be.false;
+    });
+
+  });
+
+});

--- a/client/src/util/dom/isInput.js
+++ b/client/src/util/dom/isInput.js
@@ -16,6 +16,17 @@ export function isInput(element) {
   );
 }
 
+/**
+ * Check if given element or any ancestor is a text input.
+ *
+ * @param {Element} element
+ *
+ * @returns {boolean}
+ */
+export function isTextInput(element) {
+  return element.closest('input, textarea, [contenteditable="true"]') !== null;
+}
+
 export function active(element) {
   element = element || document.activeElement;
 


### PR DESCRIPTION
Right-clicking text inputs rendered in the diagram container (e.g. FEEL popup, direct editing) opened the diagram context menu instead of the default one.

Skip the diagram context menu when the right-click target is a text input (input, textarea, contenteditable).

Related to #5803

### Proposed Changes

This is an alternative solution to what's delivered in https://github.com/camunda/camunda-modeler/pull/5847. While reviewing the pull request, I realized that we also show the canvas context menu for the direct editing content. Even though keyboard shortcuts were functioning as expected for the direct editing content, using the context menu was taking the actions for the canvas; like copying the diagram XML rather than the selected direct editing content.


Before

<img width="400" alt="image" src="https://github.com/user-attachments/assets/c41a5b07-9e02-4094-b9b7-99eb203d409e" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/d11b5b8b-1cea-4bc9-a092-ef000a61c788" />

After

<img width="400" alt="image" src="https://github.com/user-attachments/assets/346fb208-2ac9-4bd6-aaa5-962d0af7730f" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/fd37837d-71a0-410c-89b0-f6ad29bd8bec" />


<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
