### PR TITLE
feat: add business ID field to start instance form

### DIFF
--- a/app/lib/zeebe-api/zeebe-api.js
+++ b/app/lib/zeebe-api/zeebe-api.js
@@ -63,6 +63,7 @@ const {
  * @property {Array} [startInstructions]
  * @property {Array} [runtimeInstructions]
  * @property {Object} [variables]
+ * @property {string} [businessId]
  */
 
 /**
@@ -242,7 +243,8 @@ class ZeebeAPI {
       processDefinitionKey,
       processId,
       startInstructions,
-      runtimeInstructions
+      runtimeInstructions,
+      businessId
     } = config;
 
     this._log.debug('start instance', {
@@ -268,6 +270,7 @@ class ZeebeAPI {
           bpmnProcessId: processId,
           variables,
           startInstructions,
+          businessId,
         });
 
         return {
@@ -281,7 +284,8 @@ class ZeebeAPI {
         const requestBody = {
           variables,
           startInstructions,
-          runtimeInstructions
+          runtimeInstructions,
+          businessId
         };
 
         if (processDefinitionKey) {

--- a/app/test/spec/zeebe-api/zeebe-api-grpc-spec.js
+++ b/app/test/spec/zeebe-api/zeebe-api-grpc-spec.js
@@ -566,6 +566,37 @@ describe('ZeebeAPI (gRPC)', function() {
       expect(result.response).not.to.be.instanceOf(Error);
     });
 
+
+    it('should pass businessId to gRPC client', async function() {
+
+      // given
+      const createProcessInstanceSpy = sinon.spy();
+
+      const zeebeAPI = createZeebeAPI({
+        ZeebeGrpcApiClient: {
+          createProcessInstance: createProcessInstanceSpy
+        }
+      });
+
+      const parameters = {
+        endpoint: {
+          type: ENDPOINT_TYPES.SELF_HOSTED,
+          url: TEST_URL
+        },
+        processId: 'myProcess',
+        businessId: 'order-123'
+      };
+
+      // when
+      await zeebeAPI.startInstance(parameters);
+
+      // then
+      expect(createProcessInstanceSpy).to.have.been.calledOnce;
+
+      const callArgs = createProcessInstanceSpy.firstCall.args[0];
+      expect(callArgs.businessId).to.eql('order-123');
+    });
+
   });
 
 

--- a/app/test/spec/zeebe-api/zeebe-api-rest-spec.js
+++ b/app/test/spec/zeebe-api/zeebe-api-rest-spec.js
@@ -417,6 +417,37 @@ describe('ZeebeAPI (REST)', function() {
       expect(result.response).not.to.be.instanceOf(Error);
     });
 
+
+    it('should pass businessId to REST client', async function() {
+
+      // given
+      const createProcessInstanceSpy = sinon.spy();
+
+      const zeebeAPI = createZeebeAPI({
+        CamundaRestClient: {
+          createProcessInstance: createProcessInstanceSpy
+        }
+      });
+
+      const parameters = {
+        endpoint: {
+          type: ENDPOINT_TYPES.SELF_HOSTED,
+          url: TEST_URL
+        },
+        processId: 'myProcess',
+        businessId: 'order-123'
+      };
+
+      // when
+      await zeebeAPI.startInstance(parameters);
+
+      // then
+      expect(createProcessInstanceSpy).to.have.been.calledOnce;
+
+      const callArgs = createProcessInstanceSpy.firstCall.args[0];
+      expect(callArgs.businessId).to.eql('order-123');
+    });
+
   });
 
 

--- a/client/src/app/zeebe/StartInstance.js
+++ b/client/src/app/zeebe/StartInstance.js
@@ -51,7 +51,8 @@ export default class StartInstance extends EventEmitter {
       processId,
       variables = '{}',
       startInstructions,
-      runtimeInstructions
+      runtimeInstructions,
+      businessId
     } = config;
 
     const startInstanceResult = await this._zeebeAPI.startInstance({
@@ -60,7 +61,8 @@ export default class StartInstance extends EventEmitter {
       processId,
       variables: parseVariables(variables),
       startInstructions,
-      runtimeInstructions
+      runtimeInstructions,
+      businessId: businessId || undefined
     });
 
     this.emit('instanceStarted', {
@@ -82,10 +84,11 @@ export default class StartInstance extends EventEmitter {
    * @returns {Promise<StartInstanceConfig>}
    */
   async getConfigForFile(file) {
-    const { variables = JSON.stringify({}) } = await this._config.getForFile(file, CONFIG_KEYS.CONFIG, {});
+    const { variables = JSON.stringify({}), businessId = '' } = await this._config.getForFile(file, CONFIG_KEYS.CONFIG, {});
 
     return {
-      variables
+      variables,
+      businessId
     };
   }
 

--- a/client/src/app/zeebe/__tests__/StartInstanceSpec.js
+++ b/client/src/app/zeebe/__tests__/StartInstanceSpec.js
@@ -19,6 +19,52 @@ describe('StartInstance', function() {
 
   describe('#startInstance', function() {
 
+    it('should not send empty businessId in API call', async function() {
+
+      // given
+      const config = createMockConfig({ businessId: '' }),
+            startInstanceResult = createMockStartInstanceResult();
+
+      const zeebeAPI = new MockZeebeAPI({
+        startInstance: sinon.stub().resolves(startInstanceResult)
+      });
+
+      const startInstance = createStartInstance({
+        zeebeAPI
+      });
+
+      // when
+      await startInstance.startInstance(config);
+
+      // then
+      const callArgs = zeebeAPI.startInstance.firstCall.args[0];
+      expect(callArgs.businessId).to.be.undefined;
+    });
+
+
+    it('should include businessId in API call when provided', async function() {
+
+      // given
+      const config = createMockConfig({ businessId: 'order-123' }),
+            startInstanceResult = createMockStartInstanceResult();
+
+      const zeebeAPI = new MockZeebeAPI({
+        startInstance: sinon.stub().resolves(startInstanceResult)
+      });
+
+      const startInstance = createStartInstance({
+        zeebeAPI
+      });
+
+      // when
+      await startInstance.startInstance(config);
+
+      // then
+      const callArgs = zeebeAPI.startInstance.firstCall.args[0];
+      expect(callArgs).to.have.property('businessId', 'order-123');
+    });
+
+
     it('should start instance', async function() {
 
       // given
@@ -54,7 +100,8 @@ describe('StartInstance', function() {
           foo: 'bar'
         },
         startInstructions: undefined,
-        runtimeInstructions: undefined
+        runtimeInstructions: undefined,
+        businessId: undefined
       });
 
       expect(instanceStartedSpy).to.have.been.calledOnce;
@@ -94,7 +141,8 @@ describe('StartInstance', function() {
       expect(config).to.eql({
         variables: JSON.stringify({
           foo: 'bar'
-        })
+        }),
+        businessId: ''
       });
     });
 
@@ -113,7 +161,8 @@ describe('StartInstance', function() {
 
       // then
       expect(config).to.eql({
-        variables: JSON.stringify({})
+        variables: JSON.stringify({}),
+        businessId: ''
       });
     });
 

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstanceConfigForm.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstanceConfigForm.js
@@ -10,9 +10,13 @@
 
 import React from 'react';
 
+import semver from 'semver';
+
 import {
   JSONInput,
-  Section
+  Section,
+  TextInput,
+  DefinitionTooltip
 } from '../../../shared/ui';
 
 import {
@@ -20,10 +24,14 @@ import {
   Form,
   Formik
 } from 'formik';
+
 import { getMessageForReason } from '../shared/util';
+
 import FormFeedback from '../../../shared/ui/form/FormFeedback';
 
 import { utmTag } from '../../../util/utmTag';
+
+const MIN_VERSION_SUPPORTING_BUSINESS_ID = '8.9.0';
 
 export default function StartInstanceConfigForm(props) {
   const {
@@ -43,6 +51,8 @@ export default function StartInstanceConfigForm(props) {
     handleManageConnections,
     handleOpenLintingPanel
   } = props;
+
+  const businessIdUnsupported = isBusinessIdUnsupportedInConnectedCluster(connectionCheckResult);
 
   const getFieldError = (meta, fieldName) => {
     return _getFieldError(fieldName) || (meta.touched && meta.error);
@@ -86,13 +96,75 @@ export default function StartInstanceConfigForm(props) {
                           <VariablesComponent
                             field={ field }
                             form={ form }
-                            label="Variables (optional)"
+                            label={
+                              <>
+                                <DefinitionTooltip
+                                  definition={
+                                    <p>
+                                      JSON data passed into the process instance at startup. Variables can drive routing decisions, feed
+                                      service tasks, and be read or updated throughout the process.{ ' ' }
+                                      <a
+                                        href={ utmTag('https://docs.camunda.io/docs/components/concepts/variables') }
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                      >
+                                        Learn more.
+                                      </a>
+                                    </p>
+                                  }
+                                >
+                                  Variables
+                                </DefinitionTooltip>
+                                { ' ' }(optional)
+                              </>
+                            }
                             description={ <span>Must be a proper <a href="https://www.w3schools.com/js/js_json_intro.asp">JSON string</a> representing <a href={ utmTag('https://docs.camunda.io/docs/components/concepts/variables/') }>Zeebe variables</a>.</span> }
                             hint="A JSON string representing the variables the process instance is started with."
                             fieldError={ getFieldError }
                             { ...variablesComponentProps }
                           />
                         )}
+                      </Field>
+                      <Field
+                        name="businessId"
+                        validate={ value => validateField('businessId', value) }
+                      >
+                        {({ field, form }) => {
+                          return (
+                            <TextInput
+                              field={ field }
+                              form={ form }
+                              label={
+                                <>
+                                  <DefinitionTooltip
+                                    definition={
+                                      <p>
+                                        Assign an ID from your own systems (e.g., an order or case number) to this instance for easier lookup,
+                                        tracing, and duplicate prevention.{ ' ' }
+                                        <a
+                                          href={ utmTag('https://docs.camunda.io/docs/components/concepts/process-instance-creation/#business-id') }
+                                          target="_blank"
+                                          rel="noopener noreferrer"
+                                        >
+                                          Learn more.
+                                        </a>
+                                      </p>
+                                    }
+                                  >
+                                    Business ID
+                                  </DefinitionTooltip>
+                                  { ' ' }(optional)
+                                </>
+                              }
+                              description={ businessIdUnsupported && field.value
+                                ? <span className="version-hint">Requires Camunda { MIN_VERSION_SUPPORTING_BUSINESS_ID } or later</span>
+                                : null
+                              }
+                              hint="A unique identifier for the process instance."
+                              fieldError={ getFieldError }
+                            />
+                          );
+                        }}
                       </Field>
                     </div>
                   </fieldset>
@@ -130,4 +202,20 @@ export default function StartInstanceConfigForm(props) {
       }
     </Formik>
   );
+}
+
+function isBusinessIdUnsupportedInConnectedCluster(connectionCheckResult) {
+  if (!connectionCheckResult?.success) {
+    return false;
+  }
+
+  const gatewayVersion = connectionCheckResult?.response?.gatewayVersion;
+
+  if (!gatewayVersion) {
+    return false;
+  }
+
+  const coercedVersion = semver.coerce(gatewayVersion);
+
+  return semver.compare(coercedVersion || '0', MIN_VERSION_SUPPORTING_BUSINESS_ID) < 0;
 }

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstanceConfigValidator.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstanceConfigValidator.js
@@ -12,8 +12,11 @@
  * @typedef {import('../deployment-plugin/types.d.ts').DeploymentConfig} DeploymentConfig
  */
 
+export const BUSINESS_ID_MAX_LENGTH = 256;
+
 export const VALIDATION_ERROR_MESSAGES = {
   VARIABLES_MUST_BE_VALID_JSON: 'Variables must be valid JSON.',
+  BUSINESS_ID_TOO_LONG: `Business ID must not exceed ${BUSINESS_ID_MAX_LENGTH} characters.`,
 };
 
 export default class StartInstanceConfigValidator {
@@ -29,6 +32,12 @@ export default class StartInstanceConfigValidator {
   static validateConfigValue(name, value) {
     if (name === 'variables') {
       return value.trim().length && validateJSON(value, VALIDATION_ERROR_MESSAGES.VARIABLES_MUST_BE_VALID_JSON);
+    }
+
+    if (name === 'businessId') {
+      if (value && value.length > BUSINESS_ID_MAX_LENGTH) {
+        return VALIDATION_ERROR_MESSAGES.BUSINESS_ID_TOO_LONG;
+      }
     }
 
     return null;
@@ -48,6 +57,12 @@ export default class StartInstanceConfigValidator {
 
     if (variablesValidationError) {
       validationErrors['variables'] = variablesValidationError;
+    }
+
+    const businessIdValidationError = StartInstanceConfigValidator.validateConfigValue('businessId', config.businessId);
+
+    if (businessIdValidationError) {
+      validationErrors['businessId'] = businessIdValidationError;
     }
 
     return validationErrors;

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePluginOverlay.css
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePluginOverlay.css
@@ -1,4 +1,16 @@
 :local(.StartInstancePluginOverlay) {
+  .form-group > label,
+  .custom-text-input > label {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 13px;
+
+    .cds--toggletip-button {
+      inline-size: auto;
+    }
+  }
+
   .section__header {
     display: flex;
     align-items: center;
@@ -6,5 +18,12 @@
     svg {
       margin-right: 6px;
     }
+  }
+
+  .version-hint {
+    color: var(--color-red-360-100-45);
+    margin-top: 6px;
+    font-size: 13px;
+    display: inline-block;
   }
 }

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstanceConfigFormSpec.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstanceConfigFormSpec.js
@@ -98,6 +98,198 @@ describe('<StartInstanceConfigForm>', function() {
 
     });
 
+
+    describe('businessId', function() {
+
+      it('should render', function() {
+
+        // when
+        const { container } = createStartInstanceConfigForm();
+
+        // then
+        expect(container.querySelector('label[for="businessId"]')).to.not.be.null;
+      });
+
+
+      it('should be enabled when cluster version >= 8.9', function() {
+
+        // when
+        const { container } = createStartInstanceConfigForm({
+          connectionCheckResult: {
+            success: true,
+            response: {
+              gatewayVersion: '8.9.0'
+            }
+          }
+        });
+
+        // then
+        expect(container.querySelector('input[name="businessId"]').disabled).to.be.false;
+      });
+
+
+      it('should be enabled when cluster version < 8.9', function() {
+
+        // when
+        const { container } = createStartInstanceConfigForm({
+          connectionCheckResult: {
+            success: true,
+            response: {
+              gatewayVersion: '8.8.0'
+            }
+          }
+        });
+
+        // then
+        const businessIdInput = container.querySelector('input[name="businessId"]');
+        expect(businessIdInput.disabled).to.be.false;
+      });
+
+
+      it('should be enabled when no connection check result', function() {
+
+        // when
+        const { container } = createStartInstanceConfigForm();
+
+        // then
+        const businessIdInput = container.querySelector('input[name="businessId"]');
+        expect(businessIdInput.disabled).to.be.false;
+      });
+
+
+      it('should be enabled when connection check fails', function() {
+
+        // when
+        const { container } = createStartInstanceConfigForm({
+          connectionCheckResult: {
+            success: false,
+            reason: 'UNKNOWN'
+          }
+        });
+
+        // then
+        const businessIdInput = container.querySelector('input[name="businessId"]');
+        expect(businessIdInput.disabled).to.be.false;
+      });
+
+
+      it('should preserve businessId when connecting to unsupported cluster', async function() {
+
+        // given
+        const supportedCluster = {
+          success: true,
+          response: { gatewayVersion: '8.9.0' }
+        };
+
+        const unsupportedCluster = {
+          success: true,
+          response: { gatewayVersion: '8.8.0' }
+        };
+
+        const { container, rerender } = createStartInstanceConfigForm({
+          initialFieldValues: { businessId: 'my-id' },
+          connectionCheckResult: supportedCluster
+        });
+
+        // when
+        await act(async () => {
+          rerenderStartInstanceConfigForm(rerender, {
+            initialFieldValues: { businessId: 'my-id' },
+            connectionCheckResult: unsupportedCluster
+          });
+        });
+
+        // then
+        expect(container.querySelector('input[name="businessId"]').value).to.eql('my-id');
+      });
+
+
+      it('should show version hint when field has a value and cluster is unsupported', function() {
+
+        // when
+        const { container } = createStartInstanceConfigForm({
+          initialFieldValues: { businessId: 'my-id' },
+          connectionCheckResult: {
+            success: true,
+            response: { gatewayVersion: '8.8.0' }
+          }
+        });
+
+        // then
+        const businessIdInput = container.querySelector('input[name="businessId"]');
+        const description = businessIdInput.closest('.form-group').querySelector('.custom-control-description');
+        expect(description.textContent).to.include('Requires Camunda 8.9.0 or later');
+      });
+
+
+      it('should not show version hint when field is empty with unsupported cluster', function() {
+
+        // when
+        const { container } = createStartInstanceConfigForm({
+          connectionCheckResult: {
+            success: true,
+            response: { gatewayVersion: '8.8.0' }
+          }
+        });
+
+        // then
+        const businessIdInput = container.querySelector('input[name="businessId"]');
+        const description = businessIdInput.closest('.form-group').querySelector('.custom-control-description');
+        expect(description).to.be.null;
+      });
+
+
+      it('should show version hint after user types value on unsupported cluster', async function() {
+
+        // given
+        const { container } = createStartInstanceConfigForm({
+          connectionCheckResult: {
+            success: true,
+            response: { gatewayVersion: '8.8.0' }
+          }
+        });
+
+        // when
+        await act(async () => {
+          fireEvent.change(container.querySelector('input[name="businessId"]'), {
+            target: { name: 'businessId', value: 'order-123' }
+          });
+        });
+
+        // then
+        const businessIdInput = container.querySelector('input[name="businessId"]');
+        const description = businessIdInput.closest('.form-group').querySelector('.custom-control-description');
+        expect(description.textContent).to.include('Requires Camunda 8.9.0 or later');
+      });
+
+
+      it('should not show version hint when field is touched but empty on unsupported cluster', async function() {
+
+        // given
+        const { container } = createStartInstanceConfigForm({
+          connectionCheckResult: {
+            success: true,
+            response: { gatewayVersion: '8.8.0' }
+          }
+        });
+
+        // when
+        await act(async () => {
+          fireEvent.focus(container.querySelector('input[name="businessId"]'));
+        });
+
+        await act(async () => {
+          fireEvent.blur(container.querySelector('input[name="businessId"]'));
+        });
+
+        // then
+        const businessIdInput = container.querySelector('input[name="businessId"]');
+        const description = businessIdInput.closest('.form-group').querySelector('.custom-control-description');
+        expect(description).to.be.null;
+      });
+
+    });
+
   });
 
 
@@ -173,9 +365,10 @@ describe('<StartInstanceConfigForm>', function() {
       });
 
       // then
-      expect(validateFieldSpy.callCount).to.eql(1);
+      expect(validateFieldSpy.callCount).to.eql(2);
 
       expect(validateFieldSpy).to.have.been.calledWith('variables', '{}');
+      expect(validateFieldSpy).to.have.been.calledWith('businessId', undefined);
 
       expect(validateFormSpy).to.have.been.calledOnce;
 
@@ -210,7 +403,7 @@ describe('<StartInstanceConfigForm>', function() {
       });
 
       // then
-      expect(validateFieldSpy.callCount).to.eql(1);
+      expect(validateFieldSpy.callCount).to.eql(2);
       expect(validateFormSpy.callCount).to.eql(1);
     });
 
@@ -242,7 +435,7 @@ describe('<StartInstanceConfigForm>', function() {
       });
 
       // then
-      expect(validateFieldSpy.callCount).to.eql(1);
+      expect(validateFieldSpy.callCount).to.eql(2);
       expect(validateFormSpy.callCount).to.eql(1);
     });
 
@@ -448,7 +641,7 @@ const DEFAULT_INITIAL_FIELD_VALUES = {
 function createStartInstanceConfigForm(props = {}) {
   let {
     connectionCheckResult,
-    getFieldError = (meta, fieldName) => {},
+    getFieldError = (_meta, _fieldName) => {},
     handleChangeConnections = () => {},
     handleManageConnections = () => {},
     handleOpenLintingPanel = () => {},
@@ -468,6 +661,45 @@ function createStartInstanceConfigForm(props = {}) {
   initialFieldValues = merge({}, DEFAULT_INITIAL_FIELD_VALUES, initialFieldValues);
 
   return render(<StartInstanceConfigForm
+    connectionCheckResult={ connectionCheckResult }
+    getFieldError={ getFieldError }
+    handleChangeConnections={ handleChangeConnections }
+    handleManageConnections={ handleManageConnections }
+    handleOpenLintingPanel={ handleOpenLintingPanel }
+    hasLintErrors={ hasLintErrors }
+    initialFieldValues={ initialFieldValues }
+    onSubmit={ onSubmit }
+    renderHeader={ renderHeader }
+    renderSubmit={ renderSubmit }
+    validateField={ validateField }
+    validateForm={ validateForm }
+    VariablesComponent={ VariablesComponent }
+    variablesComponentProps={ variablesComponentProps } />);
+}
+
+function rerenderStartInstanceConfigForm(rerender, props = {}) {
+  let {
+    connectionCheckResult,
+    getFieldError = () => {},
+    handleChangeConnections = () => {},
+    handleManageConnections = () => {},
+    handleOpenLintingPanel = () => {},
+    hasLintErrors = false,
+    initialFieldValues = {},
+    onSubmit = () => {},
+    renderHeader = null,
+    renderSubmit = 'Submit',
+    validateField = () => {},
+    validateForm = () => {},
+    VariablesComponent = TextInput,
+    variablesComponentProps = {
+      multiline: true
+    }
+  } = props;
+
+  initialFieldValues = merge({}, DEFAULT_INITIAL_FIELD_VALUES, initialFieldValues);
+
+  rerender(<StartInstanceConfigForm
     connectionCheckResult={ connectionCheckResult }
     getFieldError={ getFieldError }
     handleChangeConnections={ handleChangeConnections }

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstanceConfigValidatorSpec.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstanceConfigValidatorSpec.js
@@ -9,7 +9,7 @@
  */
 
 import { expect } from 'chai';
-import StartInstanceConfigValidator, { VALIDATION_ERROR_MESSAGES } from '../StartInstanceConfigValidator';
+import StartInstanceConfigValidator, { BUSINESS_ID_MAX_LENGTH, VALIDATION_ERROR_MESSAGES } from '../StartInstanceConfigValidator';
 
 describe('<StartInstanceConfigValidator>', function() {
 
@@ -38,6 +38,50 @@ describe('<StartInstanceConfigValidator>', function() {
 
     });
 
+
+    describe('businessId', function() {
+
+      it('should validate (empty)', function() {
+
+        // when
+        const validationError = StartInstanceConfigValidator.validateConfigValue('businessId', '');
+
+        // then
+        expect(validationError).to.be.null;
+      });
+
+
+      it('should validate (valid)', function() {
+
+        // when
+        const validationError = StartInstanceConfigValidator.validateConfigValue('businessId', 'order-1234');
+
+        // then
+        expect(validationError).to.be.null;
+      });
+
+
+      it('should validate (at max length)', function() {
+
+        // when
+        const validationError = StartInstanceConfigValidator.validateConfigValue('businessId', 'a'.repeat(BUSINESS_ID_MAX_LENGTH));
+
+        // then
+        expect(validationError).to.be.null;
+      });
+
+
+      it('should validate (too long)', function() {
+
+        // when
+        const validationError = StartInstanceConfigValidator.validateConfigValue('businessId', 'a'.repeat(BUSINESS_ID_MAX_LENGTH + 1));
+
+        // then
+        expect(validationError).to.eql(VALIDATION_ERROR_MESSAGES.BUSINESS_ID_TOO_LONG);
+      });
+
+    });
+
   });
 
 
@@ -51,6 +95,14 @@ describe('<StartInstanceConfigValidator>', function() {
         });
       });
 
+
+      it('should be valid (with businessId)', function() {
+        expectNoValidationErrors({
+          variables: '{ "foo": "bar" }',
+          businessId: 'order-1234'
+        });
+      });
+
     });
 
 
@@ -61,6 +113,16 @@ describe('<StartInstanceConfigValidator>', function() {
           variables: '{'
         }, {
           'variables': VALIDATION_ERROR_MESSAGES.VARIABLES_MUST_BE_VALID_JSON
+        });
+      });
+
+
+      it('should not be valid (businessId too long)', function() {
+        expectValidationErrors({
+          variables: '{}',
+          businessId: 'a'.repeat(BUSINESS_ID_MAX_LENGTH + 1)
+        }, {
+          'businessId': VALIDATION_ERROR_MESSAGES.BUSINESS_ID_TOO_LONG
         });
       });
 

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/types.d.ts
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/types.d.ts
@@ -11,4 +11,5 @@ export interface StartInstanceResult {
 
 export interface StartInstanceConfig extends DeploymentConfig {
   variables: Record<string, any>;
+  businessId?: string;
 }

--- a/client/src/remote/ZeebeAPI.js
+++ b/client/src/remote/ZeebeAPI.js
@@ -60,7 +60,8 @@ export default class ZeebeAPI {
       processId,
       variables,
       startInstructions,
-      runtimeInstructions
+      runtimeInstructions,
+      businessId
     } = options;
 
     endpoint = getEndpointForTargetType(endpoint);
@@ -71,7 +72,8 @@ export default class ZeebeAPI {
       processId,
       variables,
       startInstructions,
-      runtimeInstructions
+      runtimeInstructions,
+      businessId
     });
   }
 

--- a/client/src/remote/__tests__/ZeebeAPISpec.js
+++ b/client/src/remote/__tests__/ZeebeAPISpec.js
@@ -278,7 +278,8 @@ describe('<ZeebeAPI>', function() {
         },
         variables,
         startInstructions: undefined,
-        runtimeInstructions: undefined
+        runtimeInstructions: undefined,
+        businessId: undefined
       });
     });
 
