### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/test/e2e/fixtures/c7-service-task-impl.bpmn
+++ b/test/e2e/fixtures/c7-service-task-impl.bpmn
@@ -4,7 +4,7 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:serviceTask id="ServiceTask_1" name="Check" camunda:class="com.example.Check" camunda:asyncBefore="true">
+    <bpmn:serviceTask id="Task_1" name="Check" camunda:class="com.example.Check" camunda:asyncBefore="true">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="orderId">order-123</camunda:inputParameter>
@@ -20,15 +20,15 @@
     <bpmn:endEvent id="EndEvent_1">
       <bpmn:incoming>Flow_2</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="ServiceTask_1" />
-    <bpmn:sequenceFlow id="Flow_2" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_1" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_1" targetRef="EndEvent_1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
         <dc:Bounds x="172" y="102" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
         <dc:Bounds x="270" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">

--- a/test/e2e/fixtures/c7-user-task-form.bpmn
+++ b/test/e2e/fixtures/c7-user-task-form.bpmn
@@ -4,7 +4,7 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:userTask id="UserTask_1" name="Inspect Invoice">
+    <bpmn:userTask id="Task_1" name="Inspect Invoice">
       <bpmn:extensionElements>
         <camunda:formData>
           <camunda:formField id="invoiceNumber" label="Invoice Number" type="string" />
@@ -16,15 +16,15 @@
     <bpmn:endEvent id="EndEvent_1">
       <bpmn:incoming>Flow_2</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="UserTask_1" />
-    <bpmn:sequenceFlow id="Flow_2" sourceRef="UserTask_1" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_1" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_1" targetRef="EndEvent_1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
         <dc:Bounds x="172" y="102" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_1_di" bpmnElement="UserTask_1">
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
         <dc:Bounds x="270" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">

--- a/test/e2e/fixtures/service-task-configured.bpmn
+++ b/test/e2e/fixtures/service-task-configured.bpmn
@@ -4,7 +4,7 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:serviceTask id="ServiceTask_1" name="Check">
+    <bpmn:serviceTask id="Task_1" name="Check">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="check-order" />
         <zeebe:ioMapping>
@@ -17,15 +17,15 @@
     <bpmn:endEvent id="EndEvent_1">
       <bpmn:incoming>Flow_2</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="ServiceTask_1" />
-    <bpmn:sequenceFlow id="Flow_2" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Task_1" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_1" targetRef="EndEvent_1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
         <dc:Bounds x="172" y="102" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
         <dc:Bounds x="270" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">

