### PR TITLE
feat: update 'Keyboard Shortcuts' modal to list all application shortcuts

### DIFF
--- a/client/src/app/modals/keyboard-shortcuts/KeyboardShortcutsModal.js
+++ b/client/src/app/modals/keyboard-shortcuts/KeyboardShortcutsModal.js
@@ -15,17 +15,11 @@ import View from './View';
 import getShortcuts from './getShortcuts';
 
 class KeyboardShortcutsModal extends PureComponent {
-  getModifierKey() {
+  render() {
     const platform = this.props.getGlobal('backend').getPlatform();
 
-    return platform === 'darwin' ? 'Command' : 'Control';
-  }
-
-  render() {
-    const modifierKey = this.getModifierKey();
-
     return <View
-      shortcuts={ getShortcuts(modifierKey) }
+      shortcuts={ getShortcuts(platform) }
       onClose={ this.props.onClose }
     />;
   }

--- a/client/src/app/modals/keyboard-shortcuts/View.css
+++ b/client/src/app/modals/keyboard-shortcuts/View.css
@@ -1,6 +1,25 @@
 :local(.View) {
   font-size: 1.2em;
 
+  .shortcut-group {
+    margin-bottom: 20px;
+
+    h3 {
+      margin: 0 0 6px;
+      font-size: 1em;
+    }
+
+    table {
+      width: 100%;
+      table-layout: fixed;
+    }
+
+    td {
+      width: 50%;
+      text-align: left;
+    }
+  }
+
   .binding {
     padding: 5px 10px;
     font-family: var(--font-family-monospace);

--- a/client/src/app/modals/keyboard-shortcuts/View.js
+++ b/client/src/app/modals/keyboard-shortcuts/View.js
@@ -31,23 +31,27 @@ class View extends PureComponent {
 
         <Modal.Body>
           <p>
-            The following special shortcuts can be used on opened diagrams.
+            The following keyboard and mouse shortcuts are available in the application.
           </p>
-          <table>
-            <tbody className="keyboard-shortcuts">
-              {
-                (shortcuts || []).map(s => {
-                  return <tr key={ s.id }>
-                    <td>{ s.label }</td>
-                    <td className="binding"><code>{ s.binding }</code></td>
-                  </tr>;
-                })
-              }
-            </tbody>
-          </table>
-          <p>
-            Find additional shortcuts on individual items in the application menu.
-          </p>
+          {
+            (shortcuts || []).map(group => {
+              return <section key={ group.id } className="shortcut-group">
+                <h3>{ group.title }</h3>
+                <table>
+                  <tbody className="keyboard-shortcuts">
+                    {
+                      group.shortcuts.map(s => {
+                        return <tr key={ s.id }>
+                          <td>{ s.label }</td>
+                          <td className="binding"><code>{ s.binding }</code></td>
+                        </tr>;
+                      })
+                    }
+                  </tbody>
+                </table>
+              </section>;
+            })
+          }
         </Modal.Body>
 
         <Modal.Footer>

--- a/client/src/app/modals/keyboard-shortcuts/__tests__/KeyboardShortcutsModalSpec.js
+++ b/client/src/app/modals/keyboard-shortcuts/__tests__/KeyboardShortcutsModalSpec.js
@@ -29,13 +29,17 @@ describe('<KeyboardShortcutsModal>', function() {
     it('should render shortcuts', function() {
 
       // when
-      const { getByText } = renderOverlay();
-      const shortcuts = getShortcuts(CTRL_MODIFIER);
+      const { getByText, queryAllByText } = renderOverlay();
+      const groups = getShortcuts('win32');
 
       // then
-      shortcuts.forEach((shortcut) => {
-        expect(getByText(shortcut.label)).to.exist;
-        expect(getByText(shortcut.binding)).to.exist;
+      groups.forEach((group) => {
+        expect(getByText(group.title)).to.exist;
+
+        group.shortcuts.forEach((shortcut) => {
+          expect(getByText(shortcut.label)).to.exist;
+          expect(queryAllByText(shortcut.binding).length).to.be.gt(0);
+        });
       });
     });
 
@@ -43,26 +47,33 @@ describe('<KeyboardShortcutsModal>', function() {
     it('should render Mac OS shortcuts', function() {
 
       // when
-      const { queryAllByText } = renderOverlay({
+      const { getByText, queryAllByText } = renderOverlay({
         platform: 'darwin'
       });
 
       // then
       expect(queryAllByText(COMMAND_MODIFIER, { exact: false }).length).to.be.gt(0);
-      expect(queryAllByText(CTRL_MODIFIER, { exact: false }).length).to.be.equal(0);
+
+      // OS-specific bindings
+      expect(getByText('Command + Shift + Z')).to.exist;
+      expect(getByText('Control + Command + F')).to.exist;
     });
 
 
     it('should render Windows / Linux shortcuts', function() {
 
       // when
-      const { queryAllByText } = renderOverlay({
+      const { getByText, queryAllByText } = renderOverlay({
         platform: 'linux'
       });
 
       // then
       expect(queryAllByText(CTRL_MODIFIER, { exact: false }).length).to.be.gt(0);
       expect(queryAllByText(COMMAND_MODIFIER, { exact: false }).length).to.be.equal(0);
+
+      // OS-specific bindings
+      expect(getByText('Control + Y')).to.exist;
+      expect(getByText('F11')).to.exist;
     });
 
   });

--- a/client/src/app/modals/keyboard-shortcuts/getShortcuts.js
+++ b/client/src/app/modals/keyboard-shortcuts/getShortcuts.js
@@ -16,58 +16,299 @@ const keyboardBinding = (binding, modifierKey) => {
   return binding;
 };
 
-export default function(modifierKey) {
+export default function(platform) {
+
+  const isMac = platform === 'darwin';
+
+  const modifierKey = isMac ? 'Command' : 'Control';
 
   return [
     {
-      id: 'copy',
-      label: 'Copy',
-      binding: keyboardBinding('C', modifierKey)
+      id: 'file',
+      title: 'File',
+      shortcuts: [
+        {
+          id: 'newFile',
+          label: 'New File',
+          binding: keyboardBinding('N', modifierKey)
+        },
+        {
+          id: 'openFile',
+          label: 'Open File',
+          binding: keyboardBinding('O', modifierKey)
+        },
+        {
+          id: 'reopenFile',
+          label: 'Reopen Last File',
+          binding: keyboardBinding('Shift + T', modifierKey)
+        },
+        {
+          id: 'save',
+          label: 'Save File',
+          binding: keyboardBinding('S', modifierKey)
+        },
+        {
+          id: 'saveAs',
+          label: 'Save File As',
+          binding: keyboardBinding('Shift + S', modifierKey)
+        },
+        {
+          id: 'saveAll',
+          label: 'Save All Files',
+          binding: keyboardBinding('Alt + S', modifierKey)
+        },
+        {
+          id: 'exportAsImage',
+          label: 'Export As Image',
+          binding: keyboardBinding('Shift + E', modifierKey)
+        },
+        {
+          id: 'closeTab',
+          label: 'Close Tab',
+          binding: keyboardBinding('W', modifierKey)
+        },
+        {
+          id: 'settings',
+          label: 'Settings',
+          binding: keyboardBinding(',', modifierKey)
+        },
+        {
+          id: 'quit',
+          label: 'Quit',
+          binding: keyboardBinding('Q', modifierKey)
+        }
+      ]
     },
     {
-      id: 'copyAsImage',
-      label: 'Copy as image',
-      binding: keyboardBinding('Shift + C', modifierKey)
+      id: 'edit',
+      title: 'Edit',
+      shortcuts: [
+        {
+          id: 'undo',
+          label: 'Undo',
+          binding: keyboardBinding('Z', modifierKey)
+        },
+        {
+          id: 'redo',
+          label: 'Redo',
+          binding: isMac ? 'Command + Shift + Z' : keyboardBinding('Y', modifierKey)
+        },
+        {
+          id: 'copy',
+          label: 'Copy',
+          binding: keyboardBinding('C', modifierKey)
+        },
+        {
+          id: 'copyAsImage',
+          label: 'Copy as Image',
+          binding: keyboardBinding('Shift + C', modifierKey)
+        },
+        {
+          id: 'cut',
+          label: 'Cut',
+          binding: keyboardBinding('X', modifierKey)
+        },
+        {
+          id: 'paste',
+          label: 'Paste',
+          binding: keyboardBinding('V', modifierKey)
+        },
+        {
+          id: 'duplicate',
+          label: 'Duplicate',
+          binding: keyboardBinding('D', modifierKey)
+        },
+        {
+          id: 'selectAll',
+          label: 'Select All',
+          binding: keyboardBinding('A', modifierKey)
+        },
+        {
+          id: 'removeSelected',
+          label: 'Remove Selected',
+          binding: keyboardBinding('Delete')
+        },
+        {
+          id: 'find',
+          label: 'Find',
+          binding: keyboardBinding('F', modifierKey)
+        },
+        {
+          id: 'addLineFeed',
+          label: 'Add Line Feed (in text box)',
+          binding: keyboardBinding('Shift + Enter')
+        }
+      ]
     },
     {
-      id: 'cut',
-      label: 'Cut',
-      binding: keyboardBinding('X', modifierKey)
+      id: 'modeling',
+      title: 'Modeling',
+      shortcuts: [
+        {
+          id: 'editLabel',
+          label: 'Edit Label',
+          binding: keyboardBinding('E')
+        },
+        {
+          id: 'replaceElement',
+          label: 'Replace Element',
+          binding: keyboardBinding('R')
+        },
+        {
+          id: 'appendElement',
+          label: 'Append Element',
+          binding: keyboardBinding('A')
+        },
+        {
+          id: 'createElement',
+          label: 'Create Element',
+          binding: keyboardBinding('N')
+        }
+      ]
     },
     {
-      id: 'paste',
-      label: 'Paste',
-      binding: keyboardBinding('V', modifierKey)
+      id: 'tools',
+      title: 'Tools',
+      shortcuts: [
+        {
+          id: 'handTool',
+          label: 'Hand Tool',
+          binding: keyboardBinding('H')
+        },
+        {
+          id: 'lassoTool',
+          label: 'Lasso Tool',
+          binding: keyboardBinding('L')
+        },
+        {
+          id: 'spaceTool',
+          label: 'Space Tool',
+          binding: keyboardBinding('S')
+        },
+        {
+          id: 'globalConnectTool',
+          label: 'Global Connect Tool',
+          binding: keyboardBinding('C')
+        }
+      ]
     },
     {
-      id: 'duplicate',
-      label: 'Duplicate',
-      binding: keyboardBinding('D', modifierKey)
+      id: 'view',
+      title: 'View',
+      shortcuts: [
+        {
+          id: 'zoomIn',
+          label: 'Zoom In',
+          binding: keyboardBinding('=', modifierKey)
+        },
+        {
+          id: 'zoomOut',
+          label: 'Zoom Out',
+          binding: keyboardBinding('-', modifierKey)
+        },
+        {
+          id: 'zoomActual',
+          label: 'Zoom to Actual Size',
+          binding: keyboardBinding('0', modifierKey)
+        },
+        {
+          id: 'zoomFit',
+          label: 'Zoom to Fit Diagram',
+          binding: keyboardBinding('1', modifierKey)
+        },
+        {
+          id: 'toggleProperties',
+          label: 'Toggle Properties Panel',
+          binding: keyboardBinding('P', modifierKey)
+        },
+        {
+          id: 'toggleVariables',
+          label: 'Toggle Variables Panel',
+          binding: keyboardBinding('Alt + P', modifierKey)
+        },
+        {
+          id: 'toggleBottomPanel',
+          label: 'Toggle Bottom Panel',
+          binding: keyboardBinding('B', modifierKey)
+        },
+        {
+          id: 'toggleGrid',
+          label: 'Toggle Grid',
+          binding: keyboardBinding('G', modifierKey)
+        },
+        {
+          id: 'fullscreen',
+          label: 'Fullscreen',
+          binding: isMac ? 'Control + Command + F' : keyboardBinding('F11')
+        }
+      ]
     },
     {
-      id: 'addLineFeed',
-      label: 'Add Line Feed (in text box)',
-      binding: keyboardBinding('Shift + Enter')
+      id: 'window',
+      title: 'Window',
+      shortcuts: [
+        {
+          id: 'reload',
+          label: 'Reload',
+          binding: keyboardBinding('R', modifierKey)
+        },
+        {
+          id: 'selectNextTab',
+          label: 'Select Next Tab',
+          binding: keyboardBinding('Control + Tab')
+        },
+        {
+          id: 'selectPreviousTab',
+          label: 'Select Previous Tab',
+          binding: keyboardBinding('Control + Shift + Tab')
+        }
+      ]
     },
     {
-      id: 'scrollVertical',
-      label: 'Scrolling (Vertical)',
-      binding: keyboardBinding('Mouse Wheel')
-    },
-    {
-      id: 'scrollHorizontal',
-      label: 'Scrolling (Horizontal)',
-      binding: keyboardBinding('Shift + Mouse Wheel')
-    },
-    {
-      id: 'addElementToSelection',
-      label: 'Add element to selection',
-      binding: keyboardBinding('Mouse Click', modifierKey)
-    },
-    {
-      id: 'selectMultipleElements',
-      label: 'Select multiple elements (Lasso Tool)',
-      binding: keyboardBinding('Shift + Mouse Drag')
+      id: 'canvas',
+      title: 'Canvas & Mouse',
+      shortcuts: [
+        {
+          id: 'moveCanvas',
+          label: 'Move Canvas',
+          binding: keyboardBinding('Arrow Keys', modifierKey)
+        },
+        {
+          id: 'moveCanvasAccelerated',
+          label: 'Move Canvas (Accelerated)',
+          binding: keyboardBinding('Shift + Arrow Keys', modifierKey)
+        },
+        {
+          id: 'moveSelection',
+          label: 'Move Selection',
+          binding: keyboardBinding('Arrow Keys')
+        },
+        {
+          id: 'moveSelectionAccelerated',
+          label: 'Move Selection (Accelerated)',
+          binding: keyboardBinding('Shift + Arrow Keys')
+        },
+        {
+          id: 'scrollVertical',
+          label: 'Scrolling (Vertical)',
+          binding: keyboardBinding('Mouse Wheel')
+        },
+        {
+          id: 'scrollHorizontal',
+          label: 'Scrolling (Horizontal)',
+          binding: keyboardBinding('Shift + Mouse Wheel')
+        },
+        {
+          id: 'addElementToSelection',
+          label: 'Add element to selection',
+          binding: keyboardBinding('Mouse Click', modifierKey)
+        },
+        {
+          id: 'selectMultipleElements',
+          label: 'Select multiple elements (Lasso Tool)',
+          binding: keyboardBinding('Shift + Mouse Drag')
+        }
+      ]
     }
   ];
 


### PR DESCRIPTION
### Proposed Changes

Related to camunda/camunda-modeler#6011

Reworks the Keyboard Shortcuts modal to have all available application shortcuts: shortcuts grouped by category (File, Edit, Modeling, Tools, View, Window, Canvas & Mouse). Some small tweak of modal layout to render content in 2 columns.


https://github.com/user-attachments/assets/eb76c6dc-ede6-43f5-9947-8dfc7990104d



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
