### PR TITLE
feat(client): consume linting autofix package

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "@camunda/form-playground": "^0.25.0",
     "@camunda/improved-canvas": "^1.10.4",
     "@camunda/linting": "^3.54.1",
-    "@camunda/linting-autofix": "^0.1.0",
+    "@camunda/linting-autofix": "^0.1.1",
     "@camunda/rpa-integration": "^1.3.4",
     "@camunda/task-testing": "^6.0.1",
     "@carbon/icons-react": "^11.53.0",

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "@camunda/form-playground": "^0.25.0",
     "@camunda/improved-canvas": "^1.10.4",
     "@camunda/linting": "^3.54.1",
+    "@camunda/linting-autofix": "^0.1.0",
     "@camunda/rpa-integration": "^1.3.4",
     "@camunda/task-testing": "^6.0.1",
     "@carbon/icons-react": "^11.53.0",

--- a/client/src/app/tabs/cloud-bpmn/modeler/BpmnModeler.js
+++ b/client/src/app/tabs/cloud-bpmn/modeler/BpmnModeler.js
@@ -17,6 +17,7 @@ import globalClipboardModule from './features/global-clipboard';
 import handToolOnSpaceModule from '../../bpmn/modeler/features/hand-tool-on-space';
 import propertiesPanelKeyboardBindingsModule from '../../bpmn/modeler/features/properties-panel-keyboard-bindings';
 import lintingAnnotationsModule from '@camunda/linting/modeler';
+import { agentConfigAutofillModule } from '@camunda/linting-autofix';
 
 import { BpmnJSTracking as bpmnJSTracking } from 'bpmn-js-tracking';
 
