### PR TITLE
Cache parsed templates by modification time on the application side

### DIFF
--- a/app/lib/config/__tests__/config-spec.js
+++ b/app/lib/config/__tests__/config-spec.js
@@ -11,6 +11,7 @@
 const Config = require('..');
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const sinon = require('sinon');
@@ -272,6 +273,200 @@ describe('Config', function() {
         { id: 'com.foo.Bar' }, // local
         { id: 'single', FOO: 'BAR' } // global
       ]);
+    });
+
+
+    it('should reuse cached templates when files are unchanged', function() {
+
+      // given
+      const file = {
+        path: getAbsolutePath('fixtures/project/bar.bpmn')
+      };
+
+      const config = new Config({
+        resourcesPaths: [
+          getAbsolutePath('fixtures/ok')
+        ],
+        userPath: 'foo'
+      });
+
+      const readFileSync = sinon.spy(fs, 'readFileSync');
+
+      const templateReadCount = () => readFileSync.getCalls().filter(
+        call => call.args[0].includes('element-templates')
+      ).length;
+
+      try {
+
+        // when
+        config.get('bpmn.elementTemplates', file);
+
+        const readsAfterFirst = templateReadCount();
+
+        config.get('bpmn.elementTemplates', file);
+
+        const readsAfterSecond = templateReadCount();
+
+        // then
+        // the second get reuses the cache, adding no template file reads
+        expect(readsAfterFirst).to.be.above(0);
+        expect(readsAfterSecond).to.equal(readsAfterFirst);
+      } finally {
+        readFileSync.restore();
+      }
+    });
+
+
+    it('should re-read a template when its file changes', function() {
+
+      // given
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'element-templates-'));
+      const templatesDir = path.join(tmpDir, 'element-templates');
+
+      fs.mkdirSync(templatesDir);
+
+      const templatePath = path.join(templatesDir, 'list.json');
+
+      fs.writeFileSync(templatePath, JSON.stringify([ { id: 'A' } ]));
+
+      const config = new Config({
+        resourcesPaths: [ tmpDir ],
+        userPath: 'foo'
+      });
+
+      try {
+
+        // when
+        const first = config.get('bpmn.elementTemplates', null);
+
+        // change the file, forcing a different modification time
+        fs.writeFileSync(templatePath, JSON.stringify([ { id: 'B' } ]));
+        fs.utimesSync(templatePath, new Date(), new Date(Date.now() + 1000));
+
+        const second = config.get('bpmn.elementTemplates', null);
+
+        // then
+        expect(first).to.eql([ { id: 'A' } ]);
+        expect(second).to.eql([ { id: 'B' } ]);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+
+    it('should skip a file that vanished between globbing and stat', function() {
+
+      // given
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'element-templates-'));
+      const templatesDir = path.join(tmpDir, 'element-templates');
+
+      fs.mkdirSync(templatesDir);
+
+      const keptPath = path.join(templatesDir, 'kept.json');
+      const vanishedPath = path.join(templatesDir, 'vanished.json');
+
+      fs.writeFileSync(keptPath, JSON.stringify([ { id: 'kept' } ]));
+      fs.writeFileSync(vanishedPath, JSON.stringify([ { id: 'vanished' } ]));
+
+      const config = new Config({
+        resourcesPaths: [ tmpDir ],
+        userPath: 'foo'
+      });
+
+      // globbing returns POSIX-style paths (forward slashes) on all platforms,
+      // so normalize before comparing to the native `path.join` result
+      const toPosix = p => p.split(path.sep).join(path.posix.sep);
+
+      // simulate the file disappearing after it was globbed
+      const statSync = sinon.stub(fs, 'statSync').callsFake(function(target, ...args) {
+        if (toPosix(target) === toPosix(vanishedPath)) {
+          const error = new Error('ENOENT');
+
+          error.code = 'ENOENT';
+
+          throw error;
+        }
+
+        return statSync.wrappedMethod.call(fs, target, ...args);
+      });
+
+      try {
+
+        // when
+        const templates = config.get('bpmn.elementTemplates', null);
+
+        // then
+        // the vanished file is skipped, not surfaced as an error, and the
+        // remaining templates are still returned
+        expect(templates).to.eql([ { id: 'kept' } ]);
+      } finally {
+        statSync.restore();
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+
+    it('should not evict another scope\'s cached templates', function() {
+
+      // given
+      // two independent "projects", each with its own local
+      // `.camunda/element-templates`; local dirs are derived from
+      // `parents(path.dirname(file.path))`, so the templates must live under
+      // `<project>/.camunda/element-templates`
+      const projectA = fs.mkdtempSync(path.join(os.tmpdir(), 'element-templates-a-'));
+      const projectB = fs.mkdtempSync(path.join(os.tmpdir(), 'element-templates-b-'));
+
+      const templateA = path.join(projectA, '.camunda', 'element-templates', 'a.json');
+      const templateB = path.join(projectB, '.camunda', 'element-templates', 'b.json');
+
+      fs.mkdirSync(path.dirname(templateA), { recursive: true });
+      fs.mkdirSync(path.dirname(templateB), { recursive: true });
+
+      fs.writeFileSync(templateA, JSON.stringify([ { id: 'A' } ]));
+      fs.writeFileSync(templateB, JSON.stringify([ { id: 'B' } ]));
+
+      const fileA = { path: path.join(projectA, 'a.bpmn') };
+      const fileB = { path: path.join(projectB, 'b.bpmn') };
+
+      const config = new Config({
+        resourcesPaths: [],
+        userPath: 'foo'
+      });
+
+      const readFileSync = sinon.spy(fs, 'readFileSync');
+
+      // globbing returns POSIX-style paths (forward slashes) on all platforms,
+      // so normalize before comparing to the native `path.join` result
+      const toPosix = p => p.split(path.sep).join(path.posix.sep);
+
+      const templateAReadCount = () => readFileSync.getCalls().filter(
+        call => toPosix(String(call.args[0])) === toPosix(templateA)
+      ).length;
+
+      try {
+
+        // when
+        config.get('bpmn.elementTemplates', fileA);
+
+        const readsAfterA = templateAReadCount();
+
+        // switching to another project must not evict project A's scope cache
+        config.get('bpmn.elementTemplates', fileB);
+
+        config.get('bpmn.elementTemplates', fileA);
+
+        const readsAfterReturn = templateAReadCount();
+
+        // then
+        // project A's template was read once and is still cached after the
+        // intervening `get` for project B - it is not re-read on return
+        expect(readsAfterA).to.equal(1);
+        expect(readsAfterReturn).to.equal(1);
+      } finally {
+        readFileSync.restore();
+        fs.rmSync(projectA, { recursive: true, force: true });
+        fs.rmSync(projectB, { recursive: true, force: true });
+      }
     });
 
   });

