### PR TITLE
fix: surface the reason of instance start failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: add ability to copy diagram file path ([#6059](https://github.com/camunda/camunda-modeler/pull/6059))
+* `FIX`: surface the reason of instance start failed during task testing ([#6076](https://github.com/camunda/camunda-modeler/pull/6076))
 
 ## 5.50.0
 

--- a/app/lib/zeebe-api/zeebe-api.js
+++ b/app/lib/zeebe-api/zeebe-api.js
@@ -863,6 +863,6 @@ function getErrorReason(error, endpoint) {
 
 
 function asSerializedError(error) {
-  return pick(error, [ 'message', 'code', 'details' ]);
+  return pick(error, [ 'message', 'code', 'details', 'detail' ]);
 }
 

--- a/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/TaskTestingApi.js
+++ b/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/TaskTestingApi.js
@@ -95,9 +95,12 @@ export default class TaskTestingApi {
 
     if (!result.success) {
       log('Deployment failed: ', result);
+
+      const { detail, message } = result.response || {};
+
       return {
         success: false,
-        error: result?.response?.message || 'Deployment failed'
+        error: detail || message || 'Deployment failed'
       };
     }
 
@@ -124,6 +127,17 @@ export default class TaskTestingApi {
         }
       ]
     });
+
+    if (!response.success) {
+      log('Start instance failed: ', response);
+
+      const { detail, message } = response.response || {};
+
+      return {
+        success: false,
+        error: detail || message || 'Failed to start process instance'
+      };
+    }
 
     log('Start instance successful: ', response);
     return response;

--- a/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/__tests__/TaskTestingApiSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/__tests__/TaskTestingApiSpec.js
@@ -359,6 +359,138 @@ describe('<TaskTestingApi>', function() {
         }
       ]);
     });
+
+
+    it('should return error details on failure', async function() {
+
+      // given
+      const api = new TaskTestingApi(
+        new Deployment({
+          deploy: async () => {
+            return {
+              success: false,
+              response: {
+                message: 'Response code 400 (Bad Request).',
+                title: 'INVALID_ARGUMENT',
+                status: 400,
+                detail: 'Command \'CREATE\' rejected with code \'INVALID_ARGUMENT\': Must have at least one start event'
+              }
+            };
+          },
+          getConnectionForTab: async () => {
+            return {
+              targetType: 'selfHosted'
+            };
+          },
+          once: () => {}
+        }),
+        null,
+        null,
+        {
+          path: 'path/to/file.bpmn'
+        },
+        () => {
+          return {
+            file: {
+              path: 'path/to/file.bpmn'
+            }
+          };
+        }
+      );
+
+      // when
+      const result = await api.deploy();
+
+      // then
+      expect(result).to.eql({
+        success: false,
+        error: 'Command \'CREATE\' rejected with code \'INVALID_ARGUMENT\': Must have at least one start event'
+      });
+    });
+  });
+
+
+  describe('#startInstance', function() {
+
+    it('should return error details on failure', async function() {
+
+      // given
+      const api = new TaskTestingApi(
+        new Deployment({
+          getConnectionForTab: async () => {
+            return {
+              targetType: 'selfHosted'
+            };
+          }
+        }),
+        {
+          startInstance: async () => {
+            return {
+              success: false,
+              response: {
+                message: 'Response code 400 (Bad Request).',
+                title: 'INVALID_ARGUMENT',
+                status: 400,
+                detail: 'The creation of elements inside a multi-instance subprocess is not supported.'
+              }
+            };
+          }
+        },
+        null,
+        {
+          path: 'path/to/file.bpmn'
+        },
+        null
+      );
+
+      // when
+      const result = await api.startInstance('123', 'Activity_1', {});
+
+      // then
+      expect(result).to.eql({
+        success: false,
+        error: 'The creation of elements inside a multi-instance subprocess is not supported.'
+      });
+    });
+
+
+    it('should fall back to error message without problem detail', async function() {
+
+      // given
+      const api = new TaskTestingApi(
+        new Deployment({
+          getConnectionForTab: async () => {
+            return {
+              targetType: 'selfHosted'
+            };
+          }
+        }),
+        {
+          startInstance: async () => {
+            return {
+              success: false,
+              response: {
+                message: 'connect ECONNREFUSED 127.0.0.1:8080'
+              }
+            };
+          }
+        },
+        null,
+        {
+          path: 'path/to/file.bpmn'
+        },
+        null
+      );
+
+      // when
+      const result = await api.startInstance('123', 'Activity_1', {});
+
+      // then
+      expect(result).to.eql({
+        success: false,
+        error: 'connect ECONNREFUSED 127.0.0.1:8080'
+      });
+    });
   });
 
 });


### PR DESCRIPTION
### Proposed Changes

Closes https://github.com/camunda/camunda-modeler/issues/5858

Starting a test instance inside a multi-instance subprocess fails with `The creation of elements inside a multi-instance subprocess is not supported.`, but the panel only showed `Failed to start process instance`.

The engine's reason was dropped twice:

* `asSerializedError` picked `details` (gRPC) but not `detail` (REST problem detail)
* `TaskTestingApi#startInstance` returned zeebe-api's `{ success, response }` unchanged, while the task testing library reads `error` from the top level

`deploy` already reshaped the result, but passed on the raw `message` — the HTTP status line with the JSON body appended — so it now prefers `detail` too.

Not specific to multi-instance: every deploy and start failure was affected.

https://github.com/user-attachments/assets/003b3052-6c32-4a80-b637-3585eb506f0a



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