@@ -78,6 +79,7 @@ CloudBpmnModeler.prototype._modules = [
   handToolOnSpaceModule,
   propertiesPanelKeyboardBindingsModule,
   lintingAnnotationsModule,
+  agentConfigAutofillModule,
   bpmnJSTracking,
   contextPadTracking,
   elementTemplates,

--- a/client/src/styles/_modeling.css
+++ b/client/src/styles/_modeling.css
@@ -20,6 +20,7 @@
 @import '~camunda-dmn-js/dist/assets/dmn-js-boxed-expression.css';
 @import '~camunda-dmn-js/dist/assets/dmn-js-shared.css';
 @import '~@camunda/linting/assets/linting.css';
+@import '~@camunda/linting-autofix/assets/linting-autofix.css';
 
 /* render popup menu on top of all elements */
 .djs-popup-backdrop {

--- a/client/test/bpmn-io-modelers/bpmn/CloudBpmnModelerSpec.js
+++ b/client/test/bpmn-io-modelers/bpmn/CloudBpmnModelerSpec.js
@@ -127,6 +127,20 @@ describe('BpmnModeler', function() {
   });
 
 
+  describe('agent config autofix', function() {
+
+    it('should register the agent config autofix module', async function() {
+
+      // when
+      const modeler = await createModeler();
+
+      // then
+      expect(modeler.get('agentConfigAutofillPropertiesProvider', false)).to.exist;
+    });
+
+  });
+
+
   describe('element template chooser', function() {
 
     it('should open chooser on <elementTemplates.select>', async function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -174,7 +174,7 @@
         "@camunda/form-playground": "^0.25.0",
         "@camunda/improved-canvas": "^1.10.4",
         "@camunda/linting": "^3.54.1",
-        "@camunda/linting-autofix": "^0.1.0",
+        "@camunda/linting-autofix": "^0.1.1",
         "@camunda/rpa-integration": "^1.3.4",
         "@camunda/task-testing": "^6.0.1",
         "@carbon/icons-react": "^11.53.0",
@@ -2737,9 +2737,9 @@
       }
     },
     "node_modules/@camunda/linting-autofix": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@camunda/linting-autofix/-/linting-autofix-0.1.0.tgz",
-      "integrity": "sha512-7kIXTPmM2749p4s/Z2pn3Bi3G6Yd9S6OPg9VW6EU+M8RGe3WrrPkOvnUvgzpioL2PR+r0ZXVBcR5V8YiDwiOPQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@camunda/linting-autofix/-/linting-autofix-0.1.1.tgz",
+      "integrity": "sha512-qsJsG5mDNFD+6QaOSCtLuDGl40IZKJpPJ8iNDk1zQTSmkSD7v3NZPmd8jZynkck8DPBSW5Fw+s5AAYJ+By5Cwg==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/feelin": "^6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -174,6 +174,7 @@
         "@camunda/form-playground": "^0.25.0",
         "@camunda/improved-canvas": "^1.10.4",
         "@camunda/linting": "^3.54.1",
+        "@camunda/linting-autofix": "^0.1.0",
         "@camunda/rpa-integration": "^1.3.4",
         "@camunda/task-testing": "^6.0.1",
         "@carbon/icons-react": "^11.53.0",
@@ -2733,6 +2734,22 @@
         "bpmn-js-properties-panel": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@camunda/linting-autofix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@camunda/linting-autofix/-/linting-autofix-0.1.0.tgz",
+      "integrity": "sha512-7kIXTPmM2749p4s/Z2pn3Bi3G6Yd9S6OPg9VW6EU+M8RGe3WrrPkOvnUvgzpioL2PR+r0ZXVBcR5V8YiDwiOPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/feelin": "^6.1.0",
+        "htm": "^3.1.1"
+      },
+      "peerDependencies": {
+        "@bpmn-io/properties-panel": ">= 3.26.0",
+        "bpmn-js": ">= 18.0.0",
+        "bpmn-js-properties-panel": ">= 5.0.0",
+        "diagram-js": ">= 15.0.0"
       }
     },
     "node_modules/@camunda/rpa-integration": {

--- a/test/e2e/fixtures/agentic-tool.bpmn
+++ b/test/e2e/fixtures/agentic-tool.bpmn
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_agentic_tool" targetNamespace="http://bpmn.io/schema/bpmn" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_to_agent</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:adHocSubProcess id="AgentSubProcess_1" name="Agent">
+      <bpmn:extensionElements>
+        <zeebe:adHoc />
+        <zeebe:taskDefinition type="io.camunda:agent:1" />
+        <zeebe:properties>
+          <zeebe:property name="io.camunda.agenticai.toolContainer" value="true" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_to_agent</bpmn:incoming>
+      <bpmn:outgoing>Flow_to_end</bpmn:outgoing>
+      <bpmn:serviceTask id="ToolTask_1" name="Fetch URL">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="tool" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=fromAi(url)" target="url" />
+            <zeebe:output source="=result" target="toolCallResult" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_to_agent" sourceRef="StartEvent_1" targetRef="AgentSubProcess_1" />
+    <bpmn:sequenceFlow id="Flow_to_end" sourceRef="AgentSubProcess_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="AgentSubProcess_1_di" bpmnElement="AgentSubProcess_1" isExpanded="true">
+        <dc:Bounds x="240" y="100" width="280" height="260" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ToolTask_1_di" bpmnElement="ToolTask_1">
+        <dc:Bounds x="300" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="580" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_to_agent_di" bpmnElement="Flow_to_agent">
+        <di:waypoint x="188" y="230" />
+        <di:waypoint x="240" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_to_end_di" bpmnElement="Flow_to_end">
+        <di:waypoint x="520" y="230" />
+        <di:waypoint x="580" y="230" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/e2e/specs/agent-config-autofix.spec.js
+++ b/test/e2e/specs/agent-config-autofix.spec.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+'use strict';
+
+const { test, expect } = require('../harness/test');
+const { copyFixture } = require('../harness/files');
+
+const Modeler = require('../pages/Modeler');
+
+/**
+ * Covers the integration of `@camunda/linting-autofix` — that the module is
+ * registered, its stylesheet is loaded, and its entries render through and
+ * modify the diagram via the properties panel. The affordances themselves are
+ * covered by the library.
+ */
+test.describe('agent config autofix', function() {
+
+  test('should fix a malformed fromAi() key from the properties panel', async function({ launch, tmp }) {
+
+    // given
+    const file = await copyFixture('agentic-tool.bpmn', tmp);
+
+    const app = await launch({ openFile: file });
+
+    const modeler = new Modeler(app);
+    const editor = modeler.bpmnEditor;
+    const propertiesPanel = modeler.propertiesPanel;
+
+    await editor.canvas().waitFor();
+
+    await editor.selectElement('ToolTask_1');
+
+    await propertiesPanel.waitForLoad();
+    await propertiesPanel.openGroup('Input mapping');
+    await propertiesPanel.openListItem('ToolTask_1-input-0');
+
+    const sourceEntry = propertiesPanel.entry('ToolTask_1-input-0-source');
+    const fixEntry = propertiesPanel.entry('ToolTask_1-input-0-source-fix');
+
+    await expect(sourceEntry).toContainText('fromAi(url)');
+
+    // the entry is checked for attachment rather than visibility: it is
+    // deliberately zero height, with the button lifted out of flow
+    await expect(fixEntry).toBeAttached();
+
+    const fixButton = fixEntry.locator('[data-test="agent-config-autofill-button"]');
+
+    await expect(fixButton).toBeVisible();
+
+    // when
+    await app.step('accept the correction', async () => {
+      await fixButton.click();
+    });
+
+    // then
+    await expect(sourceEntry).toContainText('fromAi(toolCall.url)');
+    await expect(fixEntry).toHaveCount(0);
+  });
+
+
+  test('should undo a fix in a single step', async function({ launch, tmp }) {
+
+    // given
+    const file = await copyFixture('agentic-tool.bpmn', tmp);
+
+    const app = await launch({ openFile: file });
+
+    const modeler = new Modeler(app);
+    const editor = modeler.bpmnEditor;
+    const propertiesPanel = modeler.propertiesPanel;
+
+    await editor.canvas().waitFor();
+
+    await editor.selectElement('ToolTask_1');
+
+    await propertiesPanel.waitForLoad();
+    await propertiesPanel.openGroup('Input mapping');
+    await propertiesPanel.openListItem('ToolTask_1-input-0');
+
+    const sourceEntry = propertiesPanel.entry('ToolTask_1-input-0-source');
+    const fixEntry = propertiesPanel.entry('ToolTask_1-input-0-source-fix');
+
+    await app.step('accept the correction', async () => {
+      await fixEntry.locator('[data-test="agent-config-autofill-button"]').click();
+    });
+
+    await expect(sourceEntry).toContainText('fromAi(toolCall.url)');
+
+    // when
+    await app.step('undo the correction', async () => {
+      await editor.undo();
+    });
+
+    // then
+    await expect(sourceEntry).toContainText('fromAi(url)');
+    await expect(fixEntry).toBeAttached();
+  });
+
+});


### PR DESCRIPTION
### Proposed Changes

Closes #6115. Related to https://github.com/camunda/experience-pdp/issues/35.

Makes Desktop Modeler consume the published `@camunda/linting-autofix@0.1.0` package, so agent tool configuration mistakes can be corrected from the properties panel.

Changes:

* Adds the published `@camunda/linting-autofix@0.1.0` dependency (replacing the earlier branch/local dependency that blocked CI).
* Registers the package's `agentConfigAutofillModule` in Camunda 8 BPMN diagrams and imports its stylesheet.
* Adds Desktop coverage for module registration plus e2e coverage of the malformed `fromAi()` correction and one-step undo.

The production change is two lines — the module goes into `CloudBpmnModeler.prototype._modules` alongside `lintingAnnotationsModule`, where the modeler's other always-on modules live. Everything else is the dependency, the stylesheet import, and tests.

Scoped to what `0.1.0` ships. The affordances themselves (`Fix`, `Autofill`, `Input from agent`) are the library's behavior and are covered by its own suite; this PR covers the integration — that the module is registered, its stylesheet loads, and its entries render through and modify the diagram via the properties panel Desktop ships. Problems-panel fix application and inline warning behavior are follow-up work.

<video src="https://github.com/user-attachments/assets/0fea26d7-5f12-493a-afd6-0d7801923ee3" width="320" height="240" controls></video>

<img width="408" height="240" alt="image" src="https://github.com/user-attachments/assets/4e82c706-a0c3-4fb1-81bb-1687e74f30ab" />

Steps to try out:

1. Open a Camunda 8 BPMN diagram with an agentic ad-hoc subprocess and a tool entry task whose input source is `=fromAi(url)` (cf. `test/e2e/fixtures/agentic-tool.bpmn`).
2. Select the task and open the Input mapping section.
3. Confirm the source field offers `Fix`; click it and confirm the value becomes `=fromAi(toolCall.url)`.
4. Undo once and confirm the previous value is restored.

Validation run locally, on this branch rebased onto current `develop`:

* `npx eslint` on the changed files — clean
* `npm run client:build` — clean
* `npm run test --workspace=camunda-modeler-client` — 2558 passed, 18 skipped
* `npm run bpmn-io-modelers:test --workspace=camunda-modeler-client` — 77 passed
* `npm run test:e2e` (full suite, not just the new spec) — 61 passed

### Review notes

* @jarekdanielak @barmac — the `lintingAutofix.fromAiDocumentationUrl` option you both flagged as unconsumed is gone; the modeler no longer passes any configuration to the module.
* The `disable-agent-config-autofix` kill switch described in the previous revision of this description has also been removed — the module is registered unconditionally. Worth a second opinion: this makes a `0.1.x` dependency's UI unconditional with no runtime escape hatch.
* Non-blocking issue found during testing by @jarekdanielak, tracked in the library: https://github.com/camunda/linting-autofix/issues/13

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
