### PR TITLE
feat: support call activity in task testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: add ability to copy diagram file path ([#6059](https://github.com/camunda/camunda-modeler/pull/6059))
+* `FEAT`: support call activities in task testing ([#6074](https://github.com/camunda/camunda-modeler/pull/6074))
 * `FIX`: surface the reason of instance start failed during task testing ([#6076](https://github.com/camunda/camunda-modeler/pull/6076))
+* `DEPS`: update to `@camunda/task-testing@6.0.0`
 
 ## 5.50.1
 

--- a/app/lib/zeebe-api/zeebe-api.js
+++ b/app/lib/zeebe-api/zeebe-api.js
@@ -373,16 +373,18 @@ class ZeebeAPI {
   }
 
   /**
-   * Search process instances. Requires Camunda REST client.
+   * Search process instances, either by their own key or by the key of their
+   * parent. Requires Camunda REST client.
    *
-   * @param {{ endpoint: import("./endpoints").Endpoint, processInstanceKey: string }} config
+   * @param {{ endpoint: import("./endpoints").Endpoint, processInstanceKey?: string, parentProcessInstanceKey?: string }} config
    *
    * @returns {Promise<{ success: boolean, response?: object, reason?: string }>}
    */
   async searchProcessInstances(config) {
     const {
       endpoint,
-      processInstanceKey
+      processInstanceKey,
+      parentProcessInstanceKey
     } = config;
 
     this._log.debug('search process instances', {
@@ -398,7 +400,8 @@ class ZeebeAPI {
 
       const response = await camundaRestClient.searchProcessInstances({
         filter: {
-          processInstanceKey
+          processInstanceKey,
+          parentProcessInstanceKey
         }
       });
 
@@ -518,7 +521,8 @@ class ZeebeAPI {
   }
 
   /**
-   * Search incidents. Requires Camunda REST client.
+   * Search incidents related to a process instance, including incidents of the
+   * process instances it called. Requires Camunda REST client.
    *
    * @param {{ endpoint: import("./endpoints").Endpoint, processInstanceKey: string }} config
    *
@@ -541,10 +545,10 @@ class ZeebeAPI {
         throw new Error('Camunda REST client is not available');
       }
 
-      const response = await camundaRestClient.searchIncidents({
-        filter: {
-          processInstanceKey
-        }
+      const response = await camundaRestClient.callApiEndpoint({
+        method: 'POST',
+        urlPath: `process-instances/${processInstanceKey}/incidents/search`,
+        body: {}
       });
 
       return {

--- a/app/test/spec/zeebe-api/zeebe-api-rest-spec.js
+++ b/app/test/spec/zeebe-api/zeebe-api-rest-spec.js
@@ -1537,6 +1537,42 @@ describe('ZeebeAPI (REST)', function() {
   });
 
 
+  describe('#searchProcessInstances (children)', function() {
+
+    it('should filter by parent process instance key', async function() {
+
+      // given
+      const searchProcessInstances = sinon.stub().returns({ items: [] });
+
+      const zeebeAPI = createZeebeAPI({
+        CamundaRestClient: {
+          searchProcessInstances
+        }
+      });
+
+      const parameters = {
+        endpoint: {
+          type: ENDPOINT_TYPES.SELF_HOSTED,
+          url: TEST_URL
+        },
+        parentProcessInstanceKey: '123'
+      };
+
+      // when
+      const result = await zeebeAPI.searchProcessInstances(parameters);
+
+      // then
+      expect(result.success).to.be.true;
+      expect(searchProcessInstances).to.have.been.calledWithMatch({
+        filter: {
+          parentProcessInstanceKey: '123'
+        }
+      });
+    });
+
+  });
+
+
   describe('#searchVariables', function() {
 
     it('should set success=true on success', async function() {
@@ -1687,7 +1723,7 @@ describe('ZeebeAPI (REST)', function() {
       // given
       const zeebeAPI = createZeebeAPI({
         CamundaRestClient: {
-          searchIncidents: () => ({ items: [] })
+          callApiEndpoint: () => ({ items: [] })
         }
       });
 
@@ -1713,7 +1749,7 @@ describe('ZeebeAPI (REST)', function() {
       // given
       const zeebeAPI = createZeebeAPI({
         CamundaRestClient: {
-          searchIncidents: () => { throw new Error('TEST ERROR.'); }
+          callApiEndpoint: () => { throw new Error('TEST ERROR.'); }
         }
       });
 
@@ -1731,6 +1767,35 @@ describe('ZeebeAPI (REST)', function() {
       // then
       expect(result.success).to.be.false;
       expect(result.reason).to.exist;
+    });
+
+
+    it('should search incidents of called process instances', async function() {
+
+      // given
+      const callApiEndpointSpy = sinon.spy(() => ({ items: [] }));
+
+      const zeebeAPI = createZeebeAPI({
+        CamundaRestClient: {
+          callApiEndpoint: callApiEndpointSpy
+        }
+      });
+
+      const parameters = {
+        endpoint: {
+          type: ENDPOINT_TYPES.SELF_HOSTED,
+          url: TEST_URL
+        },
+        processInstanceKey: '123'
+      };
+
+      // when
+      await zeebeAPI.searchIncidents(parameters);
+
+      // then
+      expect(callApiEndpointSpy).to.have.been.calledWithMatch({
+        urlPath: 'process-instances/123/incidents/search'
+      });
     });
 
   });

--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
     "@camunda/improved-canvas": "^1.10.3",
     "@camunda/linting": "^3.53.0",
     "@camunda/rpa-integration": "^1.3.4",
-    "@camunda/task-testing": "^5.1.0",
+    "@camunda/task-testing": "^6.0.0",
     "@carbon/icons-react": "^11.53.0",
     "@carbon/react": "^1.76.0",
     "@codemirror/commands": "^6.6.2",

--- a/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/TaskTestingApi.js
+++ b/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/TaskTestingApi.js
@@ -28,6 +28,7 @@ export default class TaskTestingApi {
       deploy: this.deploy.bind(this),
       startInstance: this.startInstance.bind(this),
       getProcessInstance: this.getProcessInstance.bind(this),
+      getChildProcessInstances: this.getChildProcessInstances.bind(this),
       getProcessInstanceVariables: this.getProcessInstanceVariables.bind(this),
       getProcessInstanceElementInstances: this.getProcessInstanceElementInstances.bind(this),
       getProcessInstanceIncident: this.getProcessInstanceIncident.bind(this),
@@ -147,6 +148,12 @@ export default class TaskTestingApi {
     const config = await this.getDeploymentConfig();
 
     return this._zeebeApi.searchProcessInstances(config, processInstanceKey);
+  }
+
+  async getChildProcessInstances(processInstanceKey) {
+    const config = await this.getDeploymentConfig();
+
+    return this._zeebeApi.searchChildProcessInstances(config, processInstanceKey);
   }
 
   async getProcessInstanceVariables(processInstanceKey) {

--- a/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/__tests__/TaskTestingTabSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/__tests__/TaskTestingTabSpec.js
@@ -53,7 +53,7 @@ describe('<TaskTestingTab>', function() {
     renderTab(modeler);
 
     // then
-    expect(screen.getByText('Select a task or subprocess to start testing.')).to.exist;
+    expect(screen.getByText('Select a task, subprocess, or call activity to start testing.')).to.exist;
   });
 
 

--- a/client/src/remote/ZeebeAPI.js
+++ b/client/src/remote/ZeebeAPI.js
@@ -96,6 +96,17 @@ export default class ZeebeAPI {
     });
   }
 
+  searchChildProcessInstances(options, parentProcessInstanceKey) {
+    let { endpoint } = options;
+
+    endpoint = getEndpointForTargetType(endpoint);
+
+    return this._backend.send('zeebe:searchProcessInstances', {
+      endpoint,
+      parentProcessInstanceKey
+    });
+  }
+
   searchElementInstances(options, processInstanceKey) {
     let { endpoint } = options;
 

--- a/client/src/remote/__tests__/ZeebeAPISpec.js
+++ b/client/src/remote/__tests__/ZeebeAPISpec.js
@@ -1206,6 +1206,44 @@ describe('<ZeebeAPI>', function() {
   });
 
 
+  describe('#searchChildProcessInstances', function() {
+
+    it('should search child process instances', function() {
+
+      // given
+      const backend = new MockBackend({
+        send: sinon.spy()
+      });
+
+      const zeebeAPI = new ZeebeAPI(backend);
+
+      const endpoint = {
+        targetType: TARGET_TYPES.SELF_HOSTED,
+        authType: AUTH_TYPES.NONE,
+        contactPoint: 'http://localhost:26500'
+      };
+
+      const parentProcessInstanceKey = '123';
+
+      // when
+      zeebeAPI.searchChildProcessInstances({ endpoint }, parentProcessInstanceKey);
+
+      // then
+      expect(backend.send).to.have.been.calledWith('zeebe:searchProcessInstances', {
+        endpoint: {
+          type: TARGET_TYPES.SELF_HOSTED,
+          authType: AUTH_TYPES.NONE,
+          url: endpoint.contactPoint,
+          tenantId: undefined
+        },
+        parentProcessInstanceKey
+      });
+
+    });
+
+  });
+
+
   describe('#searchVariables', function() {
 
     it('should search variables', function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -175,7 +175,7 @@
         "@camunda/improved-canvas": "^1.10.3",
         "@camunda/linting": "^3.53.0",
         "@camunda/rpa-integration": "^1.3.4",
-        "@camunda/task-testing": "^5.1.0",
+        "@camunda/task-testing": "^6.0.0",
         "@carbon/icons-react": "^11.53.0",
         "@carbon/react": "^1.76.0",
         "@codemirror/commands": "^6.6.2",
@@ -318,7 +318,9 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -327,7 +329,9 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -339,7 +343,9 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "client/node_modules/semver": {
       "version": "7.7.4",
@@ -2720,9 +2726,9 @@
       }
     },
     "node_modules/@camunda/task-testing": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@camunda/task-testing/-/task-testing-5.1.0.tgz",
-      "integrity": "sha512-mEJR3bqjxSoNGS0qrJ4VcYv1eFAT4wxQH9EoXvVsvAn9H+wqpl7XRDtKttFe2MfLkWLcOoAlJIznsbGqlhIvdw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@camunda/task-testing/-/task-testing-6.0.0.tgz",
+      "integrity": "sha512-v9nTSz6J1fsWGeK8mY6SEXMSRF/1+xwjCfkjm1LDoIrDeo/ekGc0kgdSJ42dZiQy+awS12IH9cYKxRjyv8o7Pw==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.19.1",


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/camunda/camunda-modeler/issues/6069

Backend support for testing a call activity, plus the `@camunda/task-testing@6.0.0` bump that ships the user-facing part.

Two changes to the Zeebe API layer:

- `searchIncidents` now uses the `process-instances/{key}/incidents/search` endpoint, so incidents raised inside a called process are reported on the calling instance too.
- `searchProcessInstances` accepts `parentProcessInstanceKey`, which lets task testing resolve the process instance a running call activity started. Exposed to the client as `searchChildProcessInstances` over the same IPC channel.

The user-facing part lives in [`@camunda/task-testing@6.0.0`](https://github.com/camunda/task-testing/releases/tag/v6.0.0) — while a call activity is active, the output banner reports that the called process is running and offers "Open called process in Operate", linking to the called instance.

https://github.com/user-attachments/assets/e4cfeef4-6146-4f5b-af43-c4ecf1af5c0c


### Steps to try out

```bash
npx @bpmn-io/sr camunda/camunda-modeler#call-activity-testing
```

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
