### PR TITLE
fix(FormEditor): actually lint form on any change before the file is saved

### DIFF
--- a/client/src/app/tabs/form/FormEditor.js
+++ b/client/src/app/tabs/form/FormEditor.js
@@ -121,7 +121,7 @@ export class FormEditor extends CachedComponent {
       setCached: (state) => this.setCached(state)
     });
 
-    this.handleLintingDebounced = debounce(this.handleLinting.bind(this));
+    this.handleLintingDebounced = debounce(() => this.handleLinting());
   }
 
   componentDidMount() {

--- a/client/test/mocks/form-js/index.js
+++ b/client/test/mocks/form-js/index.js
@@ -83,7 +83,7 @@ export class FormEditor {
 
   _emit(event) {
     if (this.listeners[ event ]) {
-      this.listeners[ event ].forEach(callback => callback());
+      this.listeners[ event ].forEach(callback => callback({ type: event }));
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/5861

### Proposed Changes

Agent's root causing:

> The debounced linting handler was forwarding the EventBus event object to `handleLinting`, where it was mistakenly treated as `engineProfileOverride`. Since the event object is truthy but has no `executionPlatformVersion`, `handleLinting` returned early and lint never ran after engine profile changes until the file was saved.
> 
> Additionally, fix the FormEditor mock to pass an event object to listeners (matching real EventBus behavior) so the existing test catches this class of bugs.

Fixed behavior - linting happens on unsaved file:

<img width="1129" height="910" alt="form-bugfix" src="https://github.com/user-attachments/assets/941ca0fe-ca2e-46bd-9da0-373fdd7f55d5" />

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
