### PR TITLE
feat(zeebe): rename tenant ID to logical tenant ID

### DIFF
--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettingsProperties.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettingsProperties.js
@@ -27,7 +27,7 @@ const LABELS = {
   OAUTH_URL: 'OAuth token URL',
   SELF_HOSTED: 'Camunda 8 Self-Managed',
   TARGET: 'Target',
-  TENANT_ID: 'Tenant ID',
+  TENANT_ID: 'Logical Tenant ID',
   OPERATE_URL: 'Operate URL',
   TASKLIST_URL: 'Tasklist URL'
 };
@@ -54,7 +54,7 @@ const VALIDATION_ERROR_MESSAGES = {
   CLUSTER_URL_MUST_START_WITH_PROTOCOL: 'Cluster URL must start with "http://", "grpc://", "https://", or "grpcs://".',
   MUST_PROVIDE_A_VALUE: 'Must provide a value.',
   OAUTH_URL_MUST_NOT_BE_EMPTY: 'OAuth URL must not be empty.',
-  TENANT_ID_INVALID: 'Tenant ID must be 31 characters or fewer and contain only alphanumeric characters, dots (.), dashes (-), or underscores (_).'
+  TENANT_ID_INVALID: 'Logical Tenant ID must be 31 characters or fewer and contain only alphanumeric characters, dots (.), dashes (-), or underscores (_).'
 };
 
 const REGEXES = {

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionManagerSettingsComponentSpec.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionManagerSettingsComponentSpec.js
@@ -320,7 +320,7 @@ describe('ConnectionManagerSettingsComponent', function() {
     });
 
 
-    it('should display tenant ID field for SaaS connections', async function() {
+    it('should display logical tenant ID field for SaaS connections', async function() {
 
       // given
       const connections = [
@@ -342,11 +342,12 @@ describe('ConnectionManagerSettingsComponent', function() {
       // then
       await waitFor(() => {
         expect(container.querySelector('input[name*="tenantId"]')).to.exist;
+        expect(container.textContent).to.contain('Logical Tenant ID');
       });
     });
 
 
-    it('should display tenant ID field for self-hosted connections', async function() {
+    it('should display logical tenant ID field for self-hosted connections', async function() {
 
       // given
       const connections = [
@@ -367,6 +368,7 @@ describe('ConnectionManagerSettingsComponent', function() {
       // then
       await waitFor(() => {
         expect(container.querySelector('input[name*="tenantId"]')).to.exist;
+        expect(container.textContent).to.contain('Logical Tenant ID');
       });
     });
 


### PR DESCRIPTION
### Proposed Changes

Rename the Camunda 8 connection setting and validation message to "Logical Tenant ID":

<img width="1289" height="844" alt="image" src="https://github.com/user-attachments/assets/278e5a30-e917-409a-935a-28d2b0408e29" />

Standalone "Tenant" will break with [physical tenants to be introduced in 8.10](https://camunda.com/blog/2026/08/three-tenancy-models-one-platform-why-camunda-810-introduces-physical-tenants/).

### Checklist

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__: Open a Camunda 8 connection in Settings.