--- a/app/lib/config/providers/ElementTemplatesProvider.js
+++ b/app/lib/config/providers/ElementTemplatesProvider.js
@@ -23,13 +23,40 @@ const log = require('../../log')('app:config:element-templates');
  */
 
 /**
- * Get element templates.
+ * Provides element templates for the `bpmn.elementTemplates` config key.
+ *
+ * Templates are collected from two independent sources and merged (not
+ * prioritized - there is no "use B if A is missing" fallback):
+ *
+ * 1. file-based: JSON files globbed from `element-templates/**` under the
+ *    application resources paths, plus `.camunda/element-templates`
+ *    directories walked up from the opened file's location (local, per-project
+ *    templates)
+ * 2. config-based: the `elementTemplates` array read from `config.json` via the
+ *    shared `DefaultProvider`. This is an extension hook for templates supplied
+ *    through the app config rather than dropped as files; it defaults to `[]`,
+ *    so it contributes nothing unless something populates that config key.
  */
 class ElementTemplatesProvider {
   constructor(paths, ignoredPaths, defaultProvider) {
     this._paths = paths;
     this._ignoredPaths = ignoredPaths;
     this._defaultProvider = defaultProvider;
+
+    /**
+     * Cache of parsed templates, grouped per scope (globbed directory). The
+     * outer map is keyed by the globbed directory; the inner map holds the
+     * parsed templates per file, keyed by absolute path. Entries are reused as
+     * long as the file's modification time is unchanged, so we don't re-read
+     * and re-parse every template on each `get`.
+     *
+     * Grouping per scope means a `get` scoped to one file (whose globbed dirs
+     * depend on that file's location) rebuilds only its own scopes, leaving the
+     * cached templates of unrelated scopes untouched.
+     *
+     * @type {Map<string, Map<string, { mtimeMs: number | null, templates: Array<Template> }>>}
+     */
+    this._cache = new Map();
   }
 
   /**
@@ -49,9 +76,103 @@ class ElementTemplatesProvider {
     ];
 
     return [
-      ...getTemplates(paths, this._ignoredPaths),
+
+      // retrieve templates, file-based
+      ...this._getTemplates(paths),
+
+      // legacy hook: merge templates configured in `config.json`
+      // under `elementTemplates` key
       ...this._defaultProvider.get('elementTemplates', [])
     ];
+  }
+
+  /**
+   * Get element templates for the given paths, reusing cached parses for files
+   * whose modification time did not change.
+   *
+   * @param {Array<string>} paths
+   *
+   * @returns {Array<Template>}
+   */
+  _getTemplates(paths) {
+    return paths.reduce((templates, path) => {
+      let files;
+
+      // do not throw if file not accessible or no such file
+      try {
+        files = globTemplates(path, this._ignoredPaths);
+      } catch (error) {
+        log.error(`templates ${ path } glob error`, error);
+
+        return templates;
+      }
+
+      // cache per scope (globbed directory): re-globbing a directory rebuilds
+      // its file set, so deleted/renamed files drop out - while directories
+      // outside this get's scope keep their cache, so switching between
+      // files/projects does not evict (and force re-parsing of) another
+      // scope's templates.
+      const cached = this._cache.get(path) || new Map();
+      const scope = new Map();
+
+      const scoped = files.reduce((templates, file) => {
+        const entry = this._readTemplates(file, cached);
+
+        scope.set(file, entry);
+
+        return [
+          ...templates,
+          ...entry.templates
+        ];
+      }, templates);
+
+      // only keep scopes that actually contain templates, so an empty (or
+      // emptied) directory drops out of the cache rather than lingering
+      if (scope.size) {
+        this._cache.set(path, scope);
+      } else {
+        this._cache.delete(path);
+      }
+
+      return scoped;
+    }, []);
+  }
+
+  /**
+   * Read and parse templates for a single file, using the cached result when
+   * the file's modification time is unchanged.
+   *
+   * @param {string} file
+   * @param {Map<string, { mtimeMs: number | null, templates: Array<Template> }>} cache
+   *   the scope cache to look the file up in
+   *
+   * @returns {{ mtimeMs: number | null, templates: Array<Template> }} `mtimeMs`
+   *   is `null` when the file could not be stat-ed (glob→stat race)
+   */
+  _readTemplates(file, cache) {
+    let mtimeMs;
+
+    try {
+      mtimeMs = fs.statSync(file).mtimeMs;
+    } catch (error) {
+
+      // the file vanished (or became inaccessible) between globbing and stat -
+      // a rare, transient race. Skip it rather than failing the whole `get`
+      // and hiding all templates; a genuine parse error of a readable file is
+      // still surfaced by `getTemplatesForPath` below. Consistent with the
+      // glob-level handling in `_getTemplates`.
+      log.warn(`template ${ file } stat error, skipping`, error);
+
+      return { mtimeMs: null, templates: [] };
+    }
+
+    const cached = cache.get(file);
+
+    if (cached && cached.mtimeMs === mtimeMs) {
+      return cached;
+    }
+
+    return { mtimeMs, templates: getTemplatesForPath(file) };
   }
 }
 
