### PR TITLE
fix: attach DMN overview only after parent rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: correct bug opening DMN decision table ([#5880](https://github.com/camunda/camunda-modeler/issues/5880), [#5898](https://github.com/camunda/camunda-modeler/pull/5898))
+
 ## 5.46.1
 
 ### General

--- a/client/src/app/tabs/cloud-dmn/DmnEditor.js
+++ b/client/src/app/tabs/cloud-dmn/DmnEditor.js
@@ -154,17 +154,11 @@ export class DmnEditor extends CachedComponent {
         propertiesPanel.attachTo(this.propertiesPanelRef.current);
       }
 
-      // attach overview
-      if (this.overviewRef.current) {
-        modeler.attachOverviewTo(this.overviewRef.current);
-
-        if (isOverviewOpen(this.props)) {
-          modeler._emit('overviewOpen');
-        }
-      }
     }
 
     this.gridBehavior.update(this.props.layout);
+
+    this._updateOverview();
 
     this.checkImport();
   }
@@ -186,19 +180,19 @@ export class DmnEditor extends CachedComponent {
       this.attachPropertiesPanel();
     }
 
-    // We can only notify interested parties about overview open once its parent component was
-    // rendered
-    if (isOverviewOpened(prevProps, this.props)) {
-      const modeler = this.getModeler();
-
-      modeler._emit('overviewOpen');
-    }
+    this._updateOverview();
 
     this.gridBehavior.checkUpdate(prevProps.layout, this.props.layout);
 
     if (isCachedStateChange(prevProps, this.props)) {
       this.handleChanged();
     }
