### PR TITLE
feat(element-templates): reload templates on app focus

### DIFF
--- a/client/src/app/__tests__/AppParentSpec.js
+++ b/client/src/app/__tests__/AppParentSpec.js
@@ -743,7 +743,7 @@ describe('<AppParent>', function() {
 
   describe('backend errors', function() {
 
-    it('should log backend error', function(done) {
+    it('should log backend error', async function() {
 
       // given
       const message = 'message from backend';
@@ -760,13 +760,11 @@ describe('<AppParent>', function() {
       backend.receive('backend:error', {}, message);
 
       // then
-      setTimeout(() => {
+      await waitFor(() => {
         expect(actionSpy).to.be.calledWith('log', {
           message,
           category: 'error'
         });
-
-        done();
       });
 
     });

--- a/client/src/app/__tests__/helpers/renderEditor.js
+++ b/client/src/app/__tests__/helpers/renderEditor.js
@@ -13,10 +13,14 @@ import * as sinon from 'sinon';
 
 import React, { createRef } from 'react';
 
+import EventEmitter from 'events';
+
 import { render, waitFor } from '@testing-library/react';
 
 import { SlotFillRoot } from '../../slot-fill';
 import Panel from '../../panel/Panel';
+
+import { EventsContext } from '../../EventsContext';
 
 import { WithCachedState } from '../../cached';
 import Cache from '../../cached/Cache';
@@ -69,14 +73,28 @@ export default async function renderEditor(EditorComponent, xml, options = {}) {
 
   const TestEditor = WithCachedState(EditorComponent);
 
+  const eventBus = options.eventBus || new EventEmitter();
+
+  const eventsContext = {
+    subscribe: (event, listener) => {
+      eventBus.on(event, listener);
+
+      return {
+        cancel: () => eventBus.off(event, listener)
+      };
+    }
+  };
+
   const {
     rerender,
     ...renderResults
   } = render(
-    <SlotFillRoot>
-      <TestEditor ref={ ref } { ...props } />
-      <Panel layout={ props.layout } />
-    </SlotFillRoot>
+    <EventsContext.Provider value={ eventsContext }>
+      <SlotFillRoot>
+        <TestEditor ref={ ref } { ...props } />
+        <Panel layout={ props.layout } />
+      </SlotFillRoot>
+    </EventsContext.Provider>
   );
 
   if (props.waitForImport) {
@@ -88,17 +106,20 @@ export default async function renderEditor(EditorComponent, xml, options = {}) {
   return {
     ...renderResults,
     instance: ref.current,
+    emit: (event, ...args) => eventBus.emit(event, ...args),
     rerender: (newXML, newOptions = {}) => {
       rerender(
-        <SlotFillRoot>
-          <TestEditor
-            ref={ ref }
-            { ...props }
-            xml={ newXML || xml }
-            { ...newOptions }
-          />
-          <Panel layout={ props.layout } />
-        </SlotFillRoot>
+        <EventsContext.Provider value={ eventsContext }>
+          <SlotFillRoot>
+            <TestEditor
+              ref={ ref }
+              { ...props }
+              xml={ newXML || xml }
+              { ...newOptions }
+            />
+            <Panel layout={ props.layout } />
+          </SlotFillRoot>
+        </EventsContext.Provider>
       );
     }
   };

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -28,6 +28,8 @@ import {
   CachedComponent
 } from '../../cached';
 
+import { EventsContext } from '../../EventsContext';
+
 import { Settings } from '@carbon/icons-react';
 
 import SidePanel, { DEFAULT_LAYOUT as SIDE_PANEL_DEFAULT_LAYOUT } from '../../side-panel/SidePanel';
@@ -93,6 +95,8 @@ const log = debug('BpmnEditor:platform');
 
 
 export class BpmnEditor extends CachedComponent {
+
+  static contextType = EventsContext;
 
   constructor(props) {
     super(props);
@@ -276,6 +280,15 @@ export class BpmnEditor extends CachedComponent {
     } else if (fn === 'off') {
       modeler[ fn ]('commandStack.changed', this.handleLintingDebounced);
     }
+
+    // reload templates on focus to pick up external edits to local template
+    // files made while the app was away. The editor owns this decision, not
+    // the app. Cheap: loadTemplates skips re-setting unchanged templates.
+    if (fn === 'on') {
+      this._appFocusedSubscription = this.context.subscribe('app.focused', this.handleAppFocused);
+    } else {
+      this._appFocusedSubscription?.cancel();
+    }
   }
 
   handlePropertiesPanelLayoutChange(e) {
@@ -283,6 +296,10 @@ export class BpmnEditor extends CachedComponent {
       propertiesPanel: e.layout
     });
   }
+
+  handleAppFocused = () => {
+    this.loadTemplates().catch(error => this.handleError({ error }));
+  };
 
   async loadTemplates() {
     const {

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -1721,7 +1721,7 @@ describe('<BpmnEditor>', function() {
 
       // then
       // BpmnEditor#componentDidMount is async
-      setTimeout(() => {
+      await waitFor(() => {
         expect(isImportNeededSpy).to.have.been.calledOnce;
         expect(isImportNeededSpy).to.have.always.returned(false);
       });

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -1891,6 +1891,117 @@ describe('<BpmnEditor>', function() {
     });
 
 
+    it('should reload templates when the app regains focus', async function() {
+
+      // given
+      // each fetch returns different templates so the reload is applied
+      let call = 0;
+
+      const getConfigStub = sinon.stub().callsFake(() => Promise.resolve([
+        { 'id': `template-${ call++ }` }
+      ]));
+
+      const setTemplatesSpy = sinon.spy(),
+            elementTemplatesLoaderMock = { setTemplates: setTemplatesSpy };
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: elementTemplatesLoaderMock
+            }
+          })
+        }
+      });
+
+      const { emit } = await renderEditor(diagramXML, {
+        cache,
+        getConfig: getConfigStub
+      });
+
+      getConfigStub.resetHistory();
+      setTemplatesSpy.resetHistory();
+
+      // when
+      // an external process may have edited local templates while away
+      emit('app.focused');
+
+      // then
+      await waitFor(() => {
+        expect(getConfigStub).to.be.calledOnce;
+      });
+      expect(getConfigStub).to.be.calledWith('bpmn.elementTemplates');
+      expect(setTemplatesSpy).to.be.calledOnce;
+    });
+
+
+    it('should not re-set unchanged templates when the app regains focus', async function() {
+
+      // given
+      const getConfigStub = sinon.stub().resolves([ { 'id': 'template-1' } ]);
+
+      const setTemplatesSpy = sinon.spy();
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: { setTemplates: setTemplatesSpy }
+            }
+          })
+        }
+      });
+
+      const { emit } = await renderEditor(diagramXML, {
+        cache,
+        getConfig: getConfigStub
+      });
+
+      // templates were set once on mount
+      expect(setTemplatesSpy).to.be.calledOnce;
+
+      // when
+      // focus fetches the same templates
+      emit('app.focused');
+
+      // then
+      // identical templates are not re-applied (no re-validation, linter kept)
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(setTemplatesSpy).to.be.calledOnce;
+    });
+
+
+    it('should not reload templates on focus after unmount', async function() {
+
+      // given
+      let call = 0;
+
+      const getConfigStub = sinon.stub().callsFake(() => Promise.resolve([
+        { 'id': `template-${ call++ }` }
+      ]));
+
+      const { emit, unmount } = await renderEditor(diagramXML, {
+        getConfig: getConfigStub
+      });
+
+      getConfigStub.resetHistory();
+
+      // when
+      // the subscription is cancelled on unmount
+      unmount();
+
+      emit('app.focused');
+
+      // then
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(getConfigStub).not.to.have.been.called;
+    });
+
+
     it('should invalidate linter and re-lint when element templates change', async function() {
 
       // given

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -28,6 +28,8 @@ import {
   CachedComponent
 } from '../../cached';
 
+import { EventsContext } from '../../EventsContext';
+
 import { Settings } from '@carbon/icons-react';
 
 import SidePanel, { DEFAULT_LAYOUT as SIDE_PANEL_DEFAULT_LAYOUT } from '../../side-panel/SidePanel';
@@ -91,6 +93,8 @@ const log = debug('BpmnEditor:cloud');
 
 
 export class BpmnEditor extends CachedComponent {
+
+  static contextType = EventsContext;
 
   constructor(props) {
     super(props);
@@ -290,6 +294,15 @@ export class BpmnEditor extends CachedComponent {
     } else if (fn === 'off') {
       modeler[ fn ]('commandStack.changed', this.handleLintingDebounced);
     }
+
+    // reload templates on focus to pick up external edits to local template
+    // files made while the app was away. The editor owns this decision, not
+    // the app. Cheap: loadTemplates skips re-setting unchanged templates.
+    if (fn === 'on') {
+      this._appFocusedSubscription = this.context.subscribe('app.focused', this.handleAppFocused);
+    } else {
+      this._appFocusedSubscription?.cancel();
+    }
   }
 
   handlePropertiesPanelLayoutChange(e) {
@@ -313,6 +326,10 @@ export class BpmnEditor extends CachedComponent {
     };
 
     elementTemplates.setEngines(engines);
+  };
+
+  handleAppFocused = () => {
+    this.loadTemplates().catch(error => this.handleError({ error }));
   };
 
   async loadTemplates() {

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -2041,6 +2041,128 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
     });
 
 
+    it('should reload templates when the app regains focus', async function() {
+
+      // given
+      // each fetch returns different templates so the reload is applied
+      let call = 0;
+
+      const getConfigStub = sinon.stub().callsFake(() => Promise.resolve([
+        {
+          '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+          'id': `template-${ call++ }`
+        }
+      ]));
+
+      const setTemplatesSpy = sinon.spy(),
+            elementTemplatesLoaderMock = { setTemplates: setTemplatesSpy };
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: elementTemplatesLoaderMock
+            }
+          })
+        }
+      });
+
+      const { emit } = await renderEditor(diagramXML, {
+        cache,
+        getConfig: getConfigStub
+      });
+
+      getConfigStub.resetHistory();
+      setTemplatesSpy.resetHistory();
+
+      // when
+      // an external process may have edited local templates while away
+      emit('app.focused');
+
+      // then
+      await waitFor(() => {
+        expect(getConfigStub).to.be.calledOnce;
+      });
+      expect(getConfigStub).to.be.calledWith('bpmn.elementTemplates');
+      expect(setTemplatesSpy).to.be.calledOnce;
+    });
+
+
+    it('should not re-set unchanged templates when the app regains focus', async function() {
+
+      // given
+      const getConfigStub = sinon.stub().resolves([
+        {
+          '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+          'id': 'template-1'
+        }
+      ]);
+
+      const setTemplatesSpy = sinon.spy();
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: { setTemplates: setTemplatesSpy }
+            }
+          })
+        }
+      });
+
+      const { emit } = await renderEditor(diagramXML, {
+        cache,
+        getConfig: getConfigStub
+      });
+
+      // templates were set once on mount
+      expect(setTemplatesSpy).to.be.calledOnce;
+
+      // when
+      // focus fetches the same templates
+      emit('app.focused');
+
+      // then
+      // identical templates are not re-applied (no re-validation, linter kept)
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(setTemplatesSpy).to.be.calledOnce;
+    });
+
+
+    it('should not reload templates on focus after unmount', async function() {
+
+      // given
+      let call = 0;
+
+      const getConfigStub = sinon.stub().callsFake(() => Promise.resolve([
+        {
+          '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+          'id': `template-${ call++ }`
+        }
+      ]));
+
+      const { emit, unmount } = await renderEditor(diagramXML, {
+        getConfig: getConfigStub
+      });
+
+      getConfigStub.resetHistory();
+
+      // when
+      // the subscription is cancelled on unmount
+      unmount();
+
+      emit('app.focused');
+
+      // then
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(getConfigStub).not.to.have.been.called;
+    });
+
+
     it('should invalidate linter and re-lint when element templates change', async function() {
 
       // given

--- a/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
@@ -1927,7 +1927,7 @@ describe('<DmnEditor>', function() {
 
       // then
       // DmnEditor#componentDidMount is async
-      setTimeout(() => {
+      await waitFor(() => {
         expect(isImportNeededSpy).to.have.been.calledOnce;
         expect(isImportNeededSpy).to.have.always.returned(false);
       });

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -1927,7 +1927,7 @@ describe('<DmnEditor>', function() {
 
       // then
       // DmnEditor#componentDidMount is async
-      setTimeout(() => {
+      await waitFor(() => {
         expect(isImportNeededSpy).to.have.been.calledOnce;
         expect(isImportNeededSpy).to.have.always.returned(false);
       });


### PR DESCRIPTION
### Proposed Changes

Reload element templates when the app regains focus, so external edits to local template files (made while the app was away) are picked up.

* **Reload element templates on app focus** — each editor subscribes to `app.focused` and reloads its own element templates. The editor owns this decision; the app only emits the event. Reloading stays cheap because `loadTemplates` skips re-setting (and re-validating) unchanged templates (https://github.com/camunda/camunda-modeler/commit/ac37a5613).

While adding coverage two pre-existing test bugs surfaced and are fixed here:

* **Await import assertions** — a detached, un-awaited `setTimeout` in the bpmn/dmn *"should not import when provided xml is the same as the cached one"* specs resolved the test before its assertions ran; when they threw, they leaked uncaught async errors that silently **halted the karma runner**, so the `element templates` describe and all subsequent describes never ran (~34 hidden platform tests). Awaiting via `waitFor` restores them (https://github.com/camunda/camunda-modeler/commit/7a9ebd469).
* **Migrate backend error spec to async** — same class of bug via `done` + bare `setTimeout`: a throwing `expect` skipped `done()` and leaked instead of failing cleanly (https://github.com/camunda/camunda-modeler/commit/a0055357c).

Stacked on top of #6092 (the focus reload relies on the *skip re-setting unchanged templates* optimization there). The base will retarget to `develop` once #6092 merges.

### Try out

Best experienced with C8 OOTB element templates loaded:

```
git checkout element-templates-focus-reload
npm run dev
```

Edit a local element templates file in your editor of choice while the app is unfocused, then focus the app back — the templates reload automatically.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->

---

Related to https://github.com/camunda/camunda-modeler/issues/5557
Stacked on #6092