@@ -70,50 +191,6 @@ module.exports = ElementTemplatesProvider;
  */
 function suffixAll(paths, suffix) {
   return paths.map(p => path.join(p, suffix));
-}
-
-/**
- * Get element templates.
- *
- * @param  {Array<string>} paths
- * @param  {Array<string>} ignoredPaths
- *
- * @return {Array<Template>}
- */
-function getTemplates(paths, ignoredPaths) {
-  return paths.reduce((templates, path) => {
-    let files;
-
-    // do not throw if file not accessible or no such file
-    try {
-      files = globTemplates(path, ignoredPaths);
-    } catch (error) {
-      log.error(`templates ${ path } glob error`, error);
-
-      return templates;
-    }
-
-    return [
-      ...templates,
-      ...getTemplatesForPaths(files)
-    ];
-  }, []);
-}
-
-/**
- * Get element templates from paths.
- *
- * @param  {Array<string>} paths
- *
- * @return {Array<Template>}
- */
-function getTemplatesForPaths(paths) {
-  return paths.reduce((templates, path) => {
-    return [
-      ...templates,
-      ...getTemplatesForPath(path)
-    ];
-  }, []);
 }
 
 /**

--- a/app/lib/config/providers/ElementTemplatesProvider.js
+++ b/app/lib/config/providers/ElementTemplatesProvider.js
@@ -54,6 +54,8 @@ class ElementTemplatesProvider {
      * depend on that file's location) rebuilds only its own scopes, leaving the
      * cached templates of unrelated scopes untouched.
      *
+     * Cached templates are handed out by reference. Callers must not mutate them.
+     *
      * @type {Map<string, Map<string, { mtimeMs: number | null, templates: Array<Template> }>>}
      */
     this._cache = new Map();