+  }
+
+  _updateOverview() {
+    const modeler = this.getModeler();
+
+    modeler.updateOverview(this.overviewRef.current, isOverviewOpen(this.props));
   }
 
   attachPropertiesPanel() {
@@ -354,17 +348,6 @@ export class DmnEditor extends CachedComponent {
     }
 
     this.gridBehavior.update(this.props.layout);
-
-    // attach or detach overview
-    if (activeView.type === 'drd') {
-      modeler.detachOverview();
-    } else if (previousActiveView && previousActiveView.type === 'drd') {
-      modeler.attachOverviewTo(this.overviewRef.current);
-
-      if (isOverviewOpen(this.props)) {
-        modeler._emit('overviewOpen');
-      }
-    }
 
     // must be called last
     this.setCached({
@@ -1130,16 +1113,4 @@ function isOverviewOpen(props) {
   const dmnOverview = layout.dmnOverview;
 
   return !dmnOverview || dmnOverview.open;
-}
-
-/**
- * Check layout whether overview was opened.
- *
- * @param {Object} prevProps
- * @param {Object} props
- *
- * @returns {boolean}
- */
-function isOverviewOpened(prevProps, props) {
-  return isOverviewOpen(prevProps) === false && isOverviewOpen(props) === true;
 }

--- a/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
@@ -1229,7 +1229,7 @@ describe('<DmnEditor>', function() {
 
       sinon.stub(modeler, 'getActiveView').callsFake(() => decisionTableView);
 
-      const overviewAttachSpy = sinon.spy(modeler, 'attachOverviewTo');
+      const overviewUpdateSpy = sinon.spy(modeler, 'updateOverview');
 
       // when
       instance.viewsChanged({
@@ -1238,23 +1238,31 @@ describe('<DmnEditor>', function() {
       });
 
       // then
-      expect(overviewAttachSpy).to.have.been.called;
+      await waitFor(() => {
+        expect(overviewUpdateSpy).to.have.been.called;
+      });
     });
 
 
     it('should detach overview when switching to DRD', async function() {
 
       // given
+      const modeler = instance.getModeler();
+
+      modeler.open(decisionTableView);
+
       instance.viewsChanged({
         activeView: decisionTableView,
         views
       });
 
-      const modeler = instance.getModeler();
+      await waitFor(() => {
+        expect(instance.getCached().activeView).to.eql(decisionTableView);
+      });
 
       sinon.stub(modeler, 'getActiveView').callsFake(() => drdView);
 
-      const overviewDetachSpy = sinon.spy(modeler, 'detachOverview');
+      const overviewUpdateSpy = sinon.spy(modeler, 'updateOverview');
 
       // when
       instance.viewsChanged({
@@ -1263,7 +1271,9 @@ describe('<DmnEditor>', function() {
       });
 
       // then
-      expect(overviewDetachSpy).to.have.been.called;
+      await waitFor(() => {
+        expect(overviewUpdateSpy).to.have.been.called;
+      });
     });
 
   });

--- a/client/src/app/tabs/cloud-dmn/modeler/DmnModeler.js
+++ b/client/src/app/tabs/cloud-dmn/modeler/DmnModeler.js
@@ -240,7 +240,7 @@ export default class CamundaDmnModeler extends DmnModeler {
       if (activeView.type !== 'drd') {
         const activeViewer = overview.getActiveViewer();
 
-        if (activeViewer) {
+        if (activeViewer && overview._container.parentNode) {
           activeViewer.get('eventBus').fire('drgElementOpened', {
             id: activeView.element.id
           });
@@ -304,33 +304,64 @@ export default class CamundaDmnModeler extends DmnModeler {
     }
   };
 
-  attachOverviewTo = (parentNode) => {
-    this.detachOverview();
+  updateOverview = (parentNode, open) => {
+    if (!parentNode) {
+      this._detachOverview();
+      return;
+    }
 
+    const attached = this._attachOverview(parentNode);
+
+    if (attached && open) {
+      this._emit('overviewOpen');
+    }
+  };
+
+  _attachOverview(parentNode) {
     const activeViewer = this._overview.getActiveViewer();
 
     if (!activeViewer) {
-      return;
+      return false;
     }
+
+    if (this._overview._container.parentNode === parentNode) {
+      return false;
+    }
+
+    this._detachOverview();
 
     this._emit('attachOverview');
 
     this._overview.attachTo(parentNode);
 
     activeViewer.get('canvas').resized();
-  };
 
-  detachOverview = () => {
+    const activeView = this.getActiveView();
+
+    if (activeView && activeView.type !== 'drd') {
+      activeViewer.get('eventBus').fire('drgElementOpened', {
+        id: activeView.element.id
+      });
+    }
+
+    return true;
+  }
+
+  _detachOverview() {
     const activeViewer = this._overview.getActiveViewer();
 
     if (!activeViewer) {
       return;
     }
 
+    if (!this._overview._container.parentNode) {
+      return;
+    }
+
     this._emit('detachOverview');
 
     this._overview.detach();
-  };
+  }
 }
 
 

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -154,18 +154,12 @@ export class DmnEditor extends CachedComponent {
         propertiesPanel.attachTo(this.propertiesPanelRef.current);
       }
 
-      // attach overview
-      if (this.overviewRef.current) {
-        modeler.attachOverviewTo(this.overviewRef.current);
-
-        if (isOverviewOpen(this.props)) {
-          modeler._emit('overviewOpen');
-        }
-      }
     }
 
     // grid may not be available, depending on the editor
     activeViewer && activeViewer.get('grid', false)?.toggle(this.props.layout?.grid?.visible !== false);
+
+    this._updateOverview();
 
     this.checkImport();
   }
@@ -187,19 +181,19 @@ export class DmnEditor extends CachedComponent {
       this.attachPropertiesPanel();
     }
 
-    // We can only notify interested parties about overview open once its parent component was
-    // rendered
-    if (isOverviewOpened(prevProps, this.props)) {
-      const modeler = this.getModeler();
-
-      modeler._emit('overviewOpen');
-    }
+    this._updateOverview();
 
     this.gridBehavior.checkUpdate(prevProps.layout, this.props.layout);
 
     if (isCachedStateChange(prevProps, this.props)) {
       this.handleChanged();
     }
+  }
+
+  _updateOverview() {
+    const modeler = this.getModeler();
+
+    modeler.updateOverview(this.overviewRef.current, isOverviewOpen(this.props));
   }
 
   attachPropertiesPanel() {
@@ -355,17 +349,6 @@ export class DmnEditor extends CachedComponent {
     }
 
     this.gridBehavior.update(this.props.layout);
-
-    // attach or detach overview
-    if (activeView.type === 'drd') {
-      modeler.detachOverview();
-    } else if (previousActiveView && previousActiveView.type === 'drd') {
-      modeler.attachOverviewTo(this.overviewRef.current);
-
-      if (isOverviewOpen(this.props)) {
-        modeler._emit('overviewOpen');
-      }
-    }
 
     // must be called last
     this.setCached({
@@ -1131,16 +1114,4 @@ function isOverviewOpen(props) {
   const dmnOverview = layout.dmnOverview;
 
   return !dmnOverview || dmnOverview.open;
-}
-
-/**
- * Check layout whether overview was opened.
- *
- * @param {Object} prevProps
- * @param {Object} props
- *
- * @returns {boolean}
- */
-function isOverviewOpened(prevProps, props) {
-  return isOverviewOpen(prevProps) === false && isOverviewOpen(props) === true;
 }

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -1227,7 +1227,7 @@ describe('<DmnEditor>', function() {
 
       sinon.stub(modeler, 'getActiveView').callsFake(() => decisionTableView);
 
-      const overviewAttachSpy = sinon.spy(modeler, 'attachOverviewTo');
+      const overviewUpdateSpy = sinon.spy(modeler, 'updateOverview');
 
       // when
       instance.viewsChanged({
@@ -1236,23 +1236,31 @@ describe('<DmnEditor>', function() {
       });
 
       // then
-      expect(overviewAttachSpy).to.have.been.called;
+      await waitFor(() => {
+        expect(overviewUpdateSpy).to.have.been.called;
+      });
     });
 
 
     it('should detach overview when switching to DRD', async function() {
 
       // given
+      const modeler = instance.getModeler();
+
+      modeler.open(decisionTableView);
+
       instance.viewsChanged({
         activeView: decisionTableView,
         views
       });
 
-      const modeler = instance.getModeler();
+      await waitFor(() => {
+        expect(instance.getCached().activeView).to.eql(decisionTableView);
+      });
 
       sinon.stub(modeler, 'getActiveView').callsFake(() => drdView);
 
-      const overviewDetachSpy = sinon.spy(modeler, 'detachOverview');
+      const overviewUpdateSpy = sinon.spy(modeler, 'updateOverview');
 
       // when
       instance.viewsChanged({
@@ -1261,7 +1269,9 @@ describe('<DmnEditor>', function() {
       });
 
       // then
-      expect(overviewDetachSpy).to.have.been.called;
+      await waitFor(() => {
+        expect(overviewUpdateSpy).to.have.been.called;
+      });
     });
 
   });

--- a/client/src/app/tabs/dmn/modeler/DmnModeler.js
+++ b/client/src/app/tabs/dmn/modeler/DmnModeler.js
@@ -240,7 +240,7 @@ export default class CamundaDmnModeler extends DmnModeler {
       if (activeView.type !== 'drd') {
         const activeViewer = overview.getActiveViewer();
 
-        if (activeViewer) {
+        if (activeViewer && overview._container.parentNode) {
           activeViewer.get('eventBus').fire('drgElementOpened', {
             id: activeView.element.id
           });
@@ -304,33 +304,64 @@ export default class CamundaDmnModeler extends DmnModeler {
     }
   };
 
-  attachOverviewTo = (parentNode) => {
-    this.detachOverview();
+  updateOverview = (parentNode, open) => {
+    if (!parentNode) {
+      this._detachOverview();
+      return;
+    }
 
+    const attached = this._attachOverview(parentNode);
+
+    if (attached && open) {
+      this._emit('overviewOpen');
+    }
+  };
+
+  _attachOverview(parentNode) {
     const activeViewer = this._overview.getActiveViewer();
 
     if (!activeViewer) {
-      return;
+      return false;
     }
+
+    if (this._overview._container.parentNode === parentNode) {
+      return false;
+    }
+
+    this._detachOverview();
 
     this._emit('attachOverview');
 
     this._overview.attachTo(parentNode);
 
     activeViewer.get('canvas').resized();
-  };
 
-  detachOverview = () => {
+    const activeView = this.getActiveView();
+
+    if (activeView && activeView.type !== 'drd') {
+      activeViewer.get('eventBus').fire('drgElementOpened', {
+        id: activeView.element.id
+      });
+    }
+
+    return true;
+  }
+
+  _detachOverview() {
     const activeViewer = this._overview.getActiveViewer();
 
     if (!activeViewer) {
       return;
     }
 
+    if (!this._overview._container.parentNode) {
+      return;
+    }
+
     this._emit('detachOverview');
 
     this._overview.detach();
-  };
+  }
 }
 
 

--- a/client/test/bpmn-io-modelers/dmn/CloudDmnModelerSpec.js
+++ b/client/test/bpmn-io-modelers/dmn/CloudDmnModelerSpec.js
@@ -255,7 +255,7 @@ describe('DmnModeler', function() {
         container: modelerContainer
       });
 
-      modeler.attachOverviewTo(overviewContainer);
+      modeler.updateOverview(overviewContainer, true);
     });
 
 
@@ -428,6 +428,97 @@ describe('DmnModeler', function() {
         // then
         expect(openDrgElement.canOpenDrgElement(decision)).to.be.false;
       });
+    });
+
+
+    describe('#updateOverview', function() {
+
+      it('should detach overview when parentNode is null', async function() {
+
+        // assume
+        expect(modeler._overview._container.parentNode).to.exist;
+
+        // when
+        modeler.updateOverview(null, true);
+
+        // then
+        expect(modeler._overview._container.parentNode).to.not.exist;
+      });
+
+
+      it('should not re-attach if already attached to same parent', async function() {
+
+        // given
+        const spy = sinon.spy(modeler._overview, 'attachTo');
+
+        // when
+        modeler.updateOverview(overviewContainer, true);
+
+        // then
+        expect(spy).to.not.have.been.called;
+      });
+
+
+      it('should emit overviewOpen when open is true', async function() {
+
+        // given
+        modeler.updateOverview(null, false);
+
+        const spy = sinon.spy();
+        modeler.on('overviewOpen', spy);
+
+        // when
+        modeler.updateOverview(overviewContainer, true);
+
+        // then
+        expect(spy).to.have.been.calledOnce;
+      });
+
+
+      it('should not emit overviewOpen when open is false', async function() {
+
+        // given
+        modeler.updateOverview(null, false);
+
+        const spy = sinon.spy();
+        modeler.on('overviewOpen', spy);
+
+        // when
+        modeler.updateOverview(overviewContainer, false);
+
+        // then
+        expect(spy).to.not.have.been.called;
+      });
+
+
+      it('should not emit overviewOpen when already attached', async function() {
+
+        // given
+        const spy = sinon.spy();
+        modeler.on('overviewOpen', spy);
+
+        // when
+        modeler.updateOverview(overviewContainer, true);
+
+        // then
+        expect(spy).to.not.have.been.called;
+      });
+
+
+      it('should not detach if already detached', async function() {
+
+        // given
+        modeler.updateOverview(null, false);
+
+        const spy = sinon.spy(modeler._overview, 'detach');
+
+        // when
+        modeler.updateOverview(null, false);
+
+        // then
+        expect(spy).to.not.have.been.called;
+      });
+
     });
   });
 

--- a/client/test/bpmn-io-modelers/dmn/DmnModelerSpec.js
+++ b/client/test/bpmn-io-modelers/dmn/DmnModelerSpec.js
@@ -255,7 +255,7 @@ describe('DmnModeler', function() {
         container: modelerContainer
       });
 
-      modeler.attachOverviewTo(overviewContainer);
+      modeler.updateOverview(overviewContainer, true);
     });
 
 
@@ -428,6 +428,97 @@ describe('DmnModeler', function() {
         // then
         expect(openDrgElement.canOpenDrgElement(decision)).to.be.false;
       });
+    });
+
+
+    describe('#updateOverview', function() {
+
+      it('should detach overview when parentNode is null', async function() {
+
+        // assume
+        expect(modeler._overview._container.parentNode).to.exist;
+
+        // when
+        modeler.updateOverview(null, true);
+
+        // then
+        expect(modeler._overview._container.parentNode).to.not.exist;
+      });
+
+
+      it('should not re-attach if already attached to same parent', async function() {
+
+        // given
+        const spy = sinon.spy(modeler._overview, 'attachTo');
+
+        // when
+        modeler.updateOverview(overviewContainer, true);
+
+        // then
+        expect(spy).to.not.have.been.called;
+      });
+
+
+      it('should emit overviewOpen when open is true', async function() {
+
+        // given
+        modeler.updateOverview(null, false);
+
+        const spy = sinon.spy();
+        modeler.on('overviewOpen', spy);
+
+        // when
+        modeler.updateOverview(overviewContainer, true);
+
+        // then
+        expect(spy).to.have.been.calledOnce;
+      });
+
+
+      it('should not emit overviewOpen when open is false', async function() {
+
+        // given
+        modeler.updateOverview(null, false);
+
+        const spy = sinon.spy();
+        modeler.on('overviewOpen', spy);
+
+        // when
+        modeler.updateOverview(overviewContainer, false);
+
+        // then
+        expect(spy).to.not.have.been.called;
+      });
+
+
+      it('should not emit overviewOpen when already attached', async function() {
+
+        // given
+        const spy = sinon.spy();
+        modeler.on('overviewOpen', spy);
+
+        // when
+        modeler.updateOverview(overviewContainer, true);
+
+        // then
+        expect(spy).to.not.have.been.called;
+      });
+
+
+      it('should not detach if already detached', async function() {
+
+        // given
+        modeler.updateOverview(null, false);
+
+        const spy = sinon.spy(modeler._overview, 'detach');
+
+        // when
+        modeler.updateOverview(null, false);
+
+        // then
+        expect(spy).to.not.have.been.called;
+      });
+
     });
   });
 

--- a/client/test/mocks/dmn-js/Modeler.js
+++ b/client/test/mocks/dmn-js/Modeler.js
@@ -232,9 +232,7 @@ export default class Modeler {
 
   detach() {}
 
-  attachOverviewTo() {}
-
-  detachOverview() {}
+  updateOverview() {}
 
   on(event, priority, callback) {
     if (!callback) {


### PR DESCRIPTION
**Problem:** Opening a DMN file and switching to a non-DRD view (e.g., decision table) crashed because the overview was attached before its parent DOM node existed.

**Root cause:** The`views.changed` event fires synchronously during `modeler.open(view)`, before React re-renders the overview container. Attaching the overview to a not-yet-rendered ref caused the crash.

**Changes:**

- Moved overview attach/detach from `views.changed` to `componentDidUpdate`

- Consolidated overview state management into `modeler.updateOverview`

- Guarded `drgElementOpened` in `views.changed` handler against missing parent node

- Moved `overviewOpen` emit into the modeler

<img width="1920" height="983" alt="electron_XhCVJ93ASz" src="https://github.com/user-attachments/assets/2301f215-2176-4538-9237-ca8c5e327268" />

Closes #5880

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
