### PR TITLE
fix(process-applications): guard resources.reload against stale active tab

### DIFF
--- a/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
@@ -175,7 +175,7 @@ export default function ProcessApplicationsPlugin(props) {
     if (activeTabRef.current?.type === 'cloud-bpmn') {
       triggerAction('resources.reload');
     }
-  }, [ activeTab, processApplicationItems, triggerAction ]);
+  }, [ activeTab, processApplicationItems, triggerAction, _getFromApp ]);
 
   useEffect(() => {
     const tabGroups = tabs.reduce((tabGroups, tab) => {

--- a/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
@@ -8,7 +8,7 @@
  * except in compliance with the MIT License.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import ProcessApplications from './ProcessApplications';
 import ProcessApplicationsStatusBar from './ProcessApplicationsStatusBar';
@@ -42,10 +42,15 @@ export default function ProcessApplicationsPlugin(props) {
   const [ processApplication, setProcessApplication ] = useState(null);
   const [ processApplicationItems, setProcessApplicationItems ] = useState([]);
 
+  // active tab mirrored synchronously from `app.activeTabChanged`.
+  const activeTabRef = useRef(null);
+
   const connectionCheckResult = useConnectionStatus(subscribe);
 
   useEffect(() => {
     const subscription = subscribe('app.activeTabChanged', (event) => {
+      activeTabRef.current = event.activeTab;
+
       setActiveTab(event.activeTab);
 
       processApplications.emit('activeTab-changed', event.activeTab);
@@ -165,7 +170,9 @@ export default function ProcessApplicationsPlugin(props) {
   }, [ subscribe ]);
 
   useEffect(() => {
-    if (activeTab?.type === 'cloud-bpmn') {
+
+    // only emit on cloud-bpmn tabs
+    if (activeTabRef.current?.type === 'cloud-bpmn') {
       triggerAction('resources.reload');
     }
   }, [ activeTab, processApplicationItems, triggerAction ]);

--- a/client/src/plugins/process-applications/__tests__/ProcessApplicationsPluginSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ProcessApplicationsPluginSpec.js
@@ -1,0 +1,142 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import React from 'react';
+
+import { act, render, waitFor } from '@testing-library/react';
+
+import ProcessApplicationsPlugin from '../ProcessApplicationsPlugin';
+
+import { Slot, SlotFillRoot } from '../../../app/slot-fill';
+
+import { Deployment, ZeebeAPI } from '../../../app/__tests__/mocks';
+
+const CLOUD_TAB = { id: 'cloud', type: 'cloud-bpmn', file: {} };
+const PLATFORM_TAB = { id: 'platform', type: 'bpmn', file: {} };
+
+
+describe('<ProcessApplicationsPlugin>', function() {
+
+  describe('resources.reload dispatch', function() {
+
+    it('should reload when the active tab is a cloud-bpmn editor', async function() {
+
+      // given
+      const triggerAction = sinon.spy();
+
+      const { emit } = createProcessApplicationsPlugin({ triggerAction });
+
+      // when
+      act(() => emit('app.activeTabChanged', { activeTab: CLOUD_TAB }));
+
+      // then
+      await waitFor(() => {
+        expect(triggerAction).to.have.been.calledWith('resources.reload');
+      });
+    });
+
+
+    it('should NOT reload when the active tab is not a cloud-bpmn editor', async function() {
+
+      // given
+      const triggerAction = sinon.spy();
+
+      const { emit } = createProcessApplicationsPlugin({ triggerAction });
+
+      // when
+      act(() => emit('app.activeTabChanged', { activeTab: PLATFORM_TAB }));
+
+      // then
+      await wait();
+
+      expect(triggerAction).not.to.have.been.calledWith('resources.reload');
+    });
+  });
+});
+
+
+// helpers //////////
+
+function wait(ms = 10) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function createProcessApplicationsPlugin(props = {}) {
+  const {
+    triggerAction = () => {},
+    displayNotification = () => {},
+    log = () => {}
+  } = props;
+
+  const subscribers = {};
+
+  const subscribe = (event, callback) => {
+    subscribers[ event ] = subscribers[ event ] || [];
+    subscribers[ event ].push(callback);
+
+    return {
+      cancel() {
+        subscribers[ event ] = subscribers[ event ].filter(cb => cb !== callback);
+      }
+    };
+  };
+
+  const emit = (event, payload) => {
+    (subscribers[ event ] || []).forEach(cb => cb(payload));
+  };
+
+  const _getGlobal = (name) => {
+    if (name === 'backend') {
+      return {
+        on() {
+          return { cancel() {} };
+        },
+        send() {}
+      };
+    } else if (name === 'deployment') {
+      return new Deployment({
+        async getConnectionForTab() {
+          return {};
+        },
+        registerResourcesProvider() {},
+        unregisterResourcesProvider() {}
+      });
+    } else if (name === 'zeebeAPI') {
+      return new ZeebeAPI();
+    } else if (name === 'startInstance') {
+      return {};
+    }
+  };
+
+  const _getFromApp = (prop) => {
+    if (prop === 'props') {
+      return { tabsProvider: {} };
+    }
+  };
+
+  const result = render(<SlotFillRoot>
+    <Slot name="status-bar__file" />
+    <ProcessApplicationsPlugin
+      _getFromApp={ _getFromApp }
+      _getGlobal={ _getGlobal }
+      displayNotification={ displayNotification }
+      log={ log }
+      subscribe={ subscribe }
+      triggerAction={ triggerAction } />
+  </SlotFillRoot>);
+
+  return {
+    ...result,
+    emit
+  };
+}

--- a/client/src/plugins/process-applications/__tests__/ProcessApplicationsPluginSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ProcessApplicationsPluginSpec.js
@@ -57,7 +57,7 @@ describe('<ProcessApplicationsPlugin>', function() {
       act(() => emit('app.activeTabChanged', { activeTab: PLATFORM_TAB }));
 
       // then
-      await wait();
+      await act(async () => {});
 
       expect(triggerAction).not.to.have.been.calledWith('resources.reload');
     });
@@ -66,10 +66,6 @@ describe('<ProcessApplicationsPlugin>', function() {
 
 
 // helpers //////////
-
-function wait(ms = 10) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
 
 function createProcessApplicationsPlugin(props = {}) {
   const {


### PR DESCRIPTION
### Proposed Changes

Fixes the `resources.reload is not a registered action` error that is logged when the process-applications reload effect dispatches `resources.reload` to a platform (non-cloud) BPMN editor.

**Root cause.** The reload effect in `ProcessApplicationsPlugin` guarded on the plugin's local `activeTab` state:

```js
useEffect(() => {
  if (activeTab?.type === 'cloud-bpmn') {
    triggerAction('resources.reload');
  }
}, [ activeTab, processApplicationItems, triggerAction ]);
```

That local state lags behind the actual active editor — it is updated asynchronously through the `app.activeTabChanged` subscription. `triggerAction` always dispatches to the *currently* active editor. So when `processApplicationItems` change right as the user switches away from a cloud-bpmn tab, the effect re-runs with a stale `activeTab === cloud-bpmn`, the guard passes, and `resources.reload` reaches the now-active platform BPMN editor. Only the cloud-bpmn editor registers `resources.reload` (via `ResourcesProviderModule`), so diagram-js `EditorActions` throws _"resources.reload is not a registered action"_ (caught and logged, not crashing).

**Fix.** Mirror the active tab into a `ref`, updated **synchronously** from the same `app.activeTabChanged` subscription, and guard the reload on that ref. The ref always reflects the freshest active tab, so the guard stays in sync with the editor `triggerAction` actually targets. The `activeTab` state is kept as the reactive value that drives rendering (child plugin props, create-application dialog) and as an effect re-run trigger — only the *decision* value moves to the ref.

This is the standard React idiom for "read the latest value inside an effect without making it a reactive dependency" — the plugin keeps deciding off its own event stream rather than reaching into App internals.

Closes https://github.com/camunda/camunda-modeler/issues/6061

### Steps to try out

1. Open a process application (cloud-bpmn) tab and a platform BPMN tab.
2. Switch from the cloud-bpmn tab to the platform tab while a `file-context:changed` update lands (e.g. an external change to a process-application resource).
3. Before: the dev console logs `resources.reload is not a registered action`. After: no error; reload is only dispatched while a cloud-bpmn editor is active.

### Checklist

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes — n/a (removes an erroneous console error; no UI change)
  * [x] __Steps to try out__