### PR TITLE
Add consistent process applications color coding (across files and tools)

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -220,8 +220,9 @@ export class App extends PureComponent {
    *
    * @param {string} id ID of the tab
    * @param {string} group Group name
+   * @param {string} [color] Group color
    */
-  setTabGroup(id, group) {
+  setTabGroup(id, group, color = null) {
     const tab = this.state.tabs.find((tab) => tab.id === id);
 
     if (!tab) {
@@ -232,7 +233,7 @@ export class App extends PureComponent {
       return {
         tabGroups: {
           ...tabGroups,
-          [ id ]: group
+          [ id ]: group ? { name: group, color } : null
         }
       };
     });
@@ -2182,10 +2183,11 @@ export class App extends PureComponent {
     if (action === 'set-tab-group') {
       const {
         id,
-        group
+        group,
+        color
       } = options;
 
-      return this.setTabGroup(id, group);
+      return this.setTabGroup(id, group, color);
     }
 
     if (action === 'lint-tab') {

--- a/client/src/app/primitives/TabLinks.js
+++ b/client/src/app/primitives/TabLinks.js
@@ -12,8 +12,6 @@ import React, { PureComponent } from 'react';
 
 import classNames from 'classnames';
 
-import { groupBy, omit } from 'min-dash';
-
 import * as css from './Tabbed.css';
 
 import {
@@ -48,14 +46,6 @@ const MIDDLE_MOUSE_BUTTON = 1;
  */
 const SMALL_TAB_WIDTH = 90;
 const SMALLER_TAB_WIDTH = 45;
-
-const COLORS = [
-  'rgb(30, 136, 229)',
-  'rgb(251, 140, 0)',
-  'rgb(67, 160, 71)',
-  'rgb(229, 57, 53)',
-  'rgb(142, 36, 170)'
-];
 
 export default class TabLinks extends PureComponent {
   constructor(props) {
@@ -111,14 +101,6 @@ export default class TabLinks extends PureComponent {
       isDirty = () => false
     } = this.props;
 
-    const tabsByGroup = omit(groupBy(tabs, tab => tabGroups[ tab.id ]), '_');
-
-    const colors = {};
-
-    Object.keys(tabsByGroup).forEach((key, index) => {
-      colors[ key ] = COLORS[ index % COLORS.length ];
-    });
-
     return (
       <div
         className={ classNames(css.LinksContainer, className) }
@@ -129,7 +111,7 @@ export default class TabLinks extends PureComponent {
               const dirty = isDirty(tab);
               const active = tab === activeTab;
 
-              const color = tabGroups[ tab.id ] && colors[ tabGroups[ tab.id ] ];
+              const color = tabGroups[ tab.id ]?.color;
 
               return (
                 <Tab

--- a/client/src/app/primitives/Tabbed.css
+++ b/client/src/app/primitives/Tabbed.css
@@ -6,7 +6,7 @@
   --tab-font-color: var(--color-grey-225-10-15);
   --tab-font-size: var(--font-size-default);
   --tab-icon-color: var(--color-grey-225-10-35);
-  --tab-border-right-color: var(--color-grey-225-10-75);
+  --tab-border-right-color: var(--color-grey-225-10-70);
   --tab-close-background-color: transparent;
   --tab-close-hover-background-color: var(--color-grey-225-10-70);
   --tab-close-icon-fill-color: var(--color-grey-225-10-15);
@@ -16,6 +16,7 @@
   --tab-dirty-marker-background-color: var(--color-blue-205-100-50);
   --tab-dirty-marker-border-color: var(--color-blue-205-100-45);
   --tab-active-background-color: var(--color-grey-225-10-75);
+  --tab-hover-background-color: var(--color-grey-225-10-80);
   --tab-action-icon-color: var(--color-grey-225-10-35);
   --tab-action-hover-background-color: var(--color-grey-225-10-80);
   --tab-action-active-background-color: var(--color-grey-225-10-75);
@@ -233,12 +234,19 @@
       }
     }
 
-    &.tab--active,
-    &:not(.tab--active):hover {
+    &.tab--active {
       background-color: var(--tab-active-background-color);
 
       .tab__dirty-marker {
         box-shadow: 0 0 0 2px var(--tab-active-background-color);
+      }
+    }
+
+    &:not(.tab--active):hover {
+      background-color: var(--tab-hover-background-color);
+
+      .tab__dirty-marker {
+        box-shadow: 0 0 0 2px var(--tab-hover-background-color);
       }
     }
 

--- a/client/src/app/primitives/Tabbed.css
+++ b/client/src/app/primitives/Tabbed.css
@@ -6,7 +6,7 @@
   --tab-font-color: var(--color-grey-225-10-15);
   --tab-font-size: var(--font-size-default);
   --tab-icon-color: var(--color-grey-225-10-35);
-  --tab-border-right-color: var(--color-grey-225-10-70);
+  --tab-border-right-color: var(--color-grey-225-10-75);
   --tab-close-background-color: transparent;
   --tab-close-hover-background-color: var(--color-grey-225-10-70);
   --tab-close-icon-fill-color: var(--color-grey-225-10-15);

--- a/client/src/app/primitives/Tabbed.css
+++ b/client/src/app/primitives/Tabbed.css
@@ -246,7 +246,7 @@
       z-index: 3;
       position: absolute;
       content: '';
-      bottom: -0.5px;
+      top: 0;
       left: 0px;
       right: 0px;
       height: 2px;

--- a/client/src/app/primitives/__tests__/mocks/index.js
+++ b/client/src/app/primitives/__tests__/mocks/index.js
@@ -31,7 +31,7 @@ export const defaultTabs = [
 ];
 
 export const defaultTabGroups = {
-  tab1: 'group1',
-  tab2: 'group1',
-  tab3: 'group2'
+  tab1: { name: 'group1', color: 'rgb(30, 136, 229)' },
+  tab2: { name: 'group1', color: 'rgb(30, 136, 229)' },
+  tab3: { name: 'group2', color: 'rgb(251, 140, 0)' }
 };

--- a/client/src/plugins/process-applications/ProcessApplications.js
+++ b/client/src/plugins/process-applications/ProcessApplications.js
@@ -10,6 +10,19 @@
 
 import EventEmitter from 'events';
 
+/**
+ * Palette of colors used to visually distinguish process applications.
+ *
+ * @type {string[]}
+ */
+export const PROCESS_APPLICATION_COLORS = [
+  'rgb(30, 136, 229)',
+  'rgb(251, 140, 0)',
+  'rgb(67, 160, 71)',
+  'rgb(229, 57, 53)',
+  'rgb(142, 36, 170)'
+];
+
 export default class ProcessApplications {
   constructor() {
     const events = this._events = new EventEmitter();
@@ -19,8 +32,17 @@ export default class ProcessApplications {
     this._processApplicationItems = [];
     this._activeTab = null;
 
+    /**
+     * Stable mapping of process application path to color.
+     *
+     * @type {Record<string, string>}
+     */
+    this._colors = {};
+
     events.on('items-changed', (items) => {
       this._items = items;
+
+      this._pruneColors();
 
       if (this.hasOpen()) {
         const processApplicationItem = this.findItem(this._processApplication.file.path);
@@ -179,5 +201,43 @@ export default class ProcessApplications {
    */
   findItem(path) {
     return this._items.find(item => item.file.path === path);
+  }
+
+  /**
+   * Get the stable, distinct color of a process application.
+   *
+   * The color is assigned on first request and kept stable while the process
+   * application exists. Colors of closed process applications are reused.
+   *
+   * @param {string} path process application file path
+   *
+   * @returns {string}
+   */
+  getColor(path) {
+    if (!this._colors[ path ]) {
+      const usedColors = Object.values(this._colors);
+
+      this._colors[ path ] =
+        PROCESS_APPLICATION_COLORS.find(color => !usedColors.includes(color))
+        || PROCESS_APPLICATION_COLORS[ usedColors.length % PROCESS_APPLICATION_COLORS.length ];
+    }
+
+    return this._colors[ path ];
+  }
+
+  /**
+   * Forget colors of process applications that no longer exist so that their
+   * colors can be reused.
+   */
+  _pruneColors() {
+    const paths = this._items
+      .filter(item => item.metadata?.type === 'processApplication')
+      .map(item => item.file.path);
+
+    for (const path of Object.keys(this._colors)) {
+      if (!paths.includes(path)) {
+        delete this._colors[ path ];
+      }
+    }
   }
 }

--- a/client/src/plugins/process-applications/ProcessApplicationsDeploymentPlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsDeploymentPlugin.js
@@ -29,6 +29,7 @@ export default function ProcessApplicationsDeploymentPlugin(props) {
     displayNotification,
     log,
     processApplication,
+    processApplicationColor,
     processApplicationItems,
     triggerAction,
     connectionCheckResult
@@ -111,6 +112,7 @@ export default function ProcessApplicationsDeploymentPlugin(props) {
         _getFromApp={ _getFromApp }
         activeTab={ activeTab }
         anchor={ anchorRef.current }
+        color={ processApplicationColor }
         connectionCheckResult={ connectionCheckResult }
         deployment={ deployment }
         getSuccessNotification={ (...args) => getSuccessNotification(...args, resourceConfigs) }

--- a/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
@@ -213,15 +213,21 @@ export default function ProcessApplicationsPlugin(props) {
     for (const [ id, group ] of Object.entries(tabGroups)) {
       triggerAction('set-tab-group', {
         id,
-        group
+        group,
+        color: group ? processApplications.getColor(group) : null
       });
     }
   }, [ items, tabs, triggerAction ]);
+
+  const processApplicationColor = processApplication
+    ? processApplications.getColor(processApplication.file.path)
+    : null;
 
   return <>
     <ProcessApplicationsStatusBar
       activeTab={ activeTab }
       processApplication={ processApplication }
+      processApplicationColor={ processApplicationColor }
       processApplicationItems={ processApplicationItems }
       onOpen={ (path) => triggerAction('open-diagram', { path }) }
       onRevealInFileExplorer={ (filePath) => triggerAction('reveal-in-file-explorer', { filePath }) }
@@ -235,6 +241,7 @@ export default function ProcessApplicationsPlugin(props) {
       displayNotification={ displayNotification }
       log={ log }
       processApplication={ processApplication }
+      processApplicationColor={ processApplicationColor }
       processApplicationItems={ processApplicationItems }
       triggerAction={ triggerAction }
       connectionCheckResult={ connectionCheckResult } />
@@ -245,6 +252,7 @@ export default function ProcessApplicationsPlugin(props) {
       displayNotification={ displayNotification }
       log={ log }
       processApplication={ processApplication }
+      processApplicationColor={ processApplicationColor }
       processApplicationItems={ processApplicationItems }
       triggerAction={ triggerAction }
       connectionCheckResult={ connectionCheckResult } />

--- a/client/src/plugins/process-applications/ProcessApplicationsStartInstancePlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsStartInstancePlugin.js
@@ -31,6 +31,7 @@ export default function ProcessApplicationsStartInstancePlugin(props) {
     displayNotification,
     log,
     processApplication,
+    processApplicationColor,
     processApplicationItems,
     triggerAction,
     connectionCheckResult
@@ -97,6 +98,7 @@ export default function ProcessApplicationsStartInstancePlugin(props) {
         _getFromApp={ _getFromApp }
         activeTab={ activeTab }
         anchor={ anchorRef.current }
+        color={ processApplicationColor }
         connectionCheckResult={ connectionCheckResult }
         deployment={ deployment }
         getResourceConfigs={ () => resourceConfigs }

--- a/client/src/plugins/process-applications/ProcessApplicationsStatusBar.css
+++ b/client/src/plugins/process-applications/ProcessApplicationsStatusBar.css
@@ -1,13 +1,14 @@
 :local(.ProcessApplicationsButton) {
   &.has-process-application {
-    background: hsl(205, 100%, 45%) !important;
+    background: var(--process-application-color, hsl(205, 100%, 45%)) !important;
   
     svg {
       fill: white;
     }
 
     &:hover {
-      background: hsl(205, 100%, 40%) !important;
+      background: var(--process-application-color, hsl(205, 100%, 45%)) !important;
+      filter: brightness(0.9);
   
       svg {
         fill: white;

--- a/client/src/plugins/process-applications/ProcessApplicationsStatusBar.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsStatusBar.js
@@ -36,6 +36,7 @@ export default function ProcessApplicationsStatusBar(props) {
     onRevealInFileExplorer,
     onCreateProcessApplication,
     processApplication,
+    processApplicationColor,
     processApplicationItems,
     tabsProvider
   } = props;
@@ -65,6 +66,7 @@ export default function ProcessApplicationsStatusBar(props) {
           className={ classnames('btn', css.ProcessApplicationsButton, { 'has-process-application': !!processApplication }) }
           ref={ ref }
           onClick={ () => setIsOpen(!isOpen) }
+          style={ processApplicationColor ? { '--process-application-color': processApplicationColor } : undefined }
           title={ processApplication ? 'This file is part of a process application' : 'New process application...' }
         >
           <ProcessApplicationIcon width="16" height="16" />
@@ -75,7 +77,7 @@ export default function ProcessApplicationsStatusBar(props) {
       isOpen && <Overlay className={ classnames(css.ProcessApplicationsOverlay, {
         'process-application': processApplication,
         'no-process-application': !processApplication
-      }) } id="process-application-overlay" anchor={ ref.current } onClose={ () => setIsOpen(false) }>
+      }) } id="process-application-overlay" color={ processApplicationColor } anchor={ ref.current } onClose={ () => setIsOpen(false) }>
         {
           !processApplication
             ? <>

--- a/client/src/plugins/process-applications/__tests__/ProcessApplicationsSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ProcessApplicationsSpec.js
@@ -320,6 +320,73 @@ describe('ProcessApplications', function() {
     });
   });
 
+
+  describe('#getColor', function() {
+
+    it('should assign a color', function() {
+
+      // when
+      const color = processApplications.getColor('C://foo/.process-application');
+
+      // then
+      expect(color).to.be.a('string');
+    });
+
+
+    it('should keep color stable', function() {
+
+      // given
+      const color = processApplications.getColor('C://foo/.process-application');
+
+      // when
+      const otherColor = processApplications.getColor('C://foo/.process-application');
+
+      // then
+      expect(otherColor).to.equal(color);
+    });
+
+
+    it('should assign distinct colors to different process applications', function() {
+
+      // when
+      const colorA = processApplications.getColor('C://foo/.process-application');
+      const colorB = processApplications.getColor('C://bar/.process-application');
+
+      // then
+      expect(colorB).not.to.equal(colorA);
+    });
+
+
+    it('should reuse color of removed process application', function() {
+
+      // given
+      const items = [
+        {
+          file: {
+            name: '.process-application',
+            path: 'C://foo/.process-application',
+            dirname: 'C://foo'
+          },
+          metadata: { type: 'processApplication' }
+        }
+      ];
+
+      processApplications.emit('items-changed', items);
+
+      const colorA = processApplications.getColor('C://foo/.process-application');
+
+      // when
+      // process application removed
+      processApplications.emit('items-changed', []);
+
+      const colorB = processApplications.getColor('C://bar/.process-application');
+
+      // then
+      expect(colorB).to.equal(colorA);
+    });
+
+  });
+
 });
 
 const DEFAULT_ITEMS = [

--- a/client/src/plugins/process-applications/__tests__/ProcessApplicationsStatusBarSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ProcessApplicationsStatusBarSpec.js
@@ -37,6 +37,38 @@ describe('<ProcessApplicationsStatusBar>', function() {
     });
 
 
+    it('should color button in process application color', function() {
+
+      // when
+      createProcessApplicationsStatusBar({
+        processApplicationColor: 'rgb(30, 136, 229)'
+      });
+
+      // then
+      const button = screen.getByRole('button');
+
+      expect(button.style.getPropertyValue('--process-application-color')).to.eql('rgb(30, 136, 229)');
+    });
+
+
+    it('should color overlay in process application color', function() {
+
+      // given
+      createProcessApplicationsStatusBar({
+        processApplicationColor: 'rgb(30, 136, 229)'
+      });
+
+      // when
+      fireEvent.click(screen.getByRole('button'));
+
+      // then
+      const colorStrip = screen.getByRole('dialog').querySelector('.overlay__color');
+
+      expect(colorStrip).to.exist;
+      expect(colorStrip.style.backgroundColor).to.eql('rgb(30, 136, 229)');
+    });
+
+
     it('should open overlay on click', function() {
 
       // given

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.js
@@ -62,6 +62,7 @@ export default function DeploymentPluginOverlay(props) {
     _getFromApp,
     activeTab,
     anchor,
+    color,
     connectionCheckResult,
     deployment,
     displayNotification,
@@ -172,7 +173,7 @@ export default function DeploymentPluginOverlay(props) {
   }, [ deployment, triggerAction ]);
 
   return (
-    <Overlay className={ css.DeploymentPluginOverlay } onClose={ onClose } anchor={ anchor }>
+    <Overlay className={ css.DeploymentPluginOverlay } color={ color } onClose={ onClose } anchor={ anchor }>
       <DeploymentConfigForm
         onSubmit={ onSubmit }
         renderDescription={ renderDescription }

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePluginOverlay.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePluginOverlay.js
@@ -45,6 +45,7 @@ export default function StartInstancePluginOverlay(props) {
     _getFromApp,
     activeTab,
     anchor,
+    color,
     deployment,
     displayNotification,
     getConfigFile = defaultGetConfigFile,
@@ -223,7 +224,7 @@ export default function StartInstancePluginOverlay(props) {
   }, [ deployment, triggerAction ]);
 
   return (
-    <Overlay className={ css.StartInstancePluginOverlay } onClose={ onClose } anchor={ anchor }>
+    <Overlay className={ css.StartInstancePluginOverlay } color={ color } onClose={ onClose } anchor={ anchor }>
       {startInstanceConfig ? (
         <StartInstanceConfigForm
           getFieldError={ getStartInstanceFieldError }

--- a/client/src/shared/ui/__tests__/OverlaySpec.js
+++ b/client/src/shared/ui/__tests__/OverlaySpec.js
@@ -98,6 +98,29 @@ describe('<Overlay>', function() {
       // then
       expect(overlay.id).to.eql('');
     });
+
+
+    it('should render color strip if color provided', function() {
+
+      // when
+      const { overlay } = renderOverlay({ color: 'rgb(30, 136, 229)' });
+
+      // then
+      const colorStrip = overlay.querySelector('.overlay__color');
+
+      expect(colorStrip).to.exist;
+      expect(colorStrip.style.backgroundColor).to.eql('rgb(30, 136, 229)');
+    });
+
+
+    it('should NOT render color strip if no color provided', function() {
+
+      // when
+      const { overlay } = renderOverlay();
+
+      // then
+      expect(overlay.querySelector('.overlay__color')).not.to.exist;
+    });
   });
 
 

--- a/client/src/shared/ui/overlay/Overlay.css
+++ b/client/src/shared/ui/overlay/Overlay.css
@@ -32,6 +32,14 @@
   min-width: var(--overlay-min-width);
   overflow-y: auto;
 
+  .overlay__color {
+    position: sticky;
+    top: 0;
+    flex: none;
+    height: 3px;
+    z-index: 1;
+  }
+
   h1, h2, h3, h4 {
     font-weight: 500;
     font-size: inherit;

--- a/client/src/shared/ui/overlay/Overlay.js
+++ b/client/src/shared/ui/overlay/Overlay.js
@@ -39,6 +39,7 @@ const DEFAULT_OFFSET = {
  * @prop {string | number} [minHeight]
  * @prop {string | number} [minWidth]
  * @prop {string} [className]
+ * @prop {string} [color] accent color rendered as a strip on top of the overlay
  * @prop {function} [onClose]
  * @prop {boolean} [enableFocusTrap=true] evaluated once at mount time
  * @prop {boolean} [enableEscapeTrap=true] evaluated once at mount time
@@ -179,6 +180,7 @@ export class Overlay extends PureComponent {
       anchor,
       className,
       children,
+      color,
       id,
       enableKeyboardTrap = true
     } = this.props;
@@ -199,6 +201,9 @@ export class Overlay extends PureComponent {
           className={ classNames(css.Overlay, className) } style={ style } { ...optionalId }
           ref={ this.overlayRef } role="dialog"
         >
+          {
+            color && <div className="overlay__color" style={ { backgroundColor: color } } />
+          }
           { children }
         </div>
       </Wrapper>,


### PR DESCRIPTION
### Proposed Changes

Closes #4930

With more than one open process application there was very little visual distinction between them — only the tab bottom border was colored, and overlays had no distinction at all.

This introduces **consistent color coding**: each process application gets a stable, distinct color that is used everywhere it appears.

- **Tab color strip moved to the top** of diagram/tool tabs (was at the bottom).
- **Process application status bar button** is colored in the process application color for the currently selected file, providing the link between tab and tool.
- **A matching color strip is rendered on top of every process application overlay** — the status bar overlay, the deployment overlay and the start instance overlay.


https://github.com/user-attachments/assets/88b13557-0c77-4a39-8664-4037cd221d4a


The color is assigned once per process application and reused everywhere (single source of truth in `ProcessApplications#getColor`), so tabs and overlays always match. Colors of closed process applications are freed and reused.

Implemented as a reusable, optional `color` prop on the shared `Overlay` component so overlays outside the process application context are unaffected.

### Steps to try out

1. Open two (or more) process applications with files from each.
2. Notice the distinct color strip on top of the tabs of each process application.
3. Select a file and open the process application / deploy / start instance overlays — each shows a matching color strip on top; the status bar process application button is colored to match.

### Checklist

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__ — Closes #4930
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__