### PR TITLE
fix: prevent top bar from changing height

### DIFF
--- a/client/src/app/primitives/Tabbed.less
+++ b/client/src/app/primitives/Tabbed.less
@@ -45,7 +45,7 @@
   position: relative;
   z-index: 100;
 
-  flex-basis: 28px;
+  flex-shrink: 0;
   height: 32px;
   background: var(--tab-bar-background-color);
   border-bottom: 1px solid var(--tab-bar-border-color);


### PR DESCRIPTION
### Proposed Changes

Fixes top bar height.

<img width="1108" height="643" alt="electron_QWxX85Zq94" src="https://github.com/user-attachments/assets/35a08bf3-c973-4b72-ac16-b18452bd6f2a" />

Closes #5896

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
