### PR TITLE
fix(connection-manager): de-duplicate connection status change events

### DIFF
--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerPlugin.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerPlugin.js
@@ -195,7 +195,20 @@ export default function ConnectionManagerPlugin(props) {
       }
     })();
 
+    // Track the last emitted result (per active connection) so periodic
+    // re-checks that yield an unchanged status don't trigger useless
+    // event emissions and state updates, which cause expensive re-draws
+    // in components relying on the connection status.
+    let lastEmittedResult;
+
     const connectionCheckListener = (connectionCheckResult) => {
+      if (lastEmittedResult !== undefined
+        && isSameConnectionCheckResult(lastEmittedResult, connectionCheckResult)) {
+        return;
+      }
+
+      lastEmittedResult = connectionCheckResult;
+
       const endpoint = extractEndpointUrl(activeConnection);
 
       emit('connectionManager.connectionStatusChanged', {
@@ -273,6 +286,31 @@ export default function ConnectionManagerPlugin(props) {
 }
 
 
+
+/**
+ * Checks whether two connection check results are equivalent with respect to
+ * the data consumers actually rely on (`success`, `reason`, and the gateway
+ * `protocol` + `gatewayVersion`). Used to suppress redundant status change
+ * emissions on periodic re-checks.
+ *
+ * @param {Object|null} a
+ * @param {Object|null} b
+ * @returns {boolean}
+ */
+function isSameConnectionCheckResult(a, b) {
+  if (a === b) {
+    return true;
+  }
+
+  if (!a || !b) {
+    return false;
+  }
+
+  return a.success === b.success &&
+    a.reason === b.reason &&
+    a.response?.protocol === b.response?.protocol &&
+    a.response?.gatewayVersion === b.response?.gatewayVersion;
+}
 
 /**
  * @param {{ type: string; }} tab

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionManagerPluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionManagerPluginSpec.js
@@ -566,13 +566,13 @@ describe('ConnectionManagerPlugin', function() {
             // advance to trigger a periodic check (ConnectionChecker LONG interval = 5000ms)
             await clock.tickAsync(5000);
 
-            // then - connectionStatusChanged was emitted (a result arrived from interval check)
-            expect(emit).to.have.been.calledWith(
-              'connectionManager.connectionStatusChanged',
-              sinon.match.any
+            // then - connectionStatusChanged was NOT re-emitted (result did not change)
+            const statusChangedCalls = emit.getCalls().filter(
+              call => call.args[0] === 'connectionManager.connectionStatusChanged'
             );
+            expect(statusChangedCalls).to.have.lengthOf(0);
 
-            // but connectionCheckStarted was NOT emitted (no state change occurred)
+            // and connectionCheckStarted was NOT emitted (no state change occurred)
             const checkStartedCalls = emit.getCalls().filter(
               call => call.args[0] === 'connectionManager.connectionCheckStarted'
             );
@@ -637,6 +637,111 @@ describe('ConnectionManagerPlugin', function() {
         });
 
       });
+
+
+      describe('connectionManager.connectionStatusChanged de-duplication', function() {
+
+        function createGetGlobal(checkConnection, settings) {
+          return (name) => {
+            if (name === 'deployment') {
+              return new Deployment({
+                getConnectionForTab: () => Promise.resolve(DEFAULT_CONNECTIONS[0]),
+                async setConnectionForFile() {},
+                getEndpoints() {
+                  return settings.get('connectionManagerPlugin.c8connections') || [];
+                }
+              });
+            } else if (name === 'zeebeAPI') {
+              return new ZeebeAPI({ checkConnection });
+            }
+          };
+        }
+
+        function createSubscribe() {
+          return (event, callback) => {
+            if (event === 'app.activeTabChanged') {
+              waitForNextCycle().then(() => callback({
+                activeTab: DEFAULT_ACTIVE_TAB
+              }));
+            }
+            return { cancel: () => {} };
+          };
+        }
+
+
+        it('should emit only once for repeated identical results', async function() {
+
+          // given
+          const settings = createMockSettings({
+            'connectionManagerPlugin.c8connections': DEFAULT_CONNECTIONS
+          });
+
+          const checkConnection = () => ({ success: true, response: { gatewayVersion: '8.8.0' } });
+
+          const emit = sinon.spy();
+
+          createConnectionManagerPlugin({
+            subscribe: createSubscribe(),
+            settings,
+            emit,
+            _getGlobal: createGetGlobal(checkConnection, settings)
+          });
+
+          // when - initial check + several periodic checks all return the same result
+          await waitForNextCycle(3);
+          await clock.tickAsync(2000);
+          await clock.tickAsync(5000);
+          await clock.tickAsync(5000);
+
+          // then - status change is emitted exactly once
+          const statusChangedCalls = emit.getCalls().filter(
+            call => call.args[0] === 'connectionManager.connectionStatusChanged'
+          );
+          expect(statusChangedCalls).to.have.lengthOf(1);
+          expect(statusChangedCalls[0].args[1]).to.include({ success: true });
+        });
+
+
+        it('should emit again when the result changes', async function() {
+
+          // given
+          const settings = createMockSettings({
+            'connectionManagerPlugin.c8connections': DEFAULT_CONNECTIONS
+          });
+
+          let currentResult = { success: true, response: { gatewayVersion: '8.8.0' } };
+          const checkConnection = () => currentResult;
+
+          const emit = sinon.spy();
+
+          createConnectionManagerPlugin({
+            subscribe: createSubscribe(),
+            settings,
+            emit,
+            _getGlobal: createGetGlobal(checkConnection, settings)
+          });
+
+          // when - first check succeeds
+          await waitForNextCycle(3);
+          await clock.tickAsync(2000);
+
+          // ...then the connection starts failing
+          currentResult = { success: false, reason: 'CONTACT_POINT_UNAVAILABLE' };
+          await clock.tickAsync(5000);
+
+          // then - status change emitted for both the success and the error
+          const statusChangedCalls = emit.getCalls().filter(
+            call => call.args[0] === 'connectionManager.connectionStatusChanged'
+          );
+
+          expect(statusChangedCalls.length).to.be.at.least(2);
+          expect(statusChangedCalls[0].args[1]).to.include({ success: true });
+          expect(statusChangedCalls[statusChangedCalls.length - 1].args[1])
+            .to.include({ success: false, reason: 'CONTACT_POINT_UNAVAILABLE' });
+        });
+
+      });
+
     });
   });
 


### PR DESCRIPTION
### Proposed Changes

The connection manager was spamming `connectionManager.connectionStatusChanged` events (roughly every 5s) even though the connection status had not actually changed. Components that rely on the manager for status updates re-rendered on every one of these events, causing useless, expensive re-draws.

#### The issue

`ConnectionChecker` polls the connection on a fixed interval (`DELAYS.LONG = 5000ms`) and _unconditionally_ emits a `connectionCheck` result on every poll. In `ConnectionManagerPlugin`, the listener forwarded _every_ result as a `connectionManager.connectionStatusChanged` event **and** pushed a brand-new `connectionCheckResult` object into shared state (`App.state.connectionCheckResult`, `ZeebePlugin` state) each time — even when nothing meaningful had changed.

#### The fix

With this PR the listener tracks the last emitted result (reset whenever the active connection or paused state changes) and only emits the event + updates state when the result meaningfully differs from the previous one. The first result after any connection/config change always emits, so late-mounting consumers and genuine status transitions are unaffected.

### Try it out

1. Open a `cloud-bpmn` (or `cloud-dmn`/`cloud-form`/`rpa`) tab with an active Camunda 8 connection.
2. Observe the dev console: previously `App#triggerAction emit-event {type: 'connectionManager.connectionStatusChanged'}` logged every ~5s.
3. With this change, the event fires only when the connection status actually changes (e.g. success ↔ error, gateway version change).
4. Stop C8run - see that error is still captured + propagated (with delay)
5. Restart C8run - see components recover

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

---

🤖 This is a robot contribution.