### PR TITLE
support 8.9 saas clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+## 5.46.1
+
 ### General
 
+* `FIX`: support Camunda 8.9 cluster URLs ([#5875](https://github.com/camunda/camunda-modeler/pull/5875))
 * `FIX`: make non-editable FEEL properties read-only ([#5819](https://github.com/camunda/camunda-modeler/issues/5819))
 * `DEPS`: update to `@bpmn-io/properties-panel@3.40.6`
 

--- a/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/__tests__/TaskTestingApiSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/__tests__/TaskTestingApiSpec.js
@@ -48,6 +48,35 @@ describe('<TaskTestingApi>', function() {
     });
 
 
+    it('should return Operate URL for SaaS 8.9', async function() {
+
+      // given
+      const api = new TaskTestingApi(
+        new Deployment({
+          getConnectionForTab: async () => {
+            return {
+              targetType: 'camundaCloud',
+              camundaCloudClusterUrl: 'https://yyy-1.api.camunda.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/v2'
+            };
+          }
+        }),
+        null,
+        null,
+        {
+          path: 'path/to/file.bpmn'
+        },
+        null
+      );
+
+
+      // when
+      const operateUrl = await api.getOperateUrl();
+
+      // then
+      expect(operateUrl).to.equal('https://yyy-1.api.camunda.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/operate');
+    });
+
+
     it('should return Operate URL for SM', async function() {
 
       // given
@@ -193,6 +222,35 @@ describe('<TaskTestingApi>', function() {
 
       // then
       expect(tasklistUrl).to.equal('https://yyy-1.tasklist.camunda.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
+    });
+
+
+    it('should return Tasklist URL for SaaS 8.9', async function() {
+
+      // given
+      const api = new TaskTestingApi(
+        new Deployment({
+          getConnectionForTab: async () => {
+            return {
+              targetType: 'camundaCloud',
+              camundaCloudClusterUrl: 'https://yyy-1.api.camunda.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/v2'
+            };
+          }
+        }),
+        null,
+        null,
+        {
+          path: 'path/to/file.bpmn'
+        },
+        null
+      );
+
+
+      // when
+      const tasklistUrl = await api.getTasklistUrl();
+
+      // then
+      expect(tasklistUrl).to.equal('https://yyy-1.api.camunda.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/tasklist');
     });
 
 

--- a/client/src/app/zeebe/__tests__/utilSpec.js
+++ b/client/src/app/zeebe/__tests__/utilSpec.js
@@ -16,11 +16,17 @@ import {
   getTasklistBaseUrl
 } from '../util';
 
+import sinon from 'sinon';
+
 import { TARGET_TYPES } from '../../../remote/ZeebeAPI';
 
 describe('operate-url', function() {
 
   describe('getOperateBaseUrl', function() {
+
+    afterEach(function() {
+      sinon.restore();
+    });
 
     it('should get Camunda Operate URL (gRPC)', function() {
 
@@ -61,6 +67,110 @@ describe('operate-url', function() {
         targetType: TARGET_TYPES.CAMUNDA_CLOUD,
         camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/v2/'
       };
+
+      // when
+      const url = getOperateBaseUrl(endpoint);
+
+      // then
+      expect(url).to.eql('https://yyy-1.operate.camunda.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
+    });
+
+
+    it('should get Camunda Operate URL (REST 8.9)', function() {
+
+      // given
+      const endpoint = {
+        targetType: TARGET_TYPES.CAMUNDA_CLOUD,
+        camundaCloudClusterUrl: 'https://yyy-1.api.camunda.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/v2'
+      };
+
+      // when
+      const url = getOperateBaseUrl(endpoint);
+
+      // then
+      expect(url).to.eql('https://yyy-1.api.camunda.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/operate');
+    });
+
+
+    it('should not get Camunda Operate URL if cluster ID cannot be extracted during SaaS URL generation', function() {
+
+      // given
+      const endpoint = {
+        targetType: TARGET_TYPES.CAMUNDA_CLOUD,
+        camundaCloudClusterUrl: 'https://region-1.zeebe.camunda.io/cluster-name'
+      };
+
+      const originalMatch = String.prototype.match;
+      let clusterIdCalls = 0;
+
+      sinon.stub(String.prototype, 'match').callsFake(function(regex) {
+        if (this.toString() !== endpoint.camundaCloudClusterUrl) {
+          return originalMatch.call(this, regex);
+        }
+
+        if (regex.source === /([a-z\d]+-){2,}[a-z\d]+/g.source) {
+          return clusterIdCalls++ === 0 ? [ 'xxxx-xxxx-xxxx' ] : null;
+        }
+
+        if (regex.source === /(?:(?<=\.)|(?<=:\/\/))[a-z]+-\d+(?=\.)/g.source) {
+          return [ 'region-1' ];
+        }
+
+        return originalMatch.call(this, regex);
+      });
+
+      // when
+      const url = getOperateBaseUrl(endpoint);
+
+      // then
+      expect(url).to.be.null;
+    });
+
+
+    it('should not get Camunda Operate URL if unified SaaS URL generation throws', function() {
+
+      // given
+      const endpoint = {
+        targetType: TARGET_TYPES.CAMUNDA_CLOUD,
+        camundaCloudClusterUrl: 'https://yyy-1.api.camunda.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/v2'
+      };
+
+      let callCount = 0;
+
+      sinon.stub(globalThis, 'URL').callsFake(function() {
+        if (++callCount === 1) {
+          return { hostname: 'yyy-1.api.camunda.io' };
+        }
+
+        throw new Error('failed to parse unified URL');
+      });
+
+      // when
+      const url = getOperateBaseUrl(endpoint);
+
+      // then
+      expect(url).to.be.null;
+    });
+
+
+    it('should fall back to classic SaaS URL generation if unified SaaS detection throws', function() {
+
+      // given
+      const endpoint = {
+        targetType: TARGET_TYPES.CAMUNDA_CLOUD,
+        camundaCloudClusterUrl: 'https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+      };
+
+      const OriginalURL = globalThis.URL;
+      let callCount = 0;
+
+      sinon.stub(globalThis, 'URL').callsFake(function(input) {
+        if (++callCount === 1) {
+          throw new Error('failed to inspect URL');
+        }
+
+        return new OriginalURL(input);
+      });
 
       // when
       const url = getOperateBaseUrl(endpoint);
@@ -200,6 +310,22 @@ describe('operate-url', function() {
 
       // then
       expect(url).to.eql('https://yyy-1.tasklist.camunda.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
+    });
+
+
+    it('should get Camunda Tasklist URL (REST 8.9)', function() {
+
+      // given
+      const endpoint = {
+        targetType: TARGET_TYPES.CAMUNDA_CLOUD,
+        camundaCloudClusterUrl: 'https://yyy-1.api.camunda.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/v2'
+      };
+
+      // when
+      const url = getTasklistBaseUrl(endpoint);
+
+      // then
+      expect(url).to.eql('https://yyy-1.api.camunda.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/tasklist');
     });
 
 

--- a/client/src/app/zeebe/util.js
+++ b/client/src/app/zeebe/util.js
@@ -62,7 +62,7 @@ function createOperateBaseUrl(endpoint) {
     return null;
   }
 
-  return new URL(`https://${ clusterRegion }.operate.camunda.io/${ clusterId }`);
+  return createCamundaCloudWebAppUrl(camundaCloudClusterUrl, 'operate');
 }
 
 /**
@@ -113,7 +113,43 @@ function createTasklistBaseUrl(endpoint) {
     return null;
   }
 
-  return new URL(`https://${ clusterRegion }.tasklist.camunda.io/${ clusterId }`);
+  return createCamundaCloudWebAppUrl(camundaCloudClusterUrl, 'tasklist');
+}
+
+function createCamundaCloudWebAppUrl(clusterURL, appName) {
+  const clusterId = getClusterId(clusterURL);
+
+  if (!clusterId) {
+    return null;
+  }
+
+  if (isUnifiedCamundaCloudUrl(clusterURL)) {
+    try {
+      const url = new URL(clusterURL);
+
+      return new URL(`${ url.origin }/${ clusterId }/${ appName }`);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  const clusterRegion = getClusterRegion(clusterURL);
+
+  if (!clusterRegion) {
+    return null;
+  }
+
+  return new URL(`https://${ clusterRegion }.${ appName }.camunda.io/${ clusterId }`);
+}
+
+function isUnifiedCamundaCloudUrl(clusterURL) {
+  try {
+    const url = new URL(clusterURL);
+
+    return url.hostname.endsWith('.api.camunda.io');
+  } catch (error) {
+    return false;
+  }
 }
 
 /**
@@ -184,6 +220,7 @@ function getClusterId(clusterURL) {
  *
  * https://xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.yyy-1.zeebe.example.io:443
  * https://yyy-1.zeebe.example.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+ * https://yyy-1.api.camunda.io/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
  *
  * @example
  *

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettingsProperties.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettingsProperties.js
@@ -60,7 +60,7 @@ const REGEXES = {
   URL: /^(http|grpc)s?:\/\//,
   OPTIONAL_HTTP_URL: /^$|^https?:\/\/\S+$/,
   CAMUNDA_CLOUD_GRPC_URL: /^((https|grpcs):\/\/|)[a-z\d-]+\.[a-z]+-\d+\.zeebe\.camunda\.io(:443|)\/?$/,
-  CAMUNDA_CLOUD_REST_URL: /^https:\/\/[a-z]+-\d+\.(zeebe|api)\.camunda\.io(:443|)\/[a-z\d-]+\/?$/
+  CAMUNDA_CLOUD_REST_URL: /^https:\/\/[a-z]+-\d+\.(zeebe|api)\.camunda\.io(:443|)\/[a-z\d-]+(?:\/v2)?\/?$/
 };
 REGEXES.CAMUNDA_CLOUD_URL = new RegExp(
   `${REGEXES.CAMUNDA_CLOUD_GRPC_URL.source}|${REGEXES.CAMUNDA_CLOUD_REST_URL.source}`

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettingsProperties.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettingsProperties.js
@@ -60,7 +60,7 @@ const REGEXES = {
   URL: /^(http|grpc)s?:\/\//,
   OPTIONAL_HTTP_URL: /^$|^https?:\/\/\S+$/,
   CAMUNDA_CLOUD_GRPC_URL: /^((https|grpcs):\/\/|)[a-z\d-]+\.[a-z]+-\d+\.zeebe\.camunda\.io(:443|)\/?$/,
-  CAMUNDA_CLOUD_REST_URL: /^https:\/\/[a-z]+-\d+\.zeebe\.camunda\.io(:443|)\/[a-z\d-]+\/?$/
+  CAMUNDA_CLOUD_REST_URL: /^https:\/\/[a-z]+-\d+\.(zeebe|api)\.camunda\.io(:443|)\/[a-z\d-]+\/?$/
 };
 REGEXES.CAMUNDA_CLOUD_URL = new RegExp(
   `${REGEXES.CAMUNDA_CLOUD_GRPC_URL.source}|${REGEXES.CAMUNDA_CLOUD_REST_URL.source}`

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionValidatorSpec.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionValidatorSpec.js
@@ -47,6 +47,18 @@ describe('ConnectionConfigValidator', function() {
       });
 
 
+      it('should validate valid Camunda Cloud REST (8.9)', function() {
+        const errors = validateConnectionConfig({
+          targetType: TARGET_TYPES.CAMUNDA_CLOUD,
+          camundaCloudClientId: 'client-id',
+          camundaCloudClientSecret: 'client-secret',
+          camundaCloudClusterUrl: 'https://region-1.api.camunda.io/cluster-name'
+        });
+
+        expect(errors).to.deep.equal({});
+      });
+
+
       it('should return error for missing clientId', function() {
         const errors = validateConnectionConfig({
           targetType: TARGET_TYPES.CAMUNDA_CLOUD,

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionValidatorSpec.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionValidatorSpec.js
@@ -59,6 +59,18 @@ describe('ConnectionConfigValidator', function() {
       });
 
 
+      it('should validate valid Camunda Cloud REST (8.9) with v2 suffix', function() {
+        const errors = validateConnectionConfig({
+          targetType: TARGET_TYPES.CAMUNDA_CLOUD,
+          camundaCloudClientId: 'client-id',
+          camundaCloudClientSecret: 'client-secret',
+          camundaCloudClusterUrl: 'https://region-1.api.camunda.io/cluster-name/v2'
+        });
+
+        expect(errors).to.deep.equal({});
+      });
+
+
       it('should return error for missing clientId', function() {
         const errors = validateConnectionConfig({
           targetType: TARGET_TYPES.CAMUNDA_CLOUD,


### PR DESCRIPTION
### Proposed Changes

8.9 changed the format of cluster URLs:

https://bru-2.zeebe.camunda.io/xxx -> https://bru-2.api.camunda.io/xxx
https://bru-2.operate.camunda.io/xxx -> https://bru-2.api.camunda.io/xxx/operate
https://bru-2.taskllist.camunda.io/xxx -> https://bru-2.api.camunda.io/xxx/tasklist

- accept new api url as base URL
- build operate/tasklist urls based on format

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
