### PR TITLE
fix: use node transport to surpress keychain prompt

### DIFF
--- a/app/lib/util/error-tracking.js
+++ b/app/lib/util/error-tracking.js
@@ -13,6 +13,7 @@ const os = require('os');
 const log = require('../log')('app:error-tracking');
 
 const { RewriteFrames } = require('@sentry/integrations');
+const { makeNodeTransport } = require('@sentry/node');
 
 const PRIVACY_PREFERENCES_CONFIG_KEY = 'editor.privacyPreferences';
 const EDITOR_ID_CONFIG_KEY = 'editor.id';
@@ -116,6 +117,7 @@ function initializeSentry(Sentry, editorID, release, dsn) {
     Sentry.init({
       dsn,
       release,
+      transport: makeNodeTransport,
       integrations: [
         new RewriteFrames({
           iteratee: (frame) => {

--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
     "@camunda8/sdk": "^8.7.28",
     "@sentry/electron": "^7.13.0",
     "@sentry/integrations": "^7.113.0",
+    "@sentry/node": "^10.50.0",
     "bpmn-moddle": "^10.0.0",
     "chokidar": "^5.0.0",
     "dmn-moddle": "^12.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "@camunda8/sdk": "^8.7.28",
         "@sentry/electron": "^7.13.0",
         "@sentry/integrations": "^7.113.0",
+        "@sentry/node": "^10.50.0",
         "bpmn-moddle": "^10.0.0",
         "chokidar": "^5.0.0",
         "dmn-moddle": "^12.0.1",


### PR DESCRIPTION
Closes #5977

### Proposed Changes

This PR replaces Sentry electron.net transport with a Node one. This supresses the keychain prompt, though we need to yet make a decision whether we actually want to do that.

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
