### PR TITLE
fix: make undo/redo respect focused text inputs in DMN editors.

### DIFF
--- a/client/src/app/tabs/cloud-dmn/DmnEditor.js
+++ b/client/src/app/tabs/cloud-dmn/DmnEditor.js
@@ -483,7 +483,7 @@ export class DmnEditor extends CachedComponent {
     } else if (activeView.type === 'literalExpression') {
       assign(newState, {
         defaultCopyCutPaste: true,
-        defaultUndoRedo: true,
+        defaultUndoRedo: inputActive,
         removeSelected: true,
         selectAll: true
       });
@@ -499,7 +499,7 @@ export class DmnEditor extends CachedComponent {
       // TODO(@barmac): handle boxed expression differently than literal expression when needed
       assign(newState, {
         defaultCopyCutPaste: true,
-        defaultUndoRedo: true,
+        defaultUndoRedo: inputActive,
         removeSelected: true,
         selectAll: true
       });
@@ -997,12 +997,17 @@ export class DmnEditor extends CachedComponent {
             )
           }
 
-          <div className={
-            classNames(
-              'diagram',
-              { 'drd': isDrd }
-            )
-          } ref={ this.ref }></div>
+          <div
+            className={
+              classNames(
+                'diagram',
+                { 'drd': isDrd }
+              )
+            }
+            onFocus={ this.handleChanged }
+            onBlur={ this.handleChanged }
+            ref={ this.ref }>
+          </div>
 
           {
             hasPropertiesPanel && (

--- a/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
@@ -933,6 +933,68 @@ describe('<DmnEditor>', function() {
           expect(hasMenuEntry(state.editMenu, 'Find')).to.be.false;
         });
 
+
+        it('should provide native undo/redo entries when input is focused', async function() {
+
+          // given
+          const changedSpy = sinon.spy();
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          const modeler = instance.getModeler();
+
+          modeler.open({ type: 'literalExpression' });
+
+          const input = document.createElement('input');
+          document.body.appendChild(input);
+          input.focus();
+
+          changedSpy.resetHistory();
+
+          // when
+          instance.handleChanged();
+
+          input.remove();
+
+          // then
+          expect(changedSpy).to.be.calledOnce;
+
+          const state = changedSpy.firstCall.args[0];
+
+          expect(getMenuEntry(state.editMenu, 'Undo').role).to.equal('undo');
+          expect(getMenuEntry(state.editMenu, 'Redo').role).to.equal('redo');
+        });
+
+
+        it('should provide editor undo/redo entries when no input is focused', async function() {
+
+          // given
+          const changedSpy = sinon.spy();
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          const modeler = instance.getModeler();
+
+          modeler.open({ type: 'literalExpression' });
+
+          changedSpy.resetHistory();
+
+          // when
+          instance.handleChanged();
+
+          // then
+          expect(changedSpy).to.be.calledOnce;
+
+          const state = changedSpy.firstCall.args[0];
+
+          expect(getMenuEntry(state.editMenu, 'Undo').action).to.equal('undo');
+          expect(getMenuEntry(state.editMenu, 'Redo').action).to.equal('redo');
+        });
+
       });
 
 
@@ -987,6 +1049,68 @@ describe('<DmnEditor>', function() {
 
           const state = changedSpy.firstCall.args[0];
           expect(hasMenuEntry(state.editMenu, 'Find')).to.be.false;
+        });
+
+
+        it('should provide native undo/redo entries when input is focused', async function() {
+
+          // given
+          const changedSpy = sinon.spy();
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          const modeler = instance.getModeler();
+
+          modeler.open({ type: 'boxedExpression' });
+
+          const input = document.createElement('input');
+          document.body.appendChild(input);
+          input.focus();
+
+          changedSpy.resetHistory();
+
+          // when
+          instance.handleChanged();
+
+          input.remove();
+
+          // then
+          expect(changedSpy).to.be.calledOnce;
+
+          const state = changedSpy.firstCall.args[0];
+
+          expect(getMenuEntry(state.editMenu, 'Undo').role).to.equal('undo');
+          expect(getMenuEntry(state.editMenu, 'Redo').role).to.equal('redo');
+        });
+
+
+        it('should provide editor undo/redo entries when no input is focused', async function() {
+
+          // given
+          const changedSpy = sinon.spy();
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          const modeler = instance.getModeler();
+
+          modeler.open({ type: 'boxedExpression' });
+
+          changedSpy.resetHistory();
+
+          // when
+          instance.handleChanged();
+
+          // then
+          expect(changedSpy).to.be.calledOnce;
+
+          const state = changedSpy.firstCall.args[0];
+
+          expect(getMenuEntry(state.editMenu, 'Undo').action).to.equal('undo');
+          expect(getMenuEntry(state.editMenu, 'Redo').action).to.equal('redo');
         });
 
       });

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -459,7 +459,7 @@ export class DmnEditor extends CachedComponent {
     } else if (activeView.type === 'literalExpression') {
       assign(newState, {
         defaultCopyCutPaste: true,
-        defaultUndoRedo: true,
+        defaultUndoRedo: inputActive,
         removeSelected: true,
         selectAll: true
       });
@@ -475,7 +475,7 @@ export class DmnEditor extends CachedComponent {
       // TODO(@barmac): handle boxed expression differently than literal expression when needed
       assign(newState, {
         defaultCopyCutPaste: true,
-        defaultUndoRedo: true,
+        defaultUndoRedo: inputActive,
         removeSelected: true,
         selectAll: true
       });
@@ -965,12 +965,17 @@ export class DmnEditor extends CachedComponent {
             )
           }
 
-          <div className={
-            classNames(
-              'diagram',
-              { 'drd': isDrd }
-            )
-          } ref={ this.ref }></div>
+          <div
+            className={
+              classNames(
+                'diagram',
+                { 'drd': isDrd }
+              )
+            }
+            onFocus={ this.handleChanged }
+            onBlur={ this.handleChanged }
+            ref={ this.ref }>
+          </div>
 
           {
             hasPropertiesPanel && (

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -934,6 +934,68 @@ describe('<DmnEditor>', function() {
           expect(hasMenuEntry(state.editMenu, 'Find')).to.be.false;
         });
 
+
+        it('should provide native undo/redo entries when input is focused', async function() {
+
+          // given
+          const changedSpy = sinon.spy();
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          const modeler = instance.getModeler();
+
+          modeler.open({ type: 'literalExpression' });
+
+          const input = document.createElement('input');
+          document.body.appendChild(input);
+          input.focus();
+
+          changedSpy.resetHistory();
+
+          // when
+          instance.handleChanged();
+
+          input.remove();
+
+          // then
+          expect(changedSpy).to.be.calledOnce;
+
+          const state = changedSpy.firstCall.args[0];
+
+          expect(getMenuEntry(state.editMenu, 'Undo').role).to.equal('undo');
+          expect(getMenuEntry(state.editMenu, 'Redo').role).to.equal('redo');
+        });
+
+
+        it('should provide editor undo/redo entries when no input is focused', async function() {
+
+          // given
+          const changedSpy = sinon.spy();
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          const modeler = instance.getModeler();
+
+          modeler.open({ type: 'literalExpression' });
+
+          changedSpy.resetHistory();
+
+          // when
+          instance.handleChanged();
+
+          // then
+          expect(changedSpy).to.be.calledOnce;
+
+          const state = changedSpy.firstCall.args[0];
+
+          expect(getMenuEntry(state.editMenu, 'Undo').action).to.equal('undo');
+          expect(getMenuEntry(state.editMenu, 'Redo').action).to.equal('redo');
+        });
+
       });
 
 
@@ -988,6 +1050,68 @@ describe('<DmnEditor>', function() {
 
           const state = changedSpy.firstCall.args[0];
           expect(hasMenuEntry(state.editMenu, 'Find')).to.be.false;
+        });
+
+
+        it('should provide native undo/redo entries when input is focused', async function() {
+
+          // given
+          const changedSpy = sinon.spy();
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          const modeler = instance.getModeler();
+
+          modeler.open({ type: 'boxedExpression' });
+
+          const input = document.createElement('input');
+          document.body.appendChild(input);
+          input.focus();
+
+          changedSpy.resetHistory();
+
+          // when
+          instance.handleChanged();
+
+          input.remove();
+
+          // then
+          expect(changedSpy).to.be.calledOnce;
+
+          const state = changedSpy.firstCall.args[0];
+
+          expect(getMenuEntry(state.editMenu, 'Undo').role).to.equal('undo');
+          expect(getMenuEntry(state.editMenu, 'Redo').role).to.equal('redo');
+        });
+
+
+        it('should provide editor undo/redo entries when no input is focused', async function() {
+
+          // given
+          const changedSpy = sinon.spy();
+
+          const { instance } = await renderEditor(diagramXML, {
+            onChanged: changedSpy
+          });
+
+          const modeler = instance.getModeler();
+
+          modeler.open({ type: 'boxedExpression' });
+
+          changedSpy.resetHistory();
+
+          // when
+          instance.handleChanged();
+
+          // then
+          expect(changedSpy).to.be.calledOnce;
+
+          const state = changedSpy.firstCall.args[0];
+
+          expect(getMenuEntry(state.editMenu, 'Undo').action).to.equal('undo');
+          expect(getMenuEntry(state.editMenu, 'Redo').action).to.equal('redo');
         });
 
       });

