### PR TITLE
Reload file on external changes without prompting (when safe)

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -300,6 +300,13 @@ export class App extends PureComponent {
   /**
    * Check whether file has changed externally and update accordingly.
    *
+   * If the tab has no unsaved changes the diagram is silently refreshed with
+   * the external contents. Auto-save keeps a tab's file in sync whenever it is
+   * left, so reloading only ever discards contents that are already persisted.
+   *
+   * If the tab has unsaved changes the user is asked whether to reload
+   * (discarding the local changes) or to keep the local changes.
+   *
    * @param {Tab} tab
    */
   checkFileChanged = async (tab) => {
@@ -326,6 +333,19 @@ export class App extends PureComponent {
       return tab;
     }
 
+    // if the tab has no unsaved changes we can safely refresh it with the
+    // external contents; auto-save keeps the file in sync whenever the tab
+    // is left, so this only ever discards contents that are already persisted
+    if (!this.isDirty(tab)) {
+      const updatedFile = await fileSystem.readFile(file.path);
+
+      return this.updateTab(tab, {
+        file: updatedFile
+      });
+    }
+
+    // the tab has unsaved changes that would be lost on reload; ask the user
+    // how to proceed
     const { button } = await this.showDialog(getContentChangedDialog());
 
     if (button === 'ok') {
@@ -1793,6 +1813,13 @@ export class App extends PureComponent {
    * Auto-saves the given tab with contents.
    *
    * Does NOT prompt the user for a save location.
+   *
+   * TODO(#5995): guard against clobbering external changes. The write below is
+   * unconditional, so a dirty tab auto-saved on blur / tab switch can overwrite
+   * a file that changed externally in the meantime, before #checkFileChanged
+   * gets a chance to run on focus. A follow-up will re-stat the file here and
+   * skip the write (leaving the tab dirty) when the on-disk `lastModified` is
+   * newer than what we last read, deferring to the focus-time conflict prompt.
    *
    * @param {Tab} tab - the tab to auto-save
    * @param {string} contents - the tab contents

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -339,9 +339,7 @@ export class App extends PureComponent {
     if (!this.isDirty(tab)) {
       const updatedFile = await fileSystem.readFile(file.path);
 
-      return this.updateTab(tab, {
-        file: updatedFile
-      });
+      return this.reloadTab(tab, updatedFile);
     }
 
     // the tab has unsaved changes that would be lost on reload; ask the user
@@ -351,9 +349,7 @@ export class App extends PureComponent {
     if (button === 'ok') {
       const updatedFile = await fileSystem.readFile(file.path);
 
-      return this.updateTab(tab, {
-        file: updatedFile
-      });
+      return this.reloadTab(tab, updatedFile);
     } else {
       return this.updateTab(tab, {
         file: {
@@ -363,6 +359,34 @@ export class App extends PureComponent {
       }, this.setUnsaved(tab, true));
     }
   };
+
+  /**
+   * Reload a tab with the given (externally changed) file contents.
+   *
+   * An inactive tab keeps its editor state cached (including the last imported
+   * XML) while it is in the background. Re-mounting it would restore that stale
+   * cache instead of importing the new contents, leaving the diagram unchanged
+   * and marked dirty. We drop the cache so the tab re-imports the file when it
+   * is re-activated. The active tab stays mounted and re-imports through its
+   * regular update cycle, so its (live) cache must not be destroyed.
+   *
+   * @param {Tab} tab
+   * @param {File} file
+   *
+   * @return {Tab} updated tab
+   */
+  reloadTab(tab, file) {
+
+    const { activeTab } = this.state;
+
+    if (!activeTab || activeTab.id !== tab.id) {
+      this.props.cache.destroy(tab.id);
+    }
+
+    return this.updateTab(tab, {
+      file
+    });
+  }
 
   /**
    * Update the tab with new attributes.

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -2960,6 +2960,77 @@ describe('<App>', function() {
     });
 
 
+    it('should reset the editor cache when reloading a background tab', async function() {
+
+      // given
+      const cache = new Cache();
+
+      const destroySpy = sinon.spy(cache, 'destroy');
+
+      const { app } = createApp({
+        cache,
+        globals: {
+          fileSystem
+        }
+      });
+
+      // file2 is opened last, so file1's tab stays in the background
+      const openedTabs = await app.openFiles([ file1, file2 ]);
+
+      const backgroundTab = openedTabs[0];
+
+      const lastModified = Date.now();
+
+      updateFileStats(backgroundTab.file, { lastModified }, fileSystem);
+
+      // when
+      const updatedTab = await app.checkFileChanged(backgroundTab);
+
+      // then
+      // the stale cache is dropped so the tab re-imports the external contents
+      // once it is re-activated
+      expect(destroySpy).to.have.been.calledWith(backgroundTab.id);
+
+      expect(updatedTab.file.contents).to.eql(NEW_FILE_CONTENTS);
+      expect(app.isUnsaved(updatedTab)).to.be.false;
+    });
+
+
+    it('should NOT reset the editor cache when reloading the active tab', async function() {
+
+      // given
+      const cache = new Cache();
+
+      const { app } = createApp({
+        cache,
+        globals: {
+          fileSystem
+        }
+      });
+
+      const openedTabs = await app.openFiles([ file1, file2 ]);
+
+      const tab = openedTabs[0];
+
+      // make file1's tab the active one
+      await app.showTab(tab);
+
+      const destroySpy = sinon.spy(cache, 'destroy');
+
+      const lastModified = Date.now();
+
+      updateFileStats(tab.file, { lastModified }, fileSystem);
+
+      // when
+      await app.checkFileChanged(tab);
+
+      // then
+      // the active tab stays mounted and re-imports through its update cycle,
+      // so its live cache must be kept
+      expect(destroySpy).not.to.have.been.called;
+    });
+
+
     it('should notify if content changed and tab is dirty', async function() {
 
       // given

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -2936,7 +2936,7 @@ describe('<App>', function() {
 
       const tab = openedTabs[0];
 
-      const lastModified = new Date().getMilliseconds();
+      const lastModified = Date.now();
 
       updateFileStats(tab.file, { lastModified }, fileSystem);
 
@@ -3170,7 +3170,7 @@ describe('<App>', function() {
 
       await waitFor(() => expect(app.isDirty(tab)).to.be.true);
 
-      const lastModified = new Date().getMilliseconds();
+      const lastModified = Date.now();
 
       updateFileStats(tab.file, { lastModified }, fileSystem);
 

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -2912,7 +2912,7 @@ describe('<App>', function() {
     });
 
 
-    it('should notify if content changed', async function() {
+    it('should reload without notifying if not dirty', async function() {
 
       // given
       const showSpy = spy(_ => {
@@ -2937,6 +2937,58 @@ describe('<App>', function() {
       const tab = openedTabs[0];
 
       const lastModified = new Date().getMilliseconds();
+
+      updateFileStats(tab.file, { lastModified }, fileSystem);
+
+      // when
+      const updatedTab = await app.checkFileChanged(tab);
+
+      // then
+      expect(showSpy).to.not.have.been.called;
+      expect(readFileSpy).to.have.been.called;
+
+      await waitFor(() => {
+        expect(updatedTab).to.eql(app.findOpenTab(file1));
+      });
+
+      expect(updatedTab.file.contents).to.eql(NEW_FILE_CONTENTS);
+
+      // TODO(nikku): fix test suite and properly pass last modified
+      // expect(updatedTab.file.lastModified).to.eql(lastModified);
+
+      expect(app.isUnsaved(updatedTab)).to.be.false;
+    });
+
+
+    it('should notify if content changed and tab is dirty', async function() {
+
+      // given
+      const showSpy = spy(_ => {
+        return {
+          button: 'ok'
+        };
+      });
+
+      const dialog = new Dialog({
+        show: showSpy
+      });
+
+      const { app } = createApp({
+        globals: {
+          dialog,
+          fileSystem
+        }
+      });
+
+      const openedTabs = await app.openFiles([ file1, file2 ]);
+
+      const tab = openedTabs[0];
+
+      app.setState(app.setDirty(tab));
+
+      await waitFor(() => expect(app.isDirty(tab)).to.be.true);
+
+      const lastModified = Date.now();
 
       updateFileStats(tab.file, { lastModified }, fileSystem);
 
@@ -3042,6 +3094,10 @@ describe('<App>', function() {
       const openedTabs = await app.openFiles([ file1, file2 ]);
 
       const tab = openedTabs[0];
+
+      app.setState(app.setDirty(tab));
+
+      await waitFor(() => expect(app.isDirty(tab)).to.be.true);
 
       const lastModified = new Date().getMilliseconds();
 

--- a/test/e2e/specs/external-change.spec.js
+++ b/test/e2e/specs/external-change.spec.js
@@ -88,4 +88,56 @@ test.describe('external change detection', function() {
     }, { timeout: 10000 }).toBe(true);
   });
 
+
+  test('should reload a background tab that changed on disk when it is re-activated', async function({ launch, tmp }) {
+
+    // given two open diagrams, with the first one pushed to the background
+    const fileA = await copyFixture('simple.bpmn', tmp, 'a.bpmn');
+    const fileB = await copyFixture('simple.bpmn', tmp, 'b.bpmn');
+
+    const app = await launch({ openFile: fileA });
+
+    const editor = new Modeler(app).bpmnEditor;
+
+    await editor.canvas().waitFor();
+    await expect(editor.element('Task_0zlv465')).toContainText('foo');
+
+    // edit a.bpmn and save it; this leaves the tab clean while the editor
+    // keeps the saved XML cached — the situation a background reload must reset
+    await editor.setName('Task_0zlv465', 'edited in app');
+
+    await app.shortcut('CommandOrControl+S');
+
+    await expect(app.page.locator('.tab--active.tab--dirty')).toHaveCount(0);
+
+    // open the second file; it becomes active and pushes a.bpmn to the background
+    await app.expectOpenDialog([ fileB ]);
+    await app.shortcut('CommandOrControl+O');
+
+    await expect(app.page.locator('.tab--active .tab__name', { hasText: 'b.bpmn' })).toBeVisible();
+
+    await app.recordDialogs();
+
+    // when the background file is changed by another program
+    const xml = await readFile(fileA);
+
+    await fs.writeFile(fileA, xml.replace('name="edited in app"', 'name="reloaded externally"'));
+
+    // and the tab is re-activated
+    await app.page.locator('.tab[data-tab-id] .tab__name', { hasText: 'a.bpmn' }).click();
+
+    await expect(app.page.locator('.tab--active .tab__name', { hasText: 'a.bpmn' })).toBeVisible();
+
+    // then the diagram is refreshed with the external contents...
+    await expect(editor.element('Task_0zlv465')).toContainText('reloaded externally');
+
+    // ...without a reload prompt...
+    const calls = await app.dialogCalls();
+
+    expect(calls.some(call => /changed externally/.test(call.message || ''))).toBe(false);
+
+    // ...and the tab is not marked dirty
+    await expect(app.page.locator('.tab--active.tab--dirty')).toHaveCount(0);
+  });
+
 });

--- a/test/e2e/specs/external-change.spec.js
+++ b/test/e2e/specs/external-change.spec.js
@@ -15,27 +15,70 @@ const fs = require('fs/promises');
 const { test, expect } = require('../harness/test');
 const { copyFixture, readFile } = require('../harness/files');
 
+const Modeler = require('../pages/Modeler');
+
 test.describe('external change detection', function() {
 
-  test('should prompt to reload when the open file changes on disk', async function({ launch, tmp }) {
+  test('should reload without prompting when the open file changes on disk and has no unsaved changes', async function({ launch, tmp }) {
 
-    // given an open diagram
+    // given an open, unmodified diagram (the task is labelled "foo")
     const file = await copyFixture('simple.bpmn', tmp);
 
     const app = await launch({ openFile: file });
 
-    await app.page.waitForSelector('.djs-container');
+    const editor = new Modeler(app).bpmnEditor;
+
+    await editor.canvas().waitFor();
+
+    await expect(editor.element('Task_0zlv465')).toContainText('foo');
 
     await app.recordDialogs();
 
     // when the file is changed by another program
     const xml = await readFile(file);
 
-    await fs.writeFile(file, xml.replace('isExecutable="false"', 'isExecutable="true"'));
+    await fs.writeFile(file, xml.replace('name="foo"', 'name="reloaded externally"'));
+
+    // then, once the window regains focus, the diagram is silently refreshed
+    // with the external contents — no reload prompt is shown. The watcher may
+    // not have picked up the change at the first focus, so re-focus on each poll
+    // until the new label appears.
+    await expect.poll(async () => {
+      await app.focusWindow();
+
+      return editor.element('Task_0zlv465').textContent();
+    }, { timeout: 10000 }).toContain('reloaded externally');
+
+    const calls = await app.dialogCalls();
+
+    expect(calls.some(call => /changed externally/.test(call.message || ''))).toBe(false);
+  });
+
+
+  test('should prompt to reload when the open file changes on disk and the diagram has unsaved changes', async function({ launch, tmp }) {
+
+    // given an open diagram with unsaved changes (renamed in the editor, not saved)
+    const file = await copyFixture('simple.bpmn', tmp);
+
+    const app = await launch({ openFile: file });
+
+    const editor = new Modeler(app).bpmnEditor;
+
+    await editor.canvas().waitFor();
+
+    await editor.setName('Task_0zlv465', 'local edit');
+
+    await app.recordDialogs();
+
+    // when the file is changed by another program
+    const xml = await readFile(file);
+
+    await fs.writeFile(file, xml.replace('name="foo"', 'name="external edit"'));
 
     // then, once the window regains focus, the app prompts to reload the
-    // externally changed file. The watcher may not have picked up the change at
-    // the first focus, so re-focus on each poll until the prompt appears.
+    // externally changed file (reloading would discard the unsaved edit). The
+    // watcher may not have picked up the change at the first focus, so re-focus
+    // on each poll until the prompt appears.
     await expect.poll(async () => {
       await app.focusWindow();
 


### PR DESCRIPTION
### Proposed Changes

When a file was changed externally, the diagram sometimes failed to show the new contents — and could stay marked as unsaved — even though nothing was lost, because auto-save is active.

#### Root cause

The symptom in #5995 comes from two independent defects on the external-change path:

1. **Always prompting on external change.** `App#checkFileChanged` showed the *"File changed — reload?"* dialog regardless of editor state. With auto-save active a tab's file is kept in sync whenever the tab is left (blur / tab switch), so an **unfocused (or clean) tab never has unsaved changes** — reloading its external contents can never discard anything the user hasn't already persisted. Prompting there is noise, and dismissing/mishandling it left the diagram showing stale contents.

2. **Stale editor cache on background reload.** An inactive tab is unmounted; its editor state — including the last imported XML — lives on in the shared `cache` (keyed by `tab.id`). Reloading swapped in the new `file` but left that cache untouched, so re-activating the tab **re-mounted from the stale cache**: the diagram kept the old contents and, because the cached XML no longer matched the file, was reported **dirty**. This is the "not currently open" case reported on the issue.

A third, pre-existing defect is the likely cause of the *intermittent* nature of #5995 and is deferred to a follow-up (see below).

#### Change

`checkFileChanged` now branches on dirty state, funnelling both reload branches through a new `reloadTab` helper:

- **Not dirty** → silently reload the external contents and refresh the diagram (no dialog).
- **Dirty** → keep the existing conflict dialog (reload / keep local + mark unsaved).
- `reloadTab` drops the cached editor state for a **background** tab (so it re-imports on re-activation) and keeps it for the **active** tab (which stays mounted and re-imports through its regular update cycle — destroying its live cache would dispose the mounted editor).

The logic lives in the shared `App` layer, so it applies to every editor type (BPMN, DMN, Form, RPA, XML).

#### Steps to try out

1. Open a diagram; leave it clean (or switch to another tab so it goes to the background).
2. Change the file on disk from another program.
3. Focus the window / re-activate the tab → the diagram silently reflects the external contents, no prompt, tab not marked dirty.
4. Now make an unsaved edit, then change the file on disk again → focusing the window prompts to reload or keep local changes.

#### Tests

- `AppSpec`: `should reload without notifying if not dirty`, `should notify if content changed and tab is dirty`, and cache tests `should reset the editor cache when reloading a background tab` / `should NOT reset the editor cache when reloading the active tab`.
- `external-change.spec.js` (E2E): silent reload of a clean tab, prompt on a dirty tab, and reload of a re-activated background tab.

#### Follow-up (why this is "Related to" and not "Closes")

A separate, pre-existing bug remains on the **auto-save write** path. `file-system.js` `writeFile` overwrites unconditionally (no compare-and-swap). If a tab is dirty and the file changes externally, an auto-save triggered on blur / tab switch can **clobber the external edit** before `checkFileChanged` runs — and because `tabSaved` then bumps `lastModified`, the subsequent focus check sees no change and stays silent. A `TODO(#5995)` marks the spot in `autoSaveWithContents`. The fix (re-stat before writing; skip and stay dirty so the focus-time prompt handles it) lands as a dedicated follow-up, which should be what finally closes #5995.

---

Related to #5995

---

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
