### PR TITLE
feat: add regex validation to tenant ID field

### DIFF
--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettingsProperties.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettingsProperties.js
@@ -53,14 +53,16 @@ const VALIDATION_ERROR_MESSAGES = {
   CLUSTER_URL_MUST_NOT_BE_EMPTY: 'Cluster URL must not be empty.',
   CLUSTER_URL_MUST_START_WITH_PROTOCOL: 'Cluster URL must start with "http://", "grpc://", "https://", or "grpcs://".',
   MUST_PROVIDE_A_VALUE: 'Must provide a value.',
-  OAUTH_URL_MUST_NOT_BE_EMPTY: 'OAuth URL must not be empty.'
+  OAUTH_URL_MUST_NOT_BE_EMPTY: 'OAuth URL must not be empty.',
+  TENANT_ID_INVALID: 'Tenant ID must be 31 characters or fewer and contain only alphanumeric characters, dots (.), dashes (-), or underscores (_).'
 };
 
 const REGEXES = {
   URL: /^(http|grpc)s?:\/\//,
   OPTIONAL_HTTP_URL: /^$|^https?:\/\/\S+$/,
   CAMUNDA_CLOUD_GRPC_URL: /^((https|grpcs):\/\/|)[a-z\d-]+\.[a-z]+-\d+\.zeebe\.camunda\.io(:443|)\/?$/,
-  CAMUNDA_CLOUD_REST_URL: /^https:\/\/[a-z]+-\d+\.(zeebe|api)\.camunda\.io(:443|)\/[a-z\d-]+(?:\/v2)?\/?$/
+  CAMUNDA_CLOUD_REST_URL: /^https:\/\/[a-z]+-\d+\.(zeebe|api)\.camunda\.io(:443|)\/[a-z\d-]+(?:\/v2)?\/?$/,
+  TENANT_ID: /^$|^[a-zA-Z0-9._-]{1,31}$/
 };
 REGEXES.CAMUNDA_CLOUD_URL = new RegExp(
   `${REGEXES.CAMUNDA_CLOUD_GRPC_URL.source}|${REGEXES.CAMUNDA_CLOUD_REST_URL.source}`
@@ -125,6 +127,12 @@ export const properties = [
     label: LABELS.TENANT_ID,
     hint: HINTS.TENANT_ID,
     condition: { property: 'targetType', equals: TARGET_TYPES.SELF_HOSTED },
+    constraints: {
+      pattern: {
+        value: REGEXES.TENANT_ID,
+        message: VALIDATION_ERROR_MESSAGES.TENANT_ID_INVALID
+      }
+    }
   },
 
   { key: 'operateUrl',

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionValidatorSpec.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionValidatorSpec.js
@@ -227,6 +227,7 @@ describe('ConnectionConfigValidator', function() {
         expect(errors).to.have.property('tasklistUrl');
       });
 
+
     });
 
 
@@ -348,6 +349,99 @@ describe('ConnectionConfigValidator', function() {
 
         expect(errors).to.have.property('audience');
       });
+
+    });
+
+
+    describe('tenantId validation', function() {
+
+      const AUTH_CONFIGS = [
+        {
+          label: 'no auth',
+          base: {
+            targetType: TARGET_TYPES.SELF_HOSTED,
+            contactPoint: 'http://localhost:8080',
+            authType: AUTH_TYPES.NONE
+          }
+        },
+        {
+          label: 'basic auth',
+          base: {
+            targetType: TARGET_TYPES.SELF_HOSTED,
+            contactPoint: 'http://localhost:8080',
+            authType: AUTH_TYPES.BASIC,
+            basicAuthUsername: 'user',
+            basicAuthPassword: 'password'
+          }
+        },
+        {
+          label: 'OAuth',
+          base: {
+            targetType: TARGET_TYPES.SELF_HOSTED,
+            contactPoint: 'http://localhost:8080',
+            authType: AUTH_TYPES.OAUTH,
+            clientId: 'client-id',
+            clientSecret: 'client-secret',
+            oauthURL: 'http://localhost:18080/auth/token',
+            audience: 'zeebe-api'
+          }
+        }
+      ];
+
+      for (const { label, base } of AUTH_CONFIGS) {
+
+        describe(`with ${label}`, function() {
+
+          it('should allow empty optional tenantId', function() {
+            const errors = validateConnectionConfig({ ...base, tenantId: '' });
+            expect(errors).to.not.have.property('tenantId');
+          });
+
+
+          it('should allow valid tenantId with alphanumeric characters', function() {
+            const errors = validateConnectionConfig({ ...base, tenantId: 'myTenant123' });
+            expect(errors).to.not.have.property('tenantId');
+          });
+
+
+          it('should allow valid tenantId with dots, dashes, and underscores', function() {
+            const errors = validateConnectionConfig({ ...base, tenantId: 'my.tenant-id_1' });
+            expect(errors).to.not.have.property('tenantId');
+          });
+
+
+          it('should allow tenantId of exactly 31 characters', function() {
+            const errors = validateConnectionConfig({ ...base, tenantId: 'a'.repeat(31) });
+            expect(errors).to.not.have.property('tenantId');
+          });
+
+
+          it('should return error for tenantId longer than 31 characters', function() {
+            const errors = validateConnectionConfig({ ...base, tenantId: 'a'.repeat(32) });
+            expect(errors).to.have.property('tenantId');
+          });
+
+
+          it('should return error for tenantId with invalid characters', function() {
+            const errors = validateConnectionConfig({ ...base, tenantId: 'tenant id!' });
+            expect(errors).to.have.property('tenantId');
+          });
+
+
+          it('should return error for tenantId that is only whitespace', function() {
+            const errors = validateConnectionConfig({ ...base, tenantId: '   ' });
+            expect(errors).to.have.property('tenantId');
+          });
+
+
+          it('should return error for tenantId with mixed valid and whitespace characters', function() {
+            const errors = validateConnectionConfig({ ...base, tenantId: 'tenant id' });
+            expect(errors).to.have.property('tenantId');
+          });
+
+        });
+
+      }
 
     });
 


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

closes #5905 

Add basic regex checks to the connection manager tenant ID field. Camunda enforces certain [tenant ID restrictions](https://docs.camunda.io/docs/components/concepts/multi-tenancy/#tenant-identifier) on tenant creation, so tenant ID's that don't match these validation checks would not point to a valid tenant anyway.

<img width="872" height="259" alt="Validation message for invalid tenant ID" src="https://github.com/user-attachments/assets/21568aab-fb7d-40bf-a441-032d911d818f" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
