### PR TITLE
fix(client): ignore window focus/blur caused by app dialogs

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -191,9 +191,24 @@ export class App extends PureComponent {
       this.resizeTab = debounce(this.resizeTab, 50);
     }
 
-    this.on('app.blurred', this.triggerAutoSave);
+    // window focus / blur drive auto-save and external-change detection. A
+    // modal dialog the app itself opened blurs the window while it is up and
+    // re-focuses it once dismissed. That focus / blur must NOT be treated as
+    // the user leaving or returning to the app from the outside, so we ignore
+    // it while one of our dialogs is open.
+    this.on('app.blurred', () => {
+      if (this.isDialogOpen()) {
+        return;
+      }
+
+      this.triggerAutoSave();
+    });
 
     this.on('app.focused', () => {
+      if (this.isDialogOpen()) {
+        return;
+      }
+
       this.triggerAction('check-file-changed');
     });
 
@@ -515,29 +530,20 @@ export class App extends PureComponent {
 
     const { name } = file;
 
-    try {
+    // auto-save is suppressed while the close dialog is open (cf.
+    // #isDialogOpen), so it can not interfere with the user's save decision
+    if (this.isDirty(tab)) {
+      const { button } = await this.showCloseFileDialog({ name });
 
-      // disable auto-save during <save-all> to prevent
-      // interferring with user save decisions
-      this.off('app.blurred', this.triggerAutoSave);
+      if (button === 'save') {
+        const saved = await this.saveTab(tab);
 
-      if (this.isDirty(tab)) {
-        const { button } = await this.showCloseFileDialog({ name });
-
-        if (button === 'save') {
-          const saved = await this.saveTab(tab);
-
-          if (!saved) {
-            return false;
-          }
-        } else if (button === 'cancel') {
+        if (!saved) {
           return false;
         }
+      } else if (button === 'cancel') {
+        return false;
       }
-    } finally {
-
-      // restore auto-save
-      this.on('app.blurred', this.triggerAutoSave);
     }
 
     return true;
@@ -757,6 +763,20 @@ export class App extends PureComponent {
 
     await this.openFiles(files);
   };
+
+  /**
+   * Whether a modal dialog opened by the application is currently visible.
+   *
+   * While a dialog is open the window focus / blur it causes must not be
+   * treated as the user leaving or returning to the app from the outside.
+   *
+   * @returns {boolean}
+   */
+  isDialogOpen() {
+    const dialog = this.getGlobal('dialog');
+
+    return Boolean(dialog.isDialogOpen && dialog.isDialogOpen());
+  }
 
   showCloseFileDialog = (file) => {
     const { name } = file;

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -1564,6 +1564,27 @@ describe('<App>', function() {
     });
 
 
+    it('should NOT auto-save on window blur while a dialog is open', async function() {
+
+      // given
+      const file = createFile('diagram_1.bpmn');
+      const [ tab ] = await app.openFiles([ file ]);
+
+      // mark as dirty
+      app.setState(app.setDirty(tab));
+      await waitFor(() => expect(app.isDirty(tab)).to.be.true);
+
+      // a dialog opened by the app is blurring the window
+      dialog.isDialogOpen = () => true;
+
+      // when
+      await app.triggerAction('window-blurred');
+
+      // then
+      expect(writeFileSpy).not.to.have.been.called;
+    });
+
+
     it('should show notification on auto-save error', async function() {
 
       // given
@@ -3210,6 +3231,49 @@ describe('<App>', function() {
 
       // then
       expect(checkFileChangedSpy).to.have.been.calledOnce;
+    });
+
+
+    it('should check for changes on window focus', async function() {
+
+      // given
+      const { app } = createApp({
+        globals: { fileSystem }
+      });
+
+      await app.openFiles([ file1 ]);
+
+      const checkFileChangedSpy = spy(app, 'checkFileChanged');
+
+      // when
+      await app.triggerAction('window-focused');
+
+      // then
+      expect(checkFileChangedSpy).to.have.been.called;
+    });
+
+
+    it('should NOT check for changes on window focus while a dialog is open', async function() {
+
+      // given
+      const dialog = new Dialog();
+
+      const { app } = createApp({
+        globals: { dialog, fileSystem }
+      });
+
+      await app.openFiles([ file1 ]);
+
+      const checkFileChangedSpy = spy(app, 'checkFileChanged');
+
+      // a dialog opened by the app is (re-)focusing the window
+      dialog.isDialogOpen = () => true;
+
+      // when
+      await app.triggerAction('window-focused');
+
+      // then
+      expect(checkFileChangedSpy).to.not.have.been.called;
     });
 
   });

--- a/client/src/app/__tests__/mocks/index.js
+++ b/client/src/app/__tests__/mocks/index.js
@@ -366,6 +366,20 @@ export class Dialog extends Mock {
     this.showEmptyFileDialogResponse = new Response();
     this.showFileExplorerDialogResponse = new Response();
     this.showReloadModelerDialogResponse = new Response();
+
+    this._openDialogs = 0;
+  }
+
+  isDialogOpen() {
+    return this._openDialogs > 0;
+  }
+
+  _track(result) {
+    this._openDialogs++;
+
+    return Promise.resolve(result).finally(() => {
+      this._openDialogs--;
+    });
   }
 
   setShowOpenFilesDialogResponse(index, response) {
@@ -401,39 +415,39 @@ export class Dialog extends Mock {
   }
 
   showOpenFilesDialog() {
-    return this.showOpenFilesDialogResponse.next();
+    return this._track(this.showOpenFilesDialogResponse.next());
   }
 
   showOpenFileErrorDialog() {
-    return this.showOpenFileErrorDialogResponse.next();
+    return this._track(this.showOpenFileErrorDialogResponse.next());
   }
 
   showSaveFileDialog() {
-    return this.showSaveFileDialogResponse.next();
+    return this._track(this.showSaveFileDialogResponse.next());
   }
 
   showSaveFileErrorDialog() {
-    return this.showSaveFileErrorDialogResponse.next();
+    return this._track(this.showSaveFileErrorDialogResponse.next());
   }
 
   show() {
-    return this.showResponse.next();
+    return this._track(this.showResponse.next());
   }
 
   showCloseFileDialog() {
-    return this.showCloseFileDialogResponse.next();
+    return this._track(this.showCloseFileDialogResponse.next());
   }
 
   showEmptyFileDialog() {
-    return this.showEmptyFileDialogResponse.next();
+    return this._track(this.showEmptyFileDialogResponse.next());
   }
 
   showFileExplorerDialog() {
-    return this.showFileExplorerDialogResponse.next();
+    return this._track(this.showFileExplorerDialogResponse.next());
   }
 
   showReloadDialog() {
-    return this.showReloadModelerDialogResponse.next();
+    return this._track(this.showReloadModelerDialogResponse.next());
   }
 
 }

--- a/client/src/remote/Dialog.js
+++ b/client/src/remote/Dialog.js
@@ -14,6 +14,39 @@ export default class Dialog {
 
   constructor(backend) {
     this.backend = backend;
+
+    this._openDialogs = 0;
+  }
+
+  /**
+   * Whether a modal dialog opened by the application is currently visible.
+   *
+   * Used to tell an application-triggered window focus / blur (a dialog we
+   * opened grabbing or releasing focus) apart from the user actually leaving
+   * or returning to the app from the outside.
+   *
+   * @returns {boolean}
+   */
+  isDialogOpen() {
+    return this._openDialogs > 0;
+  }
+
+  /**
+   * Send a dialog request to the backend while tracking it as an open modal
+   * dialog, so window focus / blur it causes is not mistaken for the user
+   * switching away from or back to the application.
+   *
+   * @param {string} channel
+   * @param {Object} [options]
+   *
+   * @returns {Promise}
+   */
+  _send(channel, options) {
+    this._openDialogs++;
+
+    return Promise.resolve(this.backend.send(channel, options)).finally(() => {
+      this._openDialogs--;
+    });
   }
 
   /**
@@ -27,7 +60,7 @@ export default class Dialog {
    * @returns {Promise}
    */
   showOpenFilesDialog(options) {
-    return this.backend.send('dialog:open-files', options);
+    return this._send('dialog:open-files', options);
   }
 
   /**
@@ -41,7 +74,7 @@ export default class Dialog {
    * @return {Promise}
    */
   showOpenFileErrorDialog = async (options) => {
-    return this.backend.send('dialog:open-file-error', options);
+    return this._send('dialog:open-file-error', options);
   };
 
   /**
@@ -55,7 +88,7 @@ export default class Dialog {
    * @returns {Promise}
    */
   showSaveFileDialog(options) {
-    return this.backend.send('dialog:save-file', options);
+    return this._send('dialog:save-file', options);
   }
 
   /**
@@ -67,7 +100,7 @@ export default class Dialog {
    * @returns {Promise}
    */
   showFileExplorerDialog(options) {
-    return this.backend.send('dialog:open-file-explorer', options);
+    return this._send('dialog:open-file-explorer', options);
   }
 
   /**
@@ -97,7 +130,7 @@ export default class Dialog {
    * @returns {Promise}
    */
   show(options) {
-    return this.backend.send('dialog:show', options);
+    return this._send('dialog:show', options);
   }
 
   /**

--- a/client/src/remote/Dialog.js
+++ b/client/src/remote/Dialog.js
@@ -44,9 +44,14 @@ export default class Dialog {
   _send(channel, options) {
     this._openDialogs++;
 
-    return Promise.resolve(this.backend.send(channel, options)).finally(() => {
-      this._openDialogs--;
-    });
+    // defer the send into the promise chain so a synchronous throw (e.g. a
+    // disallowed backend event) still settles through `finally` and never
+    // leaves the counter stuck, permanently suppressing focus / blur handling
+    return Promise.resolve()
+      .then(() => this.backend.send(channel, options))
+      .finally(() => {
+        this._openDialogs--;
+      });
   }
 
   /**

--- a/client/src/remote/__tests__/DialogSpec.js
+++ b/client/src/remote/__tests__/DialogSpec.js
@@ -308,4 +308,66 @@ describe('dialog', function() {
     dialog.showEmptyFileDialog();
 
   });
+
+
+  describe('#isDialogOpen', function() {
+
+    it('should report a dialog as open while the backend send is pending', async function() {
+
+      // given
+      let resolveSend;
+
+      const backend = new Backend({
+        send: () => new Promise(resolve => {
+          resolveSend = resolve;
+        })
+      });
+
+      const dialog = new Dialog(backend);
+
+      // when
+      const result = dialog.show({});
+
+      // then
+      expect(dialog.isDialogOpen()).to.be.true;
+
+      // when
+      // flush the microtask that defers the backend send, so `resolveSend`
+      // is assigned, then settle it
+      await Promise.resolve();
+
+      resolveSend({});
+
+      await result;
+
+      // then
+      expect(dialog.isDialogOpen()).to.be.false;
+    });
+
+
+    it('should not leave a dialog open if the backend throws synchronously', async function() {
+
+      // given
+      const backend = new Backend({
+        send: () => {
+          throw new Error('Disallowed event');
+        }
+      });
+
+      const dialog = new Dialog(backend);
+
+      // when
+      try {
+        await dialog.show({});
+      } catch (err) {
+
+        // expected
+      }
+
+      // then
+      expect(dialog.isDialogOpen()).to.be.false;
+    });
+
+  });
+
 });

--- a/test/e2e/specs/external-change.spec.js
+++ b/test/e2e/specs/external-change.spec.js
@@ -140,4 +140,71 @@ test.describe('external change detection', function() {
     await expect(app.page.locator('.tab--active.tab--dirty')).toHaveCount(0);
   });
 
+
+  test('should not treat window focus caused by an app dialog as an external change', async function({ launch, tmp }) {
+
+    // given an open diagram with unsaved changes
+    const file = await copyFixture('simple.bpmn', tmp);
+
+    const app = await launch({ openFile: file });
+
+    const editor = new Modeler(app).bpmnEditor;
+
+    await editor.canvas().waitFor();
+
+    await editor.setName('Task_0zlv465', 'local edit');
+
+    await expect(app.page.locator('.tab--active.tab--dirty')).toHaveCount(1);
+
+    // and the file has meanwhile changed on disk
+    const xml = await readFile(file);
+
+    await fs.writeFile(file, xml.replace('name="foo"', 'name="external edit"'));
+
+    // and the "close file" dialog answers "Don't Save", but — like a real native
+    // modal — first refocuses the window while it is still open. Record every
+    // message box so we can assert the refocus did not surface a reload prompt.
+    await app.electronApp.evaluate(async ({ app: electronApp, dialog }) => {
+      const calls = globalThis.__cmDialogCalls = [];
+
+      dialog.showMessageBox = async (...args) => {
+        const options = args[args.length - 1] || {};
+
+        calls.push({ message: options.message, title: options.title });
+
+        const buttons = options.buttons || [];
+
+        // the close dialog is modal to the window: as it is dismissed the
+        // window regains focus *before* the dialog result is delivered. Emit
+        // that focus now, while the dialog is still open, to reproduce the race.
+        if (/before closing/.test(options.message || '')) {
+          electronApp.emit('menu:action', 'window-focused');
+
+          await new Promise(resolve => setTimeout(resolve, 750));
+
+          const discard = buttons.findIndex(label => /Don't Save/.test(label));
+
+          return { response: discard === -1 ? 1 : discard };
+        }
+
+        // any external-change prompt: keep local changes (do not reload)
+        const cancel = buttons.findIndex(label => /Cancel/.test(label));
+
+        return { response: cancel === -1 ? 1 : cancel };
+      };
+    });
+
+    // when the dirty tab is closed
+    await app.shortcut('CommandOrControl+W');
+
+    // then the tab closes ...
+    await expect(app.page.locator('.tab[data-tab-id]')).toHaveCount(0);
+
+    // ... and the window focus caused by our own close dialog did not trigger
+    // an external-change reload prompt
+    const calls = await app.dialogCalls();
+
+    expect(calls.some(call => /changed externally/.test(call.message || ''))).toBe(false);
+  });
+
 });


### PR DESCRIPTION
### Proposed Changes

A modal dialog the application itself opens (close-file, save-as, reload, plugin dialogs, …) blurs the window while it is up and re-focuses it once dismissed. Today that focus/blur is treated exactly like the user leaving and returning to the app _from the outside_, which spuriously triggers:

- **auto-save** on the (dialog-induced) blur, and
- **external-file-change detection** on the (dialog-induced) focus.

The most visible symptom: closing a tab that has unsaved changes pops the "Save changes before closing?" dialog, and dismissing it re-focuses the window — which then surfaces a bogus **"The file has been changed externally"** reload prompt on top of the close flow.

**Fix.** Track open modal dialogs at their single chokepoint — the remote `Dialog` wrapper, through which every native dialog is sent — and expose `isDialogOpen()`. The `app.focused` / `app.blurred` handlers now bail out while a dialog is open, so the focus/blur our _own_ dialogs cause is no longer mistaken for the user switching away or back.

This generalises and replaces the ad-hoc auto-save toggle that was previously scoped to `saveBeforeClose` only.

**Why it is race-free.** In the main process the window `focus` event (and the `client:window-focused` message) is emitted _as the dialog is dismissed_ — before `dialog.showMessageBox`'s promise resolves and the `dialog:show` response returns. So the renderer processes `app.focused` while the dialog counter is still > 0, on every platform, without timers.

- `client/src/remote/Dialog.js` — add open-dialog tracking (`_send`, `isDialogOpen()`); route all native senders through it.
- `client/src/app/App.js` — guard `app.focused` / `app.blurred` with `isDialogOpen()`; drop the `saveBeforeClose` toggle it subsumes.
- Tests: unit coverage for focus/blur-while-a-dialog-is-open + an e2e test that injects the focus a native close dialog causes and asserts no external-change prompt appears (verified it fails without the guard).

### Steps to try out

1. Open a BPMN diagram.
2. Make an edit so the tab is dirty (do not save).
3. Change the same file on disk with another program.
4. Close the tab (`Ctrl+W`) and pick **Don't Save** on the close prompt.
5. **Before:** a spurious "file changed externally" reload dialog appears during the close. **After:** the tab closes cleanly with no reload prompt.

### Notes

- Split off from #6034 as an independent concern; it also removes the spurious reload-on-close prompt reported alongside that work.
- Related to #5995

### Checklist

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes — n/a (removes an erroneous dialog; no new UI)
  * [x] __Steps to try out__