@@ -324,7 +325,8 @@ describe('<ZeebeAPI>', function() {
         },
         variables,
         startInstructions: undefined,
-        runtimeInstructions: undefined
+        runtimeInstructions: undefined,
+        businessId: undefined
       });
     });
 
@@ -374,7 +376,8 @@ describe('<ZeebeAPI>', function() {
         },
         variables,
         startInstructions: undefined,
-        runtimeInstructions: undefined
+        runtimeInstructions: undefined,
+        businessId: undefined
       });
     });
 
@@ -429,7 +432,8 @@ describe('<ZeebeAPI>', function() {
         },
         variables,
         startInstructions: undefined,
-        runtimeInstructions: undefined
+        runtimeInstructions: undefined,
+        businessId: undefined
       });
     });
 
@@ -485,7 +489,8 @@ describe('<ZeebeAPI>', function() {
         },
         variables,
         startInstructions: undefined,
-        runtimeInstructions: undefined
+        runtimeInstructions: undefined,
+        businessId: undefined
       });
     });
 
@@ -541,7 +546,8 @@ describe('<ZeebeAPI>', function() {
         },
         variables,
         startInstructions: undefined,
-        runtimeInstructions: undefined
+        runtimeInstructions: undefined,
+        businessId: undefined
       });
     });
 

