### PR TITLE
fix(bpmn-editor): guard linting toggle during import

### DIFF
--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -213,10 +213,19 @@ export class BpmnEditor extends CachedComponent {
 
     const { panel = {} } = layout;
 
-    if (panel.open && panel.tab === 'linting') {
-      this.getModeler().get('linting').activate();
-    } else if (!panel.open || panel.tab !== 'linting') {
-      this.getModeler().get('linting').deactivate();
+    // only toggle linting once the diagram is imported; activating or
+    // deactivating while (re-)importing would access the not yet imported
+    // root element and crash (cf. #6049)
+    const { lastXML } = this.getCached();
+
+    if (lastXML && !this.state.importing && !this.isImportNeeded(prevProps)) {
+      const linting = this.getModeler().get('linting');
+
+      if (panel.open && panel.tab === 'linting') {
+        linting.activate();
+      } else {
+        linting.deactivate();
+      }
     }
 
     if (isPropertiesPanelLayoutChanged(prevProps, this.props)) {

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -593,6 +593,96 @@ describe('<BpmnEditor>', function() {
         expect(instance.getModeler().get('linting').isActive()).to.be.false;
       });
 
+
+      it('should not activate while importing (#6049)', async function() {
+
+        // given
+        const { instance } = await renderEditor(diagramXML, {
+          layout: {
+            panel: {
+              open: true,
+              tab: 'linting'
+            }
+          }
+        });
+
+        const linting = instance.getModeler().get('linting');
+
+        const activateSpy = spy(linting, 'activate'),
+              deactivateSpy = spy(linting, 'deactivate');
+
+        // assume a (re-)import is in progress
+        await new Promise(resolve => instance.setState({ importing: true }, resolve));
+
+        // when
+        instance.componentDidUpdate(instance.props);
+
+        // then
+        expect(activateSpy).not.to.have.been.called;
+        expect(deactivateSpy).not.to.have.been.called;
+      });
+
+
+      it('should not deactivate while importing (#6049)', async function() {
+
+        // given
+        const { instance } = await renderEditor(diagramXML, {
+          layout: {
+            panel: {
+              open: false
+            }
+          }
+        });
+
+        const linting = instance.getModeler().get('linting');
+
+        const activateSpy = spy(linting, 'activate'),
+              deactivateSpy = spy(linting, 'deactivate');
+
+        // assume a (re-)import is in progress
+        await new Promise(resolve => instance.setState({ importing: true }, resolve));
+
+        // when
+        instance.componentDidUpdate(instance.props);
+
+        // then
+        expect(deactivateSpy).not.to.have.been.called;
+        expect(activateSpy).not.to.have.been.called;
+      });
+
+
+      it('should not toggle while an import is pending (#6049)', async function() {
+
+        // given
+        const { instance } = await renderEditor(diagramXML, {
+          layout: {
+            panel: {
+              open: true,
+              tab: 'linting'
+            }
+          }
+        });
+
+        // props are out of sync with the imported diagram => import pending
+        instance.setCached({ lastXML: '<foo />' });
+
+        await waitFor(() => {
+          expect(instance.getCached().lastXML).to.equal('<foo />');
+        });
+
+        const linting = instance.getModeler().get('linting');
+
+        const activateSpy = spy(linting, 'activate'),
+              deactivateSpy = spy(linting, 'deactivate');
+
+        // when re-rendered before the pending import completes
+        instance.componentDidUpdate({ ...instance.props, xml: 'previous' });
+
+        // then
+        expect(activateSpy).not.to.have.been.called;
+        expect(deactivateSpy).not.to.have.been.called;
+      });
+
     });
 
   });

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -226,10 +226,19 @@ export class BpmnEditor extends CachedComponent {
 
     const { panel = {} } = layout;
 
-    if (panel.open && panel.tab === 'linting') {
-      this.getModeler().get('linting').activate();
-    } else if (!panel.open || panel.tab !== 'linting') {
-      this.getModeler().get('linting').deactivate();
+    // only toggle linting once the diagram is imported; activating or
+    // deactivating while (re-)importing would access the not yet imported
+    // root element and crash (cf. #6049)
+    const { lastXML } = this.getCached();
+
+    if (lastXML && !this.state.importing && !this.isImportNeeded(prevProps)) {
+      const linting = this.getModeler().get('linting');
+
+      if (panel.open && panel.tab === 'linting') {
+        linting.activate();
+      } else {
+        linting.deactivate();
+      }
     }
 
     if (isPropertiesPanelLayoutChanged(prevProps, this.props)) {

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -589,6 +589,96 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
         expect(instance.getModeler().get('linting').isActive()).to.be.false;
       });
 
+
+      it('should not activate while importing (#6049)', async function() {
+
+        // given
+        const { instance } = await renderEditor(diagramXML, {
+          layout: {
+            panel: {
+              open: true,
+              tab: 'linting'
+            }
+          }
+        });
+
+        const linting = instance.getModeler().get('linting');
+
+        const activateSpy = spy(linting, 'activate'),
+              deactivateSpy = spy(linting, 'deactivate');
+
+        // assume a (re-)import is in progress
+        await new Promise(resolve => instance.setState({ importing: true }, resolve));
+
+        // when
+        instance.componentDidUpdate(instance.props);
+
+        // then
+        expect(activateSpy).not.to.have.been.called;
+        expect(deactivateSpy).not.to.have.been.called;
+      });
+
+
+      it('should not deactivate while importing (#6049)', async function() {
+
+        // given
+        const { instance } = await renderEditor(diagramXML, {
+          layout: {
+            panel: {
+              open: false
+            }
+          }
+        });
+
+        const linting = instance.getModeler().get('linting');
+
+        const activateSpy = spy(linting, 'activate'),
+              deactivateSpy = spy(linting, 'deactivate');
+
+        // assume a (re-)import is in progress
+        await new Promise(resolve => instance.setState({ importing: true }, resolve));
+
+        // when
+        instance.componentDidUpdate(instance.props);
+
+        // then
+        expect(deactivateSpy).not.to.have.been.called;
+        expect(activateSpy).not.to.have.been.called;
+      });
+
+
+      it('should not toggle while an import is pending (#6049)', async function() {
+
+        // given
+        const { instance } = await renderEditor(diagramXML, {
+          layout: {
+            panel: {
+              open: true,
+              tab: 'linting'
+            }
+          }
+        });
+
+        // props are out of sync with the imported diagram => import pending
+        instance.setCached({ lastXML: '<foo />' });
+
+        await waitFor(() => {
+          expect(instance.getCached().lastXML).to.equal('<foo />');
+        });
+
+        const linting = instance.getModeler().get('linting');
+
+        const activateSpy = spy(linting, 'activate'),
+              deactivateSpy = spy(linting, 'deactivate');
+
+        // when re-rendered before the pending import completes
+        instance.componentDidUpdate({ ...instance.props, xml: 'previous' });
+
+        // then
+        expect(activateSpy).not.to.have.been.called;
+        expect(deactivateSpy).not.to.have.been.called;
+      });
+
     });
 
   });


