### PR TITLE
docs: update execution platform version to Camunda 8.2 for form errors

### DIFF
--- a/docs/.project/INTEGRATION_TEST.md
+++ b/docs/.project/INTEGRATION_TEST.md
@@ -95,7 +95,7 @@ Based on the [test diagram](./test.bpmn.png):
 * [ ] Set the __Execution Platform Version__ to `Camunda 8.2`
   * [ ] An error is shown: `Expression` is not supported by Camunda Platform 8.2
   * [ ] Clicking on the error focuses the respective element
-* [ ] Set the __Execution Platform Version__ to `Camunda 8.5` or higher
+* [ ] Set the __Execution Platform Version__ to `Camunda 8.3` or higher
   * [ ] No errors are shown
 
 #### BPMN + Camunda Forms deployment

--- a/docs/.project/INTEGRATION_TEST.md
+++ b/docs/.project/INTEGRATION_TEST.md
@@ -92,8 +92,8 @@ Based on the [test diagram](./test.bpmn.png):
 * [ ] add a regular expression (`^CAM-[0-9]+$`) to the invoice number field
 * [ ] save file on disk as `test.form`
 * [ ] file imports correctly after save
-* [ ] Set the __Execution Platform Version__ to `Camunda 8.4`
-  * [ ] An error is shown: `Expression` is not supported by Camunda Platform 8.4
+* [ ] Set the __Execution Platform Version__ to `Camunda 8.2`
+  * [ ] An error is shown: `Expression` is not supported by Camunda Platform 8.2
   * [ ] Clicking on the error focuses the respective element
 * [ ] Set the __Execution Platform Version__ to `Camunda 8.5` or higher
   * [ ] No errors are shown


### PR DESCRIPTION
### Proposed Changes

The `Expression` form field type is [introduced in form-js@1.8.0](https://github.com/camunda/form-linting/blob/main/lib/rules/form-element-type.js#L16) which [overlaps with Camunda 8.3](https://github.com/camunda/form-linting/blob/main/lib/config/formVersion.js#L12). So the execution platform versions that are equal or greater than 8.3 should not show any errors for the `Expression` field.

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
