### PR TITLE
docs: remove QA involvement from release templates

### DIFF
--- a/docs/.project/PATCH_RELEASE_TEMPLATE.md
+++ b/docs/.project/PATCH_RELEASE_TEMPLATE.md
@@ -26,14 +26,13 @@ _To be done to prepare and build the release._
   * [ ] wait for [release build](https://github.com/camunda/camunda-modeler/actions/workflows/RELEASE.yml) to create the [artifacts](https://github.com/camunda/camunda-modeler/releases)
 * [ ] prepare a list of what was changed or needs to be tested
 * [ ] execute integration test, verifying fixed things are actually fixed
-* [ ] (optional) trigger QA for testing
 
 _To be done to make the release publicly available._
 
 * [ ] publish release on [Github Releases](https://github.com/camunda/camunda-modeler/releases)
 * [ ] trigger [downloads page](https://camunda.com/download/modeler/) update via [marketing request form](https://confluence.camunda.com/display/MAR/Marketing+Request+Form)
 * [ ] add new version to [update server releases](https://github.com/camunda/camunda-modeler-update-server/blob/master/releases.json)
-  * Usually this does not contain an updated release info 
+  * Usually this does not contain an updated release info
 * [ ] publish release via update server (push to `live`)
 
 _To be done post release._

--- a/docs/.project/RELEASE_TEMPLATE.md
+++ b/docs/.project/RELEASE_TEMPLATE.md
@@ -25,13 +25,12 @@ _To be done when the release manager is assigned._
 
 _To be done before the code freeze._
 
-* [ ] inform QA about the release and its details so they can prepare for testing
 * [ ] get in touch with the team (PM, UX and Engineering side), to clarify what topics will be included in the Release and their priority. Use this information to start preparing a concept for the _blog post_ (see below) and _release info_ (see below)
   * [ ] (optional) if possible, already create a PR to update [Release Info](https://github.com/camunda/camunda-modeler/blob/develop/client/src/plugins/version-info/ReleaseInfo.js) following our [guidelines](https://github.com/bpmn-io/internal-docs/blob/main/releases/modeler/CAMUNDA_MODELER.md#whats-new-communication)
 
 _To be done after code freeze to prepare and test the release._
 
-* [ ] inform teams ([#team-modeling-group](https://camunda.slack.com/archives/C032H77434N)) that the freeze started and release prep is in progress 
+* [ ] inform teams ([#team-modeling-group](https://camunda.slack.com/archives/C032H77434N)) that the freeze started and release prep is in progress
 * [ ] make sure changes in upstream libraries are merged and released
   * `bpmn-js`, `dmn-js`, `*-properties-panel`, `*-moddle`, `camunda-bpmn-js`, `form-js`, ...
 * [ ] make sure the dependencies are updated in the [Web Modeler](https://github.com/camunda/web-modeler/)
@@ -55,7 +54,6 @@ _To be done after code freeze to prepare and test the release._
   * [ ] Works on Linux
   * [ ] Works on Mac
   * [ ] Works on Windows
-* [ ] notify QA about the release so they can test it
 
 _To be done to build the release after release testing completed._
 


### PR DESCRIPTION
Related to https://camunda.slack.com/archives/C032H77434N/p1779958441419089

### Proposed Changes

This PR removes QA mentions to reflect the changes.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