@@ -126,8 +128,7 @@ class ElementTemplatesProvider {
         ];
       }, templates);
 
-      // only keep scopes that actually contain templates, so an empty (or
-      // emptied) directory drops out of the cache rather than lingering
+      // only keep scopes with matched files
       if (scope.size) {
         this._cache.set(path, scope);
       } else {


### PR DESCRIPTION
### Proposed Changes

Part of the investigation into slow modeling with many element templates loaded (related to https://github.com/camunda/camunda-modeler/issues/5557).

Main process `ElementTemplatesProvider#get` re-globbed, re-read and re-parsed **every** element template JSON from disk on each `config.get('bpmn.elementTemplates')` call. With hundreds of templates this is expensive, and it runs often (e.g. whenever the editor (re)loads templates).

This PR adds a caching layer in the provider only — no renderer/behavioral changes:

- **Cache parsed templates**, keyed by absolute path, reused while the file's modification time (`mtimeMs`) is unchanged — this avoids re-globbing, re-reading and re-parsing every template JSON on each `config.get('bpmn.elementTemplates')`.
- **Cache per scope directory.** The globbed file set depends on the `.bpmn`'s scope (the `.camunda/element-templates` directories walked up from the file). Keying the cache per scope means re-globbing one scope only rebuilds that scope's file set — deleted/renamed files in it drop out — while other scopes keep their cached entries. Switching back to a project therefore does not re-parse its local templates, and empty scopes are pruned from the cache.
- **Tolerate the glob→stat race**: a file that vanished between globbing and `stat` is skipped (and logged) instead of failing the whole `get` and hiding all templates. Genuine parse errors of readable files are still surfaced as before.
- **Documents** that templates are merged from two sources: file-based templates and the `elementTemplates` array read from `config.json` via the shared `DefaultProvider`.

### How to try it out

Load a project with many element templates and observe repeated `config.get('bpmn.elementTemplates')` calls (e.g. on template reload); parsed templates are now reused while files are unchanged. Editing a template file invalidates only that file's cache entry, and switching between projects keeps each project's templates cached (verified by tests).

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes — n/a, main-process only, no UI change
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)