### PR TITLE
fix: correct engine profile version mismatch warning

### DIFF
--- a/client/src/app/linting/VersionMismatchChecker.js
+++ b/client/src/app/linting/VersionMismatchChecker.js
@@ -72,15 +72,16 @@ export function getVersionMismatchWarning(selectedVersion, clusterVersion) {
     return null;
   }
 
+  const selectedMinorVersion = `${ selectedCoerced.major }.${ selectedCoerced.minor }`;
   const clusterMinorVersion = `${ clusterCoerced.major }.${ clusterCoerced.minor }`;
 
   return {
     category: 'warn',
-    name: 'Version mismatch',
-    message: `The selected version (${ selectedCoerced.major }.${ selectedCoerced.minor }) differs from the connected cluster version (${ clusterMinorVersion }).`,
+    name: 'Engine profile',
+    message: `This file targets Camunda ${ selectedMinorVersion }, but the connected cluster runs Camunda ${ clusterMinorVersion }.`,
     rule: 'camunda/version-mismatch',
     action: {
-      label: `Select ${ clusterMinorVersion } instead`,
+      label: `Update engine profile to ${ clusterMinorVersion }`,
       handler: 'set-engine-profile',
       options: {
         executionPlatformVersion: `${ clusterMinorVersion }.0`

--- a/client/src/app/linting/__tests__/VersionMismatchCheckerSpec.js
+++ b/client/src/app/linting/__tests__/VersionMismatchCheckerSpec.js
@@ -30,7 +30,7 @@ describe('VersionMismatchChecker', function() {
       expect(warning.message).to.include('8.7');
       expect(warning.message).to.include('9.0');
       expect(warning.action).to.exist;
-      expect(warning.action.label).to.equal('Select 9.0 instead');
+      expect(warning.action.label).to.equal('Update engine profile to 9.0');
       expect(warning.action.handler).to.equal('set-engine-profile');
       expect(warning.action.options.executionPlatformVersion).to.equal('9.0.0');
     });

--- a/client/src/app/panel/tabs/linting/__tests__/LintingTabSpec.js
+++ b/client/src/app/panel/tabs/linting/__tests__/LintingTabSpec.js
@@ -230,11 +230,11 @@ describe('<LintingTab>', function() {
         {
           category: 'warn',
           id: 'foo',
-          name: 'Version mismatch',
-          message: 'The selected version (8.7) differs from the connected cluster version (8.8).',
+          name: 'Engine profile',
+          message: 'This file targets Camunda 8.7, but the connected cluster runs Camunda 8.8.',
           rule: 'camunda/version-mismatch',
           action: {
-            label: 'Select 8.8 instead',
+            label: 'Update engine profile to 8.8',
             handler: 'set-engine-profile',
             options: {
               executionPlatformVersion: '8.8.0'
@@ -245,9 +245,9 @@ describe('<LintingTab>', function() {
     });
 
     // then
-    const link = getByRole('button', { name: 'Select 8.8 instead' });
+    const link = getByRole('button', { name: 'Update engine profile to 8.8' });
     expect(link).to.exist;
-    expect(link.textContent).to.equal('Select 8.8 instead');
+    expect(link.textContent).to.equal('Update engine profile to 8.8');
   });
 
 
@@ -262,11 +262,11 @@ describe('<LintingTab>', function() {
         {
           category: 'warn',
           id: 'foo',
-          name: 'Version mismatch',
+          name: 'Engine profile',
           message: 'Version mismatch message',
           rule: 'camunda/version-mismatch',
           action: {
-            label: 'Select 8.8 instead',
+            label: 'Update engine profile to 8.8',
             handler: 'set-engine-profile',
             options: {
               executionPlatformVersion: '8.8.0'
@@ -277,7 +277,7 @@ describe('<LintingTab>', function() {
     });
 
     // when
-    fireEvent.click(getByRole('button', { name: 'Select 8.8 instead' }));
+    fireEvent.click(getByRole('button', { name: 'Update engine profile to 8.8' }));
 
     // then
     expect(onActionSpy).to.have.been.calledWith('set-engine-profile', {

--- a/client/src/app/tabs/EngineProfileHelper.js
+++ b/client/src/app/tabs/EngineProfileHelper.js
@@ -14,11 +14,12 @@ import {
 } from './EngineProfile';
 
 export default class EngineProfileHelper {
-  constructor({ get, set, getCached, setCached }) {
+  constructor({ get, set, getCached, setCached, onChanged }) {
     this._get = get;
     this._set = set;
     this._getCached = getCached;
     this._setCached = setCached;
+    this._onChanged = onChanged;
   }
 
   get() {
@@ -50,6 +51,10 @@ export default class EngineProfileHelper {
       this._setCached({
         engineProfile
       });
+
+      if (this._onChanged) {
+        this._onChanged(engineProfile);
+      }
     }
   }
 }

--- a/client/src/app/tabs/__tests__/EngineProfileHelperSpec.js
+++ b/client/src/app/tabs/__tests__/EngineProfileHelperSpec.js
@@ -1,0 +1,131 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import EngineProfileHelper from '../EngineProfileHelper';
+
+
+describe('EngineProfileHelper', function() {
+
+  function createHelper(overrides = {}) {
+    let cached = { engineProfile: null };
+
+    const defaults = {
+      get: () => cached.engineProfile,
+      set: sinon.spy(),
+      getCached: () => cached,
+      setCached: ({ engineProfile }) => {
+        cached = { engineProfile };
+      }
+    };
+
+    const helper = new EngineProfileHelper({ ...defaults, ...overrides });
+
+    return { helper, getCached: () => cached };
+  }
+
+
+  describe('#setCached', function() {
+
+    it('should call onChanged when engine profile changes', function() {
+
+      // given
+      const onChanged = sinon.spy();
+
+      const { helper } = createHelper({ onChanged });
+
+      // when
+      helper.setCached({
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '8.8.0'
+      });
+
+      // then
+      expect(onChanged).to.have.been.calledOnceWith({
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '8.8.0'
+      });
+    });
+
+
+    it('should call onChanged again when engine profile reverts (undo)', function() {
+
+      // given
+      const onChanged = sinon.spy();
+
+      const { helper } = createHelper({ onChanged });
+
+      helper.setCached({
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '8.9.0'
+      });
+
+      onChanged.resetHistory();
+
+      // when - engine profile reverts, e.g. through undo
+      helper.setCached({
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '8.8.0'
+      });
+
+      // then
+      expect(onChanged).to.have.been.calledOnceWith({
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '8.8.0'
+      });
+    });
+
+
+    it('should NOT call onChanged when engine profile is unchanged', function() {
+
+      // given
+      const onChanged = sinon.spy();
+
+      const { helper } = createHelper({ onChanged });
+
+      const engineProfile = {
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '8.8.0'
+      };
+
+      helper.setCached(engineProfile);
+
+      onChanged.resetHistory();
+
+      // when
+      helper.setCached(engineProfile);
+
+      // then
+      expect(onChanged).not.to.have.been.called;
+    });
+
+
+    it('should not fail without onChanged callback', function() {
+
+      // given
+      const { helper } = createHelper();
+
+      // when
+      function change() {
+        helper.setCached({
+          executionPlatform: 'Camunda Cloud',
+          executionPlatformVersion: '8.8.0'
+        });
+      }
+
+      // then
+      expect(change).not.to.throw();
+    });
+
+  });
+
+});

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -124,18 +124,14 @@ export class BpmnEditor extends CachedComponent {
           'modeler:executionPlatform': executionPlatform,
           'modeler:executionPlatformVersion': executionPlatformVersion
         });
-
-        this.props.emit('tab.engineProfileChanged', {
-          executionPlatform,
-          executionPlatformVersion
-        });
       },
       getCached: () => this.getCached(),
       setCached: ({ engineProfile }) => {
         this.handleEngineProfileChangeDebounced({ engineProfile });
 
         this.setCached({ engineProfile });
-      }
+      },
+      onChanged: (engineProfile) => this.emitEngineProfileChanged(engineProfile)
     });
 
     this.gridBehavior = new GridBehavior({
@@ -292,6 +288,18 @@ export class BpmnEditor extends CachedComponent {
     });
   }
 
+  emitEngineProfileChanged = (engineProfile) => {
+    const {
+      executionPlatform,
+      executionPlatformVersion
+    } = engineProfile;
+
+    this.props.emit('tab.engineProfileChanged', {
+      executionPlatform,
+      executionPlatformVersion
+    });
+  };
+
   handleEngineProfileChange = ({ engineProfile }) => {
     const { executionPlatformVersion: version } = engineProfile;
 
@@ -431,12 +439,7 @@ export class BpmnEditor extends CachedComponent {
       });
 
       if (engineProfile) {
-        const { executionPlatform, executionPlatformVersion } = engineProfile;
-
-        this.props.emit('tab.engineProfileChanged', {
-          executionPlatform,
-          executionPlatformVersion
-        });
+        this.emitEngineProfileChanged(engineProfile);
       }
     }
 

--- a/client/src/app/tabs/cloud-dmn/DmnEditor.js
+++ b/client/src/app/tabs/cloud-dmn/DmnEditor.js
@@ -128,19 +128,10 @@ export class DmnEditor extends CachedComponent {
           name: engineProfile.executionPlatform,
           version: engineProfile.executionPlatformVersion
         });
-
-        const {
-          executionPlatform,
-          executionPlatformVersion
-        } = engineProfile;
-
-        this.props.emit('tab.engineProfileChanged', {
-          executionPlatform,
-          executionPlatformVersion
-        });
       },
       getCached: () => this.getCached(),
-      setCached: (state) => this.setCached(state)
+      setCached: (state) => this.setCached(state),
+      onChanged: (engineProfile) => this.emitEngineProfileChanged(engineProfile)
     });
   }
 
@@ -301,12 +292,7 @@ export class DmnEditor extends CachedComponent {
       });
 
       if (engineProfile) {
-        const { executionPlatform, executionPlatformVersion } = engineProfile;
-
-        this.props.emit('tab.engineProfileChanged', {
-          executionPlatform,
-          executionPlatformVersion
-        });
+        this.emitEngineProfileChanged(engineProfile);
       }
 
       this.setState({
@@ -387,6 +373,18 @@ export class DmnEditor extends CachedComponent {
     const modeler = this.getModeler();
 
     modeler.getActiveViewer().get('commandStack').redo();
+  };
+
+  emitEngineProfileChanged = (engineProfile) => {
+    const {
+      executionPlatform,
+      executionPlatformVersion
+    } = engineProfile;
+
+    this.props.emit('tab.engineProfileChanged', {
+      executionPlatform,
+      executionPlatformVersion
+    });
   };
 
   handleChanged = () => {

--- a/client/src/app/tabs/form/FormEditor.js
+++ b/client/src/app/tabs/form/FormEditor.js
@@ -103,19 +103,10 @@ export class FormEditor extends CachedComponent {
         const modeling = editor.get('modeling');
 
         modeling.editFormField(root, engineProfile);
-
-        const {
-          executionPlatform,
-          executionPlatformVersion
-        } = engineProfile;
-
-        this.props.emit('tab.engineProfileChanged', {
-          executionPlatform,
-          executionPlatformVersion
-        });
       },
       getCached: () => this.getCached(),
-      setCached: (state) => this.setCached(state)
+      setCached: (state) => this.setCached(state),
+      onChanged: (engineProfile) => this.emitEngineProfileChanged(engineProfile)
     });
 
     this.handleLintingDebounced = debounce(() => this.handleLinting());
@@ -264,12 +255,7 @@ export class FormEditor extends CachedComponent {
       });
 
       if (engineProfile) {
-        const { executionPlatform, executionPlatformVersion } = engineProfile;
-
-        this.props.emit('tab.engineProfileChanged', {
-          executionPlatform,
-          executionPlatformVersion
-        });
+        this.emitEngineProfileChanged(engineProfile);
       }
 
       this.handleLinting(engineProfile);
@@ -385,6 +371,18 @@ export class FormEditor extends CachedComponent {
       formPreviewNode.removeEventListener('focusout', this.handleFormPreviewInteractionEnd);
     }
   }
+
+  emitEngineProfileChanged = (engineProfile) => {
+    const {
+      executionPlatform,
+      executionPlatformVersion
+    } = engineProfile;
+
+    this.props.emit('tab.engineProfileChanged', {
+      executionPlatform,
+      executionPlatformVersion
+    });
+  };
 
   handleChanged = () => {
 

--- a/client/src/app/tabs/rpa/RPAEditor.js
+++ b/client/src/app/tabs/rpa/RPAEditor.js
@@ -168,31 +168,14 @@ export class RPAEditor extends CachedComponent {
   }
 
   handleEngineProfile() {
-    let engineProfile = null;
-    let error = null;
-
     try {
-      engineProfile = this.engineProfile.get();
+      const engineProfile = this.engineProfile.get();
+
+      this.engineProfile.setCached(engineProfile);
     } catch (err) {
-      error = err;
-    }
-
-    const { engineProfile: cachedEngineProfile } = this.getCached();
-
-    if (engineProfile?.executionPlatformVersion === cachedEngineProfile?.executionPlatformVersion) {
-      return;
-    }
-
-    if (error) {
       this.setCached({
-        engineProfile: null,
+        engineProfile: null
       });
-    } else {
-      this.setCached({
-        engineProfile,
-      });
-
-      this.emitEngineProfileChanged(engineProfile);
     }
   }
 

--- a/client/src/app/tabs/rpa/RPAEditor.js
+++ b/client/src/app/tabs/rpa/RPAEditor.js
@@ -83,19 +83,10 @@ export class RPAEditor extends CachedComponent {
           key: 'executionPlatformVersion',
           value: engineProfile.executionPlatformVersion
         });
-
-        const {
-          executionPlatform,
-          executionPlatformVersion
-        } = engineProfile;
-
-        this.props.emit('tab.engineProfileChanged', {
-          executionPlatform,
-          executionPlatformVersion
-        });
       },
       getCached: () => this.getCached(),
