### PR TITLE
fix: lint tab with current contents

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1101,7 +1101,7 @@ export class App extends PureComponent {
     const relevantChange = (prev && prev.success) !== connectionCheckResult.success
       || prevVersion !== nextVersion;
 
-    this.setState({ connectionCheckResult }, () => {
+    this.setState({ connectionCheckResult }, async () => {
       if (!relevantChange) {
         return;
       }
@@ -1109,7 +1109,9 @@ export class App extends PureComponent {
       const { activeTab } = this.state;
 
       if (activeTab && activeTab !== EMPTY_TAB) {
-        this.lintTab(activeTab);
+        const contents = await this.getActiveTabContents();
+
+        this.lintTab(activeTab, contents);
       }
     });
   };
@@ -1124,10 +1126,14 @@ export class App extends PureComponent {
         ...state.engineProfiles,
         [ tab.id ]: { executionPlatform, executionPlatformVersion }
       }
-    }), () => {
+    }), async () => {
+      if (this.state.activeTab === tab) {
+        const contents = await this.getActiveTabContents();
 
-      // Re-lint to pick up version mismatch warning
-      this.lintTab(tab);
+        this.lintTab(tab, contents);
+      } else {
+        this.lintTab(tab);
+      }
     });
   };
 

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -4716,6 +4716,438 @@ describe('<App>', function() {
           });
         });
 
