### PR TITLE
Update to `yauzl@3.3.1` to be able to build on `node@24.16` again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "undici": "^7.22.0",
         "webpack": "^5.106.2",
         "webpack-cli": "^7.0.2",
-        "yauzl": "^3.3.0"
+        "yauzl": "^3.3.1"
       }
     },
     "app": {
@@ -15997,16 +15997,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/extract-zip/node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
     "node_modules/extsprintf": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
@@ -16137,15 +16127,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fecha": {
@@ -33183,9 +33164,9 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
-      "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.1.tgz",
+      "integrity": "sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,10 @@
     "undici": "^7.22.0",
     "webpack": "^5.106.2",
     "webpack-cli": "^7.0.2",
-    "yauzl": "^3.3.0"
+    "yauzl": "^3.3.1"
+  },
+  "overrides": {
+    "yauzl": "^3.3.1"
   },
   "remarkConfig": {
     "plugins": [


### PR DESCRIPTION
### Proposed Changes

Allows us to build the editor on Node v24.16+.

Validate via `npm run all`.

Related to https://github.com/electron/electron/issues/51619

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
