### PR TITLE
feat(test-mode): add --test-mode flag for automated integration testing

### DIFF
--- a/app/lib/dialog.js
+++ b/app/lib/dialog.js
@@ -32,7 +32,8 @@ class Dialog {
    * @param { {
    *   electronDialog: ElectronDialog,
    *   config: Config,
-   *   userDesktopPath: string
+   *   userDesktopPath: string,
+   *   testMode?: boolean
    * } } options
    */
   constructor(options) {
@@ -42,8 +43,21 @@ class Dialog {
 
     this.electronDialog = options.electronDialog;
     this.config = options.config;
-
     this.userDesktopPath = options.userDesktopPath;
+
+    this._testMode = !!options.testMode;
+    this._testResultQueue = [];
+  }
+
+  /**
+   * Queue a result to be returned by the next showSaveDialog or showOpenDialog
+   * call instead of showing a native OS dialog. Only effective in test mode.
+   *
+   * @param {'save'|'open'} type
+   * @param {string|string[]} result - file path for save; array of paths for open
+   */
+  queueTestResult(type, result) {
+    this._testResultQueue.push({ type, result });
   }
 
   showOpenFileErrorDialog(options) {
@@ -65,6 +79,16 @@ class Dialog {
   }
 
   showSaveDialog(options) {
+
+    // In test mode, consume a queued 'save' result instead of opening a native dialog
+    if (this._testMode) {
+      const idx = this._testResultQueue.findIndex(e => e.type === 'save');
+      if (idx !== -1) {
+        const [ { result } ] = this._testResultQueue.splice(idx, 1);
+        return Promise.resolve(result);
+      }
+    }
+
     const {
       file,
       filters,
@@ -108,6 +132,16 @@ class Dialog {
   }
 
   showOpenDialog(options) {
+
+    // In test mode, consume a queued 'open' result instead of opening a native dialog
+    if (this._testMode) {
+      const idx = this._testResultQueue.findIndex(e => e.type === 'open');
+      if (idx !== -1) {
+        const [ { result } ] = this._testResultQueue.splice(idx, 1);
+        return Promise.resolve(Array.isArray(result) ? result : [ result ]);
+      }
+    }
+
     const {
       filters,
       properties = [ 'openFile', 'multiSelections' ],

--- a/app/lib/dialog.js
+++ b/app/lib/dialog.js
@@ -50,11 +50,14 @@ class Dialog {
   }
 
   /**
-   * Queue a result to be returned by the next showSaveDialog or showOpenDialog
-   * call instead of showing a native OS dialog. Only effective in test mode.
+   * Queue a result to be returned by the next matching dialog call instead of
+   * showing a native OS dialog. Only effective in test mode.
    *
-   * @param {'save'|'open'} type
-   * @param {string|string[]} result - file path for save; array of paths for open
+   * @param {'save'|'open'|'dialog'} type
+   * @param {string|string[]|Object} result
+   *   - 'save': file path string
+   *   - 'open': file path string or array of paths
+   *   - 'dialog': response object, e.g. `{ button: 'ok' }`
    */
   queueTestResult(type, result) {
     this._testResultQueue.push({ type, result });
@@ -178,6 +181,16 @@ class Dialog {
   }
 
   showDialog(options) {
+
+    // In test mode, consume a queued 'dialog' result instead of opening a native dialog
+    if (this._testMode) {
+      const idx = this._testResultQueue.findIndex(e => e.type === 'dialog');
+      if (idx !== -1) {
+        const [ { result } ] = this._testResultQueue.splice(idx, 1);
+        return Promise.resolve(result);
+      }
+    }
+
     let { buttons } = options;
 
     if (buttons) {

--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -11,6 +11,7 @@
 const {
   app,
   dialog: electronDialog,
+  ipcMain,
   Menu: ElectronMenu,
   MenuItem,
   screen: electronScreen,
@@ -811,10 +812,23 @@ function bootstrap() {
   });
 
   // (5) dialog
+  const testMode = !!flags.get('test-mode');
+
   const dialog = new Dialog({
     config,
     electronDialog,
-    userDesktopPath
+    userDesktopPath,
+    testMode
+  });
+
+  // Test-mode IPC: lets tests queue dialog results without native OS dialogs.
+  // Always register the handler so the app can be launched with --test-mode
+  // by the integration test harness without separate build variants.
+  ipcMain.handle('dialog:test-queue-result', function(event, type, result) {
+    if (!testMode) {
+      throw new Error('dialog:test-queue-result is only available in --test-mode');
+    }
+    dialog.queueTestResult(type, result);
   });
 
   // (6) workspace

--- a/app/lib/preload.js
+++ b/app/lib/preload.js
@@ -69,6 +69,20 @@ const allowedEvents = [
   'zeebe:searchUserTasks'
 ];
 
+// Test API: exposed unconditionally so Playwright can reach it via page.evaluate().
+// The main process only registers the IPC handler when --test-mode is active.
+contextBridge.exposeInMainWorld('__cmTestApi', {
+
+  // Queue a dialog result so the next showSaveDialog / showOpenDialog call returns
+  // this value instead of opening a native OS dialog.
+  queueDialogResult: (type, result) => ipcRenderer.invoke('dialog:test-queue-result', type, result),
+
+  // Simulate a menu:action IPC message from the main process.
+  // This is the same event the React app listens to via backend.on('menu:action', ...).
+  // Used to trigger actions like 'save-as' without going through the native menu system.
+  triggerMenuAction: (action, options) => ipcRenderer.emit('menu:action', {}, action, options)
+});
+
 let executed = false;
 
 contextBridge.exposeInMainWorld('getAppPreload', function() {


### PR DESCRIPTION
## Summary

> 🤖 This PR is fully AI-generated as part of a structured experiment exploring automated E2E integration testing for Camunda Modeler.

Adds a `--test-mode` flag to the Modeler that enables automated E2E testing without native OS dialog interaction:

- **`window.__cmTestApi.queueDialogResult(type, result)`** — pre-queues a response for the next native dialog call, bypassing the OS dialog entirely. Covers all three dialog types:
  - `'save'` → `showSaveDialog` (Save As, Export As)
  - `'open'` → `showOpenDialog` (File > Open)
  - `'dialog'` → `showDialog` (any native message box, e.g. "file changed?")
- **`window.__cmTestApi.triggerMenuAction(action, options)`** — simulates a native menu action via IPC, since `page.keyboard.press()` does not reach Electron menu accelerators when driving via CDP

## Why

Native OS dialogs are invisible to Playwright/CDP. Without this bridge, tests cannot exercise any file system operation (save, open, export, reload on external change). With it, those flows become fully automatable.

## Implementation

Three files changed in `app/lib/`:

| File | Change |
|---|---|
| `dialog.js` | `queueTestResult()` + test-mode guard in `showSaveDialog`, `showOpenDialog`, `showDialog` |
| `index.js` | IPC handler `dialog:test-queue-result`; `testMode` flag read from CLI flags |
| `preload.js` | `contextBridge.exposeInMainWorld('__cmTestApi', { queueDialogResult, triggerMenuAction })` |

## Companion PR

👉 **[camunda-modeler-integration-test#1 — feat: Playwright/CDP automated integration test harness](https://github.com/camunda/camunda-modeler-integration-test/pull/1)**

That PR contains the full test suite (15 tests) that exercises this flag. Without this PR's changes, the dialog-dependent tests in the companion will hang waiting for native OS dialogs.

## Test plan

- [ ] Verify `--test-mode` has no effect when the flag is absent (dialogs behave normally)
- [ ] Run companion integration test suite — all 15 tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)