### PR TITLE
fix(process-applications): batch tab group updates

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -222,25 +222,17 @@ export class App extends PureComponent {
   }
 
   /**
-   * Set group for tab.
+   * Set groups for tabs, replacing the current mapping.
    *
-   * @param {string} id ID of the tab
-   * @param {string} group Group name
+   * @param {Object} tabGroups Map of tab ID to group name
    */
-  setTabGroup(id, group) {
-    const tab = this.state.tabs.find((tab) => tab.id === id);
+  setTabGroups(tabGroups) {
+    this.setState((state) => {
+      if (shallowEqual(state.tabGroups, tabGroups)) {
+        return null;
+      }
 
-    if (!tab) {
-      return;
-    }
-
-    this.setState(({ tabGroups }) => {
-      return {
-        tabGroups: {
-          ...tabGroups,
-          [ id ]: group
-        }
-      };
+      return { tabGroups };
     });
   }
 
@@ -2263,13 +2255,8 @@ export class App extends PureComponent {
 
     try {
 
-      if (action === 'set-tab-group') {
-        const {
-          id,
-          group
-        } = options;
-
-        return this.setTabGroup(id, group);
+      if (action === 'set-tab-groups') {
+        return this.setTabGroups(options);
       }
 
       if (action === 'lint-tab') {
@@ -3103,4 +3090,19 @@ function getProcessor(type) {
   }
 
   return null;
+}
+
+function shallowEqual(a, b) {
+  if (a === b) {
+    return true;
+  }
+
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  return keysA.every(key => a[ key ] === b[ key ]);
 }

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -12,7 +12,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import React, { createRef, Component } from 'react';
 
-import { render, waitFor, screen } from '@testing-library/react';
+import { act, render, waitFor, screen } from '@testing-library/react';
 
 import {
   App,
@@ -362,6 +362,69 @@ describe('<App>', function() {
       ]);
 
       expect(activeTab).to.eql(tabs[ tabs.length - 1 ]);
+    });
+
+  });
+
+
+  describe('#setTabGroups', function() {
+
+    it('should replace tab groups', async function() {
+
+      // given
+      const { app } = createApp();
+
+      // when
+      await app.triggerAction('set-tab-groups', { a: 'group-1', b: 'group-1' });
+
+      // then
+      await waitFor(() => {
+        expect(app.state.tabGroups).to.eql({ a: 'group-1', b: 'group-1' });
+      });
+    });
+
+
+    it('should replace wholesale, dropping stale entries', async function() {
+
+      // given
+      const { app } = createApp();
+
+      await app.triggerAction('set-tab-groups', { a: 'group-1', b: 'group-1' });
+
+      await waitFor(() => {
+        expect(app.state.tabGroups).to.eql({ a: 'group-1', b: 'group-1' });
+      });
+
+      // when
+      await app.triggerAction('set-tab-groups', { a: 'group-1' });
+
+      // then
+      await waitFor(() => {
+        expect(app.state.tabGroups).to.eql({ a: 'group-1' });
+      });
+    });
+
+
+    it('should not re-render when tab groups are unchanged', async function() {
+
+      // given
+      const { app } = createApp();
+
+      await app.triggerAction('set-tab-groups', { a: 'group-1', b: 'group-1' });
+
+      await waitFor(() => {
+        expect(app.state.tabGroups).to.eql({ a: 'group-1', b: 'group-1' });
+      });
+
+      const renderSpy = spy(app, 'render');
+
+      // when
+      await app.triggerAction('set-tab-groups', { a: 'group-1', b: 'group-1' });
+
+      await act(async () => {});
+
+      // then
+      expect(renderSpy).not.to.have.been.called;
     });
 
   });

--- a/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
@@ -211,12 +211,7 @@ export default function ProcessApplicationsPlugin(props) {
       };
     }, {});
 
-    for (const [ id, group ] of Object.entries(tabGroups)) {
-      triggerAction('set-tab-group', {
-        id,
-        group
-      });
-    }
+    triggerAction('set-tab-groups', tabGroups);
   }, [ items, tabs, triggerAction ]);
 
   return <>

--- a/client/src/plugins/process-applications/__tests__/ProcessApplicationsPluginSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ProcessApplicationsPluginSpec.js
@@ -62,6 +62,29 @@ describe('<ProcessApplicationsPlugin>', function() {
       expect(triggerAction).not.to.have.been.calledWith('resources.reload');
     });
   });
+
+
+  describe('set-tab-groups dispatch', function() {
+
+    it('should dispatch set-tab-groups with the full tab group map', async function() {
+
+      // given
+      const triggerAction = sinon.spy();
+
+      const { emit } = createProcessApplicationsPlugin({ triggerAction });
+
+      // when
+      act(() => emit('app.tabsChanged', { tabs: [ CLOUD_TAB, PLATFORM_TAB ] }));
+
+      // then
+      await waitFor(() => {
+        expect(triggerAction).to.have.been.calledWith('set-tab-groups', {
+          cloud: null,
+          platform: null
+        });
+      });
+    });
+  });
 });
 
 


### PR DESCRIPTION
### Proposed Changes

> [!NOTE]
> Found in the context of reviewing https://github.com/camunda/camunda-modeler/pull/6099.

Saving a tab triggered a `set-tab-group` action for **every** open tab, each causing a separate `App` `setState` and re-render (amplified by the follow-up `resources.reload`).

This replaces the per-tab `set-tab-group` action with a single `set-tab-groups` action:

- `ProcessApplicationsPlugin` dispatches the full tab→group map once instead of looping.
- `App.setTabGroups` replaces the mapping wholesale, guarded by a shallow-equality check so unchanged updates cause no re-render.
- Wholesale replace also drops entries for closed tabs, which `_removeTab` never cleaned up before.

Net: at most one re-render per change (was N), plus a latent stale-entry leak fixed.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)