### PR TITLE
Improve client-side linting performance (caching, preventing useless work)

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -139,6 +139,11 @@ export class App extends PureComponent {
 
     this.tabComponentCache = {};
 
+    // cache of constructed linters per tab, so we don't rebuild the linter
+    // (and re-fetch + re-validate element templates) on every modeling
+    // interaction. Invalidated when templates are (re-)loaded.
+    this.linterCache = {};
+
     // TODO(nikku): make state
     this.navigationHistory = new History();
 
@@ -657,6 +662,8 @@ export class App extends PureComponent {
 
     delete newOpenedTabs[tab.id];
 
+    delete this.linterCache[tab.id];
+
     const {
       [ tab.id ]: _removedProfile,
       ...newEngineProfiles
@@ -1132,15 +1139,7 @@ export class App extends PureComponent {
   };
 
   lintTab = async (tab, contents) => {
-    const { tabsProvider } = this.props;
-
-    const { type } = tab;
-
-    const tabProvider = tabsProvider.getProvider(type);
-
-    const plugins = this.getPlugins(`lintRules.${ type }`);
-
-    const linter = await tabProvider.getLinter(plugins, tab, this.getConfig);
+    const linter = await this.getTabLinter(tab);
 
     let results = [];
 
@@ -1164,6 +1163,60 @@ export class App extends PureComponent {
     }
 
     this.setLintingState(tab, results);
+  };
+
+  /**
+   * Get the (cached) linter for a tab, rebuilt only when its templates change.
+   *
+   * @param {Object} tab
+   *
+   * @returns {Promise<Object|null>}
+   */
+  getTabLinter = (tab) => {
+    const cached = this.linterCache[ tab.id ];
+
+    if (cached) {
+      return cached;
+    }
+
+    const { tabsProvider } = this.props;
+
+    const { type } = tab;
+
+    const tabProvider = tabsProvider.getProvider(type);
+
+    const plugins = this.getPlugins(`lintRules.${ type }`);
+
+    // cache the in-flight promise so concurrent lints (lintTab is often not
+    // awaited) share one build instead of each re-validating all templates
+    const linterPromise = Promise.resolve(
+      tabProvider.getLinter(plugins, tab, this.getConfig)
+    );
+
+    this.linterCache[ tab.id ] = linterPromise;
+
+    return linterPromise;
+  };
+
+  /**
+   * Invalidate a tab's cached linter after its element templates changed.
+   *
+   * The originating editor names its own tab, so invalidation targets exactly
+   * the tab whose templates were (re-)set - not merely whichever tab is active.
+   * Each tab loads its own, file-scoped templates, so other tabs are
+   * unaffected. Re-linting is left to the editor, which triggers it (debounced)
+   * through its own linting path - keeping cache ownership here and lint
+   * scheduling where the contents live. Runs only on genuine template
+   * (re-)loads, never on ordinary modeling interactions.
+   *
+   * @param {Object} tab
+   */
+  handleElementTemplatesChanged = (tab) => {
+    if (!tab) {
+      return;
+    }
+
+    delete this.linterCache[ tab.id ];
   };
 
   _handleConnectionCheckStarted = () => {
@@ -2212,6 +2265,10 @@ export class App extends PureComponent {
       } = options;
 
       return this.lintTab(tab, contents);
+    }
+
+    if (action === 'element-templates-changed') {
+      return this.handleElementTemplatesChanged(options.tab);
     }
 
     if (action === 'select-tab') {

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1190,7 +1190,7 @@ export class App extends PureComponent {
     // cache the in-flight promise so concurrent lints (lintTab is often not
     // awaited) share one build instead of each re-validating all templates
     const linterPromise = Promise.resolve(
-      tabProvider.getLinter(plugins, tab, this.getConfig)
+      tabProvider.getLinter(plugins, tab, this.getConfigForFile)
     );
 
     this.linterCache[ tab.id ] = linterPromise;
@@ -2525,11 +2525,14 @@ export class App extends PureComponent {
   };
 
   getConfig = (key, ...args) => {
-    const config = this.getGlobal('config');
-
     const { activeTab } = this.state;
-
     const { file } = activeTab;
+
+    return this.getConfigForFile(key, file, ...args);
+  };
+
+  getConfigForFile = (key, file, ...args) => {
+    const config = this.getGlobal('config');
 
     return config.get(key, file, ...args);
   };

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1148,7 +1148,11 @@ export class App extends PureComponent {
         contents = tab.file.contents;
       }
 
+      log('linting tab', { tabId: tab.id, path: tab.file?.path });
+
       results = await linter.lint(contents);
+
+      log('linted tab', { tabId: tab.id });
     }
 
     const getWarnings = VersionMismatchChecker({
@@ -1187,11 +1191,17 @@ export class App extends PureComponent {
 
     const plugins = this.getPlugins(`lintRules.${ type }`);
 
+    log('building linter', { tabId: tab.id, path: tab.file?.path });
+
     // cache the in-flight promise so concurrent lints (lintTab is often not
     // awaited) share one build instead of each re-validating all templates
     const linterPromise = Promise.resolve(
       tabProvider.getLinter(plugins, tab, this.getConfigForFile)
-    );
+    ).then((linter) => {
+      log('built linter', { tabId: tab.id });
+
+      return linter;
+    });
 
     this.linterCache[ tab.id ] = linterPromise;
 
@@ -1215,6 +1225,8 @@ export class App extends PureComponent {
     if (!tab) {
       return;
     }
+
+    log('invalidated linter', { tabId: tab.id });
 
     delete this.linterCache[ tab.id ];
   };

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -2259,249 +2259,255 @@ export class App extends PureComponent {
     } = this.state;
 
 
-    log('App#triggerAction %s %o', action, options);
+    log('trigger action %s %o', action, options);
 
-    if (action === 'set-tab-group') {
-      const {
-        id,
-        group
-      } = options;
+    try {
 
-      return this.setTabGroup(id, group);
-    }
+      if (action === 'set-tab-group') {
+        const {
+          id,
+          group
+        } = options;
 
-    if (action === 'lint-tab') {
-      const {
-        tab,
-        contents
-      } = options;
-
-      return this.lintTab(tab, contents);
-    }
-
-    if (action === 'element-templates-changed') {
-      return this.handleElementTemplatesChanged(options.tab);
-    }
-
-    if (action === 'select-tab') {
-      if (options === 'next') {
-        this.navigate(1);
+        return this.setTabGroup(id, group);
       }
 
-      if (options === 'previous') {
-        this.navigate(-1);
+      if (action === 'lint-tab') {
+        const {
+          tab,
+          contents
+        } = options;
+
+        return this.lintTab(tab, contents);
       }
 
-      return;
-    }
-
-    if (action === 'create-bpmn-diagram') {
-      return this.createDiagram('bpmn');
-    }
-
-    if (action === 'create-dmn-diagram') {
-      return this.createDiagram('dmn');
-    }
-
-    if (action === 'create-form') {
-      return this.createDiagram('form');
-    }
-
-    if (action === 'create-cloud-form') {
-      return this.createDiagram('cloud-form');
-    }
-
-    if (action === 'create-cloud-bpmn-diagram') {
-      return this.createDiagram('cloud-bpmn');
-    }
-
-    if (action === 'create-cloud-dmn-diagram') {
-      return this.createDiagram('cloud-dmn');
-    }
-
-    if (action === 'create-diagram') {
-      return this.createDiagram(options.type);
-    }
-
-    if (action === 'reopen-file') {
-      return this.openFiles([ options.file ]);
-    }
-
-    if (action === 'open-diagram') {
-      const { path } = options;
-
-      if (path) {
-        return this.readFileFromPath(path).then(file => this.openFiles([ file ]));
+      if (action === 'element-templates-changed') {
+        return this.handleElementTemplatesChanged(options.tab);
       }
 
-      return this.showOpenFilesDialog();
+      if (action === 'select-tab') {
+        if (options === 'next') {
+          this.navigate(1);
+        }
+
+        if (options === 'previous') {
+          this.navigate(-1);
+        }
+
+        return;
+      }
+
+      if (action === 'create-bpmn-diagram') {
+        return this.createDiagram('bpmn');
+      }
+
+      if (action === 'create-dmn-diagram') {
+        return this.createDiagram('dmn');
+      }
+
+      if (action === 'create-form') {
+        return this.createDiagram('form');
+      }
+
+      if (action === 'create-cloud-form') {
+        return this.createDiagram('cloud-form');
+      }
+
+      if (action === 'create-cloud-bpmn-diagram') {
+        return this.createDiagram('cloud-bpmn');
+      }
+
+      if (action === 'create-cloud-dmn-diagram') {
+        return this.createDiagram('cloud-dmn');
+      }
+
+      if (action === 'create-diagram') {
+        return this.createDiagram(options.type);
+      }
+
+      if (action === 'reopen-file') {
+        return this.openFiles([ options.file ]);
+      }
+
+      if (action === 'open-diagram') {
+        const { path } = options;
+
+        if (path) {
+          return this.readFileFromPath(path).then(file => this.openFiles([ file ]));
+        }
+
+        return this.showOpenFilesDialog();
+      }
+
+      if (action === 'save-all') {
+        return this.saveAllTabs();
+      }
+
+      if (action === 'save-tab') {
+        return this.saveTab(options.tab);
+      }
+
+      if (action === 'save') {
+        return this.saveTab(activeTab);
+      }
+
+      if (action === 'save-as') {
+        return this.saveTab(activeTab, { saveAs: true });
+      }
+
+      if (action === 'window-focused') {
+        return this.emit('app.focused');
+      }
+
+      if (action === 'window-blurred') {
+        return this.emit('app.blurred');
+      }
+
+      if (action === 'quit') {
+        return this.quit();
+      }
+
+      if (action === 'close-all-tabs') {
+        return this.closeTabs(t => true);
+      }
+
+      if (action === 'close-tab') {
+        return this.closeTabs(t => options && t.id === options.tabId);
+      }
+
+      if (action === 'close-active-tab') {
+        let activeId = this.state.activeTab.id;
+
+        return this.closeTabs(t => t.id === activeId);
+      }
+
+      if (action === 'close-other-tabs') {
+        let activeId = options && options.tabId || this.state.activeTab.id;
+
+        return this.closeTabs(t => t.id !== activeId);
+      }
+
+      if (action === 'reopen-last-tab') {
+        return this.reopenLastTab();
+      }
+
+      if (action === 'reveal-in-file-explorer') {
+        return this.revealInFileExplorer(options.filePath);
+      }
+
+      if (action === 'copy-file-path') {
+        return this.copyFilePath(options.filePath);
+      }
+
+      if (action === 'show-shortcuts') {
+        return this.showShortcuts();
+      }
+
+      if (action === 'update-menu') {
+        return this.updateMenu(options);
+      }
+
+      if (action === 'export-as') {
+        return this.exportAs(activeTab);
+      }
+
+      if (action === 'show-dialog') {
+        return this.showDialog(options);
+      }
+
+      if (action === 'open-modal') {
+        return this.setModal(options);
+      }
+
+      if (action === 'close-modal') {
+        return this.setModal(null);
+      }
+
+      if (action === 'open-external-url') {
+        return this.openExternalUrl(options);
+      }
+
+      if (action === 'check-file-changed') {
+        return this.checkFileChanged(activeTab);
+      }
+
+      if (action === 'resize') {
+        return this.resizeTab();
+      }
+
+      if (action === 'reload-modeler') {
+        return this.reloadModeler();
+      }
+
+      if (action === 'restart-modeler') {
+        return this.reloadModeler(true);
+      }
+
+      if (action === 'log') {
+        const {
+          action,
+          category,
+          message,
+          silent
+        } = options;
+
+        return this.logEntry(message, category, action, silent);
+      }
+
+      if (action === 'open-log') {
+        return this.openPanel('log');
+      }
+
+      if (action === 'open-panel') {
+        const { tab } = options;
+
+        return this.openPanel(tab);
+      }
+
+      if (action === 'close-panel') {
+        return this.closePanel();
+      }
+
+      if (action === 'display-notification') {
+        return this.displayNotification(options);
+      }
+
+      if (action === 'emit-event') {
+        console.error(
+          'The \'emit-event\' action has been removed. ' +
+          'Application events are now emitted through the events context. ' +
+          'Use the `emit(type, payload)` prop (or `EventsContext#emit`) instead of ' +
+          '`triggerAction(\'emit-event\', { type, payload })`. ' +
+          'See https://github.com/camunda/camunda-modeler/pull/6106 for details.'
+        );
+
+        return;
+      }
+
+      if (action === 'toggle-panel') {
+        const { panel } = this.state.layout;
+        return panel.open ? this.closePanel() : this.openPanel(panel.tab);
+      }
+
+      if (action === 'settings-open') {
+        return this.emit('app.settings-open', options);
+      }
+
+      if (action === 'open-deployment') {
+        return this.emitWithTab('app.open-deployment', activeTab);
+      }
+
+      if (action === 'open-connection-selector') {
+        return this.emitWithTab('app.open-connection-selector', activeTab);
+      }
+
+      const tab = this.tabRef.current;
+
+      return tab.triggerAction(action, options);
+
+    } finally {
+      log('triggered action %s', action);
     }
-
-    if (action === 'save-all') {
-      return this.saveAllTabs();
-    }
-
-    if (action === 'save-tab') {
-      return this.saveTab(options.tab);
-    }
-
-    if (action === 'save') {
-      return this.saveTab(activeTab);
-    }
-
-    if (action === 'save-as') {
-      return this.saveTab(activeTab, { saveAs: true });
-    }
-
-    if (action === 'window-focused') {
-      return this.emit('app.focused');
-    }
-
-    if (action === 'window-blurred') {
-      return this.emit('app.blurred');
-    }
-
-    if (action === 'quit') {
-      return this.quit();
-    }
-
-    if (action === 'close-all-tabs') {
-      return this.closeTabs(t => true);
-    }
-
-    if (action === 'close-tab') {
-      return this.closeTabs(t => options && t.id === options.tabId);
-    }
-
-    if (action === 'close-active-tab') {
-      let activeId = this.state.activeTab.id;
-
-      return this.closeTabs(t => t.id === activeId);
-    }
-
-    if (action === 'close-other-tabs') {
-      let activeId = options && options.tabId || this.state.activeTab.id;
-
-      return this.closeTabs(t => t.id !== activeId);
-    }
-
-    if (action === 'reopen-last-tab') {
-      return this.reopenLastTab();
-    }
-
-    if (action === 'reveal-in-file-explorer') {
-      return this.revealInFileExplorer(options.filePath);
-    }
-
-    if (action === 'copy-file-path') {
-      return this.copyFilePath(options.filePath);
-    }
-
-    if (action === 'show-shortcuts') {
-      return this.showShortcuts();
-    }
-
-    if (action === 'update-menu') {
-      return this.updateMenu(options);
-    }
-
-    if (action === 'export-as') {
-      return this.exportAs(activeTab);
-    }
-
-    if (action === 'show-dialog') {
-      return this.showDialog(options);
-    }
-
-    if (action === 'open-modal') {
-      return this.setModal(options);
-    }
-
-    if (action === 'close-modal') {
-      return this.setModal(null);
-    }
-
-    if (action === 'open-external-url') {
-      return this.openExternalUrl(options);
-    }
-
-    if (action === 'check-file-changed') {
-      return this.checkFileChanged(activeTab);
-    }
-
-    if (action === 'resize') {
-      return this.resizeTab();
-    }
-
-    if (action === 'reload-modeler') {
-      return this.reloadModeler();
-    }
-
-    if (action === 'restart-modeler') {
-      return this.reloadModeler(true);
-    }
-
-    if (action === 'log') {
-      const {
-        action,
-        category,
-        message,
-        silent
-      } = options;
-
-      return this.logEntry(message, category, action, silent);
-    }
-
-    if (action === 'open-log') {
-      return this.openPanel('log');
-    }
-
-    if (action === 'open-panel') {
-      const { tab } = options;
-
-      return this.openPanel(tab);
-    }
-
-    if (action === 'close-panel') {
-      return this.closePanel();
-    }
-
-    if (action === 'display-notification') {
-      return this.displayNotification(options);
-    }
-
-    if (action === 'emit-event') {
-      console.error(
-        'The \'emit-event\' action has been removed. ' +
-        'Application events are now emitted through the events context. ' +
-        'Use the `emit(type, payload)` prop (or `EventsContext#emit`) instead of ' +
-        '`triggerAction(\'emit-event\', { type, payload })`. ' +
-        'See https://github.com/camunda/camunda-modeler/pull/6106 for details.'
-      );
-
-      return;
-    }
-
-    if (action === 'toggle-panel') {
-      const { panel } = this.state.layout;
-      return panel.open ? this.closePanel() : this.openPanel(panel.tab);
-    }
-
-    if (action === 'settings-open') {
-      return this.emit('app.settings-open', options);
-    }
-
-    if (action === 'open-deployment') {
-      return this.emitWithTab('app.open-deployment', activeTab);
-    }
-
-    if (action === 'open-connection-selector') {
-      return this.emitWithTab('app.open-connection-selector', activeTab);
-    }
-
-    const tab = this.tabRef.current;
-
-    return tab.triggerAction(action, options);
   }, this.handleError);
 
   openExternalUrl(options) {

--- a/client/src/app/__tests__/AppParentSpec.js
+++ b/client/src/app/__tests__/AppParentSpec.js
@@ -743,7 +743,7 @@ describe('<AppParent>', function() {
 
   describe('backend errors', function() {
 
-    it('should log backend error', function(done) {
+    it('should log backend error', async function() {
 
       // given
       const message = 'message from backend';
@@ -760,13 +760,11 @@ describe('<AppParent>', function() {
       backend.receive('backend:error', {}, message);
 
       // then
-      setTimeout(() => {
+      await waitFor(() => {
         expect(actionSpy).to.be.calledWith('log', {
           message,
           category: 'error'
         });
-
-        done();
       });
 
     });

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -4514,6 +4514,160 @@ describe('<App>', function() {
     });
 
 
+    it('should reuse linter across lints', async function() {
+
+      // given
+      const tabsProvider = new TabsProvider();
+
+      const getLinterSpy = sinon.spy(tabsProvider.getProvider('cloud-bpmn'), 'getLinter');
+
+      const { app } = createApp({ tabsProvider });
+
+      const tab = {
+        id: 'cloud-bpmn-1',
+        type: 'cloud-bpmn',
+        file: { contents: '', path: null }
+      };
+
+      // when
+      await app.getTabLinter(tab);
+      await app.getTabLinter(tab);
+
+      // then
+      // linter is built once and reused, not rebuilt on every lint
+      expect(getLinterSpy).to.have.been.calledOnce;
+    });
+
+
+    it('should not rebuild linter for concurrent lints', async function() {
+
+      // given
+      const tabsProvider = new TabsProvider();
+
+      const getLinterSpy = sinon.spy(tabsProvider.getProvider('cloud-bpmn'), 'getLinter');
+
+      const { app } = createApp({ tabsProvider });
+
+      const tab = {
+        id: 'cloud-bpmn-1',
+        type: 'cloud-bpmn',
+        file: { contents: '', path: null }
+      };
+
+      // when
+      // two lints start before the first build resolves (lintTab is often
+      // called without awaiting), so they must share the in-flight build
+      await Promise.all([
+        app.getTabLinter(tab),
+        app.getTabLinter(tab)
+      ]);
+
+      // then
+      // the linter (and template validation) is built once, not per lint
+      expect(getLinterSpy).to.have.been.calledOnce;
+    });
+
+
+    it('should rebuild linter after templates changed', async function() {
+
+      // given
+      const tabsProvider = new TabsProvider();
+
+      const getLinterSpy = sinon.spy(tabsProvider.getProvider('cloud-bpmn'), 'getLinter');
+
+      const { app } = createApp({ tabsProvider });
+
+      const tab = {
+        id: 'cloud-bpmn-1',
+        type: 'cloud-bpmn',
+        file: { contents: '', path: null }
+      };
+
+      await app.getTabLinter(tab);
+
+      // when
+      // element templates were (re-)loaded, invalidating cached linters
+      app.linterCache = {};
+
+      await app.getTabLinter(tab);
+
+      // then
+      // templates changed, so the linter is rebuilt
+      expect(getLinterSpy).to.have.been.calledTwice;
+    });
+
+
+    it('should invalidate linter cache on element-templates-changed', async function() {
+
+      // given
+      const tabsProvider = new TabsProvider();
+
+      const getLinterSpy = sinon.spy(tabsProvider.getProvider('cloud-bpmn'), 'getLinter');
+
+      const { app } = createApp({ tabsProvider });
+
+      await app.createDiagram('cloud-bpmn');
+
+      const { activeTab } = app.state;
+
+      await app.lintTab(activeTab);
+
+      expect(getLinterSpy).to.have.been.calledOnce;
+
+      // when
+      // templates changed - the cache entry is dropped
+      await app.triggerAction('element-templates-changed', { tab: activeTab });
+
+      // then
+      // the next lint rebuilds the linter (the handler itself does not re-lint)
+      await app.lintTab(activeTab);
+
+      expect(getLinterSpy).to.have.been.calledTwice;
+    });
+
+
+    it('should invalidate only the changed tab linter on element-templates-changed', async function() {
+
+      // given
+      const tabsProvider = new TabsProvider();
+
+      const getLinterSpy = sinon.spy(tabsProvider.getProvider('cloud-bpmn'), 'getLinter');
+
+      const { app } = createApp({ tabsProvider });
+
+      await app.createDiagram('cloud-bpmn');
+
+      const otherTab = app.state.activeTab;
+
+      await app.createDiagram('cloud-bpmn');
+
+      const changedTab = app.state.activeTab;
+
+      // cache linters for both tabs
+      await app.lintTab(otherTab);
+      await app.lintTab(changedTab);
+
+      expect(getLinterSpy).to.have.been.calledTwice;
+
+      // when
+      // templates changed for one specific tab
+      await app.triggerAction('element-templates-changed', { tab: changedTab });
+
+      getLinterSpy.resetHistory();
+
+      // then
+      // the other tab's linter is retained (its templates did not change)
+      await app.lintTab(otherTab);
+
+      expect(getLinterSpy).not.to.have.been.called;
+
+      // but the changed tab's linter is rebuilt on the next lint
+      await app.lintTab(changedTab);
+
+      expect(getLinterSpy).to.have.been.calledOnce;
+    });
+
+
     it('should return empty linting state', async function() {
 
       // given

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -3786,6 +3786,102 @@ describe('<App>', function() {
       expect(getConfigSpy).to.be.calledOnceWith('foo');
     });
 
+
+    it('should get config for the active tab file', async function() {
+
+      // given
+      const getConfigSpy = spy();
+
+      const config = new Config({
+        get: getConfigSpy
+      });
+
+      const { app } = createApp({
+        globals: {
+          config
+        }
+      });
+
+      const file = { path: '/some/dir/diagram.bpmn' };
+
+      app.state.activeTab = { id: 'tab-1', file };
+
+      getConfigSpy.resetHistory();
+
+      // when
+      app.getConfig('foo');
+
+      // then
+      // the active tab's file is forwarded so file-scoped config
+      // (e.g. local element templates) resolves against it
+      expect(getConfigSpy).to.be.calledOnceWith('foo', file);
+    });
+
+  });
+
+
+  describe('#getConfigForFile', function() {
+
+    afterEach(sinon.restore);
+
+
+    it('should get config for the given file', function() {
+
+      // given
+      const getConfigSpy = spy();
+
+      const config = new Config({
+        get: getConfigSpy
+      });
+
+      const { app } = createApp({
+        globals: {
+          config
+        }
+      });
+
+      const file = { path: '/some/dir/diagram.bpmn' };
+
+      getConfigSpy.resetHistory();
+
+      // when
+      app.getConfigForFile('foo', file, 'bar');
+
+      // then
+      // the passed file is forwarded, independent from the active tab
+      expect(getConfigSpy).to.be.calledOnceWith('foo', file, 'bar');
+    });
+
+
+    it('should be callable when detached from the app', function() {
+
+      // given
+      const getConfigSpy = spy();
+
+      const config = new Config({
+        get: getConfigSpy
+      });
+
+      const { app } = createApp({
+        globals: {
+          config
+        }
+      });
+
+      getConfigSpy.resetHistory();
+
+      // when
+      // consumers (e.g. the linter) receive it as a bare callback
+      const getConfigForFile = app.getConfigForFile;
+
+      const file = { path: '/some/dir/diagram.bpmn' };
+
+      getConfigForFile('foo', file);
+
+      // then
+      expect(getConfigSpy).to.be.calledOnceWith('foo', file);
+    });
+
   });
 
 
@@ -4536,6 +4632,57 @@ describe('<App>', function() {
       // then
       // linter is built once and reused, not rebuilt on every lint
       expect(getLinterSpy).to.have.been.calledOnce;
+    });
+
+
+    it('should build linter with a file-scoped config for the tab', async function() {
+
+      // given
+      const getConfigSpy = spy();
+
+      const config = new Config({
+        get: getConfigSpy
+      });
+
+      const tabsProvider = new TabsProvider();
+
+      const getLinterSpy = sinon.spy(tabsProvider.getProvider('cloud-bpmn'), 'getLinter');
+
+      const { app } = createApp({
+        globals: {
+          config
+        },
+        tabsProvider
+      });
+
+      // active tab differs from the tab we lint
+      app.state.activeTab = { id: 'other', file: { path: '/other/dir/diagram.bpmn' } };
+
+      const file = { contents: '', path: '/some/dir/diagram.bpmn' };
+
+      const tab = {
+        id: 'cloud-bpmn-1',
+        type: 'cloud-bpmn',
+        file
+      };
+
+      // when
+      await app.getTabLinter(tab);
+
+      // then
+      // the linter is built for the linted tab, with a config accessor that
+      // resolves against that tab's file - not the active tab
+      expect(getLinterSpy).to.have.been.calledOnce;
+
+      const [ , passedTab, getConfig ] = getLinterSpy.firstCall.args;
+
+      expect(passedTab).to.equal(tab);
+
+      getConfigSpy.resetHistory();
+
+      getConfig('bpmn.elementTemplates', tab.file);
+
+      expect(getConfigSpy).to.have.been.calledOnceWith('bpmn.elementTemplates', file);
     });
 
 

--- a/client/src/app/__tests__/TabsProviderSpec.js
+++ b/client/src/app/__tests__/TabsProviderSpec.js
@@ -1042,6 +1042,30 @@ describe('TabsProvider', function() {
     });
 
 
+    it('cloud-bpmn should resolve templates for the tab file', async function() {
+
+      // given
+      const tabsProvider = new TabsProvider().getProvider('cloud-bpmn');
+
+      const calls = [];
+
+      const getConfig = (...args) => {
+        calls.push(args);
+
+        return [];
+      };
+
+      const file = { path: '/some/dir/diagram.bpmn' };
+
+      // when
+      await tabsProvider.getLinter([], { file }, getConfig);
+
+      // then
+      // templates are requested for the linted tab's file
+      expect(calls).to.eql([ [ 'bpmn.elementTemplates', file ] ]);
+    });
+
+
     it('cloud-bpmn plugins', async function() {
 
       // given

--- a/client/src/app/__tests__/helpers/renderEditor.js
+++ b/client/src/app/__tests__/helpers/renderEditor.js
@@ -13,10 +13,14 @@ import * as sinon from 'sinon';
 
 import React, { createRef } from 'react';
 
+import EventEmitter from 'events';
+
 import { render, waitFor } from '@testing-library/react';
 
 import { SlotFillRoot } from '../../slot-fill';
 import Panel from '../../panel/Panel';
+
+import { EventsContext } from '../../EventsContext';
 
 import { WithCachedState } from '../../cached';
 import Cache from '../../cached/Cache';
@@ -69,14 +73,28 @@ export default async function renderEditor(EditorComponent, xml, options = {}) {
 
   const TestEditor = WithCachedState(EditorComponent);
 
+  const eventBus = options.eventBus || new EventEmitter();
+
+  const eventsContext = {
+    subscribe: (event, listener) => {
+      eventBus.on(event, listener);
+
+      return {
+        cancel: () => eventBus.off(event, listener)
+      };
+    }
+  };
+
   const {
     rerender,
     ...renderResults
   } = render(
-    <SlotFillRoot>
-      <TestEditor ref={ ref } { ...props } />
-      <Panel layout={ props.layout } />
-    </SlotFillRoot>
+    <EventsContext.Provider value={ eventsContext }>
+      <SlotFillRoot>
+        <TestEditor ref={ ref } { ...props } />
+        <Panel layout={ props.layout } />
+      </SlotFillRoot>
+    </EventsContext.Provider>
   );
 
   if (props.waitForImport) {
@@ -88,17 +106,20 @@ export default async function renderEditor(EditorComponent, xml, options = {}) {
   return {
     ...renderResults,
     instance: ref.current,
+    emit: (event, ...args) => eventBus.emit(event, ...args),
     rerender: (newXML, newOptions = {}) => {
       rerender(
-        <SlotFillRoot>
-          <TestEditor
-            ref={ ref }
-            { ...props }
-            xml={ newXML || xml }
-            { ...newOptions }
-          />
-          <Panel layout={ props.layout } />
-        </SlotFillRoot>
+        <EventsContext.Provider value={ eventsContext }>
+          <SlotFillRoot>
+            <TestEditor
+              ref={ ref }
+              { ...props }
+              xml={ newXML || xml }
+              { ...newOptions }
+            />
+            <Panel layout={ props.layout } />
+          </SlotFillRoot>
+        </EventsContext.Provider>
       );
     }
   };

--- a/client/src/app/__tests__/mocks/index.js
+++ b/client/src/app/__tests__/mocks/index.js
@@ -115,7 +115,10 @@ const noopProvider = {
 export class TabsProvider {
 
   constructor(resolveTab) {
-    this.uuid = 0;
+
+    // start at 1 so generated tab ids are always truthy, matching production
+    // (real ids are non-empty strings; id 0 would be falsy)
+    this.uuid = 1;
 
     this.resolveTab = resolveTab || function(type) {
 

--- a/client/src/app/tabs/MultiSheetTab.js
+++ b/client/src/app/tabs/MultiSheetTab.js
@@ -360,6 +360,13 @@ export class MultiSheetTab extends CachedComponent {
       });
     }
 
+    if (action === 'element-templates-changed') {
+      return onAction('element-templates-changed', {
+        ...options,
+        tab
+      });
+    }
+
     return onAction(action, options);
   };
 

--- a/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
+++ b/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
@@ -559,6 +559,49 @@ describe('<MultiSheetTab>', function() {
       });
     });
 
+
+    it('should inject tab into element-templates-changed action', async function() {
+
+      // given
+      const onAction = sinon.spy();
+
+      const {
+        instance
+      } = renderTab({
+        onAction
+      });
+
+      // when
+      await instance.onAction('element-templates-changed');
+
+      // then
+      expect(onAction).to.have.been.calledWith('element-templates-changed', {
+        tab: instance.props.tab
+      });
+    });
+
+
+    it('should preserve options on element-templates-changed action', async function() {
+
+      // given
+      const onAction = sinon.spy();
+
+      const {
+        instance
+      } = renderTab({
+        onAction
+      });
+
+      // when
+      await instance.onAction('element-templates-changed', { foo: 'bar' });
+
+      // then
+      expect(onAction).to.have.been.calledWith('element-templates-changed', {
+        foo: 'bar',
+        tab: instance.props.tab
+      });
+    });
+
   });
 
 

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -285,9 +285,22 @@ export class BpmnEditor extends CachedComponent {
 
     const templatesLoader = modeler.get('elementTemplatesLoader');
 
-    const templates = await getConfig('bpmn.elementTemplates');
+    const templates = getPlatformTemplates(await getConfig('bpmn.elementTemplates'));
 
-    templatesLoader.setTemplates(getPlatformTemplates(templates));
+    // skip (re-)setting identical templates: setting them re-validates every
+    // template and invalidates the linter. A (re-)load only warrants that work
+    // when the fetched templates actually changed (e.g. edited locally). The
+    // key lives in the (tab-scoped) cache so it survives editor remounts, i.e.
+    // switching away and back to the tab does not re-set unchanged templates.
+    const templatesKey = JSON.stringify(templates);
+
+    if (templatesKey === this.getCached().templatesKey) {
+      return;
+    }
+
+    this.setCached({ templatesKey });
+
+    templatesLoader.setTemplates(templates);
   }
 
   undo = () => {

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -259,6 +259,8 @@ export class BpmnEditor extends CachedComponent {
 
     modeler[fn]('elementTemplates.errors', this.handleElementTemplateErrors);
 
+    modeler[fn]('elementTemplates.changed', this.handleElementTemplatesChanged);
+
     modeler[fn]('error', 1500, this.handleError);
 
     modeler[fn]('minimap.toggle', this.handleMinimapToggle);
@@ -341,6 +343,18 @@ export class BpmnEditor extends CachedComponent {
     errors.forEach(error => {
       onWarning({ message: error.message });
     });
+  };
+
+  /**
+   * React to the modeler's element templates changing - e.g. after
+   * (re-)loading them. Templates are a linting input, so we let the app
+   * invalidate the (cached) linter for this tab and then re-lint through our
+   * own debounced path - coalescing with any concurrent modeling changes.
+   */
+  handleElementTemplatesChanged = () => {
+    this.props.onAction('element-templates-changed');
+
+    this.handleLintingDebounced();
   };
 
   handleAttach = (event) => {

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -10,6 +10,8 @@
 
 import React from 'react';
 
+import debug from 'debug';
+
 import { isFunction } from 'min-dash';
 
 import {
@@ -86,6 +88,8 @@ export const DEFAULT_ENGINE_PROFILE = {
 };
 
 const LOW_PRIORITY = 500;
+
+const log = debug('BpmnEditor:platform');
 
 
 export class BpmnEditor extends CachedComponent {
@@ -281,7 +285,10 @@ export class BpmnEditor extends CachedComponent {
   }
 
   async loadTemplates() {
-    const { getConfig } = this.props;
+    const {
+      getConfig,
+      tab
+    } = this.props;
 
     const modeler = this.getModeler();
 
@@ -297,12 +304,18 @@ export class BpmnEditor extends CachedComponent {
     const templatesKey = JSON.stringify(templates);
 
     if (templatesKey === this.getCached().templatesKey) {
+      log('skip re-setting - element templates unchanged', { tabId: tab?.id, path: this.props.file?.path });
+
       return;
     }
 
     this.setCached({ templatesKey });
 
+    log('setting element templates', { tabId: tab?.id, path: this.props.file?.path });
+
     templatesLoader.setTemplates(templates);
+
+    log('element templates set', { tabId: tab?.id, path: this.props.file?.path });
   }
 
   undo = () => {
@@ -352,6 +365,8 @@ export class BpmnEditor extends CachedComponent {
    * own debounced path - coalescing with any concurrent modeling changes.
    */
   handleElementTemplatesChanged = () => {
+    log('element templates changed', { path: this.props.file?.path });
+
     this.props.onAction('element-templates-changed');
 
     this.handleLintingDebounced();

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -205,7 +205,7 @@ export class BpmnEditor extends CachedComponent {
       }
     }
 
-    if (prevProps.file !== this.props.file) {
+    if (prevProps.file?.path !== this.props.file?.path) {
       this.loadTemplates();
     }
 

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -28,6 +28,8 @@ import {
   CachedComponent
 } from '../../cached';
 
+import { EventsContext } from '../../EventsContext';
+
 import { Settings } from '@carbon/icons-react';
 
 import SidePanel, { DEFAULT_LAYOUT as SIDE_PANEL_DEFAULT_LAYOUT } from '../../side-panel/SidePanel';
@@ -93,6 +95,8 @@ const log = debug('BpmnEditor:platform');
 
 
 export class BpmnEditor extends CachedComponent {
+
+  static contextType = EventsContext;
 
   constructor(props) {
     super(props);
@@ -276,6 +280,15 @@ export class BpmnEditor extends CachedComponent {
     } else if (fn === 'off') {
       modeler[ fn ]('commandStack.changed', this.handleLintingDebounced);
     }
+
+    // reload templates on focus to pick up external edits to local template
+    // files made while the app was away. The editor owns this decision, not
+    // the app. Cheap: loadTemplates skips re-setting unchanged templates.
+    if (fn === 'on') {
+      this._appFocusedSubscription = this.context.subscribe('app.focused', this.handleAppFocused);
+    } else {
+      this._appFocusedSubscription?.cancel();
+    }
   }
 
   handlePropertiesPanelLayoutChange(e) {
@@ -283,6 +296,10 @@ export class BpmnEditor extends CachedComponent {
       propertiesPanel: e.layout
     });
   }
+
+  handleAppFocused = () => {
+    this.loadTemplates().catch(error => this.handleError({ error }));
+  };
 
   async loadTemplates() {
     const {

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -1721,7 +1721,7 @@ describe('<BpmnEditor>', function() {
 
       // then
       // BpmnEditor#componentDidMount is async
-      setTimeout(() => {
+      await waitFor(() => {
         expect(isImportNeededSpy).to.have.been.calledOnce;
         expect(isImportNeededSpy).to.have.always.returned(false);
       });
@@ -1888,6 +1888,117 @@ describe('<BpmnEditor>', function() {
       });
       expect(getConfigStub).to.be.calledWith('bpmn.elementTemplates');
       expect(setTemplatesSpy).to.be.calledOnce;
+    });
+
+
+    it('should reload templates when the app regains focus', async function() {
+
+      // given
+      // each fetch returns different templates so the reload is applied
+      let call = 0;
+
+      const getConfigStub = sinon.stub().callsFake(() => Promise.resolve([
+        { 'id': `template-${ call++ }` }
+      ]));
+
+      const setTemplatesSpy = sinon.spy(),
+            elementTemplatesLoaderMock = { setTemplates: setTemplatesSpy };
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: elementTemplatesLoaderMock
+            }
+          })
+        }
+      });
+
+      const { emit } = await renderEditor(diagramXML, {
+        cache,
+        getConfig: getConfigStub
+      });
+
+      getConfigStub.resetHistory();
+      setTemplatesSpy.resetHistory();
+
+      // when
+      // an external process may have edited local templates while away
+      emit('app.focused');
+
+      // then
+      await waitFor(() => {
+        expect(getConfigStub).to.be.calledOnce;
+      });
+      expect(getConfigStub).to.be.calledWith('bpmn.elementTemplates');
+      expect(setTemplatesSpy).to.be.calledOnce;
+    });
+
+
+    it('should not re-set unchanged templates when the app regains focus', async function() {
+
+      // given
+      const getConfigStub = sinon.stub().resolves([ { 'id': 'template-1' } ]);
+
+      const setTemplatesSpy = sinon.spy();
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: { setTemplates: setTemplatesSpy }
+            }
+          })
+        }
+      });
+
+      const { emit } = await renderEditor(diagramXML, {
+        cache,
+        getConfig: getConfigStub
+      });
+
+      // templates were set once on mount
+      expect(setTemplatesSpy).to.be.calledOnce;
+
+      // when
+      // focus fetches the same templates
+      emit('app.focused');
+
+      // then
+      // identical templates are not re-applied (no re-validation, linter kept)
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(setTemplatesSpy).to.be.calledOnce;
+    });
+
+
+    it('should not reload templates on focus after unmount', async function() {
+
+      // given
+      let call = 0;
+
+      const getConfigStub = sinon.stub().callsFake(() => Promise.resolve([
+        { 'id': `template-${ call++ }` }
+      ]));
+
+      const { emit, unmount } = await renderEditor(diagramXML, {
+        getConfig: getConfigStub
+      });
+
+      getConfigStub.resetHistory();
+
+      // when
+      // the subscription is cancelled on unmount
+      unmount();
+
+      emit('app.focused');
+
+      // then
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(getConfigStub).not.to.have.been.called;
     });
 
 

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -1894,8 +1894,14 @@ describe('<BpmnEditor>', function() {
     it('should reload templates on action triggered', async function() {
 
       // given
-      const getConfigSpy = sinon.spy(),
-            elementTemplatesLoaderStub = sinon.stub({ setTemplates() {} });
+      // each fetch returns different templates so the reload is applied
+      let call = 0;
+
+      const getConfigStub = sinon.stub().callsFake(() => Promise.resolve([
+        { 'id': `template-${ call++ }` }
+      ]));
+
+      const elementTemplatesLoaderStub = sinon.stub({ setTemplates() {} });
 
       const cache = new Cache();
 
@@ -1912,15 +1918,52 @@ describe('<BpmnEditor>', function() {
       // when
       const { instance } = await renderEditor(diagramXML, {
         cache,
-        getConfig: getConfigSpy
+        getConfig: getConfigStub
       });
 
       await instance.triggerAction('elementTemplates.reload');
 
       // expect
-      expect(getConfigSpy).to.be.calledTwice;
-      expect(getConfigSpy).to.be.always.calledWith('bpmn.elementTemplates');
+      expect(getConfigStub).to.be.calledTwice;
+      expect(getConfigStub).to.be.always.calledWith('bpmn.elementTemplates');
       expect(elementTemplatesLoaderStub.setTemplates).to.be.calledTwice;
+    });
+
+
+    it('should not re-set unchanged templates on reload', async function() {
+
+      // given
+      const getConfigStub = sinon.stub().resolves([ { 'id': 'template-1' } ]);
+
+      const setTemplatesSpy = sinon.spy();
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: { setTemplates: setTemplatesSpy }
+            }
+          })
+        }
+      });
+
+      const { instance } = await renderEditor(diagramXML, {
+        cache,
+        getConfig: getConfigStub
+      });
+
+      // templates were set once on mount
+      expect(setTemplatesSpy).to.be.calledOnce;
+
+      // when
+      // reload fetches the same templates
+      await instance.triggerAction('elementTemplates.reload');
+
+      // then
+      // identical templates are not re-applied (no re-validation, linter kept)
+      expect(setTemplatesSpy).to.be.calledOnce;
     });
 
 

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -1891,6 +1891,29 @@ describe('<BpmnEditor>', function() {
     });
 
 
+    it('should invalidate linter and re-lint when element templates change', async function() {
+
+      // given
+      const onActionSpy = sinon.spy();
+
+      const { instance } = await renderEditor(diagramXML, {
+        onAction: onActionSpy
+      });
+
+      onActionSpy.resetHistory();
+
+      // when
+      instance.getModeler()._emit('elementTemplates.changed');
+
+      // then
+      // the app is asked to invalidate the cached linter for this tab ...
+      expect(onActionSpy).to.have.been.calledWith('element-templates-changed');
+
+      // ... and the editor re-lints through its own (debounced) path
+      expect(onActionSpy).to.have.been.calledWithMatch('lint-tab');
+    });
+
+
     it('should reload templates on action triggered', async function() {
 
       // given

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -1801,7 +1801,7 @@ describe('<BpmnEditor>', function() {
     });
 
 
-    it('should reload templates on save', async function() {
+    it('should not reload templates on save (unchanged path)', async function() {
 
       // given
       const getConfigSpy = sinon.spy(),
@@ -1830,15 +1830,63 @@ describe('<BpmnEditor>', function() {
       setTemplatesSpy.resetHistory();
 
       // when
+      // save replaces the file object, but the path is unchanged
       rerender(diagramXML, {
         file: { path: '/bar' }
       });
 
       // expect
-      await waitFor(() => {
-        expect(getConfigSpy).to.be.calledOnce;
+      // templates are NOT re-fetched / re-validated on save
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(getConfigSpy).not.to.have.been.called;
+      expect(setTemplatesSpy).not.to.have.been.called;
+    });
+
+
+    it('should reload templates when file path changes', async function() {
+
+      // given
+      let call = 0;
+
+      const getConfigStub = sinon.stub().callsFake(() => Promise.resolve([
+        { 'id': `template-${ call++ }` }
+      ]));
+
+      const setTemplatesSpy = sinon.spy(),
+            elementTemplatesLoaderMock = { setTemplates: setTemplatesSpy };
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: elementTemplatesLoaderMock
+            }
+          })
+        }
       });
-      expect(getConfigSpy).to.be.calledWith('bpmn.elementTemplates');
+
+      const { rerender } = await renderEditor(diagramXML, {
+        cache,
+        getConfig: getConfigStub,
+        file: { path: '/bar' }
+      });
+
+      getConfigStub.resetHistory();
+      setTemplatesSpy.resetHistory();
+
+      // when
+      // e.g. save-as to a new path, exposing different local templates
+      rerender(diagramXML, {
+        file: { path: '/baz' }
+      });
+
+      // expect
+      await waitFor(() => {
+        expect(getConfigStub).to.be.calledOnce;
+      });
+      expect(getConfigStub).to.be.calledWith('bpmn.elementTemplates');
       expect(setTemplatesSpy).to.be.calledOnce;
     });
 

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -10,6 +10,8 @@
 
 import React from 'react';
 
+import debug from 'debug';
+
 import { isFunction } from 'min-dash';
 
 import {
@@ -84,6 +86,8 @@ export const DEFAULT_ENGINE_PROFILE = {
 };
 
 const LOW_PRIORITY = 500;
+
+const log = debug('BpmnEditor:cloud');
 
 
 export class BpmnEditor extends CachedComponent {
@@ -312,7 +316,10 @@ export class BpmnEditor extends CachedComponent {
   };
 
   async loadTemplates() {
-    const { getConfig } = this.props;
+    const {
+      getConfig,
+      tab
+    } = this.props;
 
     const modeler = this.getModeler();
 
@@ -328,12 +335,18 @@ export class BpmnEditor extends CachedComponent {
     const templatesKey = JSON.stringify(templates);
 
     if (templatesKey === this.getCached().templatesKey) {
+      log('skip re-setting - element templates unchanged', { tabId: tab?.id, path: this.props.file?.path });
+
       return;
     }
 
     this.setCached({ templatesKey });
 
+    log('setting element templates', { tabId: tab?.id, path: this.props.file?.path });
+
     templatesLoader.setTemplates(templates);
+
+    log('element templates set', { tabId: tab?.id, path: this.props.file?.path });
   }
 
   undo = () => {
@@ -383,6 +396,8 @@ export class BpmnEditor extends CachedComponent {
    * own debounced path - coalescing with any concurrent modeling changes.
    */
   handleElementTemplatesChanged = () => {
+    log('element templates changed', { path: this.props.file?.path });
+
     this.props.onAction('element-templates-changed');
 
     this.handleLintingDebounced();

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -28,6 +28,8 @@ import {
   CachedComponent
 } from '../../cached';
 
+import { EventsContext } from '../../EventsContext';
+
 import { Settings } from '@carbon/icons-react';
 
 import SidePanel, { DEFAULT_LAYOUT as SIDE_PANEL_DEFAULT_LAYOUT } from '../../side-panel/SidePanel';
@@ -91,6 +93,8 @@ const log = debug('BpmnEditor:cloud');
 
 
 export class BpmnEditor extends CachedComponent {
+
+  static contextType = EventsContext;
 
   constructor(props) {
     super(props);
@@ -290,6 +294,15 @@ export class BpmnEditor extends CachedComponent {
     } else if (fn === 'off') {
       modeler[ fn ]('commandStack.changed', this.handleLintingDebounced);
     }
+
+    // reload templates on focus to pick up external edits to local template
+    // files made while the app was away. The editor owns this decision, not
+    // the app. Cheap: loadTemplates skips re-setting unchanged templates.
+    if (fn === 'on') {
+      this._appFocusedSubscription = this.context.subscribe('app.focused', this.handleAppFocused);
+    } else {
+      this._appFocusedSubscription?.cancel();
+    }
   }
 
   handlePropertiesPanelLayoutChange(e) {
@@ -313,6 +326,10 @@ export class BpmnEditor extends CachedComponent {
     };
 
     elementTemplates.setEngines(engines);
+  };
+
+  handleAppFocused = () => {
+    this.loadTemplates().catch(error => this.handleError({ error }));
   };
 
   async loadTemplates() {

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -316,9 +316,22 @@ export class BpmnEditor extends CachedComponent {
 
     const templatesLoader = modeler.get('elementTemplatesLoader');
 
-    let templates = await getConfig('bpmn.elementTemplates');
+    const templates = getCloudTemplates(await getConfig('bpmn.elementTemplates'));
 
-    templatesLoader.setTemplates(getCloudTemplates(templates));
+    // skip (re-)setting identical templates: setting them re-validates every
+    // template and invalidates the linter. A (re-)load only warrants that work
+    // when the fetched templates actually changed (e.g. edited locally). The
+    // key lives in the (tab-scoped) cache so it survives editor remounts, i.e.
+    // switching away and back to the tab does not re-set unchanged templates.
+    const templatesKey = JSON.stringify(templates);
+
+    if (templatesKey === this.getCached().templatesKey) {
+      return;
+    }
+
+    this.setCached({ templatesKey });
+
+    templatesLoader.setTemplates(templates);
   }
 
   undo = () => {

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -215,7 +215,7 @@ export class BpmnEditor extends CachedComponent {
       }
     }
 
-    if (prevProps.file !== this.props.file) {
+    if (prevProps.file?.path !== this.props.file?.path) {
       this.loadTemplates();
     }
 

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -273,6 +273,8 @@ export class BpmnEditor extends CachedComponent {
 
     modeler[fn]('elementTemplates.errors', this.handleElementTemplateErrors);
 
+    modeler[fn]('elementTemplates.changed', this.handleElementTemplatesChanged);
+
     modeler[fn]('error', 1500, this.handleError);
 
     modeler[fn]('minimap.toggle', this.handleMinimapToggle);
@@ -372,6 +374,18 @@ export class BpmnEditor extends CachedComponent {
     errors.forEach(error => {
       onWarning({ message: error.message });
     });
+  };
+
+  /**
+   * React to the modeler's element templates changing - e.g. after
+   * (re-)loading them. Templates are a linting input, so we let the app
+   * invalidate the (cached) linter for this tab and then re-lint through our
+   * own debounced path - coalescing with any concurrent modeling changes.
+   */
+  handleElementTemplatesChanged = () => {
+    this.props.onAction('element-templates-changed');
+
+    this.handleLintingDebounced();
   };
 
   handleAttach = (event) => {

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -1867,8 +1867,17 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
     it('should reload templates on action triggered', async function() {
 
       // given
-      const getConfigSpy = sinon.spy(),
-            elementTemplatesLoaderStub = sinon.stub({ setTemplates() {} });
+      // each fetch returns different templates so the reload is applied
+      let call = 0;
+
+      const getConfigStub = sinon.stub().callsFake(() => Promise.resolve([
+        {
+          '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+          'id': `template-${ call++ }`
+        }
+      ]));
+
+      const elementTemplatesLoaderStub = sinon.stub({ setTemplates() {} });
 
       const cache = new Cache();
 
@@ -1885,15 +1894,57 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
       // when
       const { instance } = await renderEditor(diagramXML, {
         cache,
-        getConfig: getConfigSpy
+        getConfig: getConfigStub
       });
 
       await instance.triggerAction('elementTemplates.reload');
 
       // expect
-      expect(getConfigSpy).to.be.calledTwice;
-      expect(getConfigSpy).to.be.always.calledWith('bpmn.elementTemplates');
+      expect(getConfigStub).to.be.calledTwice;
+      expect(getConfigStub).to.be.always.calledWith('bpmn.elementTemplates');
       expect(elementTemplatesLoaderStub.setTemplates).to.be.calledTwice;
+    });
+
+
+    it('should not re-set unchanged templates on reload', async function() {
+
+      // given
+      const getConfigStub = sinon.stub().resolves([
+        {
+          '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+          'id': 'template-1'
+        }
+      ]);
+
+      const setTemplatesSpy = sinon.spy();
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: { setTemplates: setTemplatesSpy }
+            }
+          })
+        }
+      });
+
+      const { instance } = await renderEditor(diagramXML, {
+        cache,
+        getConfig: getConfigStub
+      });
+
+      // templates were set once on mount
+      expect(setTemplatesSpy).to.be.calledOnce;
+
+      // when
+      // reload fetches the same templates
+      await instance.triggerAction('elementTemplates.reload');
+
+      // then
+      // identical templates are not re-applied (no re-validation, linter kept)
+      expect(setTemplatesSpy).to.be.calledOnce;
     });
 
 

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -2041,6 +2041,128 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
     });
 
 
+    it('should reload templates when the app regains focus', async function() {
+
+      // given
+      // each fetch returns different templates so the reload is applied
+      let call = 0;
+
+      const getConfigStub = sinon.stub().callsFake(() => Promise.resolve([
+        {
+          '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+          'id': `template-${ call++ }`
+        }
+      ]));
+
+      const setTemplatesSpy = sinon.spy(),
+            elementTemplatesLoaderMock = { setTemplates: setTemplatesSpy };
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: elementTemplatesLoaderMock
+            }
+          })
+        }
+      });
+
+      const { emit } = await renderEditor(diagramXML, {
+        cache,
+        getConfig: getConfigStub
+      });
+
+      getConfigStub.resetHistory();
+      setTemplatesSpy.resetHistory();
+
+      // when
+      // an external process may have edited local templates while away
+      emit('app.focused');
+
+      // then
+      await waitFor(() => {
+        expect(getConfigStub).to.be.calledOnce;
+      });
+      expect(getConfigStub).to.be.calledWith('bpmn.elementTemplates');
+      expect(setTemplatesSpy).to.be.calledOnce;
+    });
+
+
+    it('should not re-set unchanged templates when the app regains focus', async function() {
+
+      // given
+      const getConfigStub = sinon.stub().resolves([
+        {
+          '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+          'id': 'template-1'
+        }
+      ]);
+
+      const setTemplatesSpy = sinon.spy();
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: { setTemplates: setTemplatesSpy }
+            }
+          })
+        }
+      });
+
+      const { emit } = await renderEditor(diagramXML, {
+        cache,
+        getConfig: getConfigStub
+      });
+
+      // templates were set once on mount
+      expect(setTemplatesSpy).to.be.calledOnce;
+
+      // when
+      // focus fetches the same templates
+      emit('app.focused');
+
+      // then
+      // identical templates are not re-applied (no re-validation, linter kept)
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(setTemplatesSpy).to.be.calledOnce;
+    });
+
+
+    it('should not reload templates on focus after unmount', async function() {
+
+      // given
+      let call = 0;
+
+      const getConfigStub = sinon.stub().callsFake(() => Promise.resolve([
+        {
+          '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+          'id': `template-${ call++ }`
+        }
+      ]));
+
+      const { emit, unmount } = await renderEditor(diagramXML, {
+        getConfig: getConfigStub
+      });
+
+      getConfigStub.resetHistory();
+
+      // when
+      // the subscription is cancelled on unmount
+      unmount();
+
+      emit('app.focused');
+
+      // then
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(getConfigStub).not.to.have.been.called;
+    });
+
+
     it('should invalidate linter and re-lint when element templates change', async function() {
 
       // given

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -2041,6 +2041,29 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
     });
 
 
+    it('should invalidate linter and re-lint when element templates change', async function() {
+
+      // given
+      const onActionSpy = sinon.spy();
+
+      const { instance } = await renderEditor(diagramXML, {
+        onAction: onActionSpy
+      });
+
+      onActionSpy.resetHistory();
+
+      // when
+      instance.getModeler()._emit('elementTemplates.changed');
+
+      // then
+      // the app is asked to invalidate the cached linter for this tab ...
+      expect(onActionSpy).to.have.been.calledWith('element-templates-changed');
+
+      // ... and the editor re-lints through its own (debounced) path
+      expect(onActionSpy).to.have.been.calledWithMatch('lint-tab');
+    });
+
+
     it('should ONLY load cloud templates', async function() {
 
       // given

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -1897,7 +1897,7 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
     });
 
 
-    it('should reload templates on save', async function() {
+    it('should not reload templates on save (unchanged path)', async function() {
 
       // given
       const getConfigSpy = sinon.spy(),
@@ -1926,15 +1926,66 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
       setTemplatesSpy.resetHistory();
 
       // when
+      // save replaces the file object, but the path is unchanged
       rerender(diagramXML, {
         file: { path: '/bar' }
       });
 
       // expect
-      await waitFor(() => {
-        expect(getConfigSpy).to.be.calledOnce;
+      // templates are NOT re-fetched / re-validated on save
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(getConfigSpy).not.to.have.been.called;
+      expect(setTemplatesSpy).not.to.have.been.called;
+    });
+
+
+    it('should reload templates when file path changes', async function() {
+
+      // given
+      let call = 0;
+
+      const getConfigStub = sinon.stub().callsFake(() => Promise.resolve([
+        {
+          '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+          'id': `template-${ call++ }`
+        }
+      ]));
+
+      const setTemplatesSpy = sinon.spy(),
+            elementTemplatesLoaderMock = { setTemplates: setTemplatesSpy };
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: elementTemplatesLoaderMock
+            }
+          })
+        }
       });
-      expect(getConfigSpy).to.be.calledWith('bpmn.elementTemplates');
+
+      const { rerender } = await renderEditor(diagramXML, {
+        cache,
+        getConfig: getConfigStub,
+        file: { path: '/bar' }
+      });
+
+      getConfigStub.resetHistory();
+      setTemplatesSpy.resetHistory();
+
+      // when
+      // e.g. save-as to a new path, exposing different local templates
+      rerender(diagramXML, {
+        file: { path: '/baz' }
+      });
+
+      // expect
+      await waitFor(() => {
+        expect(getConfigStub).to.be.calledOnce;
+      });
+      expect(getConfigStub).to.be.calledWith('bpmn.elementTemplates');
       expect(setTemplatesSpy).to.be.calledOnce;
     });
 

--- a/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
@@ -1927,7 +1927,7 @@ describe('<DmnEditor>', function() {
 
       // then
       // DmnEditor#componentDidMount is async
-      setTimeout(() => {
+      await waitFor(() => {
         expect(isImportNeededSpy).to.have.been.calledOnce;
         expect(isImportNeededSpy).to.have.always.returned(false);
       });

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -1927,7 +1927,7 @@ describe('<DmnEditor>', function() {
 
       // then
       // DmnEditor#componentDidMount is async
-      setTimeout(() => {
+      await waitFor(() => {
         expect(isImportNeededSpy).to.have.been.calledOnce;
         expect(isImportNeededSpy).to.have.always.returned(false);
       });


### PR DESCRIPTION
### Proposed Changes

Previously our client-side linting infrastructure did not efficiently handle a large amount of element templates. It **set** (expensive because of internal validation happening) templates unnecessarily - during *any* file change, and independent from whether they *actually changed* or not. For good measure it did this twice - once for the editor and once for the linter.

This PR ensures we only do the work necessary:

* Only reload element templates when the file *path* changed (https://github.com/camunda/camunda-modeler/commit/d1b11fa3b3d25b398de2191246289e10398b55ba)
* Only set element templates when they changed (*raw*, on disk) (https://github.com/camunda/camunda-modeler/commit/abd2f0f8d3aff6909854cd0cb94d51e2dc9a492a)
* Cache (and invalidate) linter per tab, hooked up against the editor *element template changed* life-cycle (https://github.com/camunda/camunda-modeler/commit/a85077361b33ca64728b3cedef9dff25f7515561)
* Resolve linter element templates against the *tab's* file, not the active tab (https://github.com/camunda/camunda-modeler/commit/08dcfd7197f2c1f25c005805a7dc963d3fc06e2d)

At the same time, we added instrumentation ([1](https://github.com/camunda/camunda-modeler/commit/cb990d097d7d0f0b0e36e0ec78a971e1cc954ecb), [2](https://github.com/camunda/camunda-modeler/commit/4630b3212e598e11f6e5dc0c3c6849eb94da30bc)) - via the developer console you can now trace all relevant element template and linting related events:

<img width="709" height="890" alt="image" src="https://github.com/user-attachments/assets/2cc0cf17-0fc1-4f0e-97a9-d52301f2df44" />

(During development *every* component is double-rendered. Every effect is caused *twice* as we don't de-duplicate the actual lint operation per diagram contents yet - future improvement). Linter creation *is* already de-duplicated with this PR.

Reloading element templates on app focus was split out into #6103.

### Design notes

**Linter cache invalidation.** A tab's linter is rebuilt only when its element templates genuinely change: `elementTemplates.changed` → `element-templates-changed` (scoped to the *originating* tab) → cache invalidation. Ordinary modeling interactions reuse the cached linter. The cache entry is dropped on tab close.

**Caching a failed build is intentional.** A broken local template file makes `getConfig('bpmn.elementTemplates', tab.file)` throw (the config provider rethrows on malformed JSON), so the linter build rejects. That rejected promise stays cached *on purpose* — rebuilding it on the next lint would re-validate every template and fail again (the "next build will not succeed" case). Caching the failure avoids exactly the expensive, useless work this PR is about. We deliberately do **not** "drop the entry on reject": that would re-introduce a rebuild + full re-validation on *every* modeling interaction while a template is broken. The malformed state is already surfaced separately via `elementTemplates.errors`.

**Recovery is bounded and by design.** The cache clears on the sanctioned reload triggers — tab reopen, file path change, and app re-focus (#6103) — matching our [documented contract](https://docs.camunda.io/docs/components/modeler/desktop-modeler/element-templates/configuring-templates/) that reloading picks up template changes. We do not promise automatic reload; the previous per-lint self-heal was accidental, not a guarantee.

### Try out

Best experienced with C8 OOTB element templates loaded:

```
git checkout client-linter-cache
npm run dev
```

---

Related to https://github.com/camunda/camunda-modeler/issues/5557
Related to https://github.com/camunda/camunda-modeler/pull/6091 (companion PR)

---

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->

