### PR TITLE
chore(workflows):  allow bpmn-io-tasks[bot] to assign milestone

### DIFF
--- a/.github/workflows/ASSIGN_MILESTONE.yml
+++ b/.github/workflows/ASSIGN_MILESTONE.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Check Permissions
         id: checkPermissions
-        env: 
+        env:
           GH_TOKEN: ${{ github.token }}
         run: |
           PERMISSION=$(gh api \
@@ -28,13 +28,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Assign Milestone
     needs: check_permissions
-    if: | 
-      needs.check_permissions.outputs.permission == 'admin' || 
-      needs.check_permissions.outputs.permission == 'write'
+    if: |
+      needs.check_permissions.outputs.permission == 'admin' ||
+      needs.check_permissions.outputs.permission == 'write' ||
+      github.event.sender.login == 'bpmn-io-tasks[bot]'
     steps:
       - name: Get current Milestone
         id: getMilestone
-        env: 
+        env:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Fetch the list of milestones for the repository
@@ -43,7 +44,7 @@ jobs:
             /repos/${{ github.repository }}/milestones \
             --jq '[.[] | select(.title | startswith("M")) | .number ][0]'
           )
-          
+
           echo "MILESTONE_NUMBER=$MILESTONE" >> $GITHUB_OUTPUT
       - name: Assign Issue
         if: |


### PR DESCRIPTION
### Proposed Changes

During my release manager activities, I realized that issues that are closed by `bpmn-io-tasks[bot]` are not automatically assigned with the current milestone. This happens because the bot auto-closes issues when a PR with `Closes #X` is merged, and the bot fails the collaborator permissions check (cf. issue [#5841](https://github.com/camunda/camunda-modeler/issues/5841) / pull request [#5962](https://github.com/camunda/camunda-modeler/pull/5962)).

I have introduced the bot as an exception to the permissions check. I found this approach acceptable because:

- GitHub App slugs are globally unique. So, no other app can impersonate `bpmn-io-tasks[bot]`.
- Installing an app in the organization requires org admin approval, which acts as an additional safeguard.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/508c33dd-4ab1-497f-9a17-6ceecd47d648" />



Note: I did not get to test this end-to-end, but [a relevant action log](https://github.com/camunda/camunda-modeler/actions/runs/26225705909/job/77172048836#step:2:4) confirms the bot's sender login is `bpmn-io-tasks[bot]`, which comes from `github.event.sender.login`.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
