### PR TITLE
fix: do not replay deferred open-files queue / stale file-context on window reopen

### DIFF
--- a/app/lib/__tests__/open-file-handler-spec.js
+++ b/app/lib/__tests__/open-file-handler-spec.js
@@ -9,42 +9,50 @@
  */
 
 const sinon = require('sinon');
+const { EventEmitter } = require('events');
 
 const OpenFileHandler = require('../open-file-handler');
 
 
 describe('open-file-handler', function() {
 
-  let ready,
+  let app,
       readFile,
       onError,
-      onOpen,
+      renderer,
       openFileHandler;
 
   beforeEach(function() {
-    ready = true;
+    app = Object.assign(new EventEmitter(), {
+      clientReady: false
+    });
 
     readFile = sinon.stub().callsFake(filePath => ({ path: filePath }));
     onError = sinon.spy();
-    onOpen = sinon.spy();
+    renderer = {
+      send: sinon.spy()
+    };
 
     openFileHandler = OpenFileHandler({
-      isReady: () => ready,
+      app,
       readFile,
       onError,
-      onOpen
+      renderer
     });
   });
 
 
   it('should open files immediately when client is ready', function() {
 
+    // given
+    app.clientReady = true;
+
     // when
     openFileHandler.open([ 'a.bpmn' ]);
 
     // then
     expect(readFile).to.have.been.calledOnceWith('a.bpmn');
-    expect(onOpen).to.have.been.calledOnceWith([ { path: 'a.bpmn' } ]);
+    expect(renderer.send).to.have.been.calledOnceWith('client:open-files', [ { path: 'a.bpmn' } ]);
     expect(onError).not.to.have.been.called;
   });
 
@@ -52,6 +60,7 @@ describe('open-file-handler', function() {
   it('should show error and still open remaining files when a file fails to read', function() {
 
     // given
+    app.clientReady = true;
     readFile.withArgs('missing.bpmn').throws(new Error('ENOENT'));
 
     // when
@@ -59,56 +68,56 @@ describe('open-file-handler', function() {
 
     // then
     expect(onError).to.have.been.calledOnceWith('missing.bpmn');
-    expect(onOpen).to.have.been.calledOnceWith([ { path: 'ok.bpmn' } ]);
+    expect(renderer.send).to.have.been.calledOnceWith('client:open-files', [ { path: 'ok.bpmn' } ]);
   });
 
 
   it('should defer opening files when client is not ready', function() {
 
     // given
-    ready = false;
+    app.clientReady = false;
 
     // when
     openFileHandler.open([ 'a.bpmn' ]);
 
     // then
     expect(readFile).not.to.have.been.called;
-    expect(onOpen).not.to.have.been.called;
+    expect(renderer.send).not.to.have.been.called;
   });
 
 
-  it('should open deferred files on drain', function() {
+  it('should open deferred files on client-ready', function() {
 
     // given
-    ready = false;
+    app.clientReady = false;
     openFileHandler.open([ 'a.bpmn', 'b.bpmn' ]);
 
     // when
-    ready = true;
-    openFileHandler.drain();
+    app.clientReady = true;
+    app.emit('app:client-ready');
 
     // then
-    expect(onOpen).to.have.been.calledOnceWith([
+    expect(renderer.send).to.have.been.calledOnceWith('client:open-files', [
       { path: 'a.bpmn' },
       { path: 'b.bpmn' }
     ]);
   });
 
 
-  it('should not replay drained files on a subsequent drain', function() {
+  it('should not replay drained files on a subsequent client-ready', function() {
 
     // given
-    ready = false;
+    app.clientReady = false;
     openFileHandler.open([ 'a.bpmn' ]);
 
-    ready = true;
-    openFileHandler.drain();
+    app.clientReady = true;
+    app.emit('app:client-ready');
 
     // when
-    openFileHandler.drain();
+    app.emit('app:client-ready');
 
     // then
-    expect(onOpen).to.have.been.calledOnce;
+    expect(renderer.send).to.have.been.calledOnce;
     expect(readFile).to.have.been.calledOnce;
   });
 
@@ -116,39 +125,39 @@ describe('open-file-handler', function() {
   it('should not replay files across close/reopen cycles', function() {
 
     // given
-    ready = false;
+    app.clientReady = false;
     openFileHandler.open([ 'a.bpmn' ]);
 
-    ready = true;
-    openFileHandler.drain();
+    app.clientReady = true;
+    app.emit('app:client-ready');
 
     // when
-    ready = false;
+    app.clientReady = false;
     openFileHandler.open([ 'b.bpmn' ]);
 
-    ready = true;
-    openFileHandler.drain();
+    app.clientReady = true;
+    app.emit('app:client-ready');
 
     // then
-    expect(onOpen).to.have.been.calledTwice;
-    expect(onOpen.secondCall).to.have.been.calledWith([ { path: 'b.bpmn' } ]);
+    expect(renderer.send).to.have.been.calledTwice;
+    expect(renderer.send.secondCall).to.have.been.calledWith('client:open-files', [ { path: 'b.bpmn' } ]);
   });
 
 
   it('should not queue duplicate file paths', function() {
 
     // given
-    ready = false;
+    app.clientReady = false;
     openFileHandler.open([ 'a.bpmn' ]);
     openFileHandler.open([ 'a.bpmn' ]);
 
     // when
-    ready = true;
-    openFileHandler.drain();
+    app.clientReady = true;
+    app.emit('app:client-ready');
 
     // then
     expect(readFile).to.have.been.calledOnce;
-    expect(onOpen).to.have.been.calledOnceWith([ { path: 'a.bpmn' } ]);
+    expect(renderer.send).to.have.been.calledOnceWith('client:open-files', [ { path: 'a.bpmn' } ]);
   });
 
 
@@ -157,33 +166,33 @@ describe('open-file-handler', function() {
     // given
     readFile.withArgs('missing.bpmn').throws(new Error('ENOENT'));
 
-    ready = false;
+    app.clientReady = false;
     openFileHandler.open([ 'missing.bpmn' ]);
     openFileHandler.open([ 'missing.bpmn' ]);
 
     // when
-    ready = true;
-    openFileHandler.drain();
+    app.clientReady = true;
+    app.emit('app:client-ready');
 
     // then
     expect(onError).to.have.been.calledOnce;
-    expect(onOpen).to.have.been.calledOnceWith([]);
+    expect(renderer.send).to.have.been.calledOnceWith('client:open-files', []);
   });
 
 
   it('should keep files queued when drained while not ready', function() {
 
     // given
-    ready = false;
+    app.clientReady = false;
     openFileHandler.open([ 'a.bpmn' ]);
     openFileHandler.drain();
 
     // when
-    ready = true;
-    openFileHandler.drain();
+    app.clientReady = true;
+    app.emit('app:client-ready');
 
     // then
-    expect(onOpen).to.have.been.calledOnceWith([ { path: 'a.bpmn' } ]);
+    expect(renderer.send).to.have.been.calledOnceWith('client:open-files', [ { path: 'a.bpmn' } ]);
   });
 
 });

--- a/app/lib/__tests__/open-file-handler-spec.js
+++ b/app/lib/__tests__/open-file-handler-spec.js
@@ -1,0 +1,189 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+const sinon = require('sinon');
+
+const OpenFileHandler = require('../open-file-handler');
+
+
+describe('open-file-handler', function() {
+
+  let ready,
+      readFile,
+      onError,
+      onOpen,
+      openFileHandler;
+
+  beforeEach(function() {
+    ready = true;
+
+    readFile = sinon.stub().callsFake(filePath => ({ path: filePath }));
+    onError = sinon.spy();
+    onOpen = sinon.spy();
+
+    openFileHandler = OpenFileHandler({
+      isReady: () => ready,
+      readFile,
+      onError,
+      onOpen
+    });
+  });
+
+
+  it('should open files immediately when client is ready', function() {
+
+    // when
+    openFileHandler.open([ 'a.bpmn' ]);
+
+    // then
+    expect(readFile).to.have.been.calledOnceWith('a.bpmn');
+    expect(onOpen).to.have.been.calledOnceWith([ { path: 'a.bpmn' } ]);
+    expect(onError).not.to.have.been.called;
+  });
+
+
+  it('should show error and still open remaining files when a file fails to read', function() {
+
+    // given
+    readFile.withArgs('missing.bpmn').throws(new Error('ENOENT'));
+
+    // when
+    openFileHandler.open([ 'missing.bpmn', 'ok.bpmn' ]);
+
+    // then
+    expect(onError).to.have.been.calledOnceWith('missing.bpmn');
+    expect(onOpen).to.have.been.calledOnceWith([ { path: 'ok.bpmn' } ]);
+  });
+
+
+  it('should defer opening files when client is not ready', function() {
+
+    // given
+    ready = false;
+
+    // when
+    openFileHandler.open([ 'a.bpmn' ]);
+
+    // then
+    expect(readFile).not.to.have.been.called;
+    expect(onOpen).not.to.have.been.called;
+  });
+
+
+  it('should open deferred files on drain', function() {
+
+    // given
+    ready = false;
+    openFileHandler.open([ 'a.bpmn', 'b.bpmn' ]);
+
+    // when
+    ready = true;
+    openFileHandler.drain();
+
+    // then
+    expect(onOpen).to.have.been.calledOnceWith([
+      { path: 'a.bpmn' },
+      { path: 'b.bpmn' }
+    ]);
+  });
+
+
+  it('should not replay drained files on a subsequent drain', function() {
+
+    // given
+    ready = false;
+    openFileHandler.open([ 'a.bpmn' ]);
+
+    ready = true;
+    openFileHandler.drain();
+
+    // when
+    openFileHandler.drain();
+
+    // then
+    expect(onOpen).to.have.been.calledOnce;
+    expect(readFile).to.have.been.calledOnce;
+  });
+
+
+  it('should not replay files across close/reopen cycles', function() {
+
+    // given
+    ready = false;
+    openFileHandler.open([ 'a.bpmn' ]);
+
+    ready = true;
+    openFileHandler.drain();
+
+    // when
+    ready = false;
+    openFileHandler.open([ 'b.bpmn' ]);
+
+    ready = true;
+    openFileHandler.drain();
+
+    // then
+    expect(onOpen).to.have.been.calledTwice;
+    expect(onOpen.secondCall).to.have.been.calledWith([ { path: 'b.bpmn' } ]);
+  });
+
+
+  it('should not queue duplicate file paths', function() {
+
+    // given
+    ready = false;
+    openFileHandler.open([ 'a.bpmn' ]);
+    openFileHandler.open([ 'a.bpmn' ]);
+
+    // when
+    ready = true;
+    openFileHandler.drain();
+
+    // then
+    expect(readFile).to.have.been.calledOnce;
+    expect(onOpen).to.have.been.calledOnceWith([ { path: 'a.bpmn' } ]);
+  });
+
+
+  it('should show the error dialog only once for a duplicated missing file', function() {
+
+    // given
+    readFile.withArgs('missing.bpmn').throws(new Error('ENOENT'));
+
+    ready = false;
+    openFileHandler.open([ 'missing.bpmn' ]);
+    openFileHandler.open([ 'missing.bpmn' ]);
+
+    // when
+    ready = true;
+    openFileHandler.drain();
+
+    // then
+    expect(onError).to.have.been.calledOnce;
+    expect(onOpen).to.have.been.calledOnceWith([]);
+  });
+
+
+  it('should keep files queued when drained while not ready', function() {
+
+    // given
+    ready = false;
+    openFileHandler.open([ 'a.bpmn' ]);
+    openFileHandler.drain();
+
+    // when
+    ready = true;
+    openFileHandler.drain();
+
+    // then
+    expect(onOpen).to.have.been.calledOnceWith([ { path: 'a.bpmn' } ]);
+  });
+
+});

--- a/app/lib/file-context/__tests__/file-context-spec.js
+++ b/app/lib/file-context/__tests__/file-context-spec.js
@@ -183,6 +183,72 @@ describe('FileContext', function() {
   });
 
 
+  describe('reset', function() {
+
+    it('should remove all indexed items', async function() {
+
+      // given
+      const filePath = path.resolve(__dirname, './tmp/foo-process-application/foo.bpmn');
+
+      await waitForEvent(() => {
+        fileContext.addFile(filePath);
+      });
+
+      expectItemsLength(fileContext, 1);
+
+      // when
+      fileContext.reset();
+
+      // then
+      expectItemsLength(fileContext, 0);
+    });
+
+
+    it('should remove all roots', async function() {
+
+      // given
+      const directoryPath = path.resolve(__dirname, './tmp/foo-process-application');
+
+      await waitForEvent(() => {
+        fileContext.addRoot(directoryPath);
+      }, 'watcher:ready');
+
+      expectRootsLength(fileContext, 1);
+
+      // when
+      fileContext.reset();
+
+      // then
+      expectRootsLength(fileContext, 0);
+      expectItemsLength(fileContext, 0);
+    });
+
+
+    it('should allow re-adding a file after reset', async function() {
+
+      // given
+      const filePath = path.resolve(__dirname, './tmp/foo-process-application/foo.bpmn'),
+            uri = toFileUrl(filePath);
+
+      await waitForEvent(() => {
+        fileContext.addFile(filePath);
+      });
+
+      fileContext.reset();
+
+      // when
+      await waitForEvent(() => {
+        fileContext.addFile(filePath);
+      });
+
+      // then
+      expectItemsLength(fileContext, 1);
+      expect(getItem(fileContext, uri)).to.exist;
+    });
+
+  });
+
+
   describe('watching', function() {
 
     it('should watch by default', function() {

--- a/app/lib/file-context/file-context.js
+++ b/app/lib/file-context/file-context.js
@@ -130,6 +130,15 @@ module.exports = class FileContext extends EventEmitter {
   }
 
   /**
+   * Reset the file context, removing all roots and indexed files.
+   */
+  reset() {
+    this._indexer.getRoots().forEach(uri => this.removeRoot(uri));
+
+    this._indexer.removeAll();
+  }
+
+  /**
    * @return { Promise<undefined> }
    */
   close() {

--- a/app/lib/file-context/indexer.js
+++ b/app/lib/file-context/indexer.js
@@ -189,6 +189,13 @@ module.exports = class Indexer {
   }
 
   /**
+   * Remove all indexed items.
+   */
+  removeAll() {
+    this.getItems().forEach(item => this.remove(item.uri));
+  }
+
+  /**
    * @internal
    *
    * @param {IndexItem} item

--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -594,6 +594,10 @@ app.createEditorWindow = function() {
 
     if (app.quitAllowed) {
 
+      // reset file context, as the next window session
+      // will re-index files it opens on its own
+      fileContext.reset();
+
       // dereferencing main window and resetting client state
       app.mainWindow = null;
       dialog.setActiveWindow(null);

--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -457,9 +457,6 @@ renderer.on('toggle-plugins', function() {
 app.on('app:client-ready', function() {
   bootstrapLog.info('received client-ready');
 
-  // open pending files
-  openFileHandler.drain();
-
   renderer.send('client:started');
 });
 
@@ -877,12 +874,12 @@ function bootstrap() {
 
   // (12) open file handler
   const openFileHandler = OpenFileHandler({
-    isReady: () => app.clientReady,
+    app,
     readFile,
     onError: (filePath) => dialog.showOpenFileErrorDialog({
       name: path.basename(filePath)
     }),
-    onOpen: (files) => renderer.send('client:open-files', files)
+    renderer
   });
 
   // queue files passed via CLI; opened once the client is ready

--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -33,6 +33,7 @@ const Flags = require('./flags');
 const Log = require('./log');
 const logTransports = require('./log/transports');
 const Menu = require('./menu');
+const OpenFileHandler = require('./open-file-handler');
 const Platform = require('./platform');
 const Plugins = require('./plugins');
 const WindowManager = require('./window-manager');
@@ -88,9 +89,9 @@ const {
   config,
   dialog,
   fileContext,
-  files,
   flags,
   menu,
+  openFileHandler,
   plugins,
   windowManager,
   zeebeAPI
@@ -457,9 +458,7 @@ app.on('app:client-ready', function() {
   bootstrapLog.info('received client-ready');
 
   // open pending files
-  if (files.length) {
-    app.openFiles(files);
-  }
+  openFileHandler.drain();
 
   renderer.send('client:started');
 });
@@ -540,28 +539,9 @@ app.on('web-contents-created', (event, webContents) => {
  * @param {Array<string>} filePaths
  */
 app.openFiles = function(filePaths) {
-
   log.info('open files', filePaths);
 
-  if (!app.clientReady) {
-
-    // defer file open
-    return files.push(...filePaths);
-  }
-
-  const existingFiles = filePaths.map(filePath => {
-
-    try {
-      return readFile(filePath);
-    } catch (e) {
-      dialog.showOpenFileErrorDialog({
-        name: path.basename(filePath)
-      });
-    }
-  }).filter(f => f);
-
-  // open files
-  renderer.send('client:open-files', existingFiles);
+  openFileHandler.open(filePaths);
 };
 
 /**
@@ -891,13 +871,26 @@ function bootstrap() {
 
   app.on('quit', () => fileContext.close());
 
+  // (12) open file handler
+  const openFileHandler = OpenFileHandler({
+    isReady: () => app.clientReady,
+    readFile,
+    onError: (filePath) => dialog.showOpenFileErrorDialog({
+      name: path.basename(filePath)
+    }),
+    onOpen: (files) => renderer.send('client:open-files', files)
+  });
+
+  // queue files passed via CLI; opened once the client is ready
+  openFileHandler.open(files);
+
   return {
     config,
     dialog,
     fileContext,
-    files,
     flags,
     menu,
+    openFileHandler,
     plugins,
     windowManager,
     zeebeAPI

--- a/app/lib/open-file-handler.js
+++ b/app/lib/open-file-handler.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+const log = require('./log')('app:open-file-handler');
+
+/**
+ * Handles opening of files, deferring the open until the client is ready.
+ *
+ * Deferred file paths are queued and deduplicated, so opening the same
+ * path multiple times while the client is not ready only opens it once.
+ *
+ * @param { {
+ *   isReady: () => boolean,
+ *   readFile: (filePath: string) => any,
+ *   onError: (filePath: string, error: Error) => void,
+ *   onOpen: (files: any[]) => void
+ * } } options
+ */
+module.exports = function OpenFileHandler(options) {
+  const {
+    isReady,
+    readFile,
+    onError,
+    onOpen
+  } = options;
+
+  const queued = [];
+
+  /**
+   * Open the given file paths, or queue them if the client is not ready.
+   *
+   * @param {string[]} filePaths
+   */
+  function open(filePaths) {
+    if (!isReady()) {
+      filePaths.forEach(filePath => {
+        if (!queued.includes(filePath)) {
+          queued.push(filePath);
+          log.info('queued %s', filePath);
+        }
+      });
+
+      return;
+    }
+
+    log.info('opening %O', filePaths);
+
+    const files = filePaths.map(filePath => {
+      try {
+        return readFile(filePath);
+      } catch (error) {
+        log.error('failed to open %s', filePath, error);
+        onError(filePath, error);
+      }
+    }).filter(file => file);
+
+    onOpen(files);
+  }
+
+  /**
+   * Open all queued files, clearing the queue.
+   */
+  function drain() {
+    if (queued.length) {
+      log.info('draining queue %O', queued);
+      open(queued.splice(0));
+    }
+  }
+
+  return {
+    open,
+    drain
+  };
+};

--- a/app/lib/open-file-handler.js
+++ b/app/lib/open-file-handler.js
@@ -17,7 +17,7 @@ const log = require('./log')('app:open-file-handler');
  * path multiple times while the client is not ready only opens it once.
  *
  * @param { {
- *   isReady: () => boolean,
+ *   app: any,
  *   readFile: (filePath: string) => any,
  *   onError: (filePath: string, error: Error) => void,
  *   onOpen: (files: any[]) => void
@@ -25,13 +25,17 @@ const log = require('./log')('app:open-file-handler');
  */
 module.exports = function OpenFileHandler(options) {
   const {
-    isReady,
+    app,
     readFile,
     onError,
-    onOpen
+    renderer
   } = options;
 
   const queued = [];
+
+  app.on('app:client-ready', () => {
+    drain();
+  });
 
   /**
    * Open the given file paths, or queue them if the client is not ready.
@@ -39,7 +43,7 @@ module.exports = function OpenFileHandler(options) {
    * @param {string[]} filePaths
    */
   function open(filePaths) {
-    if (!isReady()) {
+    if (!app.clientReady) {
       filePaths.forEach(filePath => {
         if (!queued.includes(filePath)) {
           queued.push(filePath);
@@ -61,7 +65,7 @@ module.exports = function OpenFileHandler(options) {
       }
     }).filter(file => file);
 
-    onOpen(files);
+    renderer.send('client:open-files', files);
   }
 
   /**


### PR DESCRIPTION
### Proposed Changes

This PR aims to fix the problem of stalled files queue (#6012). Since the broken code was placed in the app bootstrapping file, I decided that we should first extract that part to enable automated testing.

From AI:

On macOS, closing the main window keeps the app running in the dock and resets `clientReady`, but the deferred open-files queue was drained by passing it into `app.openFiles` **by reference, without ever clearing it**. Every windowless file open (Finder double-click, second instance) accumulated in the queue, and the *entire* accumulated queue was replayed on every subsequent window reopen — duplicated, and including stale paths for files since renamed or deleted. Each stale path retriggered the blocking `Unable to open "<file>"` dialog on every launch (see the diagnosis in the linked issue's comment log).

Separately, files added to the in-memory file-context indexer (via opened tabs) were only ever removed on explicit tab close, so entries from a previous window session — including the renamed/deleted file — lingered into the next session after the window was reopened.

This PR:
1. Extracts the defer/drain logic into a small, dependency-injected `open-file-handler` module ([app/lib/open-file-handler.js](app/lib/open-file-handler.js)) so it's unit-testable in isolation from `app/lib/index.js` (which has no tests and runs bootstrap side effects at require time). The queue is now **cleared on drain** and **deduplicated on insert**, so a file opened multiple times while the client isn't ready is only read/opened once.
2. Adds `FileContext#reset()` (and `Indexer#removeAll()`), called when the main window closes, so stale roots/items from the prior session can't survive into the next one. The next window session re-indexes the files it opens on its own, same as a fresh app start.

Closes #6012 

### Steps to try out

1. `npm run dev`
2. Close the window (app stays in the dock on macOS).
3. From another terminal, run `npm run app:dev -- /absolute/path/to/some.bpmn` twice with the same path (simulates a windowless double-click while not ready — same code path as the mac `open-file` handler).
4. Click the dock icon to reopen the window — the file should open **exactly once** (previously: duplicated, and replayed again on every subsequent reopen).
5. Repeat with a path that doesn't exist — the "Unable to open" dialog should appear exactly once, on the first reopen only, not on every subsequent launch.

### Checklist

* [x] Contribution meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)
* [x] Pull request establishes context
  * [x] Link to related issue(s): Closes #6012
  * [x] Brief textual description of the changes
  * [ ] Screenshots or short videos showing UI/UX changes — n/a, main-process/backend fix only
  * [x] Steps to try out