### PR TITLE
fix: keep the minimap above the context and append pads

### DIFF
--- a/client/src/styles/_modeling.css
+++ b/client/src/styles/_modeling.css
@@ -26,6 +26,12 @@
   z-index: 1001;
 }
 
+/* keep the minimap above the pads but below the open popup menu,
+ so an active menu still shows on top (#6075) */
+.djs-minimap {
+  z-index: 175;
+}
+
 .bio-properties-panel-group-header:has(.bio-properties-panel-tooltip) {
   z-index: 1002;
 }


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/6075

### Proposed Changes

Keep the minimap above the context and append pads.

Before:
<img width="974" height="528" alt="image" src="https://github.com/user-attachments/assets/31bf133f-261c-4743-ae83-5226986c11a7" />


After:

<img width="505" height="338" alt="image" src="https://github.com/user-attachments/assets/df64351a-5c09-4b1b-8ea3-0d27f18350ef" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
