### PR TITLE
fix: allow to paste into start instance variables field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ___Note:__ Yet to be released changes appear here._
 
 ### General
 
+* `FIX`: allow to paste into start instance variables field ([#6003](https://github.com/camunda/camunda-modeler/issues/6003))
 * `DEPS`: update to `@camunda/task-testing@5`
 
 ## 5.48.0

--- a/client/src/shared/ui/__tests__/KeyboardInteractionTrapSpec.js
+++ b/client/src/shared/ui/__tests__/KeyboardInteractionTrapSpec.js
@@ -165,6 +165,60 @@ describe('<KeyboardInteractionTrap>', function() {
   });
 
 
+  it('should update menu when contenteditable element receives focus', function() {
+
+    // given
+    const triggerAction = sinon.spy();
+
+    const { container } = render(
+      <KeyboardInteractionTrapContext.Provider value={ triggerAction }>
+        <KeyboardInteractionTrap>
+          <div contentEditable="true" suppressContentEditableWarning />
+        </KeyboardInteractionTrap>
+      </KeyboardInteractionTrapContext.Provider>
+    );
+
+    const div = container.querySelector('[contenteditable]');
+
+    // when
+    div.focus();
+
+    // then
+    expect(triggerAction).to.have.been.calledWith('update-menu', {
+      editMenu: [
+        [
+          {
+            role: 'undo',
+            enabled: true
+          },
+          {
+            role: 'redo',
+            enabled: true
+          }
+        ],
+        [
+          {
+            role: 'copy',
+            enabled: true
+          },
+          {
+            role: 'cut',
+            enabled: true
+          },
+          {
+            role: 'paste',
+            enabled: true
+          },
+          {
+            role: 'selectAll',
+            enabled: true
+          }
+        ]
+      ]
+    });
+  });
+
+
   it('should disable menu when non-input element receives focus', function() {
 
     // given

--- a/client/src/shared/ui/trap/KeyboardInteractionTrap.js
+++ b/client/src/shared/ui/trap/KeyboardInteractionTrap.js
@@ -10,6 +10,8 @@
 
 import React, { PureComponent, createContext } from 'react';
 
+import { isTextInput } from '../../../util/dom/isInput';
+
 export const KeyboardInteractionTrapContext = createContext(() => {});
 
 /**
@@ -44,7 +46,7 @@ class KeyboardInteractionTrapComponent extends PureComponent {
 
   updateMenu(element) {
 
-    const enabled = [ 'INPUT', 'TEXTAREA' ].includes(element.tagName);
+    const enabled = isTextInput(element);
 
     const editMenu = [
       [


### PR DESCRIPTION
This PR enables the respective menu entry so that you can paste text into any contenteditable field.

Closes https://github.com/camunda/camunda-modeler/issues/6003

### Proposed Changes

https://github.com/user-attachments/assets/eb3e691f-faf5-4b1d-9cb7-1d4a3337db59

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
