### PR TITLE
feat(events): emit application events via events context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: add ability to copy diagram file path ([#6059](https://github.com/camunda/camunda-modeler/pull/6059))
+* `FEAT`: emit application events via event context ([#6106](https://github.com/camunda/camunda-modeler/pull/6106))
 * `DEPS`: update to `bpmn-js@18.24.0`
 * `DEPS`: update to `camunda-bpmn-js@5.31.1`
 * `DEPS`: update to `bpmn-js-properties-panel@5.63.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: add ability to copy diagram file path ([#6059](https://github.com/camunda/camunda-modeler/pull/6059))
+* `FEAT`: allow event emitters to override tab context ([#6106](https://github.com/camunda/camunda-modeler/pull/6106))
 * `FEAT`: emit application events via event context ([#6106](https://github.com/camunda/camunda-modeler/pull/6106))
 * `DEPS`: update to `bpmn-js@18.24.0`
 * `DEPS`: update to `camunda-bpmn-js@5.31.1`

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -149,7 +149,8 @@ export class App extends PureComponent {
         return {
           cancel: () => this.off(event, listener)
         };
-      }
+      },
+      emit: (event, payload) => this.emitEvent(event, payload)
     };
 
     // TODO(nikku): make state
@@ -563,11 +564,8 @@ export class App extends PureComponent {
       return false;
     }
 
-    this.triggerAction('emit-event', {
-      type: 'tab.closed',
-      payload: {
-        tab
-      }
+    this.emitEvent('tab.closed', {
+      tab
     });
 
     await this._removeTab(tab);
@@ -990,7 +988,7 @@ export class App extends PureComponent {
   }
 
   emit(event, ...args) {
-    this.events.emit(event, ...args);
+    return this.events.emit(event, ...args);
   }
 
   on(event, listener) {
@@ -1003,11 +1001,25 @@ export class App extends PureComponent {
 
   emitWithTab(type, tab, payload) {
 
-    this.emit(type, {
+    return this.emit(type, {
       ...payload,
       tab
     });
   }
+
+  /**
+   * Emit an application event on the shared event bus, enriched with the
+   * currently active tab.
+   *
+   * This is the public counterpart to `subscribe` (cf. `EventsContext`) and
+   * the way components and plug-ins produce events.
+   *
+   * @param {string} type
+   * @param {Object} [payload]
+   */
+  emitEvent = (type, payload) => {
+    return this.emitWithTab(type, this.state.activeTab, payload);
+  };
 
   openTabLinksMenu = (tab, event) => {
     event.preventDefault();
@@ -2384,15 +2396,6 @@ export class App extends PureComponent {
       return this.displayNotification(options);
     }
 
-    if (action === 'emit-event') {
-      const {
-        type,
-        payload
-      } = options;
-
-      return this.emitWithTab(type, activeTab, payload);
-    }
-
     if (action === 'toggle-panel') {
       const { panel } = this.state.layout;
       return panel.open ? this.closePanel() : this.openPanel(panel.tab);
@@ -2616,6 +2619,7 @@ export class App extends PureComponent {
                         onLayoutChanged={ this.handleLayoutChanged }
                         onContextMenu={ this.openTabMenu }
                         onAction={ this.triggerAction }
+                        emit={ this.emitEvent }
                         onModal={ this.openModal }
                         onUpdateMenu={ this.updateMenu }
                         getConfig={ this.getConfig }

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -2396,6 +2396,18 @@ export class App extends PureComponent {
       return this.displayNotification(options);
     }
 
+    if (action === 'emit-event') {
+      console.error(
+        'The \'emit-event\' action has been removed. ' +
+        'Application events are now emitted through the events context. ' +
+        'Use the `emit(type, payload)` prop (or `EventsContext#emit`) instead of ' +
+        '`triggerAction(\'emit-event\', { type, payload })`. ' +
+        'See https://github.com/camunda/camunda-modeler/pull/6106 for details.'
+      );
+
+      return;
+    }
+
     if (action === 'toggle-panel') {
       const { panel } = this.state.layout;
       return panel.open ? this.closePanel() : this.openPanel(panel.tab);

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1001,15 +1001,20 @@ export class App extends PureComponent {
 
   emitWithTab(type, tab, payload) {
 
+    // default to the given tab (typically the active one),
+    // but let producers override it via `payload.tab`
     return this.emit(type, {
-      ...payload,
-      tab
+      tab,
+      ...payload
     });
   }
 
   /**
    * Emit an application event on the shared event bus, enriched with the
    * currently active tab.
+   *
+   * The event carries the active tab by default; producers may target a
+   * different tab by passing `tab` in the payload.
    *
    * This is the public counterpart to `subscribe` (cf. `EventsContext`) and
    * the way components and plug-ins produce events.

--- a/client/src/app/AppParent.js
+++ b/client/src/app/AppParent.js
@@ -77,6 +77,34 @@ export default class AppParent extends PureComponent {
     return exec().catch(this.handleError);
   };
 
+  /**
+   * Handle an action received via the Electron menu channel.
+   *
+   * Menu items may emit application events (formerly routed through the
+   * removed `emit-event` action). These are forwarded to the events context;
+   * everything else is a regular action.
+   *
+   * @param {string} action
+   * @param {Object} [options]
+   */
+  handleMenuAction = (action, options) => {
+    if (action === 'emit-event') {
+      const {
+        type,
+        payload
+      } = options || {};
+
+      // fail-safe emit, mirroring #triggerAction
+      try {
+        return this.getApp().emitEvent(type, payload);
+      } catch (error) {
+        return this.handleError(error);
+      }
+    }
+
+    return this.triggerAction(action, options);
+  };
+
   handleOpenFiles = (event, newFiles) => {
 
     const { prereadyState } = this;
@@ -347,7 +375,7 @@ export default class AppParent extends PureComponent {
 
     this.subscriptions = [
       backend.once('client:started', this.handleStarted),
-      backend.on('menu:action', (_, action, options) => this.triggerAction(action, options)),
+      backend.on('menu:action', (_, action, options) => this.handleMenuAction(action, options)),
       backend.on('client:open-files', this.handleOpenFiles),
       backend.on('client:window-focused', this.handleFocused),
       backend.on('client:window-blurred', this.handleBlurred),

--- a/client/src/app/EmptyTab.js
+++ b/client/src/app/EmptyTab.js
@@ -126,7 +126,7 @@ export default class EmptyTab extends PureComponent {
           </div>
           <div className="article">
             <p>About Modeler 5</p>
-            <a href="#" onClick={ () => this.props.onAction('emit-event', { type: 'versionInfo.open' }) }>Open &quot;What&apos;s new&quot;</a>
+            <a href="#" onClick={ () => this.props.emit('versionInfo.open') }>Open &quot;What&apos;s new&quot;</a>
           </div>
           <div className="article">
             <p>Model your first diagram</p>

--- a/client/src/app/EventsContext.js
+++ b/client/src/app/EventsContext.js
@@ -23,8 +23,8 @@ export const EventsContext = createContext({
   },
   emit: (event, payload) => {
     return eventEmitter.emit(event, {
-      ...payload,
-      tab: null
+      tab: null,
+      ...payload
     });
   }
 });

--- a/client/src/app/EventsContext.js
+++ b/client/src/app/EventsContext.js
@@ -20,5 +20,11 @@ export const EventsContext = createContext({
     return {
       cancel: () => eventEmitter.off(event, listener)
     };
+  },
+  emit: (event, payload) => {
+    return eventEmitter.emit(event, {
+      ...payload,
+      tab: null
+    });
   }
 });

--- a/client/src/app/__tests__/AppParentSpec.js
+++ b/client/src/app/__tests__/AppParentSpec.js
@@ -412,6 +412,80 @@ describe('<AppParent>', function() {
   });
 
 
+  describe('menu action', function() {
+
+    it('should emit application event for <emit-event>', function() {
+
+      // given
+      const backend = new Backend();
+
+      const {
+        instance
+      } = createAppParent({ globals: { backend } });
+
+      const app = instance.getApp();
+      const emitSpy = spy(app, 'emitEvent');
+
+      // when
+      backend.receive('menu:action', null, 'emit-event', {
+        type: 'versionInfo.open',
+        payload: { foo: 'bar' }
+      });
+
+      // then
+      expect(emitSpy).to.have.been.calledWith('versionInfo.open', { foo: 'bar' });
+    });
+
+
+    it('should trigger action for other actions', function() {
+
+      // given
+      const backend = new Backend();
+
+      const {
+        instance
+      } = createAppParent({ globals: { backend } });
+
+      const app = instance.getApp();
+      const actionSpy = spy(app, 'triggerAction');
+
+      // when
+      backend.receive('menu:action', null, 'undo', { foo: 'bar' });
+
+      // then
+      expect(actionSpy).to.have.been.calledWith('undo', { foo: 'bar' });
+    });
+
+
+    it('should handle error thrown while emitting', function() {
+
+      // given
+      const backend = new Backend();
+
+      const {
+        instance
+      } = createAppParent({ globals: { backend } });
+
+      const app = instance.getApp();
+
+      const error = new Error('emit failed');
+
+      sinon.stub(app, 'emitEvent').throws(error);
+
+      const handleErrorStub = sinon.stub(instance, 'handleError');
+
+      // when
+      backend.receive('menu:action', null, 'emit-event', {
+        type: 'versionInfo.open'
+      });
+
+      // then
+      expect(handleErrorStub).to.have.been.calledWith(error);
+    });
+
+  });
+
+
   describe('trigger action', function() {
 
     describe('quit', function() {

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -2883,7 +2883,7 @@ describe('<App>', function() {
       await findByText('test-notification-3');
 
       // when
-      await app.triggerAction('emit-event', { type: 'tab.activeSheetChanged' });
+      await app.emitEvent('tab.activeSheetChanged');
 
       // then
       await waitFor(() => {
@@ -4060,6 +4060,42 @@ describe('<App>', function() {
 
       // when
       app.emitWithTab('foo', activeTab, payload);
+
+      // then
+      expect(eventSpy).to.have.been.called;
+    });
+
+  });
+
+
+  describe('#emitEvent', function() {
+
+    it('should emit event with active tab', function() {
+
+      // given
+      const { app } = createApp();
+
+      const {
+        activeTab
+      } = app.state;
+
+      const payload = { foo: 'bar' };
+
+      const eventSpy = sinon.spy((event) => {
+
+        const {
+          foo,
+          tab
+        } = event;
+
+        expect(foo).to.equal('bar');
+        expect(tab).to.eql(activeTab);
+      });
+
+      app.on('foo', eventSpy);
+
+      // when
+      app.emitEvent('foo', payload);
 
       // then
       expect(eventSpy).to.have.been.called;

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -4101,6 +4101,27 @@ describe('<App>', function() {
       expect(eventSpy).to.have.been.called;
     });
 
+
+    it('should allow overriding the tab via payload', function() {
+
+      // given
+      const { app } = createApp();
+
+      const overrideTab = { id: 'other-tab' };
+
+      const eventSpy = sinon.spy((event) => {
+        expect(event.tab).to.equal(overrideTab);
+      });
+
+      app.on('foo', eventSpy);
+
+      // when
+      app.emitEvent('foo', { tab: overrideTab });
+
+      // then
+      expect(eventSpy).to.have.been.called;
+    });
+
   });
 
 

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -4104,6 +4104,39 @@ describe('<App>', function() {
   });
 
 
+  describe('deprecated #emit-event action', function() {
+
+    afterEach(sinon.restore);
+
+    it('should be a NOOP and log an error', async function() {
+
+      // given
+      const { app } = createApp();
+
+      const errorSpy = sinon.stub(console, 'error');
+
+      const eventSpy = sinon.spy();
+
+      app.on('foo', eventSpy);
+
+      // when
+      const result = await app.triggerAction('emit-event', {
+        type: 'foo',
+        payload: { bar: 'baz' }
+      });
+
+      // then
+      expect(result).not.to.exist;
+      expect(eventSpy).not.to.have.been.called;
+
+      expect(errorSpy).to.have.been.calledOnce;
+      expect(errorSpy.getCall(0).args[0]).to.match(/emit-event/);
+      expect(errorSpy.getCall(0).args[0]).to.match(/pull\/6106/);
+    });
+
+  });
+
+
   describe('layout', function() {
 
     it('should emit <layout.changed> event on layout update', async function() {

--- a/client/src/app/__tests__/helpers/renderEditor.js
+++ b/client/src/app/__tests__/helpers/renderEditor.js
@@ -44,6 +44,7 @@ export default async function renderEditor(EditorComponent, xml, options = {}) {
   const props = {
     cache: new Cache(),
     config: new Config(),
+    emit: noop,
     getConfig: noop,
     getPlugins: () => [],
     id: 'editor',

--- a/client/src/app/plugins/PluginsRoot.js
+++ b/client/src/app/plugins/PluginsRoot.js
@@ -98,6 +98,7 @@ export default class PluginsRoot extends PureComponent {
             getConfig={ app.getConfig }
             setConfig={ app.setConfig }
             subscribe={ subscribe }
+            emit={ app.emitEvent }
             log={ this.log }
             displayNotification={ this.displayNotification }
             settings={ pluginSettings }

--- a/client/src/app/plugins/__tests__/PluginsRootSpec.js
+++ b/client/src/app/plugins/__tests__/PluginsRootSpec.js
@@ -28,6 +28,7 @@ describe('<PluginsRoot>', function() {
       plugins: [
         props => {
           expect(props.triggerAction).to.exist;
+          expect(props.emit).to.exist;
           expect(props.config).to.exist;
           expect(props.getConfig).to.exist;
           expect(props.setConfig).to.exist;
@@ -72,6 +73,8 @@ class App {
   };
 
   triggerAction = () => {};
+
+  emitEvent = () => {};
 }
 
 class Config {

--- a/client/src/app/tabs/MultiSheetTab.js
+++ b/client/src/app/tabs/MultiSheetTab.js
@@ -298,9 +298,8 @@ export class MultiSheetTab extends CachedComponent {
       lastXML: xml
     });
 
-    this.props.onAction('emit-event', {
-      type: 'tab.activeSheetChanged',
-      payload: { activeSheet: sheet }
+    this.props.emit('tab.activeSheetChanged', {
+      activeSheet: sheet
     });
   };
 
@@ -404,6 +403,7 @@ export class MultiSheetTab extends CachedComponent {
             onSheetsChanged={ this.sheetsChanged }
             onContextMenu={ this.handleContextMenu }
             onAction={ this.onAction }
+            emit={ this.props.emit }
             onChanged={ this.handleChanged }
             onContentUpdated={ this.handleContentUpdated }
             onError={ this.handleError }

--- a/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
+++ b/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
@@ -372,7 +372,7 @@ describe('<MultiSheetTab>', function() {
       // given
       const emitEventSpy = sinon.spy();
       const { instance } = renderTab({
-        onAction: (...args) => args[0] === 'emit-event' && emitEventSpy(...args),
+        emit: emitEventSpy,
         providers: [ {
           type: 'foo',
           editor: DefaultEditor,
@@ -392,7 +392,7 @@ describe('<MultiSheetTab>', function() {
       // then
       expect(emitEventSpy).to.have.been.calledOnce;
       expect(emitEventSpy.args).to.eql([
-        [ 'emit-event', { type: 'tab.activeSheetChanged', payload: { activeSheet: sheets[1] } } ]
+        [ 'tab.activeSheetChanged', { activeSheet: sheets[1] } ]
       ]);
     });
   });
@@ -611,6 +611,7 @@ function renderTab(options = {}) {
     onLayoutChanged,
     onContextMenu,
     onAction,
+    emit,
     providers
   } = options;
 
@@ -631,6 +632,7 @@ function renderTab(options = {}) {
         onLayoutChanged={ onLayoutChanged || noop }
         onContextMenu={ onContextMenu || noop }
         onAction={ onAction || noop }
+        emit={ emit || noop }
         providers={ providers || defaultProviders }
         cache={ cache || new Cache() }
         layout={ layout || {
@@ -665,6 +667,7 @@ function renderTab(options = {}) {
           onLayoutChanged={ mergedOptions.onLayoutChanged || noop }
           onContextMenu={ mergedOptions.onContextMenu || noop }
           onAction={ mergedOptions.onAction || noop }
+          emit={ mergedOptions.emit || noop }
           providers={ mergedOptions.providers || defaultProviders }
           cache={ mergedOptions.cache || new Cache() }
           layout={ mergedOptions.layout || {

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -885,7 +885,7 @@ export class BpmnEditor extends CachedComponent {
 
     const {
       getPlugins,
-      onAction,
+      emit,
       onError,
       layout = {},
       settings
@@ -893,11 +893,8 @@ export class BpmnEditor extends CachedComponent {
 
     // notify interested parties that modeler will be configured
     const handleMiddlewareExtensions = (middlewares) => {
-      onAction('emit-event', {
-        type: 'bpmn.modeler.configure',
-        payload: {
-          middlewares
-        }
+      emit('bpmn.modeler.configure', {
+        middlewares
       });
     };
 
@@ -940,11 +937,8 @@ export class BpmnEditor extends CachedComponent {
     const stackIdx = commandStack._stackIdx;
 
     // notify interested parties that modeler was created
-    onAction('emit-event', {
-      type: 'bpmn.modeler.created',
-      payload: {
-        modeler
-      }
+    emit('bpmn.modeler.created', {
+      modeler
     });
 
     return {

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -242,6 +242,7 @@ describe('<BpmnEditor>', function() {
         },
         onError: onErrorSpy,
         onAction: noop,
+        emit: noop,
         settings,
       };
 
@@ -2289,8 +2290,8 @@ describe('<BpmnEditor>', function() {
     beforeEach(function() {
       emittedEvents = [];
 
-      recordActions = (action, options) => {
-        emittedEvents.push(options);
+      recordActions = (type, payload) => {
+        emittedEvents.push({ type, payload });
       };
     });
 
@@ -2298,7 +2299,7 @@ describe('<BpmnEditor>', function() {
 
       // when
       await renderEditor(diagramXML, {
-        onAction: recordActions
+        emit: recordActions
       });
 
       // then
@@ -2319,7 +2320,7 @@ describe('<BpmnEditor>', function() {
       const {
         instance
       } = await renderEditor(diagramXML, {
-        onAction: recordActions
+        emit: recordActions
       });
 
       // then

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -125,12 +125,9 @@ export class BpmnEditor extends CachedComponent {
           'modeler:executionPlatformVersion': executionPlatformVersion
         });
 
-        this.props.onAction('emit-event', {
-          type: 'tab.engineProfileChanged',
-          payload: {
-            executionPlatform,
-            executionPlatformVersion
-          }
+        this.props.emit('tab.engineProfileChanged', {
+          executionPlatform,
+          executionPlatformVersion
         });
       },
       getCached: () => this.getCached(),
@@ -436,12 +433,9 @@ export class BpmnEditor extends CachedComponent {
       if (engineProfile) {
         const { executionPlatform, executionPlatformVersion } = engineProfile;
 
-        this.props.onAction('emit-event', {
-          type: 'tab.engineProfileChanged',
-          payload: {
-            executionPlatform,
-            executionPlatformVersion
-          }
+        this.props.emit('tab.engineProfileChanged', {
+          executionPlatform,
+          executionPlatformVersion
         });
       }
     }
@@ -1018,7 +1012,7 @@ export class BpmnEditor extends CachedComponent {
 
     const {
       getPlugins,
-      onAction,
+      emit,
       onError,
       layout = {},
       settings
@@ -1026,11 +1020,8 @@ export class BpmnEditor extends CachedComponent {
 
     // notify interested parties that modeler will be configured
     const handleMiddlewareExtensions = (middlewares) => {
-      onAction('emit-event', {
-        type: 'bpmn.modeler.configure',
-        payload: {
-          middlewares
-        }
+      emit('bpmn.modeler.configure', {
+        middlewares
       });
     };
 
@@ -1084,11 +1075,8 @@ export class BpmnEditor extends CachedComponent {
     const stackIdx = commandStack._stackIdx;
 
     // notify interested parties that modeler was created
-    onAction('emit-event', {
-      type: 'bpmn.modeler.created',
-      payload: {
-        modeler
-      }
+    emit('bpmn.modeler.created', {
+      modeler
     });
 
     return {

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -234,6 +234,7 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
       },
       onError: onErrorSpy,
       onAction: noop,
+      emit: noop,
       settings
     };
 
@@ -2516,8 +2517,8 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
     beforeEach(function() {
       emittedEvents = [];
 
-      recordActions = (action, options) => {
-        emittedEvents.push(options);
+      recordActions = (type, payload) => {
+        emittedEvents.push({ type, payload });
       };
     });
 
@@ -2525,7 +2526,7 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
 
       // when
       await renderEditor(diagramXML, {
-        onAction: recordActions
+        emit: recordActions
       });
 
       // then
@@ -2544,7 +2545,7 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
 
       // when
       const { instance } = await renderEditor(diagramXML, {
-        onAction: recordActions
+        emit: recordActions
       });
 
       // then
@@ -2629,20 +2630,17 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
     it('should emit tab.engineProfileChanged event on import', async function() {
 
       // given
-      const onActionSpy = sinon.spy();
+      const emitSpy = sinon.spy();
 
       // when
       await renderEditor(engineProfileXML, {
-        onAction: onActionSpy
+        emit: emitSpy
       });
 
       // then
-      expect(onActionSpy).to.have.been.calledWithMatch('emit-event', {
-        type: 'tab.engineProfileChanged',
-        payload: {
-          executionPlatform: 'Camunda Cloud',
-          executionPlatformVersion: '1.1.0'
-        }
+      expect(emitSpy).to.have.been.calledWithMatch('tab.engineProfileChanged', {
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '1.1.0'
       });
     });
 
@@ -2650,13 +2648,13 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
     it('should emit tab.engineProfileChanged event on set engine profile', async function() {
 
       // given
-      const onActionSpy = sinon.spy();
+      const emitSpy = sinon.spy();
 
       const { instance } = await renderEditor(engineProfileXML, {
-        onAction: onActionSpy
+        emit: emitSpy
       });
 
-      onActionSpy.resetHistory();
+      emitSpy.resetHistory();
 
       // when
       instance.engineProfile.set({
@@ -2665,12 +2663,9 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
       });
 
       // then
-      expect(onActionSpy).to.have.been.calledWithMatch('emit-event', {
-        type: 'tab.engineProfileChanged',
-        payload: {
-          executionPlatform: 'Camunda Cloud',
-          executionPlatformVersion: '1.2.0'
-        }
+      expect(emitSpy).to.have.been.calledWithMatch('tab.engineProfileChanged', {
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '1.2.0'
       });
     });
 

--- a/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/TaskTestingApi.js
+++ b/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/TaskTestingApi.js
@@ -15,11 +15,12 @@ import { getOperateBaseUrl, getTasklistBaseUrl } from '../../../../../zeebe/util
 const log = debug('TaskTestingApi');
 
 export default class TaskTestingApi {
-  constructor(deployment, startInstance, zeebeApi, tab, onAction) {
+  constructor(deployment, startInstance, zeebeApi, tab, onAction, emit) {
     this._deployment = deployment;
     this._startInstance = startInstance;
     this._zeebeApi = zeebeApi;
     this._onAction = onAction;
+    this._emit = emit;
     this._tab = tab;
   }
 
@@ -195,21 +196,15 @@ export default class TaskTestingApi {
   _handleDeployment({ context, deploymentResult, endpoint }) {
 
     if (deploymentResult.success) {
-      this._onAction('emit-event', {
-        type: 'deployment.done',
-        payload: {
-          context,
-          targetType: endpoint?.targetType,
-        }
+      this._emit('deployment.done', {
+        context,
+        targetType: endpoint?.targetType,
       });
     } else {
-      this._onAction('emit-event', {
-        type: 'deployment.error',
-        payload: {
-          context,
-          error: deploymentResult?.response,
-          targetType: endpoint?.targetType,
-        }
+      this._emit('deployment.error', {
+        context,
+        error: deploymentResult?.response,
+        targetType: endpoint?.targetType,
       });
     }
   }

--- a/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/TaskTestingTab.js
+++ b/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/TaskTestingTab.js
@@ -67,7 +67,7 @@ export default function TaskTestingTab(props) {
     zeebeApi
   } = props;
 
-  const { subscribe } = useContext(EventsContext);
+  const { subscribe, emit } = useContext(EventsContext);
 
   const [ taskTestingConfig, setTaskTestingConfig ] = useState(DEFAULT_CONFIG);
 
@@ -80,8 +80,8 @@ export default function TaskTestingTab(props) {
   }), [ id, file ]);
 
   const taskTestingApi = useMemo(() => {
-    return new TaskTestingApi(deployment, startInstance, zeebeApi, tab, onAction);
-  }, [ deployment, startInstance, zeebeApi, tab, onAction ]);
+    return new TaskTestingApi(deployment, startInstance, zeebeApi, tab, onAction, emit);
+  }, [ deployment, startInstance, zeebeApi, tab, onAction, emit ]);
 
   const api = useMemo(() => taskTestingApi.getApi(), [ taskTestingApi ]);
 
@@ -136,13 +136,10 @@ export default function TaskTestingTab(props) {
   }, [ taskTestingConfig ]);
 
   const handleTaskExecutionStarted = useCallback((element) => {
-    onAction('emit-event', {
-      type: 'taskTesting.started',
-      payload: {
-        element
-      }
+    emit('taskTesting.started', {
+      element
     });
-  }, [ onAction ]);
+  }, [ emit ]);
 
   const handleTaskExecutionFinished = useCallback((element, result) => {
 
@@ -158,16 +155,13 @@ export default function TaskTestingTab(props) {
       return;
     }
 
-    onAction('emit-event', {
-      type: 'taskTesting.finished',
-      payload: {
-        element: element,
-        success,
-        incident,
-        output: lastPolledResult
-      }
+    emit('taskTesting.finished', {
+      element: element,
+      success,
+      incident,
+      output: lastPolledResult
     });
-  }, [ onAction ]);
+  }, [ emit ]);
 
   const handleTaskExecutionInterrupted = useCallback(() => {
     onAction('display-notification', {

--- a/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/__tests__/TaskTestingTabSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/__tests__/TaskTestingTabSpec.js
@@ -268,6 +268,7 @@ describe('<TaskTestingTab>', function() {
 
       // given
       const onAction = sinon.spy();
+      const emit = sinon.spy();
 
       renderTab(modeler, {
         connectionCheckResult: {
@@ -280,7 +281,8 @@ describe('<TaskTestingTab>', function() {
         linting: [
           { category: 'error' }
         ],
-        onAction
+        onAction,
+        emit
       });
 
       await selectElement(modeler, 'Task_1');
@@ -292,11 +294,8 @@ describe('<TaskTestingTab>', function() {
 
       // then
       await waitFor(() => {
-        expect(onAction).to.have.been.calledWith('emit-event', {
-          type: 'taskTesting.started',
-          payload: {
-            element: modeler.get('elementRegistry').get('Task_1')
-          }
+        expect(emit).to.have.been.calledWith('taskTesting.started', {
+          element: modeler.get('elementRegistry').get('Task_1')
         });
       });
 
@@ -462,6 +461,7 @@ function renderTab(modeler, options = {}) {
       path: 'foo.bpmn'
     },
     onAction: () => {},
+    emit: () => {},
     ...options
   };
 
@@ -475,7 +475,8 @@ function renderTab(modeler, options = {}) {
   };
 
   const eventsContext = {
-    subscribe: mockSubscribe
+    subscribe: mockSubscribe,
+    emit: props.emit
   };
 
   render(

--- a/client/src/app/tabs/cloud-dmn/DmnEditor.js
+++ b/client/src/app/tabs/cloud-dmn/DmnEditor.js
@@ -134,12 +134,9 @@ export class DmnEditor extends CachedComponent {
           executionPlatformVersion
         } = engineProfile;
 
-        this.props.onAction('emit-event', {
-          type: 'tab.engineProfileChanged',
-          payload: {
-            executionPlatform,
-            executionPlatformVersion
-          }
+        this.props.emit('tab.engineProfileChanged', {
+          executionPlatform,
+          executionPlatformVersion
         });
       },
       getCached: () => this.getCached(),
@@ -306,12 +303,9 @@ export class DmnEditor extends CachedComponent {
       if (engineProfile) {
         const { executionPlatform, executionPlatformVersion } = engineProfile;
 
-        this.props.onAction('emit-event', {
-          type: 'tab.engineProfileChanged',
-          payload: {
-            executionPlatform,
-            executionPlatformVersion
-          }
+        this.props.emit('tab.engineProfileChanged', {
+          executionPlatform,
+          executionPlatformVersion
         });
       }
 
@@ -1048,18 +1042,15 @@ export class DmnEditor extends CachedComponent {
 
     const {
       getPlugins,
-      onAction,
+      emit,
       onError,
       settings
     } = props;
 
     // notify interested parties that modeler will be configured
     const handleMiddlewareExtensions = (middlewares) => {
-      onAction('emit-event', {
-        type: 'dmn.modeler.configure',
-        payload: {
-          middlewares
-        }
+      emit('dmn.modeler.configure', {
+        middlewares
       });
     };
 
@@ -1093,11 +1084,8 @@ export class DmnEditor extends CachedComponent {
     const stackIdx = modeler.getStackIdx();
 
     // notify interested parties that modeler was created
-    onAction('emit-event', {
-      type: 'dmn.modeler.created',
-      payload: {
-        modeler
-      }
+    emit('dmn.modeler.created', {
+      modeler
     });
 
     return {

--- a/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
@@ -303,7 +303,8 @@ describe('<DmnEditor>', function() {
           return [];
         },
         onError: onErrorSpy,
-        onAction: noop
+        onAction: noop,
+        emit: noop
       };
 
       // then
@@ -2273,8 +2274,8 @@ describe('<DmnEditor>', function() {
     beforeEach(function() {
       emittedEvents = [];
 
-      recordActions = (action, options) => {
-        emittedEvents.push(options);
+      recordActions = (type, payload) => {
+        emittedEvents.push({ type, payload });
       };
     });
 
@@ -2282,7 +2283,7 @@ describe('<DmnEditor>', function() {
 
       // when
       await renderEditor(diagramXML, {
-        onAction: recordActions
+        emit: recordActions
       });
 
       // then
@@ -2303,7 +2304,7 @@ describe('<DmnEditor>', function() {
       const {
         instance
       } = await renderEditor(diagramXML, {
-        onAction: recordActions
+        emit: recordActions
       });
 
       // then
@@ -2467,20 +2468,17 @@ describe('<DmnEditor>', function() {
     it('should emit tab.engineProfileChanged event on import', async function() {
 
       // given
-      const onActionSpy = sinon.spy();
+      const emitSpy = sinon.spy();
 
       // when
       await renderEditor(engineProfileXML, {
-        onAction: onActionSpy
+        emit: emitSpy
       });
 
       // then
-      expect(onActionSpy).to.have.been.calledWithMatch('emit-event', {
-        type: 'tab.engineProfileChanged',
-        payload: {
-          executionPlatform: 'Camunda Cloud',
-          executionPlatformVersion: '8.0.0'
-        }
+      expect(emitSpy).to.have.been.calledWithMatch('tab.engineProfileChanged', {
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '8.0.0'
       });
     });
 
@@ -2488,13 +2486,13 @@ describe('<DmnEditor>', function() {
     it('should emit tab.engineProfileChanged event on set engine profile', async function() {
 
       // given
-      const onActionSpy = sinon.spy();
+      const emitSpy = sinon.spy();
 
       const { instance } = await renderEditor(engineProfileXML, {
-        onAction: onActionSpy
+        emit: emitSpy
       });
 
-      onActionSpy.resetHistory();
+      emitSpy.resetHistory();
 
       // when
       instance.engineProfile.set({
@@ -2503,12 +2501,9 @@ describe('<DmnEditor>', function() {
       });
 
       // then
-      expect(onActionSpy).to.have.been.calledWithMatch('emit-event', {
-        type: 'tab.engineProfileChanged',
-        payload: {
-          executionPlatform: 'Camunda Cloud',
-          executionPlatformVersion: '8.1.0'
-        }
+      expect(emitSpy).to.have.been.calledWithMatch('tab.engineProfileChanged', {
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '8.1.0'
       });
     });
 

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -1015,18 +1015,15 @@ export class DmnEditor extends CachedComponent {
 
     const {
       getPlugins,
-      onAction,
+      emit,
       onError,
       settings
     } = props;
 
     // notify interested parties that modeler will be configured
     const handleMiddlewareExtensions = (middlewares) => {
-      onAction('emit-event', {
-        type: 'dmn.modeler.configure',
-        payload: {
-          middlewares
-        }
+      emit('dmn.modeler.configure', {
+        middlewares
       });
     };
 
@@ -1060,11 +1057,8 @@ export class DmnEditor extends CachedComponent {
     const stackIdx = modeler.getStackIdx();
 
     // notify interested parties that modeler was created
-    onAction('emit-event', {
-      type: 'dmn.modeler.created',
-      payload: {
-        modeler
-      }
+    emit('dmn.modeler.created', {
+      modeler
     });
 
     return {

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -303,7 +303,8 @@ describe('<DmnEditor>', function() {
           return [];
         },
         onError: onErrorSpy,
-        onAction: noop
+        onAction: noop,
+        emit: noop
       };
 
       // then
@@ -2273,8 +2274,8 @@ describe('<DmnEditor>', function() {
     beforeEach(function() {
       emittedEvents = [];
 
-      recordActions = (action, options) => {
-        emittedEvents.push(options);
+      recordActions = (type, payload) => {
+        emittedEvents.push({ type, payload });
       };
     });
 
@@ -2282,7 +2283,7 @@ describe('<DmnEditor>', function() {
 
       // when
       await renderEditor(diagramXML, {
-        onAction: recordActions
+        emit: recordActions
       });
 
       // then
@@ -2303,7 +2304,7 @@ describe('<DmnEditor>', function() {
       const {
         instance
       } = await renderEditor(diagramXML, {
-        onAction: recordActions
+        emit: recordActions
       });
 
       // then

--- a/client/src/app/tabs/form/FormEditor.js
+++ b/client/src/app/tabs/form/FormEditor.js
@@ -109,12 +109,9 @@ export class FormEditor extends CachedComponent {
           executionPlatformVersion
         } = engineProfile;
 
-        this.props.onAction('emit-event', {
-          type: 'tab.engineProfileChanged',
-          payload: {
-            executionPlatform,
-            executionPlatformVersion
-          }
+        this.props.emit('tab.engineProfileChanged', {
+          executionPlatform,
+          executionPlatformVersion
         });
       },
       getCached: () => this.getCached(),
@@ -269,12 +266,9 @@ export class FormEditor extends CachedComponent {
       if (engineProfile) {
         const { executionPlatform, executionPlatformVersion } = engineProfile;
 
-        this.props.onAction('emit-event', {
-          type: 'tab.engineProfileChanged',
-          payload: {
-            executionPlatform,
-            executionPlatformVersion
-          }
+        this.props.emit('tab.engineProfileChanged', {
+          executionPlatform,
+          executionPlatformVersion
         });
       }
 
@@ -322,16 +316,14 @@ export class FormEditor extends CachedComponent {
 
   handleDataEditorInteractionEnd = () => {
     const {
-      onAction
+      emit
     } = this.props;
 
     const newData = this.getInputData();
 
     // fire event once data was touched (changed)
     if (this.state.lastInputData !== newData) {
-      onAction('emit-event', {
-        type: 'form.modeler.inputDataChanged'
-      });
+      emit('form.modeler.inputDataChanged');
     }
 
     this.setState({
@@ -363,16 +355,14 @@ export class FormEditor extends CachedComponent {
 
   handleFormPreviewInteractionEnd = () => {
     const {
-      onAction
+      emit
     } = this.props;
 
     const newformPreviewState = this.getFormPreviewState();
 
     // fire event once preview was touched (changed)
     if (this.state.lastFormPreviewState !== newformPreviewState) {
-      onAction('emit-event', {
-        type: 'form.modeler.previewChanged'
-      });
+      emit('form.modeler.previewChanged');
     }
 
     this.setState({
@@ -471,7 +461,7 @@ export class FormEditor extends CachedComponent {
     } = event;
 
     const {
-      onAction,
+      emit,
       onLayoutChanged
     } = this.props;
 
@@ -483,14 +473,11 @@ export class FormEditor extends CachedComponent {
     }
 
     // (2) notify interested parties that playground layout has changed
-    onAction('emit-event', {
-      type: 'form.modeler.playgroundLayoutChanged',
-      payload: {
-        layout,
+    emit('form.modeler.playgroundLayoutChanged', {
+      layout,
 
-        // assumption: everything else is internally triggered by the playground
-        triggeredBy: this.state.triggeredBy || FORM_PREVIEW_TRIGGER.PREVIEW_PANEL
-      }
+      // assumption: everything else is internally triggered by the playground
+      triggeredBy: this.state.triggeredBy || FORM_PREVIEW_TRIGGER.PREVIEW_PANEL
     });
 
     // (3) toggle preview
@@ -666,7 +653,7 @@ export class FormEditor extends CachedComponent {
 
     const {
       layout = {},
-      onAction
+      emit
     } = props;
 
     const {
@@ -686,10 +673,7 @@ export class FormEditor extends CachedComponent {
       }
     });
 
-    onAction('emit-event', {
-      type: 'form.modeler.created',
-      payload: form
-    });
+    emit('form.modeler.created', form);
 
     return {
       __destroy: () => {

--- a/client/src/app/tabs/form/__tests__/FormEditorSpec.js
+++ b/client/src/app/tabs/form/__tests__/FormEditorSpec.js
@@ -728,21 +728,18 @@ describe('<FormEditor>', function() {
     it('should emit tab.engineProfileChanged event on import', async function() {
 
       // given
-      const onActionSpy = spy();
+      const emitSpy = spy();
 
       // when
       await renderEditor(engineProfileSchema, {
-        onAction: onActionSpy
+        emit: emitSpy
       });
 
       // then
       await waitFor(() => {
-        expect(onActionSpy).to.have.been.calledWithMatch('emit-event', {
-          type: 'tab.engineProfileChanged',
-          payload: {
-            executionPlatform: 'Camunda Platform',
-            executionPlatformVersion: '7.16.0'
-          }
+        expect(emitSpy).to.have.been.calledWithMatch('tab.engineProfileChanged', {
+          executionPlatform: 'Camunda Platform',
+          executionPlatformVersion: '7.16.0'
         });
       });
     });
@@ -1034,8 +1031,8 @@ describe('<FormEditor>', function() {
     beforeEach(function() {
       emittedEvents = [];
 
-      recordActions = (action, options) => {
-        emittedEvents.push(options);
+      recordActions = (type, payload) => {
+        emittedEvents.push({ type, payload });
       };
     });
 
@@ -1046,7 +1043,7 @@ describe('<FormEditor>', function() {
       const {
         instance
       } = await renderEditor(engineProfileSchema, {
-        onAction: recordActions
+        emit: recordActions
       });
 
       const {
@@ -1071,7 +1068,7 @@ describe('<FormEditor>', function() {
       const {
         instance
       } = await renderEditor(schema, {
-        onAction: recordActions
+        emit: recordActions
       });
 
       const {
@@ -1110,7 +1107,7 @@ describe('<FormEditor>', function() {
       const {
         instance
       } = await renderEditor(schema, {
-        onAction: recordActions
+        emit: recordActions
       });
 
       const layout = {
@@ -1166,7 +1163,7 @@ describe('<FormEditor>', function() {
         container
       } = await renderEditor(engineProfileSchema, {
         cache,
-        onAction: recordActions
+        emit: recordActions
       });
 
       const previewContainer = container.querySelector('.cfp-preview-container');
@@ -1188,7 +1185,7 @@ describe('<FormEditor>', function() {
       const {
         container
       } = await renderEditor(engineProfileSchema, {
-        onAction: recordActions
+        emit: recordActions
       });
 
       const previewContainer = container.querySelector('.cfp-preview-container');
@@ -1225,7 +1222,7 @@ describe('<FormEditor>', function() {
         container
       } = await renderEditor(engineProfileSchema, {
         cache,
-        onAction: recordActions
+        emit: recordActions
       });
 
       // when
@@ -1264,7 +1261,7 @@ describe('<FormEditor>', function() {
         container
       } = await renderEditor(engineProfileSchema, {
         cache,
-        onAction: recordActions
+        emit: recordActions
       });
 
       const dataContainer = container.querySelector('.cfp-data-container');
@@ -1286,7 +1283,7 @@ describe('<FormEditor>', function() {
       const {
         container
       } = await renderEditor(engineProfileSchema, {
-        onAction: recordActions
+        emit: recordActions
       });
 
       const dataContainer = container.querySelector('.cfp-data-container');
@@ -1323,7 +1320,7 @@ describe('<FormEditor>', function() {
         container
       } = await renderEditor(engineProfileSchema, {
         cache,
-        onAction: recordActions
+        emit: recordActions
       });
 
       // when
@@ -1358,6 +1355,7 @@ async function renderEditor(schema, options = {}) {
     id = 'editor',
     layout = {},
     onAction = noop,
+    emit = noop,
     onChanged = noop,
     onContentUpdated = noop,
     onError = noop,
@@ -1389,6 +1387,7 @@ async function renderEditor(schema, options = {}) {
           id={ id }
           layout={ layout }
           onAction={ onAction }
+          emit={ emit }
           onChanged={ onChanged }
           onContentUpdated={ onContentUpdated }
           onError={ onError }

--- a/client/src/app/tabs/rpa/RPAEditor.js
+++ b/client/src/app/tabs/rpa/RPAEditor.js
@@ -89,12 +89,9 @@ export class RPAEditor extends CachedComponent {
           executionPlatformVersion
         } = engineProfile;
 
-        this.props.onAction('emit-event', {
-          type: 'tab.engineProfileChanged',
-          payload: {
-            executionPlatform,
-            executionPlatformVersion
-          }
+        this.props.emit('tab.engineProfileChanged', {
+          executionPlatform,
+          executionPlatformVersion
         });
       },
       getCached: () => this.getCached(),
@@ -209,12 +206,9 @@ export class RPAEditor extends CachedComponent {
         executionPlatformVersion
       } = engineProfile;
 
-      this.props.onAction('emit-event', {
-        type: 'tab.engineProfileChanged',
-        payload: {
-          executionPlatform,
-          executionPlatformVersion
-        }
+      this.props.emit('tab.engineProfileChanged', {
+        executionPlatform,
+        executionPlatformVersion
       });
     }
   }

--- a/client/src/app/tabs/rpa/__tests__/RPAEditorSpec.js
+++ b/client/src/app/tabs/rpa/__tests__/RPAEditorSpec.js
@@ -349,21 +349,18 @@ describe('<RPAEditor>', function() {
     it('should emit tab.engineProfileChanged event on import', async function() {
 
       // given
-      const onActionSpy = sinon.spy();
+      const emitSpy = sinon.spy();
 
       // when
       renderEditor(RPA, {
-        onAction: onActionSpy
+        emit: emitSpy
       });
 
       // then
       await waitFor(() => {
-        expect(onActionSpy).to.have.been.calledWithMatch('emit-event', {
-          type: 'tab.engineProfileChanged',
-          payload: {
-            executionPlatform: 'Camunda Cloud',
-            executionPlatformVersion: '8.8.0'
-          }
+        expect(emitSpy).to.have.been.calledWithMatch('tab.engineProfileChanged', {
+          executionPlatform: 'Camunda Cloud',
+          executionPlatformVersion: '8.8.0'
         });
       });
     });
@@ -372,13 +369,13 @@ describe('<RPAEditor>', function() {
     it('should emit tab.engineProfileChanged event on set engine profile', async function() {
 
       // given
-      const onActionSpy = sinon.spy();
+      const emitSpy = sinon.spy();
 
       const { instance } = renderEditor(RPA, {
-        onAction: onActionSpy
+        emit: emitSpy
       });
 
-      onActionSpy.resetHistory();
+      emitSpy.resetHistory();
 
       // when
       instance.engineProfile.set({
@@ -388,12 +385,9 @@ describe('<RPAEditor>', function() {
 
       // then
       await waitFor(() => {
-        expect(onActionSpy).to.have.been.calledWithMatch('emit-event', {
-          type: 'tab.engineProfileChanged',
-          payload: {
-            executionPlatform: 'Camunda Cloud',
-            executionPlatformVersion: '8.9.0'
-          }
+        expect(emitSpy).to.have.been.calledWithMatch('tab.engineProfileChanged', {
+          executionPlatform: 'Camunda Cloud',
+          executionPlatformVersion: '8.9.0'
         });
       });
     });
@@ -437,6 +431,7 @@ function renderEditor(xml, options = {}) {
       ref={ ref }
       getConfig={ () => ({}) }
       onAction={ noop }
+      emit={ noop }
       onImport={ onImport || noop }
       id={ id || 'editor' }
       xml={ xml }

--- a/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/DeploymentTool.js
@@ -179,7 +179,7 @@ export default class DeploymentTool extends PureComponent {
   async handleDeploymentSuccess(tab, deployment, version, configuration) {
     const {
       displayNotification,
-      triggerAction
+      emit
     } = this.props;
 
     const {
@@ -200,17 +200,14 @@ export default class DeploymentTool extends PureComponent {
     });
 
     // notify interested parties
-    triggerAction('emit-event', {
-      type: 'deployment.done',
-      payload: {
-        deployment,
-        targetType: SELF_HOSTED,
-        deployedTo: {
-          executionPlatformVersion: version,
-          executionPlatform: ENGINES.PLATFORM
-        },
-        context: 'deploymentTool'
-      }
+    emit('deployment.done', {
+      deployment,
+      targetType: SELF_HOSTED,
+      deployedTo: {
+        executionPlatformVersion: version,
+        executionPlatform: ENGINES.PLATFORM
+      },
+      context: 'deploymentTool'
     });
   }
 
@@ -239,7 +236,8 @@ export default class DeploymentTool extends PureComponent {
     const {
       log,
       displayNotification,
-      triggerAction
+      triggerAction,
+      emit
     } = this.props;
 
     const logMessage = {
@@ -267,14 +265,11 @@ export default class DeploymentTool extends PureComponent {
       { executionPlatformVersion: version, executionPlatform: ENGINES.PLATFORM }) || undefined;
 
     // notify interested parties
-    triggerAction('emit-event', {
-      type: 'deployment.error',
-      payload: {
-        error,
-        targetType: SELF_HOSTED,
-        context: 'deploymentTool',
-        ...(deployedTo && { deployedTo: deployedTo })
-      }
+    emit('deployment.error', {
+      error,
+      targetType: SELF_HOSTED,
+      context: 'deploymentTool',
+      ...(deployedTo && { deployedTo: deployedTo })
     });
   }
 

--- a/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentToolSpec.js
+++ b/client/src/plugins/camunda-plugin/deployment-tool/__tests__/DeploymentToolSpec.js
@@ -580,7 +580,7 @@ describe('<DeploymentTool>', function() {
     });
 
 
-    describe('emit-event action', function() {
+    describe('events', function() {
 
       it('should trigger deployment.done action after successful deployment', async function() {
 
@@ -590,7 +590,6 @@ describe('<DeploymentTool>', function() {
 
         const actionSpy = sinon.spy(),
               actionTriggered = {
-                emitEvent: 'emit-event',
                 type: 'deployment.done',
                 handler: actionSpy
               };
@@ -614,7 +613,6 @@ describe('<DeploymentTool>', function() {
 
         const actionSpy = sinon.spy(),
               actionTriggered = {
-                emitEvent: 'emit-event',
                 type: 'deployment.done',
                 handler: actionSpy
               };
@@ -645,7 +643,6 @@ describe('<DeploymentTool>', function() {
 
         const actionSpy = sinon.spy(),
               actionTriggered = {
-                emitEvent: 'emit-event',
                 type: 'deployment.done',
                 handler:actionSpy
               };
@@ -676,7 +673,6 @@ describe('<DeploymentTool>', function() {
 
         const actionSpy = sinon.spy(),
               actionTriggered = {
-                emitEvent: 'emit-event',
                 type: 'deployment.done',
                 handler:actionSpy
               };
@@ -703,7 +699,6 @@ describe('<DeploymentTool>', function() {
 
         const actionSpy = sinon.spy(),
               actionTriggered = {
-                emitEvent: 'emit-event',
                 type: 'deployment.error',
                 handler:actionSpy
               };
@@ -730,7 +725,6 @@ describe('<DeploymentTool>', function() {
 
         const actionSpy = sinon.spy(),
               actionTriggered = {
-                emitEvent: 'emit-event',
                 type: 'deployment.error',
                 handler:actionSpy
               };
@@ -765,7 +759,6 @@ describe('<DeploymentTool>', function() {
 
         const actionSpy = sinon.spy(),
               actionTriggered = {
-                emitEvent: 'emit-event',
                 type: 'deployment.error',
                 handler:actionSpy
               };
@@ -790,7 +783,6 @@ describe('<DeploymentTool>', function() {
 
         const actionSpy = sinon.spy(),
               actionTriggered = {
-                emitEvent: 'emit-event',
                 type: 'deployment.error',
                 handler:actionSpy
               };
@@ -1437,10 +1429,13 @@ describe('<DeploymentTool>', function() {
       switch (true) {
       case (event === 'save-tab'):
         return activeTab;
-      case (props.actionTriggered &&
-      props.actionTriggered.emitEvent == event &&
-      props.actionTriggered.type == context.type):
-        return props.actionTriggered.handler(context);
+      }
+    };
+
+    const emit = (type, payload) => {
+      if (props.actionTriggered &&
+        props.actionTriggered.type == type) {
+        return props.actionTriggered.handler({ type, payload });
       }
     };
 
@@ -1456,6 +1451,7 @@ describe('<DeploymentTool>', function() {
         ref={ ref }
         subscribe={ props.subcribe || subscribe }
         triggerAction={ triggerAction }
+        emit={ emit }
         displayNotification={ noop }
         log={ noop }
         _getGlobal={ (name) => (name === 'fileSystem' && createFileSystem(props.fileSystem)) }

--- a/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/StartInstanceTool.js
@@ -450,19 +450,16 @@ export default class StartInstanceTool extends PureComponent {
   handleDeploymentSuccess(tab, deployment, version) {
 
     const {
-      triggerAction
+      emit
     } = this.props;
 
     // notify interested parties
-    triggerAction('emit-event', {
-      type: 'deployment.done',
-      payload: {
-        deployment,
-        context: 'startInstanceTool',
-        deployedTo: {
-          executionPlatformVersion: version,
-          executionPlatform: ENGINES.PLATFORM
-        }
+    emit('deployment.done', {
+      deployment,
+      context: 'startInstanceTool',
+      deployedTo: {
+        executionPlatformVersion: version,
+        executionPlatform: ENGINES.PLATFORM
       }
     });
 
@@ -473,7 +470,7 @@ export default class StartInstanceTool extends PureComponent {
     const {
       log,
       displayNotification,
-      triggerAction
+      emit
     } = this.props;
 
     const logMessage = {
@@ -498,13 +495,10 @@ export default class StartInstanceTool extends PureComponent {
        { executionPlatformVersion: version, executionPlatform: ENGINES.PLATFORM }) || undefined;
 
     // notify interested parties
-    triggerAction('emit-event', {
-      type: 'deployment.error',
-      payload: {
-        error,
-        context: 'startInstanceTool',
-        ...(deployedTo && { deployedTo: deployedTo })
-      }
+    emit('deployment.error', {
+      error,
+      context: 'startInstanceTool',
+      ...(deployedTo && { deployedTo: deployedTo })
     });
   }
 

--- a/client/src/plugins/camunda-plugin/start-instance-tool/__tests__/StartInstanceToolSpec.js
+++ b/client/src/plugins/camunda-plugin/start-instance-tool/__tests__/StartInstanceToolSpec.js
@@ -290,8 +290,7 @@ describe('<StartInstanceTool>', function() {
 
       // given
       let deployedTo;
-      const actionTriggered = {
-        emitEvent: 'emit-event',
+      const eventEmitted = {
         type: 'deployment.done',
         handler: deployment => deployedTo = deployment.payload.deployedTo
       };
@@ -300,7 +299,7 @@ describe('<StartInstanceTool>', function() {
           throw new ConnectionError({ status: 404 });
         }
       };
-      const { instance } = createStartInstanceTool({ actionTriggered, deployService });
+      const { instance } = createStartInstanceTool({ eventEmitted, deployService });
 
       // when
       await instance.startInstance();
@@ -316,8 +315,7 @@ describe('<StartInstanceTool>', function() {
 
       // given
       const handler = sinon.spy();
-      const actionTriggered = {
-        emitEvent: 'emit-event',
+      const eventEmitted = {
         type: 'deployment.done',
         handler
       };
@@ -326,7 +324,7 @@ describe('<StartInstanceTool>', function() {
           throw new TypeError('we don\'t want to ignore that!');
         }
       };
-      const { instance } = createStartInstanceTool({ actionTriggered, deployService });
+      const { instance } = createStartInstanceTool({ eventEmitted, deployService });
 
       // when
       let error;
@@ -395,7 +393,7 @@ describe('<StartInstanceTool>', function() {
     });
 
 
-    describe('emit-event action', function() {
+    describe('events', function() {
 
       it('should trigger deployment.done action after successful deployment', async function() {
 
@@ -403,15 +401,14 @@ describe('<StartInstanceTool>', function() {
         const activeTab = createTab({ name: 'foo.bpmn' });
 
         const actionSpy = sinon.spy(),
-              actionTriggered = {
-                emitEvent: 'emit-event',
+              eventEmitted = {
                 type: 'deployment.done',
                 handler:actionSpy
               };
 
         const {
           instance
-        } = createStartInstanceTool({ activeTab, actionTriggered });
+        } = createStartInstanceTool({ activeTab, eventEmitted });
 
         // when
         await instance.startInstance();
@@ -428,8 +425,7 @@ describe('<StartInstanceTool>', function() {
 
         const actionSpy = sinon.spy(),
               getVersionSpy = sinon.spy(() => { return { version: '7.14.0' }; }),
-              actionTriggered = {
-                emitEvent: 'emit-event',
+              eventEmitted = {
                 type: 'deployment.done',
                 handler:actionSpy
               };
@@ -440,7 +436,7 @@ describe('<StartInstanceTool>', function() {
 
         const {
           instance
-        } = createStartInstanceTool({ activeTab, actionTriggered, deployService });
+        } = createStartInstanceTool({ activeTab, eventEmitted, deployService });
 
         // when
         await instance.startInstance();
@@ -461,8 +457,7 @@ describe('<StartInstanceTool>', function() {
         const activeTab = createTab({ name: 'foo.bpmn' });
 
         const actionSpy = sinon.spy(),
-              actionTriggered = {
-                emitEvent: 'emit-event',
+              eventEmitted = {
                 type: 'deployment.done',
                 handler:actionSpy
               };
@@ -471,7 +466,7 @@ describe('<StartInstanceTool>', function() {
 
         const {
           instance
-        } = createStartInstanceTool({ activeTab, actionTriggered, deployErrorThrown });
+        } = createStartInstanceTool({ activeTab, eventEmitted, deployErrorThrown });
 
         // when
         await instance.startInstance();
@@ -487,8 +482,7 @@ describe('<StartInstanceTool>', function() {
         const activeTab = createTab({ name: 'foo.bpmn' });
 
         const actionSpy = sinon.spy(),
-              actionTriggered = {
-                emitEvent: 'emit-event',
+              eventEmitted = {
                 type: 'deployment.error',
                 handler:actionSpy
               };
@@ -497,7 +491,7 @@ describe('<StartInstanceTool>', function() {
 
         const {
           instance
-        } = createStartInstanceTool({ activeTab, actionTriggered, deployErrorThrown });
+        } = createStartInstanceTool({ activeTab, eventEmitted, deployErrorThrown });
 
         // when
         await instance.startInstance();
@@ -513,8 +507,7 @@ describe('<StartInstanceTool>', function() {
         const activeTab = createTab({ name: 'foo.bpmn' });
 
         const actionSpy = sinon.spy(),
-              actionTriggered = {
-                emitEvent: 'emit-event',
+              eventEmitted = {
                 type: 'deployment.error',
                 handler:actionSpy
               };
@@ -523,7 +516,7 @@ describe('<StartInstanceTool>', function() {
 
         const {
           instance
-        } = createStartInstanceTool({ activeTab, actionTriggered, deployErrorThrown });
+        } = createStartInstanceTool({ activeTab, eventEmitted, deployErrorThrown });
 
         // when
         await instance.startInstance();
@@ -544,15 +537,14 @@ describe('<StartInstanceTool>', function() {
         const activeTab = createTab({ name: 'foo.bpmn' });
 
         const actionSpy = sinon.spy(),
-              actionTriggered = {
-                emitEvent: 'emit-event',
+              eventEmitted = {
                 type: 'deployment.error',
                 handler:actionSpy
               };
 
         const {
           instance
-        } = createStartInstanceTool({ activeTab, actionTriggered });
+        } = createStartInstanceTool({ activeTab, eventEmitted });
 
         // when
         await instance.startInstance();
@@ -817,8 +809,7 @@ describe('<StartInstanceTool>', function() {
       const displayNotification = sinon.spy();
 
       const actionSpy = sinon.spy(),
-            actionTriggered = {
-              emitEvent: 'emit-event',
+            eventEmitted = {
               type: 'deployment.done',
               handler: actionSpy
             };
@@ -831,7 +822,7 @@ describe('<StartInstanceTool>', function() {
         activeTab,
         displayNotification,
         startSpy,
-        actionTriggered
+        eventEmitted
       });
 
       // when
@@ -859,8 +850,7 @@ describe('<StartInstanceTool>', function() {
       const logSpy = sinon.spy();
 
       const actionSpy = sinon.spy(),
-            actionTriggered = {
-              emitEvent: 'emit-event',
+            eventEmitted = {
               type: 'deployment.done',
               handler: actionSpy
             };
@@ -873,7 +863,7 @@ describe('<StartInstanceTool>', function() {
         activeTab,
         log: logSpy,
         startSpy,
-        actionTriggered
+        eventEmitted
       });
 
       let error;
@@ -944,7 +934,7 @@ describe('<StartInstanceTool>', function() {
 
       const actionSpy = sinon.spy(),
             actionTriggered = {
-              emitEvent: 'open-log',
+              action: 'open-log',
               handler: actionSpy
             };
 
@@ -1285,9 +1275,15 @@ function createStartInstanceTool({
     case (event === 'save'):
       return activeTab;
     case (props.actionTriggered &&
-      props.actionTriggered.emitEvent == event &&
+      props.actionTriggered.action == event &&
       props.actionTriggered.type == (context ? context.type : undefined)):
       props.actionTriggered.handler(context);
+    }
+  };
+
+  const emit = (type, payload) => {
+    if (props.eventEmitted && props.eventEmitted.type === type) {
+      props.eventEmitted.handler({ type, payload });
     }
   };
 
@@ -1318,6 +1314,7 @@ function createStartInstanceTool({
       ref={ ref }
       subscribe={ props.subscribe || subscribe }
       triggerAction={ triggerAction }
+      emit={ emit }
       displayNotification={ noop }
       log={ props.log || noop }
       { ...props }

--- a/client/src/plugins/privacy-preferences/PrivacyPreferences.js
+++ b/client/src/plugins/privacy-preferences/PrivacyPreferences.js
@@ -81,7 +81,7 @@ export default class PrivacyPreferences extends PureComponent {
   };
 
   emit(event, payload) {
-    this.props.triggerAction('emit-event', { type: event, payload });
+    this.props.emit(event, payload);
   }
 
   render() {

--- a/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
@@ -31,6 +31,7 @@ export default function ProcessApplicationsPlugin(props) {
     _getFromApp,
     _getGlobal,
     displayNotification,
+    emit,
     log,
     subscribe,
     triggerAction
@@ -225,7 +226,7 @@ export default function ProcessApplicationsPlugin(props) {
       processApplicationItems={ processApplicationItems }
       onOpen={ (path) => triggerAction('open-diagram', { path }) }
       onRevealInFileExplorer={ (filePath) => triggerAction('reveal-in-file-explorer', { filePath }) }
-      onCreateProcessApplication={ () => triggerAction('emit-event', { type: 'create-process-application' }) }
+      onCreateProcessApplication={ () => emit('create-process-application') }
       tabsProvider={ _getFromApp('props').tabsProvider }
     />
     <ProcessApplicationsDeploymentPlugin

--- a/client/src/plugins/settings/SettingsPlugin.js
+++ b/client/src/plugins/settings/SettingsPlugin.js
@@ -44,6 +44,7 @@ export default function SettingsPlugin(props) {
   const {
     subscribe,
     triggerAction,
+    emit,
     _getGlobal
   } = props;
 
@@ -134,7 +135,7 @@ export default function SettingsPlugin(props) {
   };
 
   const handleClose = () => {
-    triggerAction('emit-event', { type: 'settings.closed' });
+    emit('settings.closed');
     setOpen(false);
   };
 

--- a/client/src/plugins/update-checks/UpdateChecks.js
+++ b/client/src/plugins/update-checks/UpdateChecks.js
@@ -189,14 +189,11 @@ export default class UpdateChecks extends PureComponent {
 
   openPrivacyPreferences = () => {
     const {
-      triggerAction
+      emit
     } = this.props;
 
-    triggerAction('emit-event', {
-      type: 'show-privacy-preferences',
-      payload: {
-        autoFocusKey: 'ENABLE_UPDATE_CHECKS'
-      }
+    emit('show-privacy-preferences', {
+      autoFocusKey: 'ENABLE_UPDATE_CHECKS'
     });
   };
 

--- a/client/src/plugins/user-journey-statistics/UserJourneyStatistics.js
+++ b/client/src/plugins/user-journey-statistics/UserJourneyStatistics.js
@@ -80,7 +80,7 @@ export default class UserJourneyStatistics extends PureComponent {
   };
 
   emit(event, payload) {
-    this.props.triggerAction('emit-event', { type: event, payload });
+    this.props.emit(event, payload);
   }
 
   disable = () => {

--- a/client/src/plugins/user-journey-statistics/__tests__/UserJourneyStatisticsSpec.js
+++ b/client/src/plugins/user-journey-statistics/__tests__/UserJourneyStatisticsSpec.js
@@ -375,7 +375,8 @@ function createJourneyStatistics(props = {}) {
       }
     },
     _getGlobal: () => ({}),
-    triggerAction: () => {}
+    triggerAction: () => {},
+    emit: props.emit || (() => {})
   });
 }
 

--- a/client/src/plugins/version-info/VersionInfo.js
+++ b/client/src/plugins/version-info/VersionInfo.js
@@ -69,7 +69,7 @@ export class VersionInfo extends PureComponent {
 
   _triggerEvent(event) {
     if (event.type === 'open') {
-      this.props.triggerAction('emit-event', { type: 'versionInfo.opened', payload: event });
+      this.props.emit('versionInfo.opened', event);
     }
   }
 

--- a/client/src/plugins/version-info/__tests__/VersionInfoSpec.js
+++ b/client/src/plugins/version-info/__tests__/VersionInfoSpec.js
@@ -141,15 +141,15 @@ describe('<VersionInfo>', function() {
     it('should notify that overlay was opened', function() {
 
       // given
-      const triggerAction = sinon.spy();
-      createVersionInfo({ triggerAction });
+      const emit = sinon.spy();
+      createVersionInfo({ emit });
 
       // when
       fireEvent.click(screen.getByRole('button'));
 
       // then
-      expect(triggerAction).to.have.been.calledOnceWith(
-        'emit-event', { type: 'versionInfo.opened', payload: { type: 'open', source: 'statusBar' } }
+      expect(emit).to.have.been.calledOnceWith(
+        'versionInfo.opened', { type: 'open', source: 'statusBar' }
       );
     });
 
@@ -157,17 +157,17 @@ describe('<VersionInfo>', function() {
     it('should propagate the source', async function() {
 
       // given
-      const triggerAction = sinon.spy();
+      const emit = sinon.spy();
       const subscribe = createSubscribe();
-      createVersionInfo({ subscribe, triggerAction });
+      createVersionInfo({ subscribe, emit });
 
       // when
       subscribe.emit({ source: 'menu' });
 
       // then
       await waitFor(() => {
-        expect(triggerAction).to.have.been.calledOnceWith(
-          'emit-event', { type: 'versionInfo.opened', payload: { type: 'open', source: 'menu' } }
+        expect(emit).to.have.been.calledOnceWith(
+          'versionInfo.opened', { type: 'open', source: 'menu' }
         );
       });
     });
@@ -176,22 +176,22 @@ describe('<VersionInfo>', function() {
     it('should NOT notify again when overlay is already open', async function() {
 
       // given
-      const triggerAction = sinon.spy();
+      const emit = sinon.spy();
       const subscribe = createSubscribe();
-      createVersionInfo({ subscribe, triggerAction });
+      createVersionInfo({ subscribe, emit });
       subscribe.emit({ source: 'menu' });
 
       await waitFor(() => {
         expect(screen.getByRole('dialog')).to.exist;
       });
 
-      triggerAction.resetHistory();
+      emit.resetHistory();
 
       // when
       subscribe.emit({ source: 'menu' });
 
       // then
-      expect(triggerAction).to.not.have.been.called;
+      expect(emit).to.not.have.been.called;
     });
   });
 
@@ -236,7 +236,8 @@ function createVersionInfo(props = {}) {
   const {
     config = new Config(),
     subscribe = noop,
-    triggerAction = noop
+    triggerAction = noop,
+    emit = noop
   } = props;
 
   render(
@@ -246,6 +247,7 @@ function createVersionInfo(props = {}) {
         config={ config }
         subscribe={ subscribe }
         triggerAction={ triggerAction }
+        emit={ emit }
       />
     </SlotFillRoot>
   );

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerPlugin.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerPlugin.js
@@ -53,6 +53,7 @@ export default function ConnectionManagerPlugin(props) {
     subscribe,
     settings,
     triggerAction,
+    emit,
     _getGlobal,
     connectionCheckResult,
     setConnectionCheckResult
@@ -174,12 +175,9 @@ export default function ConnectionManagerPlugin(props) {
   // update connection checker on connection change
   useEffect(() => {
     (async () => {
-      triggerAction('emit-event', {
-        type: 'connectionManager.connectionCheckStarted',
-        payload: {
-          connectionId: activeConnection?.id,
-          connection: activeConnection,
-        }
+      emit('connectionManager.connectionCheckStarted', {
+        connectionId: activeConnection?.id,
+        connection: activeConnection,
       });
 
       setConnectionCheckResult(null);
@@ -200,14 +198,11 @@ export default function ConnectionManagerPlugin(props) {
     const connectionCheckListener = (connectionCheckResult) => {
       const endpoint = extractEndpointUrl(activeConnection);
 
-      triggerAction('emit-event', {
-        type: 'connectionManager.connectionStatusChanged',
-        payload: {
-          ...connectionCheckResult,
-          connectionId: activeConnection?.id,
-          connection: activeConnection,
-          isLocal: endpoint ? isLocalEndpoint(endpoint) : null
-        }
+      emit('connectionManager.connectionStatusChanged', {
+        ...connectionCheckResult,
+        connectionId: activeConnection?.id,
+        connection: activeConnection,
+        isLocal: endpoint ? isLocalEndpoint(endpoint) : null
       });
       setConnectionCheckResult(connectionCheckResult);
     };
@@ -220,7 +215,7 @@ export default function ConnectionManagerPlugin(props) {
       globalConnectionChecker.current.off('connectionCheck', connectionCheckListener);
       globalConnectionChecker.current.stopChecking();
     };
-  }, [ activeConnection, globalConnectionChecker, deployment, setConnectionCheckResult, paused, triggerAction ]);
+  }, [ activeConnection, globalConnectionChecker, deployment, setConnectionCheckResult, paused, emit ]);
 
   function getStatus(connectionCheckResult, activeConnection) {
     if (activeConnection?.id === NO_CONNECTION.id || paused) {

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionManagerPluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionManagerPluginSpec.js
@@ -407,14 +407,14 @@ describe('ConnectionManagerPlugin', function() {
           'connectionManagerPlugin.c8connections': DEFAULT_CONNECTIONS
         });
 
-        const triggerAction = sinon.spy();
+        const emit = sinon.spy();
 
         // when
         createConnectionManagerPlugin({
           getConnectionForTab: () => Promise.resolve(DEFAULT_CONNECTIONS[0]),
           subscribe,
           settings,
-          triggerAction,
+          emit,
           connectionCheckResult: { success: true }
         });
 
@@ -425,14 +425,11 @@ describe('ConnectionManagerPlugin', function() {
         await clock.tickAsync(2000);
 
         // then
-        expect(triggerAction).to.have.been.calledWith(
-          'emit-event',
+        expect(emit).to.have.been.calledWith(
+          'connectionManager.connectionStatusChanged',
           sinon.match({
-            type: 'connectionManager.connectionStatusChanged',
-            payload: {
-              name: 'plugin',
-              success: true
-            }
+            name: 'plugin',
+            success: true
           })
         );
       });
@@ -459,12 +456,12 @@ describe('ConnectionManagerPlugin', function() {
           'connectionManagerPlugin.c8connections': DEFAULT_CONNECTIONS
         });
 
-        const triggerAction = sinon.spy();
+        const emit = sinon.spy();
         createConnectionManagerPlugin({
           getConnectionForTab: () => Promise.resolve(DEFAULT_CONNECTIONS[0]),
           subscribe,
           settings,
-          triggerAction,
+          emit,
           connectionCheckResult: { success: true }
         });
 
@@ -478,11 +475,9 @@ describe('ConnectionManagerPlugin', function() {
         await clock.tickAsync(2000);
 
         // then
-        expect(triggerAction).not.to.have.been.calledWith(
-          'emit-event',
-          sinon.match({
-            type: 'connectionManager.connectionStatusChanged'
-          })
+        expect(emit).not.to.have.been.calledWith(
+          'connectionManager.connectionStatusChanged',
+          sinon.match.any
         );
       });
 
@@ -507,14 +502,14 @@ describe('ConnectionManagerPlugin', function() {
             'connectionManagerPlugin.c8connections': DEFAULT_CONNECTIONS
           });
 
-          const triggerAction = sinon.spy();
+          const emit = sinon.spy();
 
           // when
           createConnectionManagerPlugin({
             getConnectionForTab: () => Promise.resolve(DEFAULT_CONNECTIONS[0]),
             subscribe,
             settings,
-            triggerAction,
+            emit,
           });
 
           // make React state settle and let the connection resolve
@@ -522,14 +517,11 @@ describe('ConnectionManagerPlugin', function() {
           await clock.tickAsync(2000);
 
           // then
-          expect(triggerAction).to.have.been.calledWith(
-            'emit-event',
+          expect(emit).to.have.been.calledWith(
+            'connectionManager.connectionCheckStarted',
             sinon.match({
-              type: 'connectionManager.connectionCheckStarted',
-              payload: sinon.match({
-                connectionId: DEFAULT_CONNECTIONS[0].id,
-                connection: DEFAULT_CONNECTIONS[0],
-              })
+              connectionId: DEFAULT_CONNECTIONS[0].id,
+              connection: DEFAULT_CONNECTIONS[0],
             })
           );
         });
@@ -554,13 +546,13 @@ describe('ConnectionManagerPlugin', function() {
               'connectionManagerPlugin.c8connections': DEFAULT_CONNECTIONS
             });
 
-            const triggerAction = sinon.spy();
+            const emit = sinon.spy();
 
             createConnectionManagerPlugin({
               getConnectionForTab: () => Promise.resolve(DEFAULT_CONNECTIONS[0]),
               subscribe,
               settings,
-              triggerAction,
+              emit,
               connectionCheckResult: { success }
             });
 
@@ -569,21 +561,20 @@ describe('ConnectionManagerPlugin', function() {
             await clock.tickAsync(2000);
 
             // isolate: reset history so assertions only cover the next check cycle
-            triggerAction.resetHistory();
+            emit.resetHistory();
 
             // advance to trigger a periodic check (ConnectionChecker LONG interval = 5000ms)
             await clock.tickAsync(5000);
 
             // then - connectionStatusChanged was emitted (a result arrived from interval check)
-            expect(triggerAction).to.have.been.calledWith(
-              'emit-event',
-              sinon.match({ type: 'connectionManager.connectionStatusChanged' })
+            expect(emit).to.have.been.calledWith(
+              'connectionManager.connectionStatusChanged',
+              sinon.match.any
             );
 
             // but connectionCheckStarted was NOT emitted (no state change occurred)
-            const checkStartedCalls = triggerAction.getCalls().filter(
-              call => call.args[0] === 'emit-event' &&
-                call.args[1]?.type === 'connectionManager.connectionCheckStarted'
+            const checkStartedCalls = emit.getCalls().filter(
+              call => call.args[0] === 'connectionManager.connectionCheckStarted'
             );
             expect(checkStartedCalls).to.have.lengthOf(0);
           });
@@ -611,13 +602,13 @@ describe('ConnectionManagerPlugin', function() {
             'connectionManagerPlugin.c8connections': DEFAULT_CONNECTIONS
           });
 
-          const triggerAction = sinon.spy();
+          const emit = sinon.spy();
 
           createConnectionManagerPlugin({
             getConnectionForTab: () => Promise.resolve(DEFAULT_CONNECTIONS[0]),
             subscribe,
             settings,
-            triggerAction,
+            emit,
             connectionCheckResult: { success: true }
           });
 
@@ -633,15 +624,14 @@ describe('ConnectionManagerPlugin', function() {
           await clock.tickAsync(1000);
 
           // isolate: reset history so assertions only cover the post-cancel window
-          triggerAction.resetHistory();
+          emit.resetHistory();
 
           // advance clock past where the cancelled check interval would have fired
           await clock.tickAsync(5000);
 
           // then - no connectionCheckStarted from the cancelled check
-          const checkStartedCalls = triggerAction.getCalls().filter(
-            call => call.args[0] === 'emit-event' &&
-                    call.args[1]?.type === 'connectionManager.connectionCheckStarted'
+          const checkStartedCalls = emit.getCalls().filter(
+            call => call.args[0] === 'connectionManager.connectionCheckStarted'
           );
           expect(checkStartedCalls).to.have.lengthOf(0);
         });
@@ -1298,6 +1288,7 @@ function createPluginProps(props = {}, globals = {}) {
     log = () => {},
     subscribe = () => ({ cancel: () => {} }),
     triggerAction = () => {},
+    emit = () => {},
     settings = createMockSettings(),
     config = createMockConfig(),
     getConfig = () => config,
@@ -1313,6 +1304,7 @@ function createPluginProps(props = {}, globals = {}) {
     log,
     subscribe,
     triggerAction,
+    emit,
     settings,
     config,
     getConfig,

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPluginOverlay.js
@@ -74,7 +74,8 @@ export default function DeploymentPluginOverlay(props) {
     renderDescription = null,
     renderHeader = 'Deploy',
     renderSubmit = 'Deploy',
-    triggerAction
+    triggerAction,
+    emit
   } = props;
 
   const getLintingState = _getFromApp && _getFromApp('getLintingState');
@@ -135,32 +136,26 @@ export default function DeploymentPluginOverlay(props) {
   useEffect(() => {
     const onDeployed = ({ context = 'deploymentTool', deploymentResult, endpoint, gatewayVersion }) => {
       if (deploymentResult.success) {
-        triggerAction('emit-event', {
-          type: 'deployment.done',
-          payload: {
-            deployment: deploymentResult.response,
-            context,
-            targetType: endpoint.targetType,
-            deployedTo: {
-              executionPlatformVersion: gatewayVersion,
-              executionPlatform: ENGINES.CLOUD
-            }
+        emit('deployment.done', {
+          deployment: deploymentResult.response,
+          context,
+          targetType: endpoint.targetType,
+          deployedTo: {
+            executionPlatformVersion: gatewayVersion,
+            executionPlatform: ENGINES.CLOUD
           }
         });
       } else {
-        triggerAction('emit-event', {
-          type: 'deployment.error',
-          payload: {
-            error: {
-              ...deploymentResult.response,
-              code: getGRPCErrorCode(deploymentResult.response)
-            },
-            context,
-            targetType: endpoint.targetType,
-            deployedTo: {
-              executionPlatformVersion: gatewayVersion,
-              executionPlatform: ENGINES.CLOUD
-            }
+        emit('deployment.error', {
+          error: {
+            ...deploymentResult.response,
+            code: getGRPCErrorCode(deploymentResult.response)
+          },
+          context,
+          targetType: endpoint.targetType,
+          deployedTo: {
+            executionPlatformVersion: gatewayVersion,
+            executionPlatform: ENGINES.CLOUD
           }
         });
       }
@@ -169,7 +164,7 @@ export default function DeploymentPluginOverlay(props) {
     deployment.on('deployed', onDeployed);
 
     return () => deployment.off('deployed', onDeployed);
-  }, [ deployment, triggerAction ]);
+  }, [ deployment, emit ]);
 
   return (
     <Overlay className={ css.DeploymentPluginOverlay } onClose={ onClose } anchor={ anchor }>

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginOverlaySpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginOverlaySpec.js
@@ -153,11 +153,11 @@ describe('DeploymentPluginOverlay', function() {
         getConnectionForTab: () => Promise.resolve(endpoint)
       });
 
-      const triggerActionSpy = sinon.spy();
+      const emitSpy = sinon.spy();
 
       createDeploymentPluginOverlay({
         deployment,
-        triggerAction: triggerActionSpy
+        emit: emitSpy
       });
 
       await waitFor(() => {
@@ -175,17 +175,14 @@ describe('DeploymentPluginOverlay', function() {
       });
 
       // then
-      expect(triggerActionSpy).to.have.been.calledOnce;
-      expect(triggerActionSpy).to.have.been.calledWith('emit-event', sinon.match({
-        type: 'deployment.done',
-        payload: {
-          deployment: mockDeploymentResult.response,
-          context: 'deploymentTool',
-          targetType: 'camundaCloud',
-          deployedTo: {
-            executionPlatformVersion: '7.0.0',
-            executionPlatform: 'Camunda Cloud'
-          }
+      expect(emitSpy).to.have.been.calledOnce;
+      expect(emitSpy).to.have.been.calledWith('deployment.done', sinon.match({
+        deployment: mockDeploymentResult.response,
+        context: 'deploymentTool',
+        targetType: 'camundaCloud',
+        deployedTo: {
+          executionPlatformVersion: '7.0.0',
+          executionPlatform: 'Camunda Cloud'
         }
       }));
     });
@@ -207,11 +204,11 @@ describe('DeploymentPluginOverlay', function() {
         getConnectionForTab: () => Promise.resolve(endpoint)
       });
 
-      const triggerActionSpy = sinon.spy();
+      const emitSpy = sinon.spy();
 
       createDeploymentPluginOverlay({
         deployment,
-        triggerAction: triggerActionSpy
+        emit: emitSpy
       });
 
       await waitFor(() => {
@@ -229,20 +226,17 @@ describe('DeploymentPluginOverlay', function() {
       });
 
       // then
-      expect(triggerActionSpy).to.have.been.calledOnce;
-      expect(triggerActionSpy).to.have.been.calledWith('emit-event', sinon.match({
-        type: 'deployment.error',
-        payload: {
-          error: {
-            ...mockDeploymentResult.response,
-            code: 'INVALID_ARGUMENT'
-          },
-          context: 'deploymentTool',
-          targetType: 'camundaCloud',
-          deployedTo: {
-            executionPlatformVersion: '7.0.0',
-            executionPlatform: 'Camunda Cloud'
-          }
+      expect(emitSpy).to.have.been.calledOnce;
+      expect(emitSpy).to.have.been.calledWith('deployment.error', sinon.match({
+        error: {
+          ...mockDeploymentResult.response,
+          code: 'INVALID_ARGUMENT'
+        },
+        context: 'deploymentTool',
+        targetType: 'camundaCloud',
+        deployedTo: {
+          executionPlatformVersion: '7.0.0',
+          executionPlatform: 'Camunda Cloud'
         }
       }));
     });
@@ -675,6 +669,7 @@ function createDeploymentPluginOverlay(props = {}) {
     renderHeader = 'Deploy',
     renderSubmit = 'Deploy',
     triggerAction = () => {},
+    emit = () => {},
   } = props;
 
   return render(
@@ -694,6 +689,7 @@ function createDeploymentPluginOverlay(props = {}) {
       onClose={ onClose }
       renderHeader={ renderHeader }
       renderSubmit={ renderSubmit }
-      triggerAction={ triggerAction } />
+      triggerAction={ triggerAction }
+      emit={ emit } />
   );
 }

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePluginOverlay.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePluginOverlay.js
@@ -60,6 +60,7 @@ export default function StartInstancePluginOverlay(props) {
     StartInstanceConfigForm = DefaultStartInstanceConfigForm,
     startInstanceConfigValidator,
     triggerAction,
+    emit,
     connectionCheckResult
   } = props;
 
@@ -186,32 +187,26 @@ export default function StartInstancePluginOverlay(props) {
   useEffect(() => {
     const onDeployed = ({ deploymentResult, endpoint, gatewayVersion }) => {
       if (deploymentResult.success) {
-        triggerAction('emit-event', {
-          type: 'deployment.done',
-          payload: {
-            deployment: deploymentResult.response,
-            context: 'startInstanceTool',
-            targetType: endpoint.targetType,
-            deployedTo: {
-              executionPlatformVersion: gatewayVersion,
-              executionPlatform: ENGINES.CLOUD
-            }
+        emit('deployment.done', {
+          deployment: deploymentResult.response,
+          context: 'startInstanceTool',
+          targetType: endpoint.targetType,
+          deployedTo: {
+            executionPlatformVersion: gatewayVersion,
+            executionPlatform: ENGINES.CLOUD
           }
         });
       } else {
-        triggerAction('emit-event', {
-          type: 'deployment.error',
-          payload: {
-            error: {
-              ...deploymentResult.response,
-              code: getGRPCErrorCode(deploymentResult.response)
-            },
-            context: 'startInstanceTool',
-            targetType: endpoint.targetType,
-            deployedTo: {
-              executionPlatformVersion: gatewayVersion,
-              executionPlatform: ENGINES.CLOUD
-            }
+        emit('deployment.error', {
+          error: {
+            ...deploymentResult.response,
+            code: getGRPCErrorCode(deploymentResult.response)
+          },
+          context: 'startInstanceTool',
+          targetType: endpoint.targetType,
+          deployedTo: {
+            executionPlatformVersion: gatewayVersion,
+            executionPlatform: ENGINES.CLOUD
           }
         });
       }
@@ -220,7 +215,7 @@ export default function StartInstancePluginOverlay(props) {
     deployment.on('deployed', onDeployed);
 
     return () => deployment.off('deployed', onDeployed);
-  }, [ deployment, triggerAction ]);
+  }, [ deployment, emit ]);
 
   return (
     <Overlay className={ css.StartInstancePluginOverlay } onClose={ onClose } anchor={ anchor }>

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginOverlaySpec.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginOverlaySpec.js
@@ -207,12 +207,12 @@ describe('StartInstancePluginOverlay', function() {
         startInstance: sinon.spy(() => Promise.resolve(createMockStartInstanceResult()))
       });
 
-      const triggerActionSpy = sinon.spy();
+      const emitSpy = sinon.spy();
 
       createStartInstancePluginOverlay({
         deployment,
         startInstance,
-        triggerAction: triggerActionSpy
+        emit: emitSpy
       });
 
       await waitFor(() => {
@@ -230,17 +230,14 @@ describe('StartInstancePluginOverlay', function() {
       });
 
       // then
-      expect(triggerActionSpy).to.have.been.calledOnce;
-      expect(triggerActionSpy).to.have.been.calledWith('emit-event', sinon.match({
-        type: 'deployment.done',
-        payload: {
-          deployment: mockDeploymentResult.response,
-          context: 'startInstanceTool',
-          targetType: 'camundaCloud',
-          deployedTo: {
-            executionPlatformVersion: '7.0.0',
-            executionPlatform: 'Camunda Cloud'
-          }
+      expect(emitSpy).to.have.been.calledOnce;
+      expect(emitSpy).to.have.been.calledWith('deployment.done', sinon.match({
+        deployment: mockDeploymentResult.response,
+        context: 'startInstanceTool',
+        targetType: 'camundaCloud',
+        deployedTo: {
+          executionPlatformVersion: '7.0.0',
+          executionPlatform: 'Camunda Cloud'
         }
       }));
     });
@@ -269,12 +266,12 @@ describe('StartInstancePluginOverlay', function() {
         startInstance: sinon.spy(() => Promise.resolve(createMockStartInstanceResult()))
       });
 
-      const triggerActionSpy = sinon.spy();
+      const emitSpy = sinon.spy();
 
       createStartInstancePluginOverlay({
         deployment,
         startInstance,
-        triggerAction: triggerActionSpy
+        emit: emitSpy
       });
 
       await waitFor(() => {
@@ -292,20 +289,17 @@ describe('StartInstancePluginOverlay', function() {
       });
 
       // then
-      expect(triggerActionSpy).to.have.been.calledOnce;
-      expect(triggerActionSpy).to.have.been.calledWith('emit-event', sinon.match({
-        type: 'deployment.error',
-        payload: {
-          error: {
-            ...mockDeploymentResult.response,
-            code: 'INVALID_ARGUMENT'
-          },
-          context: 'startInstanceTool',
-          targetType: 'camundaCloud',
-          deployedTo: {
-            executionPlatformVersion: '7.0.0',
-            executionPlatform: 'Camunda Cloud'
-          }
+      expect(emitSpy).to.have.been.calledOnce;
+      expect(emitSpy).to.have.been.calledWith('deployment.error', sinon.match({
+        error: {
+          ...mockDeploymentResult.response,
+          code: 'INVALID_ARGUMENT'
+        },
+        context: 'startInstanceTool',
+        targetType: 'camundaCloud',
+        deployedTo: {
+          executionPlatformVersion: '7.0.0',
+          executionPlatform: 'Camunda Cloud'
         }
       }));
     });
@@ -872,6 +866,7 @@ function createStartInstancePluginOverlay(props = {}) {
     StartInstanceConfigForm,
     startInstanceConfigValidator = MockConfigValidator,
     triggerAction = () => {},
+    emit = () => {},
   } = props;
 
   return render(
@@ -898,6 +893,7 @@ function createStartInstancePluginOverlay(props = {}) {
       startInstance={ startInstance }
       StartInstanceConfigForm={ StartInstanceConfigForm }
       startInstanceConfigValidator={ startInstanceConfigValidator }
-      triggerAction={ triggerAction } />
+      triggerAction={ triggerAction }
+      emit={ emit } />
   );
 }


### PR DESCRIPTION
### Proposed Changes

Application events were emitted by abusing the `emit-event` action, tunneling pub/sub through the command dispatcher (`App#triggerAction`) even though the app already has a dedicated event bus. The eventing surface was asymmetric: consumers could `subscribe`, but producers had no `emit` and had to reach for the command channel instead.

This moves event emission onto the proper eventing system:

* Add a tab-aware `emit(type, payload)` on `App` (`emitEvent`) — the producer counterpart to the existing `subscribe`.
* Thread it as an `emit` prop to tabs and editors, to plug-ins via `PluginsRoot`, and onto `EventsContext`.
* Migrate all producers — editors, plug-ins, task testing, and the Electron menu — to the new API.
* Remove the `emit-event` branch from `App#triggerAction`.

Behavior is preserved: events are emitted on the same bus and still carry the active tab.

### Migrating plug-ins

The `emit-event` action is **removed**. Plug-ins that emit application events must use the `emit` prop instead:

```diff
- this.props.triggerAction('emit-event', {
-   type: 'my-plugin.something-happened',
-   payload: { foo: 'bar' }
- });
+ this.props.emit('my-plugin.something-happened', { foo: 'bar' });
```

* `emit` is provided as a prop alongside `subscribe`, `triggerAction`, `config`, … Components with `EventsContext` access can use `EventsContext#emit` instead.
* Events are enriched with the active `tab` by default; pass `tab` in the payload to target a different tab.
* `triggerAction` stays for genuine commands — only event emission moved off of it.

### Backwards compatibility

`triggerAction('emit-event', …)` no longer throws or emits. It is a no-op that logs a descriptive `console.error` linking this PR, so plug-ins still on the old API keep the modeler working while their authors get a clear, actionable migration message.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes — N/A, internal refactor with no UI/UX change
  * [ ] __Steps to try out__ — N/A, no behavior change; covered by existing tests

---

🤖 Created by Copilot