### PR DESCRIPTION
### Proposed Changes

Closes #6049

Rejecting the _"reload external changes"_ dialog (and other re-renders that coincide with a diagram (re-)import) could crash the tab and lose unsaved work.

**Root cause:** `BpmnEditor.componentDidUpdate` toggled linting (`linting.activate()` / `linting.deactivate()`) unconditionally, even while a diagram was being (re-)imported. During import the canvas root is cleared, so `linting._update()` → `canvas.getRootElement()` lazily creates an _implicit_ root without a moddle business object, and `@camunda/linting`'s `getErrors()` then calls `.get('id')` on it → `(...).get is not a function` → the tab crashes.

The nearby `setErrors` call was already guarded with `lastXML && !this.state.importing`; the activate/deactivate calls were not. This aligns them: linting is only toggled once the diagram is imported. After import completes, the next `componentDidUpdate` re-applies the correct linting state, so no behaviour is lost.

Applied to both the `bpmn` and `cloud-bpmn` editors.

### Steps to try out

1. Open a BPMN diagram (Camunda 8), open a FEEL expression in the popup editor
2. Change the file externally so the modeler detects an external change
3. Reject the _"reload external changes"_ dialog
4. The tab keeps working instead of crashing

### Checklist

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__: Closes #6049
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes — n/a (crash fix, no UI change)
  * [x] __Steps to try out__