### PR TITLE
feat(element-templates): do not report `engine` incompatible template validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ___Note:__ Yet to be released changes appear here._
 ### General
 
 * `FEAT`: list all application shortcuts in the 'Keyboard Shortcuts' modal ([#6050](https://github.com/camunda/camunda-modeler/pull/6050))
+* `FIX`: suppress errors for invalid, `template#engine` incompatible element templates ([#6071](https://github.com/camunda/camunda-modeler/issues/6071), [#6072](https://github.com/camunda/camunda-modeler/pull/6072), [bpmn-io/bpmn-js-element-templates#273](https://github.com/bpmn-io/bpmn-js-element-templates/pull/273))
 * `FIX`: correct discarting unsaved changes on fast tab switches ([#6063](https://github.com/camunda/camunda-modeler/issues/6063), [#6064](https://github.com/camunda/camunda-modeler/issues/6064))
 * `FIX`: reload auto-saved diagrams when they changed externally ([#5995](https://github.com/camunda/camunda-modeler/issues/5995))
 * `FIX`: do not treat application dialogs as window focus changes, avoiding bogus external-change prompts ([#5995](https://github.com/camunda/camunda-modeler/issues/5995))

--- a/client/package.json
+++ b/client/package.json
@@ -37,7 +37,7 @@
     "@sentry/electron": "^7.15.0",
     "@uiw/codemirror-theme-vscode": "^4.23.12",
     "bpmn-js": "^18.22.1",
-    "bpmn-js-element-templates": "^2.28.0",
+    "bpmn-js-element-templates": "^2.30.0",
     "bpmn-js-properties-panel": "^5.62.0",
     "bpmn-js-tracking": "^0.6.0",
     "bpmn-moddle": "^10.1.0",

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -2158,6 +2158,23 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
       expect(warningSpy).to.have.been.calledWith({ message: error3.message });
     });
 
+
+    it('should NOT warn when there are no template errors', async function() {
+
+      // given
+      const warningSpy = spy();
+
+      const { instance } = await renderEditor(diagramXML, {
+        onWarning: warningSpy
+      });
+
+      // when
+      await instance.handleElementTemplateErrors({ errors: [] });
+
+      // then
+      expect(warningSpy).not.to.have.been.called;
+    });
+
   });
 
 

--- a/client/test/bpmn-io-modelers/bpmn/CloudBpmnModelerSpec.js
+++ b/client/test/bpmn-io-modelers/bpmn/CloudBpmnModelerSpec.js
@@ -9,6 +9,7 @@
  */
 
 import { expect } from 'chai';
+
 import TestContainer from 'mocha-test-container-support';
 
 import { waitFor } from '@testing-library/react';
@@ -174,6 +175,159 @@ describe('BpmnModeler', function() {
 
   });
 
+
+  describe('element templates - engine compatibility', function() {
+
+    // cf. https://docs.camunda.io/docs/components/modeler/element-templates/template-metadata/#engine-compatibility-engines
+    // and https://github.com/camunda/camunda-modeler/issues/6071
+
+    const SCHEMA = 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json';
+
+    // the desktop modeler advertises itself as `camundaDesktopModeler` (cf.
+    // BpmnEditor#createCachedState); `camunda` is intentionally not provided at
+    // load time (it is only added on engine-profile change)
+    const HOST_ENGINES = {
+      camundaDesktopModeler: '5.30.0'
+    };
+
+    // schema-VALID, no engines => compatible with any host
+    const VALID_COMPATIBLE = {
+      $schema: SCHEMA,
+      name: 'Valid Compatible',
+      id: 'valid.compatible',
+      appliesTo: [ 'bpmn:Task' ],
+      properties: [
+        {
+          label: 'Name',
+          type: 'String',
+          binding: {
+            type: 'property',
+            name: 'name'
+          }
+        }
+      ]
+    };
+
+    // schema-INVALID (`optional` not supported for property binding), compatible
+    const INVALID_COMPATIBLE = {
+      $schema: SCHEMA,
+      name: 'Invalid Compatible',
+      id: 'invalid.compatible',
+      appliesTo: [ 'bpmn:Task' ],
+      properties: [
+        {
+          type: 'String',
+          optional: true,
+          binding: {
+            type: 'property',
+            name: 'name'
+          }
+        }
+      ]
+    };
+
+    // schema-INVALID + INCOMPATIBLE: authored for a newer desktop modeler than
+    // the host provides (the #6071 scenario)
+    const INVALID_INCOMPATIBLE = {
+      ...INVALID_COMPATIBLE,
+      name: 'Invalid Incompatible',
+      id: 'invalid.incompatible',
+      engines: {
+        camundaDesktopModeler: '>=999.0.0'
+      }
+    };
+
+    // schema-VALID, declares only a `camunda` engine which the host does not
+    // provide at load => the engine key is ignored => compatible
+    const VALID_CAMUNDA_ONLY = {
+      $schema: SCHEMA,
+      name: 'Valid Camunda Only',
+      id: 'valid.camunda-only',
+      engines: {
+        camunda: '>=8.6'
+      },
+      appliesTo: [ 'bpmn:Task' ],
+      properties: []
+    };
+
+    async function loadTemplates(templates) {
+
+      // given
+      const modeler = await createModeler({
+        container: modelerContainer,
+        elementTemplates: { engines: HOST_ENGINES },
+        templates: []
+      });
+
+      const elementTemplates = modeler.get('elementTemplates'),
+            elementTemplatesLoader = modeler.get('elementTemplatesLoader'),
+            eventBus = modeler.get('eventBus');
+
+      let reportedErrors = null;
+
+      eventBus.on('elementTemplates.errors', (event) => {
+        reportedErrors = event.errors;
+      });
+
+      // when
+      elementTemplatesLoader.setTemplates(templates);
+
+      return { modeler, elementTemplates, reportedErrors };
+    }
+
+
+    it('should silently ignore an engine-incompatible template', async function() {
+
+      // when
+      const { elementTemplates, reportedErrors } = await loadTemplates([ INVALID_INCOMPATIBLE ]);
+
+      // then
+      expect(reportedErrors).to.be.null;
+
+      expect(elementTemplates.getAll()).to.be.empty;
+    });
+
+
+    it('should still report errors for an engine-compatible invalid template', async function() {
+
+      // when
+      const { elementTemplates, reportedErrors } = await loadTemplates([ INVALID_COMPATIBLE ]);
+
+      // then
+      expect(reportedErrors).not.to.be.empty;
+
+      expect(elementTemplates.getAll()).to.be.empty;
+    });
+
+
+    it('should load an engine-compatible valid template', async function() {
+
+      // when
+      const { elementTemplates, reportedErrors } = await loadTemplates([ VALID_COMPATIBLE ]);
+
+      // then
+      expect(reportedErrors).to.be.null;
+
+      const loaded = elementTemplates.getAll();
+
+      expect(loaded).to.have.length(1);
+      expect(loaded[0].id).to.eql('valid.compatible');
+    });
+
+
+    it('should treat a template with only a not-provided engine as compatible', async function() {
+
+      // when
+      const { elementTemplates, reportedErrors } = await loadTemplates([ VALID_CAMUNDA_ONLY ]);
+
+      // then
+      expect(reportedErrors).to.be.null;
+
+      expect(elementTemplates.get('valid.camunda-only')).to.exist;
+    });
+
+  });
+
 });
 
 // helpers //////////
@@ -184,14 +338,19 @@ describe('BpmnModeler', function() {
  * @param {Object} [options]
  */
 async function createModeler(options = {}) {
+  const {
+    templates = [ ELEMENT_TEMPLATE ],
+    ...modelerOptions
+  } = options;
+
   const modeler = new BpmnModeler({
     ...DEFAULT_OPTIONS,
-    ...options
+    ...modelerOptions
   });
 
   await modeler.importXML(diagramXML);
 
-  modeler.get('elementTemplatesLoader').setTemplates([ ELEMENT_TEMPLATE ]);
+  modeler.get('elementTemplatesLoader').setTemplates(templates);
 
   return modeler;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -190,7 +190,7 @@
         "@sentry/electron": "^7.15.0",
         "@uiw/codemirror-theme-vscode": "^4.23.12",
         "bpmn-js": "^18.22.1",
-        "bpmn-js-element-templates": "^2.28.0",
+        "bpmn-js-element-templates": "^2.30.0",
         "bpmn-js-properties-panel": "^5.62.0",
         "bpmn-js-tracking": "^0.6.0",
         "bpmn-moddle": "^10.1.0",
@@ -10719,13 +10719,14 @@
       }
     },
     "node_modules/bpmn-js-element-templates": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-2.28.0.tgz",
-      "integrity": "sha512-F/Kh8Uc1H2V2QUXSIgr45cXSjuxtIk1p06+cunr/T2Gh4dh5jkCd2lZpvwm8O4u6pEu3diqk51LStLlHmvYGOg==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-2.30.0.tgz",
+      "integrity": "sha512-vlVAndeyT7bSBzGKjvXQV8RvDHRr2cNmKPpAxtUnHe1f4G9TeHkIsie++G/mDXla0wmgjBEPJ1LWL1ACaEAHgA==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/element-templates-validator": "^2.25.0",
         "@bpmn-io/extract-process-variables": "^2.2.1",
+        "@bpmn-io/moddle-utils": "^0.3.0",
         "@bpmn-io/semver-compat": "^0.1.0",
         "bpmnlint": "^11.12.1",
         "classnames": "^2.5.1",


### PR DESCRIPTION
### Proposed Changes

Pulls in [`bpmn-js-element-templates@2.30.0`](https://github.com/bpmn-io/bpmn-js-element-templates/blob/main/CHANGELOG.md#2300) - updating the way validation errors for incompatible (per `engines`) field element are handled, cf. [ENGINE-COMPATIBILITY contract](https://docs.camunda.io/docs/components/modeler/element-templates/template-metadata/#engine-compatibility-engines). With this PR, templates incompatible with the running modeler are **ignored quietly**, while genuine template errors are still surfaced.

Closes #6071.

### Improved test coverage

The following ensures the [ENGINE-COMPATIBILITY contract](https://docs.camunda.io/docs/components/modeler/element-templates/template-metadata/#engine-compatibility-engines) is validated:

**Level 1 — app layer** (`BpmnEditorSpec`, default/mock-modeler suite):
- `camundaDesktopModeler` is injected as the host engine (app version).
- an engine-profile change **merges** `camunda` into the host engines **without dropping** `camundaDesktopModeler` (guards against 'stale drop').
- template errors are still surfaced as `onWarning`, and an **empty** error set produces **no** warning (the Output panel stays quiet — good UX).

**Level 2 — real stack** (`CloudBpmnModelerSpec`, `MODELERS` suite): drives the real cloud `BpmnModeler` + `elementTemplatesLoader` to prove:
- an engine-compatible **valid** template loads;
- an engine-compatible **schema-invalid** template still reports an error (over-suppression guard);
- a template declaring only a **not-provided** engine (`camunda`) is treated compatible;
- an engine-**incompatible** template is skipped **without** a warning

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__: Related to #6071; depends on bpmn-io/bpmn-js-element-templates#273 for the skipped Level 2 case
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes — n/a (test-only)
  * [x] __Steps to try out__: `npm run client:test` and `npm run bpmn-io-modelers:test`