--- a/test/e2e/harness/electron-app.js
+++ b/test/e2e/harness/electron-app.js
@@ -64,6 +64,19 @@ class ElectronApp {
   }
 
   /**
+   * Whether the canvas is focused, read from the Edit menu: the editor exposes
+   * the diagram undo/redo only while the canvas is focused, and the native
+   * (role-based) entries otherwise. Reflects a focus change asynchronously.
+   *
+   * @return {Promise<boolean>}
+   */
+  async isCanvasFocused() {
+    const undo = await findMenuItem(this.electronApp, 'Undo');
+
+    return !!undo && undo.role !== 'undo';
+  }
+
+  /**
    * Click an application menu item by label. For menu actions without a
    * keyboard accelerator (e.g. "New File > DMN diagram (Camunda 8)").
    *

--- a/test/e2e/harness/menu.js
+++ b/test/e2e/harness/menu.js
@@ -128,7 +128,7 @@ function clickMenuItem(electronApp, label) {
  * @param {import('@playwright/test').ElectronApplication} electronApp
  * @param {string} label
  *
- * @return {Promise<{ label: string, enabled: boolean, accelerator: string|null }|null>}
+ * @return {Promise<{ label: string, enabled: boolean, accelerator: string|null, role: string|null }|null>}
  */
 function findMenuItem(electronApp, label) {
   return electronApp.evaluate(({ Menu }, label) => {
@@ -137,7 +137,7 @@ function findMenuItem(electronApp, label) {
     const walk = (items) => {
       for (const item of items) {
         if (item.label === label) {
-          found = { label: item.label, enabled: item.enabled, accelerator: item.accelerator || null };
+          found = { label: item.label, enabled: item.enabled, accelerator: item.accelerator || null, role: item.role || null };
 
           return;
         }

--- a/test/e2e/pages/BpmnEditorPage.js
+++ b/test/e2e/pages/BpmnEditorPage.js
@@ -97,20 +97,25 @@ class BpmnEditorPage extends DiagramEditorPage {
   }
 
   /**
-   * Undo the last command (Cmd/Ctrl+Z).
+   * Undo the last command. Focuses the canvas first so the accelerator reaches
+   * the diagram rather than the native no-op handler.
    *
    * @return {Promise<void>}
    */
-  undo() {
+  async undo() {
+    await this.focusCanvas();
+
     return this.app.shortcut('CommandOrControl+Z');
   }
 
   /**
-   * Redo the last undone command (Cmd/Ctrl+Y).
+   * Redo the last undone command. Mirror of {@link undo}.
    *
    * @return {Promise<void>}
    */
-  redo() {
+  async redo() {
+    await this.focusCanvas();
+
     return this.app.shortcut('CommandOrControl+Y');
   }
 

--- a/test/e2e/pages/DiagramEditorPage.js
+++ b/test/e2e/pages/DiagramEditorPage.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+const { expect } = require('@playwright/test');
+
 /**
  * Shared base for the diagram-js based editors (bpmn-js, dmn-js). Holds the
  * common canvas/element/selection/context-pad interactions; the BPMN and DMN
@@ -30,6 +32,20 @@ class DiagramEditorPage {
    */
   canvas() {
     return this.page.locator('.djs-container');
+  }
+
+  /**
+   * Focus the diagram canvas so undo/redo reach the diagram rather than the
+   * native (no-op) handler. Focuses the tabindexed canvas SVG without changing
+   * the selection, then waits for the Edit menu to switch to the diagram
+   * undo/redo, which the editor derives from canvas focus asynchronously.
+   *
+   * @return {Promise<void>}
+   */
+  async focusCanvas() {
+    await this.canvas().locator('svg[tabindex]').first().evaluate((el) => el.focus({ preventScroll: true }));
+
+    await expect.poll(() => this.app.isCanvasFocused(), { timeout: 5000 }).toBe(true);
   }
 
   /**
@@ -100,14 +116,9 @@ class DiagramEditorPage {
   }
 
   /**
-   * Open a context-pad popup menu (e.g. via 'replace' or 'append') and click one
-   * of its entries by its visible label text.
-   *
-   * The whole open-then-click is retried as a unit: a background re-render — most
-   * notably the connection check / "Camunda Connector templates updated" toast
-   * landing — can tear the popup down again right after it opens, so clicking the
-   * entry on its own would hang on a popup that just vanished. Re-opening and
-   * re-clicking rides out that teardown.
+   * Open a context-pad popup menu (e.g. via 'replace' or 'append') and click the
+   * entry with the given label. Opens and clicks as a retried unit because a
+   * background re-render can tear the popup down right after it opens.
    *
    * @param {string} elementId
    * @param {string} action the context-pad entry's `data-action`, e.g. 'replace'
@@ -137,16 +148,18 @@ class DiagramEditorPage {
         continue;
       }
 
-      // surface entries hidden inside drill-in categories; the search field
-      // filters on keyup, so real keystrokes are required (fill alone won't do)
+      // the search filters on keyup, so focus it and type real keystrokes
+      // (fill alone does not trigger the filter)
       if (await search.count() && !(await entry.count())) {
+        await search.click();
         await search.fill('');
         await search.pressSequentially(entryLabel);
       }
 
-      // popup is open — try to pick the entry; it can be torn down before the
-      // click lands, in which case we loop to re-open and retry
+      // wait for the entry (the filter may still be settling), then click; if
+      // the popup was torn down, loop to re-open and retry
       try {
+        await entry.waitFor({ state: 'visible', timeout: 2000 });
         await entry.click({ timeout: 2000 });
 
         return;

--- a/test/e2e/specs/bpmn-copy-paste.spec.js
+++ b/test/e2e/specs/bpmn-copy-paste.spec.js
@@ -111,7 +111,7 @@ test.describe('BPMN copy/paste', function() {
 
     // when copying it and pasting a second copy
     await app.step('copy + paste the service task', async () => {
-      await editor.copy('ServiceTask_1');
+      await editor.copy('Task_1');
       await editor.pasteAt(0.5, 0.72);
     });
 

--- a/test/e2e/specs/bpmn-morph.spec.js
+++ b/test/e2e/specs/bpmn-morph.spec.js
@@ -33,7 +33,7 @@ test.describe('BPMN keep implementation details (Camunda 8)', function() {
 
     // when morphing it to a user task
     await app.step('morph service task to user task', () => {
-      return editor.changeType('ServiceTask_1', 'User task');
+      return editor.changeType('Task_1', 'User task');
     });
 
     await app.step('save file', () => app.shortcut('CommandOrControl+S'));
@@ -70,7 +70,7 @@ test.describe('BPMN keep implementation details (Camunda 8)', function() {
     // when morphing it to a send task (also a job-worker task, so it supports
     // the same task definition)
     await app.step('morph service task to send task', () => {
-      return editor.changeType('ServiceTask_1', 'Send task');
+      return editor.changeType('Task_1', 'Send task');
     });
 
     await app.step('save file', () => app.shortcut('CommandOrControl+S'));
@@ -117,7 +117,9 @@ test.describe('BPMN keep implementation details (Camunda 8)', function() {
 
     // morph service task -> user task, save as `output`
     await app.step('morph to user task', async () => {
-      await editor.changeType('ServiceTask_1', 'User task');
+      await editor.changeType('Task_1', 'User task');
+
+      await expect.poll(() => editor.getElementType('Task_1'), { timeout: 10000 }).toBe('User Task');
 
       await app.expectSaveDialog(output);
       await app.shortcut('CommandOrControl+Shift+S');
@@ -127,15 +129,17 @@ test.describe('BPMN keep implementation details (Camunda 8)', function() {
 
     // undo -> back to a service task
     await app.step('undo restores the service task', async () => {
-      await app.shortcut('CommandOrControl+Z');
+      await editor.undo();
 
+      await expect.poll(() => editor.getElementType('Task_1'), { timeout: 10000 }).toBe('Service Task');
       await expect.poll(savedType, { timeout: 10000 }).toBe('serviceTask');
     });
 
     // redo -> user task again
     await app.step('redo re-applies the morph', async () => {
-      await app.shortcut('CommandOrControl+Y');
+      await editor.redo();
 
+      await expect.poll(() => editor.getElementType('Task_1'), { timeout: 10000 }).toBe('User Task');
       await expect.poll(savedType, { timeout: 10000 }).toBe('userTask');
     });
   });
@@ -157,7 +161,7 @@ test.describe('BPMN keep implementation details (Camunda 7)', function() {
     await editor.canvas().waitFor();
 
     // when morphing it to a send task (also a job-based task)
-    await app.step('morph service task to send task', () => editor.changeType('ServiceTask_1', 'Send task'));
+    await app.step('morph service task to send task', () => editor.changeType('Task_1', 'Send task'));
     await app.step('save file', () => app.shortcut('CommandOrControl+S'));
 
     // then all of the implementation is preserved
@@ -187,7 +191,7 @@ test.describe('BPMN keep implementation details (Camunda 7)', function() {
     await editor.canvas().waitFor();
 
     // when morphing it to a user task
-    await app.step('morph service task to user task', () => editor.changeType('ServiceTask_1', 'User task'));
+    await app.step('morph service task to user task', () => editor.changeType('Task_1', 'User task'));
     await app.step('save file', () => app.shortcut('CommandOrControl+S'));
 
     // then the service-task-specific implementation is dropped, but the shared
@@ -226,8 +230,9 @@ test.describe('BPMN keep implementation details (Camunda 7)', function() {
 
     // when morphing the user task to a service task, the form is dropped
     await app.step('morph to service task drops the form', async () => {
-      await editor.changeType('UserTask_1', 'Service task');
+      await editor.changeType('Task_1', 'Service task');
 
+      await expect.poll(() => editor.getElementType('Task_1'), { timeout: 10000 }).toBe('Service Task');
       await expect.poll(hasForm, { timeout: 10000 }).toBe(false);
     });
 
@@ -235,9 +240,7 @@ test.describe('BPMN keep implementation details (Camunda 7)', function() {
     await app.step('undo restores the form', async () => {
       await editor.undo();
 
-      // wait for the morph to revert before checking the file
-      await expect.poll(() => editor.getElementType('UserTask_1'), { timeout: 10000 }).toBe('User Task');
-
+      await expect.poll(() => editor.getElementType('Task_1'), { timeout: 10000 }).toBe('User Task');
       await expect.poll(hasForm, { timeout: 10000 }).toBe(true);
     });
 
@@ -245,9 +248,7 @@ test.describe('BPMN keep implementation details (Camunda 7)', function() {
     await app.step('redo drops the form again', async () => {
       await editor.redo();
 
-      // wait for the morph to re-apply before checking the file
-      await expect.poll(() => editor.getElementType('UserTask_1'), { timeout: 10000 }).toBe('Service Task');
-
+      await expect.poll(() => editor.getElementType('Task_1'), { timeout: 10000 }).toBe('Service Task');
       await expect.poll(hasForm, { timeout: 10000 }).toBe(false);
     });
   });


### PR DESCRIPTION
### Proposed Changes

Fixes two e2e tests that flaked on macOS CI: `bpmn-morph` undo/redo and `bpmn-modeling` replace-popup select.

Root cause: undo/redo only reach the diagram while the canvas is focused, but after a popup morph the canvas focus was racy — so `Cmd+Z`/`Cmd+Y` hit the native no-op handler (and on macOS `Cmd+Y` wasn't bound at all). Now the canvas is focused explicitly before undo/redo, and the replace-popup select rides out the popup re-rendering.

Additionally rename elements ids to use a type-neutral task id in morph fixtures.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
