### PR TITLE
fix: restore opening settings in dev mode

### DIFF
--- a/client/src/app/Settings.js
+++ b/client/src/app/Settings.js
@@ -177,6 +177,22 @@ export default class Settings {
   }
 
   /**
+   * Unregister a settings group and all its properties.
+   *
+   * @param {string} id
+   */
+  unregister(id) {
+    const group = this._settings[id];
+    if (!group) return;
+
+    forEach(group.properties, (_, key) => {
+      delete this._defaults[key];
+    });
+
+    delete this._settings[id];
+  }
+
+  /**
    * Get value for the specified setting or all settings if no key is provided.
    *
    * If a setting is controlled by a flag and the flag is set,

--- a/client/src/app/__tests__/SettingsSpec.js
+++ b/client/src/app/__tests__/SettingsSpec.js
@@ -179,6 +179,17 @@ describe('Settings', function() {
     });
 
 
+    it('should allow re-registration after unregistration', function() {
+
+      // given
+      settings.register(settingsMock);
+      settings.unregister(settingsMock.id);
+
+      // when / then
+      expect(() => settings.register(settingsMock)).not.to.throw();
+    });
+
+
     it('should throw error when property ID does not start with group ID', function() {
 
       // given

--- a/client/src/plugins/settings/__tests__/useBuiltInSettingsSpec.js
+++ b/client/src/plugins/settings/__tests__/useBuiltInSettingsSpec.js
@@ -8,7 +8,25 @@
  * except in compliance with the MIT License.
  */
 
-import { schema } from '../useBuiltInSettings';
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import useBuiltInSettings, { schema } from '../useBuiltInSettings';
+
+import Settings from '../../../app/Settings';
+
+
+function TestComponent({ settings }) {
+  useBuiltInSettings(settings);
+  return null;
+}
+
+const noop = () => {};
+
+function createSettings() {
+  return new Settings({ config: { get: noop, set: noop } });
+}
 
 
 describe('useBuiltInSettings', function() {
@@ -18,6 +36,20 @@ describe('useBuiltInSettings', function() {
     // then
     expect(schema.properties['app.defaultC8Version'].default).to.equal('8.9.0');
     expect(schema.properties['app.defaultC7Version'].default).to.equal('7.24.0');
+  });
+
+
+  it('should not throw when re-mounted with the same settings instance (strict mode)', function() {
+
+    // given - initial mount registers settings
+    const settings = createSettings();
+    const { unmount } = render(<TestComponent settings={ settings } />);
+
+    // when - unmount triggers cleanup (unregister), then remount re-registers
+    unmount();
+
+    // then - second mount must not throw
+    expect(() => render(<TestComponent settings={ settings } />)).not.to.throw();
   });
 
 });

--- a/client/src/plugins/settings/useBuiltInSettings.js
+++ b/client/src/plugins/settings/useBuiltInSettings.js
@@ -25,6 +25,7 @@ export default function useBuiltInSettings(settings) {
 
   useEffect(() => {
     settings.register(schema);
+    return () => settings.unregister(schema.id);
   }, []);
 }
 


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

closes #5872 

Introduces a cleanup for `settings.register` to prevent an error on re-registration.

React strict mode mounts components twice to expose potential render issues. Settings are registered when the `Settings` component is rendered. When the same setting is already registered, an Error was thrown, and the Settings modal crashed.

With this PR, settings are unregistered on unmount. When the component is mounted again, the setting is not registered, so no Error is thrown.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
