### PR TITLE
feat: allow SaaS connections to be configured with a tenant ID

### DIFF
--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettingsProperties.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettingsProperties.js
@@ -126,7 +126,6 @@ export const properties = [
     type: 'text',
     label: LABELS.TENANT_ID,
     hint: HINTS.TENANT_ID,
-    condition: { property: 'targetType', equals: TARGET_TYPES.SELF_HOSTED },
     constraints: {
       pattern: {
         value: REGEXES.TENANT_ID,

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionManagerSettingsComponentSpec.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionManagerSettingsComponentSpec.js
@@ -320,6 +320,57 @@ describe('ConnectionManagerSettingsComponent', function() {
     });
 
 
+    it('should display tenant ID field for SaaS connections', async function() {
+
+      // given
+      const connections = [
+        {
+          id: 'conn-1',
+          name: 'Test Connection',
+          targetType: 'camundaCloud',
+          camundaCloudClusterUrl: 'https://test.zeebe.camunda.io',
+          camundaCloudClientId: 'test-client-id'
+        }
+      ];
+
+      const { container } = createComponent({ initialValues: connections });
+
+      // when
+      const expandButton = container.querySelector('button[aria-label="Expand current row"]');
+      fireEvent.click(expandButton);
+
+      // then
+      await waitFor(() => {
+        expect(container.querySelector('input[name*="tenantId"]')).to.exist;
+      });
+    });
+
+
+    it('should display tenant ID field for self-hosted connections', async function() {
+
+      // given
+      const connections = [
+        {
+          id: 'conn-1',
+          name: 'Test Connection',
+          targetType: 'selfHosted',
+          contactPoint: 'http://localhost:26500'
+        }
+      ];
+
+      const { container } = createComponent({ initialValues: connections });
+
+      // when
+      const expandButton = container.querySelector('button[aria-label="Expand current row"]');
+      fireEvent.click(expandButton);
+
+      // then
+      await waitFor(() => {
+        expect(container.querySelector('input[name*="tenantId"]')).to.exist;
+      });
+    });
+
+
     it('should show target type radio buttons', async function() {
 
       // given

--- a/client/src/remote/ZeebeAPI.js
+++ b/client/src/remote/ZeebeAPI.js
@@ -236,6 +236,7 @@ export function getEndpointForTargetType(endpoint) {
       url: camundaCloudClusterUrl,
       clientId: camundaCloudClientId,
       clientSecret: camundaCloudClientSecret,
+      tenantId
     };
   }
 

--- a/client/src/remote/__tests__/ZeebeAPISpec.js
+++ b/client/src/remote/__tests__/ZeebeAPISpec.js
@@ -202,7 +202,154 @@ describe('<ZeebeAPI>', function() {
     });
 
 
-    it('should check connection (SaaS)', function() {
+    it('should check connection (self-managed, no auth, with tenant id)', function() {
+
+      // given
+      const backend = new MockBackend({
+        send: sinon.spy()
+      });
+
+      const zeebeAPI = new ZeebeAPI(backend);
+
+      const tenantId = 'my-tenant';
+
+      const endpoint = {
+        targetType: TARGET_TYPES.SELF_HOSTED,
+        authType: AUTH_TYPES.NONE,
+        contactPoint: 'http://localhost:26500',
+        tenantId
+      };
+
+      // when
+      zeebeAPI.checkConnection(endpoint);
+
+      // then
+      expect(backend.send).to.have.been.calledOnce;
+      expect(backend.send).to.have.been.calledWith('zeebe:checkConnection', {
+        endpoint: {
+          type: TARGET_TYPES.SELF_HOSTED,
+          authType: AUTH_TYPES.NONE,
+          url: endpoint.contactPoint,
+          tenantId: 'my-tenant'
+        }
+      });
+    });
+
+
+    it('should check connection (self-managed, basic auth, with tenant id)', function() {
+
+      // given
+      const backend = new MockBackend({
+        send: sinon.spy()
+      });
+
+      const zeebeAPI = new ZeebeAPI(backend);
+
+      const tenantId = 'my-tenant';
+
+      const endpoint = {
+        targetType: TARGET_TYPES.SELF_HOSTED,
+        authType: AUTH_TYPES.BASIC,
+        contactPoint: 'http://localhost:26500',
+        basicAuthUsername: 'username',
+        basicAuthPassword: 'password',
+        tenantId
+      };
+
+      // when
+      zeebeAPI.checkConnection(endpoint);
+
+      // then
+      expect(backend.send).to.have.been.calledOnce;
+      expect(backend.send).to.have.been.calledWith('zeebe:checkConnection', {
+        endpoint: {
+          type: TARGET_TYPES.SELF_HOSTED,
+          authType: AUTH_TYPES.BASIC,
+          url: endpoint.contactPoint,
+          basicAuthUsername: 'username',
+          basicAuthPassword: 'password',
+          tenantId: 'my-tenant'
+        }
+      });
+    });
+
+
+    it('should check connection (self-managed, oauth, with tenant id)', function() {
+
+      // given
+      const backend = new MockBackend({
+        send: sinon.spy()
+      });
+
+      const zeebeAPI = new ZeebeAPI(backend);
+
+      const tenantId = 'my-tenant';
+
+      const endpoint = {
+        targetType: TARGET_TYPES.SELF_HOSTED,
+        authType: AUTH_TYPES.OAUTH,
+        contactPoint: 'http://localhost:26500',
+        oauthURL: 'foo.com',
+        audience: 'bar.com',
+        scope: 'baz',
+        clientId: 'foo',
+        clientSecret: 'bar',
+        tenantId
+      };
+
+      // when
+      zeebeAPI.checkConnection(endpoint);
+
+      // then
+      expect(backend.send).to.have.been.calledWith('zeebe:checkConnection', {
+        endpoint: {
+          type: TARGET_TYPES.SELF_HOSTED,
+          authType: AUTH_TYPES.OAUTH,
+          url: endpoint.contactPoint,
+          oauthURL: endpoint.oauthURL,
+          audience: endpoint.audience,
+          scope: endpoint.scope,
+          clientId: endpoint.clientId,
+          clientSecret: endpoint.clientSecret,
+          tenantId: 'my-tenant'
+        }
+      });
+    });
+
+
+    it('should check connection (SaaS, with tenant id)', function() {
+
+      // given
+      const backend = new MockBackend({
+        send: sinon.spy()
+      });
+
+      const zeebeAPI = new ZeebeAPI(backend);
+
+      const endpoint = {
+        targetType: TARGET_TYPES.CAMUNDA_CLOUD,
+        camundaCloudClientId: 'foo',
+        camundaCloudClientSecret: 'bar',
+        camundaCloudClusterUrl: 'https://xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.yyy-1.zeebe.example.io:443',
+        tenantId: 'my-tenant'
+      };
+
+      // when
+      zeebeAPI.checkConnection(endpoint);
+
+      // then
+      expect(backend.send).to.have.been.calledWith('zeebe:checkConnection', {
+        endpoint: {
+          type: TARGET_TYPES.CAMUNDA_CLOUD,
+          url: endpoint.camundaCloudClusterUrl,
+          clientId: endpoint.camundaCloudClientId,
+          clientSecret: endpoint.camundaCloudClientSecret,
+          tenantId: endpoint.tenantId
+        }
+      });
+    });
+
+    it('should check connection (SaaS, without tenant id)', function() {
 
       // given
       const backend = new MockBackend({
@@ -227,7 +374,8 @@ describe('<ZeebeAPI>', function() {
           type: TARGET_TYPES.CAMUNDA_CLOUD,
           url: endpoint.camundaCloudClusterUrl,
           clientId: endpoint.camundaCloudClientId,
-          clientSecret: endpoint.camundaCloudClientSecret
+          clientSecret: endpoint.camundaCloudClientSecret,
+          tenantId: undefined
         }
       });
     });


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

related #5818 

Allow users to define a tenant ID as part of their SaaS connection, which will be forwarded in all Zeebe/OC API calls made with that connection

<img width="1061" height="712" alt="Tenant ID field in SaaS connection config" src="https://github.com/user-attachments/assets/e836f38b-8fc5-4ab2-93a5-bc0c9e961fb2" />

### Testing Hints

Follow these steps to test:
- Check out this PR's branch locally
- Create an API client in Console for the cluster
- Ask @ev-codes to join their organization OR create your own prod cluster using an 8.10 generation, then create a tenant
- Assign your client to the tenant using the Orchestration Cluster API
- Input the client details into the Connection Manager as usual

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