--- a/client/src/app/tabs/dmn/getDmnEditMenu.js
+++ b/client/src/app/tabs/dmn/getDmnEditMenu.js
@@ -13,6 +13,7 @@ import {
   getCopyCutPasteEntries,
   getAlignDistributeEntries,
   getDefaultCopyCutPasteEntries,
+  getDefaultUndoRedoEntries,
   getDiagramFindEntries,
   getSelectionEntries,
   getToolEntries,
@@ -77,28 +78,36 @@ export function getDmnDecisionTableEditMenu(state) {
 }
 
 export function getDmnLiteralExpressionEditMenu(state) {
-  const { defaultCopyCutPaste } = state;
+  const { defaultCopyCutPaste, defaultUndoRedo } = state;
+
+  const undoRedoEntries = defaultUndoRedo
+    ? getDefaultUndoRedoEntries(true)
+    : getUndoRedoEntries(state);
 
   const copyCutPasteEntries = defaultCopyCutPaste
     ? getDefaultCopyCutPasteEntries(true)
     : getCopyCutPasteEntries(state);
 
   return [
-    getUndoRedoEntries(state),
+    undoRedoEntries,
     copyCutPasteEntries,
     getSelectionEntries(state)
   ];
 }
 
 export function getDmnBoxedExpressionEditMenu(state) {
-  const { defaultCopyCutPaste } = state;
+  const { defaultCopyCutPaste, defaultUndoRedo } = state;
+
+  const undoRedoEntries = defaultUndoRedo
+    ? getDefaultUndoRedoEntries(true)
+    : getUndoRedoEntries(state);
 
   const copyCutPasteEntries = defaultCopyCutPaste
     ? getDefaultCopyCutPasteEntries(true)
     : getCopyCutPasteEntries(state);
 
   return [
-    getUndoRedoEntries(state),
+    undoRedoEntries,
     copyCutPasteEntries,
     getSelectionEntries(state)
   ];


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/4613

### Proposed Changes

In the DMN literal and boxed expression views, `Ctrl+Z` always triggered
editor undo — even while typing in a text input (e.g. the BKM name),
reverting unrelated model changes and suppressing the browser's text undo.

The `defaultUndoRedo` menu state was set for these views but never honored
by the edit menu builders. It now follows the actual input focus (same
pattern as the BPMN and form editors): focus in a text input → native text
undo/redo; focus elsewhere → editor undo/redo. The menu refreshes on
focus changes via `onFocus`/`onBlur` on the editor container.

#### Steps to try out

1. Open a DMN diagram, open a BKM
2. Change the body or formal parameters
3. Type in the name box, press `Ctrl+Z` — only the typed text is undone
4. Unfocus the input, press `Ctrl+Z` — model changes are undone

<img width="1145" height="787" alt="dmn-bugfix" src="https://github.com/user-attachments/assets/be2dd90a-fe94-4524-b3ff-f481be36ba30" />

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
