### PR TITLE
chore(bpmn-io-modelers): remove deprecated `importXML` callback

### DIFF
--- a/client/test/bpmn-io-modelers/dmn/CloudDmnModelerSpec.js
+++ b/client/test/bpmn-io-modelers/dmn/CloudDmnModelerSpec.js
@@ -581,16 +581,17 @@ async function createModeler(options = {}) {
 
   const modelerImport = new Promise(resolve => {
     modeler.once('views.changed', VERY_LOW_PRIORITY, resolve);
-
-    modeler.importXML(diagramXML, (err, warnings) => {
-
-      // assume
-      expect(err).not.to.exist;
-      expect(warnings).to.be.empty;
-    });
   });
 
-  return Promise.all([ overviewImport, modelerImport ]).then(() => modeler);
+  // when
+  const { warnings } = await modeler.importXML(diagramXML);
+
+  // then
+  expect(warnings).to.be.empty;
+
+  await Promise.all([ overviewImport, modelerImport ]);
+
+  return modeler;
 }
 
 function inlineCSS(css) {

--- a/client/test/bpmn-io-modelers/dmn/DmnModelerSpec.js
+++ b/client/test/bpmn-io-modelers/dmn/DmnModelerSpec.js
@@ -608,16 +608,17 @@ async function createModeler(options = {}) {
 
   const modelerImport = new Promise(resolve => {
     modeler.once('views.changed', VERY_LOW_PRIORITY, resolve);
-
-    modeler.importXML(diagramXML, (err, warnings) => {
-
-      // assume
-      expect(err).not.to.exist;
-      expect(warnings).to.be.empty;
-    });
   });
 
-  return Promise.all([ overviewImport, modelerImport ]).then(() => modeler);
+  // when
+  const { warnings } = await modeler.importXML(diagramXML);
+
+  // then
+  expect(warnings).to.be.empty;
+
+  await Promise.all([ overviewImport, modelerImport ]);
+
+  return modeler;
 }
 
 function inlineCSS(css) {


### PR DESCRIPTION
### Proposed Changes

Updates the tests so that they don't use deprecated `Modeler#importXML(..., callback)` anymore. Embrace the future!

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