--- a/client/src/shared/ui/DefinitionTooltip.js
+++ b/client/src/shared/ui/DefinitionTooltip.js
@@ -1,0 +1,182 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import React, { useState, useRef, useEffect, useLayoutEffect, useCallback } from 'react';
+
+const SHOW_DELAY = 250;
+const HIDE_DELAY = 250;
+
+export function DefinitionTooltip({ children, definition, direction = 'right' }) {
+  const [ visible, setVisible ] = useState(false);
+  const [ tooltipPosition, setTooltipPosition ] = useState(null);
+  const [ arrowOffset, setArrowOffset ] = useState(null);
+
+  const showTimeoutRef = useRef(null);
+  const hideTimeoutRef = useRef(null);
+  const wrapperRef = useRef(null);
+  const tooltipRef = useRef(null);
+
+  const clearTimeouts = useCallback(() => {
+    clearTimeout(showTimeoutRef.current);
+    clearTimeout(hideTimeoutRef.current);
+  }, []);
+
+  useEffect(() => clearTimeouts, [ clearTimeouts ]);
+
+  const show = useCallback((delay = false) => {
+    clearTimeouts();
+    if (delay) {
+      showTimeoutRef.current = setTimeout(() => setVisible(true), SHOW_DELAY);
+    } else {
+      setVisible(true);
+    }
+  }, [ clearTimeouts ]);
+
+  const hide = useCallback((delay = false) => {
+    clearTimeouts();
+    if (delay) {
+      hideTimeoutRef.current = setTimeout(() => setVisible(false), HIDE_DELAY);
+    } else {
+      setVisible(false);
+    }
+  }, [ clearTimeouts ]);
+
+  useEffect(() => {
+    if (!visible) return;
+
+    const handleClickOutside = (e) => {
+      if (
+        wrapperRef.current && !wrapperRef.current.contains(e.target) &&
+        tooltipRef.current && !tooltipRef.current.contains(e.target)
+      ) {
+        hide(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [ visible, hide ]);
+
+  useLayoutEffect(() => {
+    if (!visible || !wrapperRef.current || !tooltipRef.current) {
+      setTooltipPosition(null);
+      setArrowOffset(null);
+      return;
+    }
+
+    const refRect = wrapperRef.current.getBoundingClientRect();
+    const tooltipRect = tooltipRef.current.getBoundingClientRect();
+    const viewportHeight = window.innerHeight;
+
+    const right = `calc(100% - ${refRect.x}px)`;
+    let top = refRect.top - 10;
+    let offset = null;
+
+    if (direction === 'right') {
+      const maxTop = viewportHeight - tooltipRect.height;
+      const originalTop = top;
+
+      top = Math.max(0, Math.min(top, maxTop));
+
+      if (top !== originalTop) {
+        offset = 16 - (top - originalTop);
+      }
+    }
+
+    setTooltipPosition({ right, top });
+    setArrowOffset(offset);
+  }, [ visible, direction ]);
+
+  const handleMouseLeave = ({ relatedTarget }) => {
+    if (
+      relatedTarget === wrapperRef.current ||
+      relatedTarget === tooltipRef.current ||
+      relatedTarget?.parentElement === tooltipRef.current
+    ) {
+      return;
+    }
+
+    const selection = window.getSelection();
+    if (selection && selection.toString().length > 0) {
+      const range = selection.getRangeAt(0);
+      if (
+        tooltipRef.current?.contains(range.commonAncestorContainer) ||
+        tooltipRef.current?.contains(selection.anchorNode) ||
+        tooltipRef.current?.contains(selection.focusNode)
+      ) {
+        return;
+      }
+    }
+
+    hide(true);
+  };
+
+  const handleFocusOut = (e) => {
+    const { relatedTarget } = e;
+    if (
+      tooltipRef.current?.contains(relatedTarget) ||
+      wrapperRef.current?.contains(relatedTarget)
+    ) {
+      return;
+    }
+    hide(false);
+  };
+
+  const tooltipStyle = {
+    ...(tooltipPosition
+      ? { right: tooltipPosition.right, top: `${tooltipPosition.top}px` }
+      : {}),
+    '--tooltip-background-color': 'hsl(0, 0%, 22%)',
+    '--tooltip-link': 'hsl(218, 100%, 74%)',
+    '--tooltip-code-background-color': 'hsl(225, 10%, 97%)',
+    '--tooltip-code-border-color': 'hsl(225, 10%, 85%)',
+    '--text-size-small': '13px',
+    '--font-family': "'IBM Plex Sans', system-ui, Arial, sans-serif"
+  };
+
+  const arrowStyle = arrowOffset != null
+    ? { marginTop: `${arrowOffset}px` }
+    : undefined;
+
+  return (
+    <div
+      className="bio-properties-panel-tooltip-wrapper"
+      style={ { padding: '2px' } }
+      tabIndex="0"
+      ref={ wrapperRef }
+      onMouseEnter={ () => show(true) }
+      onMouseLeave={ handleMouseLeave }
+      onFocus={ () => show() }
+      onBlur={ handleFocusOut }
+      onKeyDown={ (e) => e.key === 'Escape' && hide(false) }
+    >
+      { children }
+      { visible && (
+        <div
+          className={ `bio-properties-panel-tooltip ${direction}` }
+          role="tooltip"
+          style={ tooltipStyle }
+          ref={ tooltipRef }
+          onClick={ (e) => e.stopPropagation() }
+          onMouseEnter={ () => clearTimeout(hideTimeoutRef.current) }
+          onMouseLeave={ handleMouseLeave }
+        >
+          <div className="bio-properties-panel-tooltip-content">
+            { definition }
+          </div>
+          <div
+            className="bio-properties-panel-tooltip-arrow"
+            style={ arrowStyle }
+          />
+        </div>
+      ) }
+    </div>
+  );
+}

--- a/client/src/shared/ui/__tests__/DefinitionTooltipSpec.js
+++ b/client/src/shared/ui/__tests__/DefinitionTooltipSpec.js
@@ -1,0 +1,328 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import React from 'react';
+
+import {
+  render,
+  fireEvent,
+  act
+} from '@testing-library/react';
+
+import { DefinitionTooltip } from '../DefinitionTooltip';
+
+
+describe('<DefinitionTooltip>', function() {
+
+  let clock;
+
+  beforeEach(function() {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(function() {
+    clock.restore();
+  });
+
+
+  it('should render children', function() {
+
+    // when
+    const { getByText } = render(
+      <DefinitionTooltip definition="Tooltip content">
+        Label
+      </DefinitionTooltip>
+    );
+
+    // then
+    expect(getByText('Label')).to.exist;
+  });
+
+
+  it('should not show tooltip by default', function() {
+
+    // when
+    const { container } = render(
+      <DefinitionTooltip definition="Tooltip content">
+        Label
+      </DefinitionTooltip>
+    );
+
+    // then
+    expect(container.querySelector('[role="tooltip"]')).to.be.null;
+  });
+
+
+  it('should show tooltip on focus', function() {
+
+    // given
+    const { container } = render(
+      <DefinitionTooltip definition="Tooltip content">
+        Label
+      </DefinitionTooltip>
+    );
+
+    const wrapper = container.querySelector('.bio-properties-panel-tooltip-wrapper');
+
+    // when
+    act(() => {
+      fireEvent.focus(wrapper);
+    });
+
+    // then
+    expect(container.querySelector('[role="tooltip"]')).to.exist;
+  });
+
+
+  it('should show tooltip content', function() {
+
+    // given
+    const { container, getByText } = render(
+      <DefinitionTooltip definition={ <p>My definition</p> }>
+        Label
+      </DefinitionTooltip>
+    );
+
+    const wrapper = container.querySelector('.bio-properties-panel-tooltip-wrapper');
+
+    // when
+    act(() => {
+      fireEvent.focus(wrapper);
+    });
+
+    // then
+    expect(getByText('My definition')).to.exist;
+  });
+
+
+  it('should show tooltip on mouse enter after delay', function() {
+
+    // given
+    const { container } = render(
+      <DefinitionTooltip definition="Tooltip content">
+        Label
+      </DefinitionTooltip>
+    );
+
+    const wrapper = container.querySelector('.bio-properties-panel-tooltip-wrapper');
+
+    // when
+    act(() => {
+      fireEvent.mouseEnter(wrapper);
+    });
+
+    // then - not visible yet
+    expect(container.querySelector('[role="tooltip"]')).to.be.null;
+
+    // when - advance past show delay
+    act(() => {
+      clock.tick(300);
+    });
+
+    // then
+    expect(container.querySelector('[role="tooltip"]')).to.exist;
+  });
+
+
+  it('should hide tooltip on Escape', function() {
+
+    // given
+    const { container } = render(
+      <DefinitionTooltip definition="Tooltip content">
+        Label
+      </DefinitionTooltip>
+    );
+
+    const wrapper = container.querySelector('.bio-properties-panel-tooltip-wrapper');
+
+    act(() => {
+      fireEvent.focus(wrapper);
+    });
+
+    expect(container.querySelector('[role="tooltip"]')).to.exist;
+
+    // when
+    act(() => {
+      fireEvent.keyDown(wrapper, { key: 'Escape' });
+    });
+
+    // then
+    expect(container.querySelector('[role="tooltip"]')).to.be.null;
+  });
+
+
+  it('should hide tooltip on blur', function() {
+
+    // given
+    const { container } = render(
+      <DefinitionTooltip definition="Tooltip content">
+        Label
+      </DefinitionTooltip>
+    );
+
+    const wrapper = container.querySelector('.bio-properties-panel-tooltip-wrapper');
+
+    act(() => {
+      fireEvent.focus(wrapper);
+    });
+
+    expect(container.querySelector('[role="tooltip"]')).to.exist;
+
+    // when
+    act(() => {
+      fireEvent.blur(wrapper, { relatedTarget: document.body });
+    });
+
+    // then
+    expect(container.querySelector('[role="tooltip"]')).to.be.null;
+  });
+
+
+  it('should hide tooltip on click outside', function() {
+
+    // given
+    const { container } = render(
+      <div>
+        <DefinitionTooltip definition="Tooltip content">
+          Label
+        </DefinitionTooltip>
+        <button>Outside</button>
+      </div>
+    );
+
+    const wrapper = container.querySelector('.bio-properties-panel-tooltip-wrapper');
+
+    act(() => {
+      fireEvent.focus(wrapper);
+    });
+
+    expect(container.querySelector('[role="tooltip"]')).to.exist;
+
+    // when
+    act(() => {
+      fireEvent.mouseDown(container.querySelector('button'));
+    });
+
+    // then
+    expect(container.querySelector('[role="tooltip"]')).to.be.null;
+  });
+
+
+  it('should apply direction class', function() {
+
+    // given
+    const { container } = render(
+      <DefinitionTooltip definition="Tooltip content" direction="left">
+        Label
+      </DefinitionTooltip>
+    );
+
+    const wrapper = container.querySelector('.bio-properties-panel-tooltip-wrapper');
+
+    // when
+    act(() => {
+      fireEvent.focus(wrapper);
+    });
+
+    // then
+    const tooltip = container.querySelector('[role="tooltip"]');
+    expect(tooltip.classList.contains('left')).to.be.true;
+  });
+
+
+  it('should apply default direction class', function() {
+
+    // given
+    const { container } = render(
+      <DefinitionTooltip definition="Tooltip content">
+        Label
+      </DefinitionTooltip>
+    );
+
+    const wrapper = container.querySelector('.bio-properties-panel-tooltip-wrapper');
+
+    // when
+    act(() => {
+      fireEvent.focus(wrapper);
+    });
+
+    // then
+    const tooltip = container.querySelector('[role="tooltip"]');
+    expect(tooltip.classList.contains('right')).to.be.true;
+  });
+
+
+  it('should hide tooltip on mouse leave after delay', function() {
+
+    // given
+    const { container } = render(
+      <DefinitionTooltip definition="Tooltip content">
+        Label
+      </DefinitionTooltip>
+    );
+
+    const wrapper = container.querySelector('.bio-properties-panel-tooltip-wrapper');
+
+    act(() => {
+      fireEvent.focus(wrapper);
+    });
+
+    expect(container.querySelector('[role="tooltip"]')).to.exist;
+
+    // when
+    act(() => {
+      fireEvent.mouseLeave(wrapper, { relatedTarget: document.body });
+    });
+
+    // then - still visible during delay
+    expect(container.querySelector('[role="tooltip"]')).to.exist;
+
+    // when - advance past hide delay
+    act(() => {
+      clock.tick(300);
+    });
+
+    // then
+    expect(container.querySelector('[role="tooltip"]')).to.be.null;
+  });
+
+
+  it('should cancel show on mouse leave before delay', function() {
+
+    // given
+    const { container } = render(
+      <DefinitionTooltip definition="Tooltip content">
+        Label
+      </DefinitionTooltip>
+    );
+
+    const wrapper = container.querySelector('.bio-properties-panel-tooltip-wrapper');
+
+    // when - enter then leave before show delay
+    act(() => {
+      fireEvent.mouseEnter(wrapper);
+    });
+
+    act(() => {
+      fireEvent.mouseLeave(wrapper, { relatedTarget: document.body });
+    });
+
+    act(() => {
+      clock.tick(300);
+    });
+
+    // then
+    expect(container.querySelector('[role="tooltip"]')).to.be.null;
+  });
+
+});

--- a/client/src/shared/ui/index.js
+++ b/client/src/shared/ui/index.js
@@ -14,5 +14,6 @@ export { Icon } from './icon';
 export { Modal } from './modal';
 export { Overlay, OverlayDropdown } from './overlay';
 export { Section } from './Section';
+export { DefinitionTooltip } from './DefinitionTooltip';
 
 export * from './form';


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

Closes https://github.com/camunda/camunda-modeler/issues/5913

Allow users to assign a business ID to a process instance created in Modeler.

<img width="320" height="246" alt="Enabled field with tooltip hidden" src="https://github.com/user-attachments/assets/ede2e523-0964-467a-9146-68c2ae5dca84" />

<img width="337" height="269" alt="Enabled field with tooltip visible" src="https://github.com/user-attachments/assets/0300f557-cf95-4cfb-8c26-65367795fe48" />


When the connected cluster version doesn't support Business ID (or no connection is selected), the field is disabled, and this help text appears:

<img width="337" height="275" alt="Disabled field" src="https://github.com/user-attachments/assets/0bda0b16-994f-4a2f-a5c0-a93bc525513f" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