+
+        it('should re-lint with current editor contents, not stale file contents', async function() {
+
+          // given
+          const { app } = createApp();
+
+          await app.openFiles([
+            createFile('1.cloud-bpmn', {
+              contents: 'linting-errors'
+            })
+          ]);
+
+          const { activeTab } = app.state;
+
+          setVersionState(app, activeTab, {
+            engineProfile: {
+              executionPlatform: 'Camunda Cloud',
+              executionPlatformVersion: '8.7.0'
+            },
+            connectionCheckResult: {
+              success: false,
+              reason: 'UNAVAILABLE'
+            }
+          });
+
+          // lint with saved file contents — error should exist
+          await app.lintTab(activeTab, 'linting-errors');
+
+          await waitFor(() => {
+            const errors = app.getLintingState(activeTab);
+
+            expect(errors.some(e => e.id === 'Task_1')).to.be.true;
+          });
+
+          // simulate user removing the task in the editor (unsaved)
+          const tabComponent = app.tabRef.current;
+          tabComponent.currentContents = 'no-errors';
+
+          // when - connection status changes, triggering re-lint
+          app.emit('connectionManager.connectionStatusChanged', {
+            tab: activeTab,
+            success: true,
+            response: { gatewayVersion: '8.8.0' }
+          });
+
+          // then - lint should use current editor contents (task removed),
+          // not stale file contents (task still present)
+          await waitFor(() => {
+            const errors = app.getLintingState(activeTab);
+
+            expect(errors.some(e => e.id === 'Task_1')).to.be.false;
+          });
+        });
+
+
+        it('should re-lint RPA tab with current editor contents', async function() {
+
+          // given
+          const { app } = createApp();
+
+          await app.openFiles([
+            createFile('1.rpa', {
+              contents: 'linting-errors'
+            })
+          ]);
+
+          const { activeTab } = app.state;
+
+          setVersionState(app, activeTab, {
+            engineProfile: {
+              executionPlatform: 'Camunda Cloud',
+              executionPlatformVersion: '8.7.0'
+            },
+            connectionCheckResult: {
+              success: false,
+              reason: 'UNAVAILABLE'
+            }
+          });
+
+          await app.lintTab(activeTab, 'linting-errors');
+
+          await waitFor(() => {
+            const errors = app.getLintingState(activeTab);
+
+            expect(errors.some(e => e.id === 'Script_1')).to.be.true;
+          });
+
+          // simulate user editing in the editor (unsaved)
+          const tabComponent = app.tabRef.current;
+          tabComponent.currentContents = 'no-errors';
+
+          // when
+          app.emit('connectionManager.connectionStatusChanged', {
+            tab: activeTab,
+            success: true,
+            response: { gatewayVersion: '8.8.0' }
+          });
+
+          // then
+          await waitFor(() => {
+            const errors = app.getLintingState(activeTab);
+
+            expect(errors.some(e => e.id === 'Script_1')).to.be.false;
+          });
+        });
+
+
+        it('should re-lint Form (C7) tab with current editor contents', async function() {
+
+          // given
+          const { app } = createApp();
+
+          await app.openFiles([
+            createFile('1.form', {
+              contents: 'linting-errors'
+            })
+          ]);
+
+          const { activeTab } = app.state;
+
+          setVersionState(app, activeTab, {
+            engineProfile: {
+              executionPlatform: 'Camunda Platform',
+              executionPlatformVersion: '7.15'
+            },
+            connectionCheckResult: {
+              success: false,
+              reason: 'UNAVAILABLE'
+            }
+          });
+
+          await app.lintTab(activeTab, 'linting-errors');
+
+          await waitFor(() => {
+            const errors = app.getLintingState(activeTab);
+
+            expect(errors.some(e => e.id === 'Field_1')).to.be.true;
+          });
+
+          // simulate user editing in the editor (unsaved)
+          const tabComponent = app.tabRef.current;
+          tabComponent.currentContents = 'no-errors';
+
+          // when
+          app.emit('connectionManager.connectionStatusChanged', {
+            tab: activeTab,
+            success: true,
+            response: { gatewayVersion: '8.8.0' }
+          });
+
+          // then
+          await waitFor(() => {
+            const errors = app.getLintingState(activeTab);
+
+            expect(errors.some(e => e.id === 'Field_1')).to.be.false;
+          });
+        });
+
+
+        it('should re-lint BPMN (C7) tab with current editor contents', async function() {
+
+          // given
+          const { app } = createApp();
+
+          await app.openFiles([
+            createFile('1.bpmn', {
+              contents: 'linting-errors'
+            })
+          ]);
+
+          const { activeTab } = app.state;
+
+          setVersionState(app, activeTab, {
+            engineProfile: {
+              executionPlatform: 'Camunda Platform',
+              executionPlatformVersion: '7.15'
+            },
+            connectionCheckResult: {
+              success: false,
+              reason: 'UNAVAILABLE'
+            }
+          });
+
+          await app.lintTab(activeTab, 'linting-errors');
+
+          await waitFor(() => {
+            const errors = app.getLintingState(activeTab);
+
+            expect(errors.some(e => e.id === 'Task_1')).to.be.true;
+          });
+
+          // simulate user editing in the editor (unsaved)
+          const tabComponent = app.tabRef.current;
+          tabComponent.currentContents = 'no-errors';
+
+          // when
+          app.emit('connectionManager.connectionStatusChanged', {
+            tab: activeTab,
+            success: true,
+            response: { gatewayVersion: '8.8.0' }
+          });
+
+          // then
+          await waitFor(() => {
+            const errors = app.getLintingState(activeTab);
+
+            expect(errors.some(e => e.id === 'Task_1')).to.be.false;
+          });
+        });
+
+      });
+
+
+      describe('engine profile changed re-lint', function() {
+
+        it('should re-lint active cloud-bpmn tab with current editor contents', async function() {
+
+          // given
+          const { app } = createApp();
+
+          // create dummy tab to advance uuid past 0
+          // (_handleEngineProfileChanged guards on !tab.id)
+          await app.createDiagram('cloud-bpmn');
+
+          await app.openFiles([
+            createFile('1.cloud-bpmn', {
+              contents: 'linting-errors'
+            })
+          ]);
+
+          const { activeTab } = app.state;
+
+          await app.lintTab(activeTab, 'linting-errors');
+
+          await waitFor(() => {
+            const errors = app.getLintingState(activeTab);
+
+            expect(errors.some(e => e.id === 'Task_1')).to.be.true;
+          });
+
+          // simulate user editing in the editor (unsaved)
+          const tabComponent = app.tabRef.current;
+          tabComponent.currentContents = 'no-errors';
+
+          // when - engine profile changes on active tab
+          app.emit('tab.engineProfileChanged', {
+            tab: activeTab,
+            executionPlatform: 'Camunda Cloud',
+            executionPlatformVersion: '8.8.0'
+          });
+
+          // then - should use current editor contents
+          await waitFor(() => {
+            const errors = app.getLintingState(activeTab);
+
+            expect(errors.some(e => e.id === 'Task_1')).to.be.false;
+          });
+        });
+
+
+        it('should re-lint active RPA tab with current editor contents', async function() {
+
+          // given
+          const { app } = createApp();
+
+          await app.createDiagram('rpa');
+
+          await app.openFiles([
+            createFile('1.rpa', {
+              contents: 'linting-errors'
+            })
+          ]);
+
+          const { activeTab } = app.state;
+
+          await app.lintTab(activeTab, 'linting-errors');
+
+          await waitFor(() => {
+            const errors = app.getLintingState(activeTab);
+
+            expect(errors.some(e => e.id === 'Script_1')).to.be.true;
+          });
+
+          const tabComponent = app.tabRef.current;
+          tabComponent.currentContents = 'no-errors';
+
+          // when
+          app.emit('tab.engineProfileChanged', {
+            tab: activeTab,
+            executionPlatform: 'Camunda Cloud',
+            executionPlatformVersion: '8.8.0'
+          });
+
+          // then
+          await waitFor(() => {
+            const errors = app.getLintingState(activeTab);
+
+            expect(errors.some(e => e.id === 'Script_1')).to.be.false;
+          });
+        });
+
+
+        it('should re-lint active Form (C7) tab with current editor contents', async function() {
+
+          // given
+          const { app } = createApp();
+
+          await app.createDiagram('form');
+
+          await app.openFiles([
+            createFile('1.form', {
+              contents: 'linting-errors'
+            })
+          ]);
+
+          const { activeTab } = app.state;
+
+          await app.lintTab(activeTab, 'linting-errors');
+
+          await waitFor(() => {
+            const errors = app.getLintingState(activeTab);
+
+            expect(errors.some(e => e.id === 'Field_1')).to.be.true;
+          });
+
+          const tabComponent = app.tabRef.current;
+          tabComponent.currentContents = 'no-errors';
+
+          // when
+          app.emit('tab.engineProfileChanged', {
+            tab: activeTab,
+            executionPlatform: 'Camunda Platform',
+            executionPlatformVersion: '7.16'
+          });
+
+          // then
+          await waitFor(() => {
+            const errors = app.getLintingState(activeTab);
+
+            expect(errors.some(e => e.id === 'Field_1')).to.be.false;
+          });
+        });
+
+
+        it('should re-lint active BPMN (C7) tab with current editor contents', async function() {
+
+          // given
+          const { app } = createApp();
+
+          await app.createDiagram('bpmn');
+
+          await app.openFiles([
+            createFile('1.bpmn', {
+              contents: 'linting-errors'
+            })
+          ]);
+
+          const { activeTab } = app.state;
+
+          await app.lintTab(activeTab, 'linting-errors');
+
+          await waitFor(() => {
+            const errors = app.getLintingState(activeTab);
+
+            expect(errors.some(e => e.id === 'Task_1')).to.be.true;
+          });
+
+          const tabComponent = app.tabRef.current;
+          tabComponent.currentContents = 'no-errors';
+
+          // when
+          app.emit('tab.engineProfileChanged', {
+            tab: activeTab,
+            executionPlatform: 'Camunda Platform',
+            executionPlatformVersion: '7.16'
+          });
+
+          // then
+          await waitFor(() => {
+            const errors = app.getLintingState(activeTab);
+
+            expect(errors.some(e => e.id === 'Task_1')).to.be.false;
+          });
+        });
+
+
+        it('should re-lint non-active tab with file contents', async function() {
+
+          // given
+          const { app } = createApp();
+
+          await app.createDiagram('cloud-bpmn');
+
+          await app.openFiles([
+            createFile('1.cloud-bpmn', {
+              contents: 'linting-errors'
+            }),
+            createFile('2.cloud-bpmn', {
+              contents: 'no-errors'
+            })
+          ]);
+
+          // last opened tab is active, '1.cloud-bpmn' is background
+          const backgroundTab = app.state.tabs.find(t => t.file && t.file.path === '1.cloud-bpmn');
+          const { activeTab } = app.state;
+
+          expect(activeTab).to.not.eql(backgroundTab);
+
+          await app.lintTab(backgroundTab, 'linting-errors');
+
+          await waitFor(() => {
+            const errors = app.getLintingState(backgroundTab);
+
+            expect(errors.some(e => e.id === 'Task_1')).to.be.true;
+          });
+
+          // when - engine profile changes on background tab
+          app.emit('tab.engineProfileChanged', {
+            tab: backgroundTab,
+            executionPlatform: 'Camunda Cloud',
+            executionPlatformVersion: '8.8.0'
+          });
+
+          // then - should use file contents (linting-errors), not editor contents,
+          // because the tab is not active
+          await waitFor(() => {
+            const errors = app.getLintingState(backgroundTab);
+
+            expect(errors.some(e => e.id === 'Task_1')).to.be.true;
+          });
+        });
+
       });
 
     });

--- a/client/src/app/__tests__/mocks/index.js
+++ b/client/src/app/__tests__/mocks/index.js
@@ -72,7 +72,9 @@ class FakeTab extends Component {
   triggerAction(action, options) {
 
     if (action === 'save') {
-      return 'CONTENTS';
+      return this.currentContents !== undefined
+        ? this.currentContents
+        : 'CONTENTS';
     }
 
     if (action === 'export-as') {
@@ -250,7 +252,17 @@ export class TabsProvider {
         extensions: [ 'rpa' ],
         getLinter() {
           return {
-            lint() {
+            lint(contents) {
+              if (contents === 'linting-errors') {
+                return [
+                  {
+                    id: 'Script_1',
+                    path: [],
+                    message: 'foo'
+                  }
+                ];
+              }
+
               return [];
             }
           };


### PR DESCRIPTION

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

Run the linter with the current file contents (not the last saved contents) on connection change.

Closes https://github.com/camunda/camunda-modeler/issues/5949


https://github.com/user-attachments/assets/38aa2b7f-35fc-423d-8c66-4dbe7ae8994a



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
