### PR TITLE
feat(menu): add copy file path to tab context menu

### DIFF
--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -101,7 +101,8 @@ class MenuBuilder {
     if (this.options.type === 'tab') {
       return this.appendContextCloseTab()
         .appendSeparator()
-        .appendContextRevealInFileExplorerTab();
+        .appendContextRevealInFileExplorerTab()
+        .appendContextCopyFilePathTab();
     }
 
     if (contextMenu) {
@@ -741,6 +742,26 @@ class MenuBuilder {
       enabled: !!filePath,
       click: function() {
         app.emit('menu:action', 'reveal-in-file-explorer', {
+          filePath
+        });
+      }
+    }));
+
+    return this;
+  }
+
+  appendContextCopyFilePathTab() {
+    const attrs = this.options.attrs,
+          tabs = this.options.state.tabs,
+          tabId = attrs.tabId;
+
+    const filePath = tabs.find(t => t.id === tabId).file.path;
+
+    this.menu.append(new MenuItem({
+      label: 'Copy File Path',
+      enabled: !!filePath,
+      click: function() {
+        app.emit('menu:action', 'copy-file-path', {
           filePath
         });
       }

--- a/app/lib/menu/menu-builder.js
+++ b/app/lib/menu/menu-builder.js
@@ -755,7 +755,7 @@ class MenuBuilder {
           tabs = this.options.state.tabs,
           tabId = attrs.tabId;
 
-    const filePath = tabs.find(t => t.id === tabId).file.path;
+    const filePath = tabs.find(t => t.id === tabId)?.file?.path;
 
     this.menu.append(new MenuItem({
       label: 'Copy File Path',

--- a/app/test/spec/menu/menu-builder-spec.js
+++ b/app/test/spec/menu/menu-builder-spec.js
@@ -72,7 +72,8 @@ describe('MenuBuilder', function() {
       'Close All Tabs',
       'Close Other Tabs',
       undefined,
-      'Reveal in File Explorer'
+      'Reveal in File Explorer',
+      'Copy File Path'
     ]);
   });
 

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1405,7 +1405,8 @@ export class App extends PureComponent {
 
     if (
       tabState !== prevState.tabState ||
-      recentTabs !== prevState.recentTabs
+      recentTabs !== prevState.recentTabs ||
+      tabs !== prevState.tabs
     ) {
       this.updateMenu(tabState);
     }

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -2014,6 +2014,10 @@ export class App extends PureComponent {
     return this.getGlobal('dialog').showFileExplorerDialog({ path: filePath });
   };
 
+  copyFilePath = (filePath) => {
+    return this.getGlobal('systemClipboard').writeText({ text: filePath });
+  };
+
   reopenLastTab = () => {
 
     const lastTab = this.closedTabs.pop();
@@ -2300,6 +2304,10 @@ export class App extends PureComponent {
 
     if (action === 'reveal-in-file-explorer') {
       return this.revealInFileExplorer(options.filePath);
+    }
+
+    if (action === 'copy-file-path') {
+      return this.copyFilePath(options.filePath);
     }
 
     if (action === 'show-shortcuts') {

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -4184,6 +4184,33 @@ describe('<App>', function() {
   });
 
 
+  describe('#copyFilePath', function() {
+
+    it('should call systemClipboard#writeText', async function() {
+
+      // given
+      const systemClipboard = new SystemClipboard();
+
+      const writeTextSpy = sinon.spy(systemClipboard, 'writeText');
+
+      const { app } = createApp({
+        globals: {
+          systemClipboard
+        }
+      });
+
+      const [ tab ] = await app.openFiles([ createFile('1.bpmn') ]);
+
+      // when
+      app.copyFilePath(tab.file.path);
+
+      // then
+      expect(writeTextSpy).to.have.been.calledOnceWith({ text: tab.file.path });
+    });
+
+  });
+
+
   describe('linting', function() {
 
     it('should lint tab (no errors)', async function() {

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -144,6 +144,32 @@ describe('<App>', function() {
         expect(updateMenuSpy).to.have.been.called;
       });
 
+
+      it('on tab file path change (e.g. save as)', async function() {
+
+        // given
+        const updateMenuSpy = spy();
+
+        const { app } = createApp({
+          onMenuUpdate: updateMenuSpy
+        });
+
+        const [ tab ] = await app.openFiles([ createFile('1.bpmn') ]);
+
+        updateMenuSpy.resetHistory();
+
+        // when
+        // simulate saving the tab to a different location
+        app.tabSaved(tab, createFile('1.bpmn', { path: '/other/folder/1.bpmn' }));
+
+        // then
+        await waitFor(() => {
+          expect(updateMenuSpy).to.have.been.calledWith(sinon.match({
+            tabs: app.state.tabs
+          }));
+        });
+      });
+
     });
 
 


### PR DESCRIPTION
### Proposed Changes

Adds a **Copy File Path** entry to the diagram tab context menu, directly below **Reveal in File Explorer**. Selecting it copies the tab's file path to the system clipboard. The item is disabled for unsaved diagrams (no file path yet), mirroring the enable/disable behavior of _Reveal in File Explorer_:

<img width="1324" height="861" alt="capture iwX3NZ_optimized" src="https://github.com/user-attachments/assets/5ef95f26-9b1a-4150-830c-0601194b324d" />

Implementation follows the existing conventions:
- `menu-builder.js` (main process) appends the item and emits a `copy-file-path` `menu:action` — consistent with how its sibling _Reveal in File Explorer_ is wired.
- `App.triggerAction` handles the action via a new `copyFilePath` method, which writes to the clipboard through the existing `systemClipboard` global (`system-clipboard:write-text`) — the same clipboard plumbing used by _Copy System Info_.

**Steps to try out**
1. Open a saved diagram.
2. Right-click its tab.
3. Click _Copy File Path_ and paste — the absolute file path is on the clipboard.
4. For an unsaved diagram, the entry is disabled.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)