### PR TITLE
fix: add default description for task testing configure button tooltip

### DIFF
--- a/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/TaskTestingTab.js
+++ b/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/TaskTestingTab.js
@@ -50,6 +50,8 @@ export const UNSUPPORTED_EXECUTION_PLATFORM_VERSION_DESCRIPTION = `Task testing 
 export const LINTING_ERRORS_TITLE = 'Diagram has errors';
 export const LINTING_ERRORS_DESCRIPTION = 'Task testing requires a diagram without errors.';
 
+export const DEFAULT_CONFIGURE_DESCRIPTION = 'Configure cluster connection.';
+
 const DOCUMENTATION_URL = utmTag('https://docs.camunda.io/docs/components/modeler/desktop-modeler/task-testing/');
 
 export default function TaskTestingTab(props) {
@@ -256,7 +258,7 @@ function getConfigureConnectionBannerDescription(connectionCheckResult, hasLinti
   } else if (hasLintingErrors) {
     return LINTING_ERRORS_DESCRIPTION;
   }
-  return null;
+  return DEFAULT_CONFIGURE_DESCRIPTION;
 }
 
 function canConnectToCluster(connectionCheckResult) {

--- a/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/__tests__/TaskTestingTabSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/__tests__/TaskTestingTabSpec.js
@@ -20,6 +20,7 @@ import { render, waitFor, screen } from '@testing-library/react';
 
 import TaskTestingTab, {
   CANNOT_CONNECT_TITLE,
+  DEFAULT_CONFIGURE_DESCRIPTION,
   LINTING_ERRORS_TITLE,
   UNSUPPORTED_EXECUTION_PLATFORM_VERSION_TITLE,
   UNSUPPORTED_PROTOCOL_TITLE
@@ -66,6 +67,19 @@ describe('<TaskTestingTab>', function() {
 
     // then
     expect(screen.getByRole('button', { name: 'Run test' })).to.exist;
+  });
+
+
+  it('should label the configure button without connection or linting errors', async function() {
+
+    // given
+    renderTab(modeler);
+
+    // when
+    await selectElement(modeler, 'Task_1');
+
+    // then
+    expect(await screen.findByRole('button', { name: DEFAULT_CONFIGURE_DESCRIPTION })).to.exist;
   });
 
 


### PR DESCRIPTION
### Proposed Changes

Previously, if there were no diagram or connection errors, the configuration button rendered an empty tooltip and logged an accessibility error to the console. Fixed this by providing a default tooltip message, which is also used for the button label.

**Before:**
<img width="176" height="199" alt="image" src="https://github.com/user-attachments/assets/b5a691ae-70bc-4c91-bfd1-92a4d515597a" />
<img width="1057" height="30" alt="image" src="https://github.com/user-attachments/assets/8a94f1a9-fbea-42e8-a353-0b58b65445ff" />


**After:**

<img width="295" height="251" alt="image" src="https://github.com/user-attachments/assets/5d71650d-0b99-4c6e-b30b-dc9369391398" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
