### PR TITLE
fix: fix Select All shortcut(cmd + a) in variables panel search input

### DIFF
--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -256,6 +256,8 @@ export class BpmnEditor extends CachedComponent {
       'elements.copied',
       'propertiesPanel.focusin',
       'propertiesPanel.focusout',
+      'variablesPanel.focusin',
+      'variablesPanel.focusout',
       'canvas.focus.changed'
     ].forEach((event) => {
       modeler[fn](event, this.handleChanged);

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -361,6 +361,12 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
     it('propertiesPanel.focusout', expectHandleChanged('propertiesPanel.focusout'));
 
 
+    it('variablesPanel.focusin', expectHandleChanged('variablesPanel.focusin'));
+
+
+    it('variablesPanel.focusout', expectHandleChanged('variablesPanel.focusout'));
+
+
   });
 
 

--- a/client/src/app/tabs/cloud-bpmn/variables-side-panel/VariablesSidePanel.js
+++ b/client/src/app/tabs/cloud-bpmn/variables-side-panel/VariablesSidePanel.js
@@ -8,7 +8,7 @@
  * except in compliance with the MIT License.
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 
 import classNames from 'classnames';
 
@@ -41,6 +41,24 @@ export default function VariablesSidePanel(props) {
     maxWidth,
     onLayoutChanged
   } = props;
+
+  const bodyRef = useRef();
+
+  useEffect(() => {
+    const eventBus = injector.get('eventBus');
+    const container = bodyRef.current;
+
+    const handleFocusin = () => eventBus.fire('variablesPanel.focusin');
+    const handleFocusout = () => eventBus.fire('variablesPanel.focusout');
+
+    container.addEventListener('focusin', handleFocusin);
+    container.addEventListener('focusout', handleFocusout);
+
+    return () => {
+      container.removeEventListener('focusin', handleFocusin);
+      container.removeEventListener('focusout', handleFocusout);
+    };
+  }, [ injector ]);
 
   const { variablesSidePanel = DEFAULT_LAYOUT } = layout;
 
@@ -82,7 +100,7 @@ export default function VariablesSidePanel(props) {
     >
       <SidePanelTitleBar title="Variables" onClose={ onClose } />
 
-      <div className="variables-side-panel__body">
+      <div className="variables-side-panel__body" ref={ bodyRef }>
         <VariableOutline
           injector={ injector }
           learnMoreUrl={ DOCUMENTATION_URL }


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/5841

### Proposed Changes

When focus moves to the Variable Panel search input, `handleChanged` is not called, so `inputActive` remains false and Electron doesn't allow Select All action on macOS. Fixed by firing `variablesPanel.focusin/focusout` events on the event bus, which triggers `handleChanged` to re-evaluate `inputActive`.


https://github.com/user-attachments/assets/a5d8aacf-e2c0-4600-a60a-6d191d84235e



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
