### PR TITLE
fix(credentials-manager): support clusters without authorization

### DIFF
--- a/app/lib/index.js
+++ b/app/lib/index.js
@@ -425,6 +425,16 @@ renderer.on('zeebe:getAuthorizations', async function(options, done) {
   }
 });
 
+renderer.on('zeebe:getCurrentUser', async function(options, done) {
+  try {
+    const getCurrentUserResponse = await zeebeAPI.getCurrentUser(options);
+
+    done(null, getCurrentUserResponse);
+  } catch (err) {
+    done(err);
+  }
+});
+
 renderer.on('zeebe:searchClusterVariables', async function(options, done) {
   try {
     const searchClusterVariablesResponse = await zeebeAPI.searchClusterVariables(options);

--- a/app/lib/preload.js
+++ b/app/lib/preload.js
@@ -68,6 +68,7 @@ const allowedEvents = [
   'zeebe:searchMessageSubscriptions',
   'zeebe:searchUserTasks',
   'zeebe:getAuthorizations',
+  'zeebe:getCurrentUser',
   'zeebe:searchClusterVariables',
   'zeebe:getClusterVariable',
   'zeebe:createClusterVariable',

--- a/app/lib/zeebe-api/zeebe-api.js
+++ b/app/lib/zeebe-api/zeebe-api.js
@@ -776,6 +776,57 @@ class ZeebeAPI {
   }
 
   /**
+   * Get the authenticated user, including the components they are authorized for.
+   * An `authorizedComponents` of `[ "*" ]` signals full access — either
+   * authorizations are disabled on the cluster, or the user is a wildcard admin.
+   * Requires Camunda REST client.
+   *
+   * @param {{ endpoint: import("./endpoints").Endpoint }} config
+   *
+   * @returns {Promise<{ success: boolean, response?: object, reason?: string }>}
+   */
+  async getCurrentUser(config) {
+    const {
+      endpoint
+    } = config;
+
+    this._log.debug('get current user', {
+      parameters: sanitizeConfigWithEndpoint(config)
+    });
+
+    try {
+      const { camundaRestClient } = await this._getClients(endpoint);
+
+      if (!camundaRestClient) {
+        throw new Error('Camunda REST client is not available');
+      }
+
+      const response = await camundaRestClient.callApiEndpoint({
+        method: 'GET',
+        urlPath: 'authentication/me'
+      });
+
+      this._log.debug('get current user succeeded', {
+        authorizedComponents: response.authorizedComponents
+      });
+
+      return {
+        success: true,
+        response: response
+      };
+    } catch (err) {
+      this._log.error('get current user failed', {
+        parameters: sanitizeConfigWithEndpoint(config)
+      }, err);
+
+      return {
+        success: false,
+        reason: getErrorReason(err, endpoint)
+      };
+    }
+  }
+
+  /**
    * Search cluster variables. Requires Camunda REST client.
    *
    * @param {{ endpoint: import("./endpoints").Endpoint, filter: object, page?: object }} config

--- a/app/test/spec/zeebe-api/zeebe-api-rest-spec.js
+++ b/app/test/spec/zeebe-api/zeebe-api-rest-spec.js
@@ -2113,6 +2113,112 @@ describe('ZeebeAPI (REST)', function() {
   });
 
 
+  describe('#getCurrentUser', function() {
+
+    it('should set success=false when the REST client is not available', async function() {
+
+      // given
+      const zeebeAPI = createZeebeAPI();
+
+      sinon.stub(zeebeAPI._camundaClients, 'getSupportedCamundaClients').resolves({});
+
+      const parameters = {
+        endpoint: {
+          type: ENDPOINT_TYPES.SELF_HOSTED,
+          url: TEST_URL
+        }
+      };
+
+      // when
+      const result = await zeebeAPI.getCurrentUser(parameters);
+
+      // then
+      expect(result.success).to.be.false;
+    });
+
+
+    it('should set success=true on success', async function() {
+
+      // given
+      const zeebeAPI = createZeebeAPI({
+        CamundaRestClient: {
+          callApiEndpoint: () => ({ authorizedComponents: [ '*' ] })
+        }
+      });
+
+      const parameters = {
+        endpoint: {
+          type: ENDPOINT_TYPES.SELF_HOSTED,
+          url: TEST_URL
+        }
+      };
+
+      // when
+      const result = await zeebeAPI.getCurrentUser(parameters);
+
+      // then
+      expect(result.success).to.be.true;
+      expect(result.response).to.exist;
+      expect(result.response.authorizedComponents).to.eql([ '*' ]);
+    });
+
+
+    it('should set success=false on failure', async function() {
+
+      // given
+      const zeebeAPI = createZeebeAPI({
+        CamundaRestClient: {
+          callApiEndpoint: () => { throw new Error('TEST ERROR.'); }
+        }
+      });
+
+      const parameters = {
+        endpoint: {
+          type: ENDPOINT_TYPES.SELF_HOSTED,
+          url: TEST_URL
+        }
+      };
+
+      // when
+      const result = await zeebeAPI.getCurrentUser(parameters);
+
+      // then
+      expect(result.success).to.be.false;
+      expect(result.reason).to.exist;
+    });
+
+
+    it('should get the current user', async function() {
+
+      // given
+      const callApiEndpointSpy = sinon.spy(() => ({ authorizedComponents: [] }));
+
+      const zeebeAPI = createZeebeAPI({
+        CamundaRestClient: {
+          callApiEndpoint: callApiEndpointSpy
+        }
+      });
+
+      const parameters = {
+        endpoint: {
+          type: ENDPOINT_TYPES.SELF_HOSTED,
+          url: TEST_URL
+        }
+      };
+
+      // when
+      await zeebeAPI.getCurrentUser(parameters);
+
+      // then
+      expect(callApiEndpointSpy).to.have.been.calledWithMatch({
+        method: 'GET',
+        urlPath: 'authentication/me'
+      });
+    });
+
+  });
+
+
   describe('#searchClusterVariables', function() {
 
     it('should set success=false when the REST client is not available', async function() {

--- a/client/src/app/tabs/cloud-bpmn/credentials-manager/CredentialsManager.js
+++ b/client/src/app/tabs/cloud-bpmn/credentials-manager/CredentialsManager.js
@@ -250,8 +250,8 @@ export default class CredentialsManager extends PureComponent {
       return;
     }
 
-    const [ authorizationsResult, variablesResults ] = await Promise.all([
-      this.getAllAuthorizations(endpoint),
+    const [ permissions, variablesResults ] = await Promise.all([
+      this.resolvePermissions(endpoint),
       Promise.all(filters.map(filter => this.getAllClusterVariables(endpoint, filter)))
     ]);
 
@@ -274,10 +274,37 @@ export default class CredentialsManager extends PureComponent {
       available: true,
       loading: false,
       error: false,
-      permissions: getConfigurationPermissions(authorizationsResult),
+      permissions,
       selectableInstances,
       referencedInstances
     });
+  }
+
+  /**
+   * Resolve the user's create/update permissions for credentials.
+   *
+   * Authorizations are only enforced — and thus only searchable — when they are
+   * enabled on the cluster. When disabled, the authorization search returns
+   * empty even though everything is permitted, which would wrongly disable
+   * create/update. The current user's `authorizedComponents` is the only
+   * REST-visible tell: a `*` entry means full access (authorizations disabled or
+   * a wildcard admin), so we grant everything without searching. Otherwise we
+   * derive the concrete grants from the authorization search.
+   *
+   * @param {Object} endpoint
+   *
+   * @returns {Promise<{ create: boolean, update: boolean }>}
+   */
+  async resolvePermissions(endpoint) {
+    const currentUserResult = await this.props.zeebeApi.getCurrentUser({ endpoint });
+
+    if (hasFullAccess(currentUserResult)) {
+      return { create: true, update: true };
+    }
+
+    const authorizationsResult = await this.getAllAuthorizations(endpoint);
+
+    return getConfigurationPermissions(authorizationsResult);
   }
 
   getAllAuthorizations(endpoint) {
@@ -985,6 +1012,25 @@ function upsertInstance(instances, instance) {
     ...instances.filter(existing => existing.name !== instance.name),
     instance
   ];
+}
+
+/**
+ * Whether the current user has full access — either authorizations are disabled
+ * on the cluster or the user is a wildcard admin — signalled by a `*` entry in
+ * their `authorizedComponents`.
+ *
+ * @param {Object} currentUserResult
+ *
+ * @returns {boolean}
+ */
+function hasFullAccess(currentUserResult) {
+  if (!currentUserResult || !currentUserResult.success || !currentUserResult.response) {
+    return false;
+  }
+
+  const { authorizedComponents } = currentUserResult.response;
+
+  return Array.isArray(authorizedComponents) && authorizedComponents.includes('*');
 }
 
 /**

--- a/client/src/app/tabs/cloud-bpmn/credentials-manager/__tests__/CredentialsManagerSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/credentials-manager/__tests__/CredentialsManagerSpec.js
@@ -367,6 +367,59 @@ describe('<CredentialsManager>', function() {
   });
 
 
+  it('should grant full permissions when authorizations are disabled', async function() {
+
+    // given
+    const getAuthorizations = sinon.stub().resolves({
+      success: true,
+      response: { items: [] }
+    });
+    const getCurrentUser = sinon.stub().resolves({
+      success: true,
+      response: { authorizedComponents: [ '*' ] }
+    });
+
+    const zeebeApi = createZeebeApi({ getAuthorizations, getCurrentUser });
+    const { configurationInstances } = renderManager({ zeebeApi });
+
+    // then
+    await waitFor(() => {
+      const call = fedInstancesCall(configurationInstances);
+
+      expect(call.permissions).to.eql({ create: true, update: true });
+    });
+
+    // does not fall back to the authorization search
+    expect(getAuthorizations).not.to.have.been.called;
+  });
+
+
+  it('should derive permissions from search when authorizations are enabled', async function() {
+
+    // given
+    const getAuthorizations = sinon.stub().resolves({
+      success: true,
+      response: { items: [ { permissionTypes: [ 'CREATE' ] } ] }
+    });
+    const getCurrentUser = sinon.stub().resolves({
+      success: true,
+      response: { authorizedComponents: [ 'operate', 'tasklist' ] }
+    });
+
+    const zeebeApi = createZeebeApi({ getAuthorizations, getCurrentUser });
+    const { configurationInstances } = renderManager({ zeebeApi });
+
+    // then
+    await waitFor(() => {
+      const call = fedInstancesCall(configurationInstances);
+
+      expect(call.permissions).to.eql({ create: true, update: false });
+    });
+
+    expect(getAuthorizations).to.have.been.called;
+  });
+
+
   it('should reload credentials for each connection status event', async function() {
 
     // given
@@ -718,6 +771,7 @@ function createElementTemplates(get = () => ({
 function createZeebeApi(overrides = {}) {
   return {
     getAuthorizations: sinon.stub().resolves({ success: true, response: { items: [] } }),
+    getCurrentUser: sinon.stub().resolves({ success: true, response: { authorizedComponents: [] } }),
     searchClusterVariables: sinon.stub().resolves({ success: true, response: { items: [] } }),
     getClusterVariable: sinon.stub().resolves({ success: true, response: { metadata: {}, value: {} } }),
     createClusterVariable: sinon.stub().resolves({ success: true }),

--- a/client/src/remote/ZeebeAPI.js
+++ b/client/src/remote/ZeebeAPI.js
@@ -185,6 +185,16 @@ export default class ZeebeAPI {
     });
   }
 
+  getCurrentUser(options) {
+    let { endpoint } = options;
+
+    endpoint = getEndpointForTargetType(endpoint);
+
+    return this._backend.send('zeebe:getCurrentUser', {
+      endpoint
+    });
+  }
+
   searchClusterVariables(options, filter, page) {
     let { endpoint } = options;
 

--- a/client/src/remote/__tests__/ZeebeAPISpec.js
+++ b/client/src/remote/__tests__/ZeebeAPISpec.js
@@ -1492,6 +1492,41 @@ describe('<ZeebeAPI>', function() {
   });
 
 
+  describe('#getCurrentUser', function() {
+
+    it('should get current user', function() {
+
+      // given
+      const backend = new MockBackend({
+        send: sinon.spy()
+      });
+
+      const zeebeAPI = new ZeebeAPI(backend);
+
+      const endpoint = {
+        targetType: TARGET_TYPES.SELF_HOSTED,
+        authType: AUTH_TYPES.NONE,
+        contactPoint: 'http://localhost:26500'
+      };
+
+      // when
+      zeebeAPI.getCurrentUser({ endpoint });
+
+      // then
+      expect(backend.send).to.have.been.calledWith('zeebe:getCurrentUser', {
+        endpoint: {
+          type: TARGET_TYPES.SELF_HOSTED,
+          authType: AUTH_TYPES.NONE,
+          url: endpoint.contactPoint,
+          tenantId: undefined
+        }
+      });
+
+    });
+
+  });
+
+
   describe('#searchClusterVariables', function() {
 
     it('should search cluster variables', function() {


### PR DESCRIPTION
### Proposed Changes

> [!WARNING]
> Here for local unblocking - not a reliable fix. The actual fix is gated on closing https://github.com/camunda/camunda/issues/60605.

The authorization endpoint returns empty results in environments where authorization is disabled - proper detection requires querying `authentication/me` upfront - that is the only endpoint today that allows us to figure if authorizations are even enabled.

With the change I'm able to interact with a cluster with authentication disabled:

<img width="1326" height="866" alt="image" src="https://github.com/user-attachments/assets/b2873b44-bcf6-488b-95d0-afe3e2281b2e" />

Builds on top of #6099 

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
