### PR TITLE
fix: use consistent height for the tabs header

### DIFF
--- a/client/src/app/primitives/Tabbed.less
+++ b/client/src/app/primitives/Tabbed.less
@@ -45,7 +45,7 @@
   position: relative;
   z-index: 100;
 
-  flex-basis: 28px;
+  flex: none;
   height: 32px;
   background: var(--tab-bar-background-color);
   border-bottom: 1px solid var(--tab-bar-border-color);


### PR DESCRIPTION
Closes #5887

### Proposed Changes

We use a consistent height between the welcome tab and any tab open:

https://github.com/user-attachments/assets/8a8d0750-1b04-4047-bb8c-dffb0c35f336

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
