### PR TITLE
fix: keep undo/redo working after properties panel interaction removes focus

### DIFF
--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/PropertiesPanelKeyboardBindings.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/PropertiesPanelKeyboardBindings.js
@@ -16,7 +16,8 @@ import {
 
 
 export default class PropertiesPanelKeyboardBindings {
-  constructor(commandStack, eventBus, propertiesPanel) {
+  constructor(canvas, commandStack, eventBus, propertiesPanel) {
+    this._canvas = canvas;
     this._commandStack = commandStack;
     this._eventBus = eventBus;
     this._propertiesPanel = propertiesPanel;
@@ -24,6 +25,7 @@ export default class PropertiesPanelKeyboardBindings {
     eventBus.on('propertiesPanel.attach', this._addEventListeners);
 
     eventBus.on('propertiesPanel.detach', this._removeEventListeners);
+    eventBus.on('commandStack.changed', this.restoreCanvasFocus);
   }
 
   _addEventListeners = () => {
@@ -48,6 +50,22 @@ export default class PropertiesPanelKeyboardBindings {
 
   handleFocusout = () => {
     this._eventBus.fire('propertiesPanel.focusout');
+  };
+
+  /**
+   * Restore canvas focus if the focused element is removed from the properties
+   * panel as a result of a command (e.g. undo removing the entry it was in).
+   * Focus would otherwise be lost to `<body>`, where keyboard shortcuts like
+   * undo/redo are not handled.
+   */
+  restoreCanvasFocus = () => {
+    const container = this._getContainer();
+
+    if (!container || !container.contains(document.activeElement)) {
+      return;
+    }
+
+    setTimeout(() => this._canvas.restoreFocus());
   };
 
   handleKeydown = event => {
@@ -79,7 +97,7 @@ export default class PropertiesPanelKeyboardBindings {
   }
 }
 
-PropertiesPanelKeyboardBindings.$inject = [ 'commandStack', 'eventBus', 'propertiesPanel' ];
+PropertiesPanelKeyboardBindings.$inject = [ 'canvas', 'commandStack', 'eventBus', 'propertiesPanel' ];
 
 // helpers //////////
 

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/__tests__/PropertiesPanelKeyboardBindingsSpec.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-keyboard-bindings/__tests__/PropertiesPanelKeyboardBindingsSpec.js
@@ -31,6 +31,10 @@ describe('PropertiesPanelKeyboardBindings', function() {
     container = document.createElement('div');
   });
 
+  afterEach(function() {
+    container.remove();
+  });
+
 
   it('should undo', function() {
 
@@ -89,6 +93,76 @@ describe('PropertiesPanelKeyboardBindings', function() {
 
     // then
     expect(redoSpy).to.have.been.called;
+  });
+
+
+  it('should restore canvas focus when focused element is removed on command', async function() {
+
+    // given
+    const restoreFocusSpy = spy();
+
+    const input = document.createElement('input');
+
+    container.appendChild(input);
+
+    document.body.appendChild(container);
+
+    const modeler = createModeler({
+      canvas: {
+        restoreFocus: restoreFocusSpy
+      },
+      eventBus: {
+        on: (_, callback) => callback()
+      },
+      propertiesPanel: {
+        _container: container
+      }
+    });
+
+    const propertiesPanelKeyboardBindings = modeler.get('propertiesPanelKeyboardBindings');
+
+    input.focus();
+
+    // when
+    propertiesPanelKeyboardBindings.restoreCanvasFocus();
+
+    input.remove();
+
+    await nextTick();
+
+    // then
+    expect(restoreFocusSpy).to.have.been.called;
+  });
+
+
+  it('should not restore canvas focus when properties panel is not focused', async function() {
+
+    // given
+    const restoreFocusSpy = spy();
+
+    document.body.appendChild(container);
+
+    const modeler = createModeler({
+      canvas: {
+        restoreFocus: restoreFocusSpy
+      },
+      eventBus: {
+        on: (_, callback) => callback()
+      },
+      propertiesPanel: {
+        _container: container
+      }
+    });
+
+    const propertiesPanelKeyboardBindings = modeler.get('propertiesPanelKeyboardBindings');
+
+    // when
+    propertiesPanelKeyboardBindings.restoreCanvasFocus();
+
+    await nextTick();
+
+    // then
+    expect(restoreFocusSpy).not.to.have.been.called;
   });
 
 
@@ -163,6 +237,10 @@ function createModeler(dependencies) {
       )
     }
   });
+}
+
+function nextTick() {
+  return new Promise(resolve => setTimeout(resolve, 0));
 }
 
 /**


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/4772

### Proposed Changes

When a command (e.g. undo) removes the focused element from the properties panel, focus silently falls to `<body>`, where no keyboard bindings handle undo/redo - the user has to click the canvas to continue. 

We now restore canvas focus after a command if focus was in the properties panel and got lost, so undo/redo shortcuts keep working.

#### Steps to try out

1. Open a C8 BPMN diagram, select a task
2. Add an execution listener via the properties panel
3. Press `Ctrl+Z` — the listener is removed
4. Press `Ctrl+Shift+Z` / `Ctrl+Y` — **the listener is now re-added**

<img width="1147" height="956" alt="pp-focus-fix" src="https://github.com/user-attachments/assets/d53ed13b-65ad-4c69-bec3-786d19bedf35" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
