### PR TITLE
feat: use EU endpoint for tracking

### DIFF
--- a/client/src/plugins/user-journey-statistics/MixpanelHandler.js
+++ b/client/src/plugins/user-journey-statistics/MixpanelHandler.js
@@ -11,6 +11,8 @@
 import mixpanel from 'mixpanel-browser';
 import Metadata from '../../util/Metadata';
 
+const MIXPANEL_ENDPOINT = 'https://api-eu.mixpanel.com';
+
 export default class MixpanelHandler {
 
   constructor() {
@@ -39,6 +41,7 @@ export default class MixpanelHandler {
     const debug = stage === 'prod' ? false : true;
 
     mixpanel.init(token, {
+      api_host: MIXPANEL_ENDPOINT,
       property_blacklist: [ '$current_url' ],
       debug
     });


### PR DESCRIPTION
Related to https://docs.mixpanel.com/changelogs/2026-02-20-eu-forwarding-deprecation

### Proposed Changes

We need to change the endpoint due to Mixpanel US-to-EU data forwarding deprecation. The sooner we do this, the less data will be lost. Unfortunately, it looks that the tracking data for the old releases will stop being accepted by Mixpanel.
No tests because we mock Mixpanel library, so I'd be essentially verifying that the method is called with the arguments I pass it. Manual test is necessary.

`MIXPANEL_STAGE=dev MIXPANEL_TOKEN=test npm start`

https://github.com/user-attachments/assets/55c164ba-f8e8-4406-8cb3-08aef338974b

Cf. also https://camunda.slack.com/archives/C0B6T5U9QAU

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
