### PR TITLE
fix: return stack index of -1 initially

### DIFF
--- a/client/src/app/tabs/cloud-dmn/modeler/DmnModeler.js
+++ b/client/src/app/tabs/cloud-dmn/modeler/DmnModeler.js
@@ -150,19 +150,19 @@ export default class CamundaDmnModeler extends DmnModeler {
   /**
    * Get stack index of active viewer.
    *
-   * @returns {?number} Stack index or null.
+   * @returns {number} Stack index or -1.
    */
   getStackIdx() {
     const viewer = this.getActiveViewer();
 
     if (!viewer) {
-      return null;
+      return -1;
     }
 
     const commandStack = viewer.get('commandStack', false);
 
     if (!commandStack) {
-      return null;
+      return -1;
     }
 
     return commandStack._stackIdx;

--- a/client/src/app/tabs/dmn/modeler/DmnModeler.js
+++ b/client/src/app/tabs/dmn/modeler/DmnModeler.js
@@ -150,19 +150,19 @@ export default class CamundaDmnModeler extends DmnModeler {
   /**
    * Get stack index of active viewer.
    *
-   * @returns {?number} Stack index or null.
+   * @returns {number} Stack index or -1.
    */
   getStackIdx() {
     const viewer = this.getActiveViewer();
 
     if (!viewer) {
-      return null;
+      return -1;
     }
 
     const commandStack = viewer.get('commandStack', false);
 
     if (!commandStack) {
-      return null;
+      return -1;
     }
 
     return commandStack._stackIdx;

--- a/client/test/bpmn-io-modelers/dmn/CloudDmnModelerSpec.js
+++ b/client/test/bpmn-io-modelers/dmn/CloudDmnModelerSpec.js
@@ -198,15 +198,51 @@ describe('DmnModeler', function() {
   });
 
 
-  it('#getStackIdx', async function() {
+  describe('#getStackIdx', function() {
 
-    // when
-    const modeler = await createModeler({
-      container: modelerContainer
+    it('should return -1 initially', async function() {
+
+      // when
+      const modeler = await createModeler({
+        container: modelerContainer
+      });
+
+      // then
+      expect(modeler.getStackIdx()).to.equal(-1);
     });
 
-    // then
-    expect(modeler.getStackIdx()).to.equal(-1);
+
+    it('should return -1 when no active viewer', async function() {
+
+      // given
+      const modeler = await createModeler({
+        container: modelerContainer
+      });
+
+      sinon.stub(modeler, 'getActiveViewer').returns(null);
+
+      // then
+      expect(modeler.getStackIdx()).to.equal(-1);
+    });
+
+
+    it('should return -1 when there is no command stack', async function() {
+
+      // given
+      const modeler = await createModeler({
+        container: modelerContainer
+      });
+
+      const viewer = modeler.getActiveViewer();
+
+      sinon.stub(viewer, 'get')
+        .withArgs('commandStack', false)
+        .returns(null);
+
+      // then
+      expect(modeler.getStackIdx()).to.equal(-1);
+    });
+
   });
 
 

--- a/client/test/bpmn-io-modelers/dmn/DmnModelerSpec.js
+++ b/client/test/bpmn-io-modelers/dmn/DmnModelerSpec.js
@@ -198,15 +198,51 @@ describe('DmnModeler', function() {
   });
 
 
-  it('#getStackIdx', async function() {
+  describe('#getStackIdx', function() {
 
-    // when
-    const modeler = await createModeler({
-      container: modelerContainer
+    it('should return -1 initially', async function() {
+
+      // when
+      const modeler = await createModeler({
+        container: modelerContainer
+      });
+
+      // then
+      expect(modeler.getStackIdx()).to.equal(-1);
     });
 
-    // then
-    expect(modeler.getStackIdx()).to.equal(-1);
+
+    it('should return -1 when no active viewer', async function() {
+
+      // given
+      const modeler = await createModeler({
+        container: modelerContainer
+      });
+
+      sinon.stub(modeler, 'getActiveViewer').returns(null);
+
+      // then
+      expect(modeler.getStackIdx()).to.equal(-1);
+    });
+
+
+    it('should return -1 when there is no command stack', async function() {
+
+      // given
+      const modeler = await createModeler({
+        container: modelerContainer
+      });
+
+      const viewer = modeler.getActiveViewer();
+
+      sinon.stub(viewer, 'get')
+        .withArgs('commandStack', false)
+        .returns(null);
+
+      // then
+      expect(modeler.getStackIdx()).to.equal(-1);
+    });
+
   });
 
 


### PR DESCRIPTION
[Command stack returns -1 initially](https://github.com/bpmn-io/diagram-js/blob/develop/lib/command/CommandStack.js#L131) so the wrapper should return -1 as well.

Closes #5751

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
