### PR TITLE
chore(build): do not double promisfy API

### DIFF
--- a/tasks/after-pack/add-platform-files.js
+++ b/tasks/after-pack/add-platform-files.js
@@ -11,16 +11,12 @@
 const fs = require('fs');
 
 const {
-  copy: _copyGlob
+  copy: copyGlob
 } = require('cpx2');
-
-const { promisify } = require('util');
 
 const {
   Transform: TransformStream
 } = require('stream');
-
-const copyGlob = promisify(_copyGlob);
 
 const {
   name,


### PR DESCRIPTION
### Proposed Changes

Local modeler build reported:

```
Local build reports

>   • setting file permissions    file={PROJECT_DIR}/camunda-modeler/dist/linux-unpacked
(node:867445) [DEP0174] DeprecationWarning: Calling promisify on a function that returns a Promise is likely a mistake.
(node:867445) [DEP0174] DeprecationWarning: Calling promisify on a function that returns a Promise is likely a mistake.
```

Root cause analysis confirmed this was due to `util.promisify` of an already `cpx2` promisified API. This PR removes the double promisification.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