-      setCached: (state) => this.setCached(state)
+      setCached: (state) => this.setCached(state),
+      onChanged: (engineProfile) => this.emitEngineProfileChanged(engineProfile)
     });
   }
 
@@ -201,15 +192,7 @@ export class RPAEditor extends CachedComponent {
         engineProfile,
       });
 
-      const {
-        executionPlatform,
-        executionPlatformVersion
-      } = engineProfile;
-
-      this.props.emit('tab.engineProfileChanged', {
-        executionPlatform,
-        executionPlatformVersion
-      });
+      this.emitEngineProfileChanged(engineProfile);
     }
   }
 
@@ -372,6 +355,18 @@ export class RPAEditor extends CachedComponent {
 
     return isXMLChange(editor.getValue(), lastXML);
   }
+
+  emitEngineProfileChanged = (engineProfile) => {
+    const {
+      executionPlatform,
+      executionPlatformVersion
+    } = engineProfile;
+
+    this.props.emit('tab.engineProfileChanged', {
+      executionPlatform,
+      executionPlatformVersion
+    });
+  };
 
   handleChanged = () => {
     const {


### PR DESCRIPTION
### Proposed Changes

Two fixes for the engine profile version mismatch lint warning:

* **Re-appear on undo/redo** — the warning is derived from app-level engine profile state that was only updated on import and explicit changes. Undo/redo reverted the profile without notifying the app, so the warning stayed gone. Now `EngineProfileHelper` emits an `onChanged` notification whenever the cached profile actually changes, so the tab re-lints with the correct version.
* **Clearer wording** — reframed as an *Engine profile* problem (previously the element-scope field was abused with "Version mismatch") and reworded the message/action to name the engine profile explicitly.
* **Align RPA editor**  —  now uses the exact same mechanism that all other editors use.

#### Before - bogus error (with insufficient context)

<img width="1333" height="884" alt="screenshot 22t37x" src="https://github.com/user-attachments/assets/b57488ae-ebaa-4f70-af44-c613892db1a2" />

#### With this change

Error message establishes proper context ("this file", "engine profile"):

<img width="1335" height="884" alt="screenshot 1AndAb" src="https://github.com/user-attachments/assets/658c7546-adf0-4188-aa65-0282b13755ee" />

Works consistently for all tab types:

<img width="1333" height="885" alt="screenshot BmP2x9" src="https://github.com/user-attachments/assets/4c4e3bbb-917f-457c-9c7b-9e33aab65d44" />

Also, undo and re-do now re-trigger the update.


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)