### PR TITLE
fix(zeebe-api): reuse cached client without re-probing protocol

### DIFF
--- a/app/lib/zeebe-api/camunda-client-factory.js
+++ b/app/lib/zeebe-api/camunda-client-factory.js
@@ -72,11 +72,14 @@ class CamundaClientFactory {
    * @param {import("./endpoints").Endpoint} endpoint
    */
   async getCamundaClient(endpoint) {
-    const protocol = await this._getProtocol(endpoint);
 
-    if (this._isCacheValid(endpoint, protocol)) {
+    // check the cache before protocol detection, as detection creates
+    // throwaway clients and must not run on every interaction
+    if (this._isCacheValid(endpoint)) {
       return this._cachedClient;
     }
+
+    const protocol = await this._getProtocol(endpoint);
 
     this._cachedClient?.closeAllClients();
 
@@ -186,14 +189,11 @@ class CamundaClientFactory {
   }
 
   /**
-   * Checks if the current cache is valid for the given endpoint and protocol
    * @param {import("./endpoints").Endpoint} endpoint
-   * @param {'grpc'|'grpcs'|'http'|'https'} protocol
    * @returns {boolean}
    */
-  _isCacheValid(endpoint, protocol) {
-    return this._cachedClient &&
-           this._cachedProtocol === protocol &&
+  _isCacheValid(endpoint) {
+    return Boolean(this._cachedClient) &&
            this._isEndpointEqual(endpoint, this._cachedEndpoint);
   }
 

--- a/app/lib/zeebe-api/camunda-client-factory.js
+++ b/app/lib/zeebe-api/camunda-client-factory.js
@@ -84,7 +84,7 @@ class CamundaClientFactory {
     this._cachedClient?.closeAllClients();
 
     this._cachedProtocol = protocol;
-    this._cachedClient = await this._createCamundaClient(endpoint);
+    this._cachedClient = await this._createCamundaClient(endpoint, protocol);
     this._cachedEndpoint = endpoint;
 
     return this._cachedClient;
@@ -162,12 +162,8 @@ class CamundaClientFactory {
   async _canConnectWithProtocol(endpoint, protocol) {
     try {
 
-      // Temporarily set the protocol for testing
-      const originalProtocol = this._cachedProtocol;
-      this._cachedProtocol = protocol;
-
       // Create a test client with the specific protocol
-      const testClient = await this._createCamundaClient(endpoint);
+      const testClient = await this._createCamundaClient(endpoint, protocol);
 
       if ([ 'grpc', 'grpcs' ].includes(protocol)) {
         const zeebeClient = testClient.getZeebeGrpcApiClient();
@@ -178,9 +174,6 @@ class CamundaClientFactory {
       }
 
       testClient.closeAllClients();
-
-      // Restore original protocol
-      this._cachedProtocol = originalProtocol;
 
       return true;
     } catch (error) {
@@ -222,8 +215,9 @@ class CamundaClientFactory {
 
   /**
    * @param {import("./endpoints").Endpoint} endpoint
+   * @param {'grpc'|'grpcs'|'http'|'https'} protocol
    */
-  async _createCamundaClient(endpoint) {
+  async _createCamundaClient(endpoint, protocol) {
     const {
       type,
       authType = AUTH_TYPES.NONE,
@@ -237,7 +231,7 @@ class CamundaClientFactory {
       return;
     }
 
-    const clientConfig = await this._getClientConfig(endpoint);
+    const clientConfig = await this._getClientConfig(endpoint, protocol);
 
     this._log.debug('creating client', {
       url,
@@ -247,7 +241,7 @@ class CamundaClientFactory {
     return new this._Camunda8(clientConfig);
   }
 
-  async _getClientConfig(endpoint) {
+  async _getClientConfig(endpoint, protocol) {
 
     const {
       type,
@@ -262,10 +256,10 @@ class CamundaClientFactory {
       clientConfig.CAMUNDA_TENANT_ID = endpoint.tenantId;
     }
 
-    switch (this._cachedProtocol) {
+    switch (protocol) {
     case 'grpc':
     case 'grpcs':
-      clientConfig.ZEEBE_GRPC_ADDRESS = url ? overwriteProtocol(url, this._cachedProtocol) : '';
+      clientConfig.ZEEBE_GRPC_ADDRESS = url ? overwriteProtocol(url, protocol) : '';
       clientConfig.zeebeGrpcSettings = {
         ZEEBE_GRPC_CLIENT_RETRY: false
       };

--- a/app/lib/zeebe-api/camunda-client-factory.js
+++ b/app/lib/zeebe-api/camunda-client-factory.js
@@ -31,6 +31,10 @@ const {
  * @typedef {import('@camunda8/sdk/dist/c8').Camunda8} Camunda8
  * @typedef {typeof import('@camunda8/sdk').Camunda8} Camunda8Constructor
  * @typedef {import('@camunda8/sdk/dist/zeebe').ZeebeGrpcClient} ZeebeGrpcClient
+ * @typedef {import('@camunda8/sdk').CamundaRestClient} CamundaRestClient
+ * @typedef {import('@camunda8/sdk/dist/lib').Camunda8ClientConfiguration} Camunda8ClientConfiguration
+ * @typedef {import('./endpoints').Endpoint} Endpoint
+ * @typedef {'grpc'|'grpcs'|'http'|'https'} Protocol
  */
 
 /**
@@ -61,15 +65,17 @@ class CamundaClientFactory {
     /** @type {Camunda8} */
     this._cachedClient = null;
 
-    /** @type {import("./endpoints").Endpoint} */
+    /** @type {Endpoint} */
     this._cachedEndpoint = null;
 
-    /** @type {'http'|'https'|'grpc'|'grpcs'} */
+    /** @type {Protocol} */
     this._cachedProtocol = 'grpc';
   }
 
   /**
-   * @param {import("./endpoints").Endpoint} endpoint
+   * @param {Endpoint} endpoint
+   *
+   * @returns {Promise<Camunda8>}
    */
   async getCamundaClient(endpoint) {
 
@@ -91,9 +97,9 @@ class CamundaClientFactory {
   }
 
   /**
-   * @param {import("./endpoints").Endpoint} endpoint
+   * @param {Endpoint} endpoint
    *
-   * @returns {Promise<{ zeebeGrpcClient?: ZeebeGrpcClient, camundaRestClient?: import('@camunda8/sdk').CamundaRestClient}>}
+   * @returns {Promise<{ zeebeGrpcClient?: ZeebeGrpcClient, camundaRestClient?: CamundaRestClient}>}
    */
   async getSupportedCamundaClients(endpoint) {
     const camundaClient = await this.getCamundaClient(endpoint);
@@ -114,9 +120,9 @@ class CamundaClientFactory {
   /**
    * Get the appropriate protocol (gRPC or REST) for the endpoint.
    *
-   * @param {import("./endpoints").Endpoint} endpoint
+   * @param {Endpoint} endpoint
    *
-   * @returns {Promise<'grpc'|'grpcs'|'http'|'https'>}
+   * @returns {Promise<Protocol>}
    */
   async _getProtocol(endpoint) {
     const matchedProtocol = endpoint.url.match(/^(https?|grpcs?):\/\//)?.[1];
@@ -154,8 +160,8 @@ class CamundaClientFactory {
   /**
    * Check if the endpoint can be connected with the specified protocol.
    *
-   * @param {import("./endpoints").Endpoint} endpoint
-   * @param {'grpc'|'grpcs'|'http'|'https'} protocol
+   * @param {Endpoint} endpoint
+   * @param {Protocol} protocol
    *
    * @returns {Promise<boolean>}
    */
@@ -182,7 +188,10 @@ class CamundaClientFactory {
   }
 
   /**
-   * @param {import("./endpoints").Endpoint} endpoint
+   * Check if the current cache is valid for the given endpoint.
+   *
+   * @param {Endpoint} endpoint
+   *
    * @returns {boolean}
    */
   _isCacheValid(endpoint) {
@@ -193,8 +202,8 @@ class CamundaClientFactory {
   /**
    * Check if two endpoints are equal.
    *
-   * @param {import("./endpoints").Endpoint} endpoint1
-   * @param {import("./endpoints").Endpoint} endpoint2
+   * @param {Endpoint} endpoint1
+   * @param {Endpoint} endpoint2
    *
    * @returns {boolean}
    */
@@ -214,8 +223,10 @@ class CamundaClientFactory {
   }
 
   /**
-   * @param {import("./endpoints").Endpoint} endpoint
-   * @param {'grpc'|'grpcs'|'http'|'https'} protocol
+   * @param {Endpoint} endpoint
+   * @param {Protocol} protocol
+   *
+   * @returns {Promise<Camunda8|undefined>}
    */
   async _createCamundaClient(endpoint, protocol) {
     const {
@@ -241,6 +252,12 @@ class CamundaClientFactory {
     return new this._Camunda8(clientConfig);
   }
 
+  /**
+   * @param {Endpoint} endpoint
+   * @param {Protocol} protocol
+   *
+   * @returns {Promise<Camunda8ClientConfiguration>}
+   */
   async _getClientConfig(endpoint, protocol) {
 
     const {
@@ -249,7 +266,7 @@ class CamundaClientFactory {
       url
     } = endpoint;
 
-    /** @type {import('@camunda8/sdk/dist/lib').Camunda8ClientConfiguration} */
+    /** @type {Camunda8ClientConfiguration} */
     let clientConfig = {};
 
     if (endpoint.tenantId) {
@@ -320,6 +337,12 @@ class CamundaClientFactory {
     return clientConfig;
   }
 
+  /**
+   * @param {string} url
+   * @param {Camunda8ClientConfiguration} options
+   *
+   * @returns {Promise<Camunda8ClientConfiguration>}
+   */
   async _withTLSConfig(url, options) {
     const rootCerts = [];
 
@@ -351,6 +374,12 @@ class CamundaClientFactory {
     };
   }
 
+  /**
+   * @param {string} url
+   * @param {Camunda8ClientConfiguration} options
+   *
+   * @returns {Camunda8ClientConfiguration}
+   */
   _withPortConfig(url, options) {
 
     // do not override camunda cloud port (handled by zeebe-node)
@@ -371,6 +400,11 @@ class CamundaClientFactory {
     };
   }
 
+  /**
+   * @param {string} certPath
+   *
+   * @returns {string|undefined}
+   */
   _readRootCertificate(certPath) {
     let cert;
 

--- a/app/test/spec/zeebe-api/camunda-client-factory-spec.js
+++ b/app/test/spec/zeebe-api/camunda-client-factory-spec.js
@@ -319,6 +319,50 @@ describe('CamundaClientFactory', function() {
       expect(clients._cachedProtocol).to.equal('grpc');
     });
 
+
+    it('should reuse cached client for unchanged endpoint', async function() {
+
+      // given
+      const endpoint = {
+        type: ENDPOINT_TYPES.SELF_HOSTED,
+        url: 'http://localhost:8080'
+      };
+
+      clients._getProtocol.resolves('grpc');
+
+      // when
+      await clients.getSupportedCamundaClients(endpoint);
+      await clients.getSupportedCamundaClients({ ...endpoint });
+
+      // then
+      // client is created only once, protocol is not re-probed
+      expect(Camunda8).to.have.been.calledOnce;
+      expect(clients._getProtocol).to.have.been.calledOnce;
+      expect(mockCamundaClient.closeAllClients).not.to.have.been.called;
+    });
+
+
+    it('should recreate client for changed endpoint', async function() {
+
+      // given
+      const endpoint = {
+        type: ENDPOINT_TYPES.SELF_HOSTED,
+        url: 'http://localhost:8080'
+      };
+
+      clients._getProtocol.resolves('grpc');
+
+      // when
+      await clients.getSupportedCamundaClients(endpoint);
+      await clients.getSupportedCamundaClients({ ...endpoint, url: 'http://localhost:9090' });
+
+      // then
+      // previous client is closed and a new one is created
+      expect(Camunda8).to.have.been.calledTwice;
+      expect(clients._getProtocol).to.have.been.calledTwice;
+      expect(mockCamundaClient.closeAllClients).to.have.been.called;
+    });
+
   });
 
 


### PR DESCRIPTION
### Proposed Changes

`getCamundaClient` ran protocol detection on every call _before_ consulting the cache. For self-managed HTTP(S) endpoints, detection creates a throwaway probe client on each interaction (`DEBUG app:zeebe-api creating client ...`), so the cache never spared the expensive client (re-)creation.

Now the endpoint cache is consulted first and the cached client is returned without re-probing the protocol when the endpoint is unchanged — a client is reused across a connection with no rebuild per interaction.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes (n/a — no UI changes)
  * [x] __Steps to try out__: start the modeler with `DEBUG=1`, connect to a self-managed endpoint, and trigger multiple interactions (e.g. deploy) — only one `creating client` is logged per connection instead of one per interaction