### PR TITLE
Schedule linting as a debounced, lifecycle-aware follow-up

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -90,6 +90,20 @@ const FILTER_ALL_EXTENSIONS = {
 
 const EMPTY_LINTING_STATE = [];
 
+/**
+ * Additional lint sources contribute warnings on top of the content linter's
+ * results. Unlike content linting - which is expensive and cached per tab -
+ * these are cheap, derived purely from app state, and (re)composed with the
+ * stored content results whenever the linting state is read. A change to their
+ * inputs (e.g. the connected cluster version) therefore surfaces without
+ * re-running the content linter.
+ *
+ * Each source is a factory: (appState) => (tab) => LintEntry[].
+ */
+const ADDITIONAL_LINT_SOURCES = [
+  VersionMismatchChecker
+];
+
 const INITIAL_STATE = {
   activeTab: EMPTY_TAB,
   dirtyTabs: {},
@@ -1147,17 +1161,6 @@ export class App extends PureComponent {
       log('linted tab', { tabId: tab.id });
     }
 
-    const getWarnings = VersionMismatchChecker({
-      connectionCheckResult: this.state.connectionCheckResult,
-      engineProfiles: this.state.engineProfiles
-    });
-
-    const warnings = getWarnings(tab);
-
-    if (warnings.length) {
-      results = [ ...results, ...warnings ];
-    }
-
     this.setLintingState(tab, results);
   };
 
@@ -1228,30 +1231,10 @@ export class App extends PureComponent {
   };
 
   _handleConnectionStatusChanged = ({ tab, ...connectionCheckResult }) => {
-    const prev = this.state.connectionCheckResult;
 
-    // Only re-lint when the data relevant to version mismatch
-    // warning actually changes, not on every periodic poll
-    const prevVersion = prev && prev.success && prev.response
-      ? prev.response.gatewayVersion : null;
-    const nextVersion = connectionCheckResult.success && connectionCheckResult.response
-      ? connectionCheckResult.response.gatewayVersion : null;
-    const relevantChange = (prev && prev.success) !== connectionCheckResult.success
-      || prevVersion !== nextVersion;
-
-    this.setState({ connectionCheckResult }, async () => {
-      if (!relevantChange) {
-        return;
-      }
-
-      const { activeTab } = this.state;
-
-      if (activeTab && activeTab !== EMPTY_TAB) {
-        const contents = await this.getActiveTabContents();
-
-        this.lintTab(activeTab, contents);
-      }
-    });
+    // The cluster connection feeds the additional lint sources, not the content
+    // linter, so updating state is enough - the warning is recomposed on read.
+    this.setState({ connectionCheckResult });
   };
 
   _handleEngineProfileChanged = ({ tab, executionPlatform, executionPlatformVersion }) => {
@@ -1259,37 +1242,63 @@ export class App extends PureComponent {
       return;
     }
 
+    // An engine profile change is a document change, so the editor re-lints its
+    // contents on its own - we only record the selected version here, no
+    // App-side re-lint needed.
     this.setState(state => ({
       engineProfiles: {
         ...state.engineProfiles,
         [ tab.id ]: { executionPlatform, executionPlatformVersion }
       }
-    }), async () => {
-      if (this.state.activeTab === tab) {
-        const contents = await this.getActiveTabContents();
-
-        this.lintTab(tab, contents);
-      } else {
-        this.lintTab(tab);
-      }
-    });
+    }));
   };
 
   getLintingState = (tab) => {
-    return this.state.lintingState[ tab.id ] || EMPTY_LINTING_STATE;
+    const contentResults = this.state.lintingState[ tab.id ] || EMPTY_LINTING_STATE;
+
+    const additionalResults = this.getAdditionalLintResults(tab);
+
+    if (!additionalResults.length) {
+      return contentResults;
+    }
+
+    return [ ...contentResults, ...additionalResults ];
+  };
+
+  /**
+   * Compose the warnings contributed by the additional lint sources for a tab
+   * (see ADDITIONAL_LINT_SOURCES).
+   */
+  getAdditionalLintResults = (tab) => {
+    const appState = {
+      connectionCheckResult: this.state.connectionCheckResult,
+      engineProfiles: this.state.engineProfiles
+    };
+
+    return ADDITIONAL_LINT_SOURCES.reduce((results, createSource) => {
+      return [ ...results, ...createSource(appState)(tab) ];
+    }, []);
   };
 
   setLintingState = (tab, results) => {
     const { tabs } = this.state;
 
+    // store the raw content lint results; additional sources are composed on
+    // read (see getLintingState), so they must not be persisted here
     const lintingState = reduce(tabs, (lintingState, t) => {
       if (t === tab) {
         return lintingState;
       }
 
+      const existing = this.state.lintingState[ t.id ];
+
+      if (!existing) {
+        return lintingState;
+      }
+
       return {
         ...lintingState,
-        [ t.id ]: this.getLintingState(t)
+        [ t.id ]: existing
       };
     }, {
       [ tab.id ]: results

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -4926,25 +4926,17 @@ describe('<App>', function() {
           }
         });
 
-        const setLintingSpy = sinon.spy(app, 'setLintingState');
-
         // when
         await app.lintTab(activeTab);
 
         // then
-        const lastCall = setLintingSpy.lastCall;
-
-        expect(lastCall).to.exist;
-
-        const results = lastCall.args[ 1 ];
+        const results = app.getLintingState(activeTab);
         const warning = results.find(r => r.rule === 'camunda/version-mismatch');
 
         expect(warning).to.exist;
         expect(warning.category).to.equal('warn');
         expect(warning.message).to.include('8.7');
         expect(warning.message).to.include('8.8');
-
-        setLintingSpy.restore();
       });
 
 
@@ -4968,19 +4960,16 @@ describe('<App>', function() {
           }
         });
 
-        const setLintingSpy = sinon.spy(app, 'setLintingState');
-
         // when
         await app.lintTab(activeTab);
 
         // then
-        const results = setLintingSpy.lastCall.args[ 1 ];
+        const results = app.getLintingState(activeTab);
         const warning = results.find(r => r.rule === 'camunda/version-mismatch');
 
         expect(warning).to.exist;
         expect(warning.category).to.equal('warn');
 
-        setLintingSpy.restore();
       });
 
 
@@ -5004,19 +4993,16 @@ describe('<App>', function() {
           }
         });
 
-        const setLintingSpy = sinon.spy(app, 'setLintingState');
-
         // when
         await app.lintTab(activeTab);
 
         // then
-        const results = setLintingSpy.lastCall.args[ 1 ];
+        const results = app.getLintingState(activeTab);
         const warning = results.find(r => r.rule === 'camunda/version-mismatch');
 
         expect(warning).to.exist;
         expect(warning.category).to.equal('warn');
 
-        setLintingSpy.restore();
       });
 
 
@@ -5040,19 +5026,16 @@ describe('<App>', function() {
           }
         });
 
-        const setLintingSpy = sinon.spy(app, 'setLintingState');
-
         // when
         await app.lintTab(activeTab);
 
         // then
-        const results = setLintingSpy.lastCall.args[ 1 ];
+        const results = app.getLintingState(activeTab);
         const warning = results.find(r => r.rule === 'camunda/version-mismatch');
 
         expect(warning).to.exist;
         expect(warning.category).to.equal('warn');
 
-        setLintingSpy.restore();
       });
 
 
@@ -5076,18 +5059,15 @@ describe('<App>', function() {
           }
         });
 
-        const setLintingSpy = sinon.spy(app, 'setLintingState');
-
         // when
         await app.lintTab(activeTab);
 
         // then
-        const results = setLintingSpy.lastCall.args[ 1 ];
+        const results = app.getLintingState(activeTab);
         const warning = results.find(r => r.rule === 'camunda/version-mismatch');
 
         expect(warning).to.not.exist;
 
-        setLintingSpy.restore();
       });
 
 
@@ -5111,18 +5091,15 @@ describe('<App>', function() {
           }
         });
 
-        const setLintingSpy = sinon.spy(app, 'setLintingState');
-
         // when
         await app.lintTab(activeTab);
 
         // then
-        const results = setLintingSpy.lastCall.args[ 1 ];
+        const results = app.getLintingState(activeTab);
         const warning = results.find(r => r.rule === 'camunda/version-mismatch');
 
         expect(warning).to.not.exist;
 
-        setLintingSpy.restore();
       });
 
 
@@ -5143,18 +5120,15 @@ describe('<App>', function() {
           connectionCheckResult: null
         });
 
-        const setLintingSpy = sinon.spy(app, 'setLintingState');
-
         // when
         await app.lintTab(activeTab);
 
         // then
-        const results = setLintingSpy.lastCall.args[ 1 ];
+        const results = app.getLintingState(activeTab);
         const warning = results.find(r => r.rule === 'camunda/version-mismatch');
 
         expect(warning).to.not.exist;
 
-        setLintingSpy.restore();
       });
 
 
@@ -5178,18 +5152,15 @@ describe('<App>', function() {
           }
         });
 
-        const setLintingSpy = sinon.spy(app, 'setLintingState');
-
         // when
         await app.lintTab(activeTab);
 
         // then
-        const results = setLintingSpy.lastCall.args[ 1 ];
+        const results = app.getLintingState(activeTab);
         const warning = results.find(r => r.rule === 'camunda/version-mismatch');
 
         expect(warning).to.not.exist;
 
-        setLintingSpy.restore();
       });
 
 
@@ -5209,24 +5180,21 @@ describe('<App>', function() {
           }
         });
 
-        const setLintingSpy = sinon.spy(app, 'setLintingState');
-
         // when
         await app.lintTab(activeTab);
 
         // then
-        const results = setLintingSpy.lastCall.args[ 1 ];
+        const results = app.getLintingState(activeTab);
         const warning = results.find(r => r.rule === 'camunda/version-mismatch');
 
         expect(warning).to.not.exist;
 
-        setLintingSpy.restore();
       });
 
 
-      describe('connection status changed re-lint', function() {
+      describe('connection status changed', function() {
 
-        it('should re-lint when connection success state changes', async function() {
+        it('should recompose version warning without re-linting content', async function() {
 
           // given
           const { app } = createApp();
@@ -5235,58 +5203,19 @@ describe('<App>', function() {
 
           const { activeTab } = app.state;
 
-          setVersionState(app, activeTab, {
-            engineProfile: {
-              executionPlatform: 'Camunda Cloud',
-              executionPlatformVersion: '8.7.0'
-            },
-            connectionCheckResult: {
-              success: false,
-              reason: 'UNAVAILABLE'
-            }
-          });
-
-          const lintTabSpy = sinon.spy(app, 'lintTab');
-
-          // when - success state changes from false to true
-          app.emit('connectionManager.connectionStatusChanged', {
+          app.emit('tab.engineProfileChanged', {
             tab: activeTab,
-            success: true,
-            response: { gatewayVersion: '8.8.0' }
+            executionPlatform: 'Camunda Cloud',
+            executionPlatformVersion: '8.7.0'
           });
 
-          // then
           await waitFor(() => {
-            expect(lintTabSpy).to.have.been.calledOnce;
-          });
-
-          lintTabSpy.restore();
-        });
-
-
-        it('should re-lint when gateway version changes', async function() {
-
-          // given
-          const { app } = createApp();
-
-          await app.createDiagram('cloud-bpmn');
-
-          const { activeTab } = app.state;
-
-          setVersionState(app, activeTab, {
-            engineProfile: {
-              executionPlatform: 'Camunda Cloud',
-              executionPlatformVersion: '8.7.0'
-            },
-            connectionCheckResult: {
-              success: true,
-              response: { gatewayVersion: '8.8.0' }
-            }
+            expect(app.state.engineProfiles[ activeTab.id ].executionPlatformVersion).to.equal('8.7.0');
           });
 
           const lintTabSpy = sinon.spy(app, 'lintTab');
 
-          // when - gateway version changes
+          // when
           app.emit('connectionManager.connectionStatusChanged', {
             tab: activeTab,
             success: true,
@@ -5295,555 +5224,144 @@ describe('<App>', function() {
 
           // then
           await waitFor(() => {
-            expect(lintTabSpy).to.have.been.calledOnce;
-          });
+            const warning = app.getLintingState(activeTab)
+              .find(r => r.rule === 'camunda/version-mismatch');
 
-          lintTabSpy.restore();
-        });
-
-
-        it('should NOT re-lint on periodic poll with same result', async function() {
-
-          // given
-          const { app } = createApp();
-
-          await app.createDiagram('cloud-bpmn');
-
-          const { activeTab } = app.state;
-
-          setVersionState(app, activeTab, {
-            engineProfile: {
-              executionPlatform: 'Camunda Cloud',
-              executionPlatformVersion: '8.7.0'
-            },
-            connectionCheckResult: {
-              success: true,
-              response: { gatewayVersion: '8.8.0' }
-            }
-          });
-
-          const lintTabSpy = sinon.spy(app, 'lintTab');
-
-          // when - same success + same version (periodic poll)
-          app.emit('connectionManager.connectionStatusChanged', {
-            tab: activeTab,
-            success: true,
-            response: { gatewayVersion: '8.8.0' }
-          });
-
-          // then - wait for setState to commit, verify state updated
-          await waitFor(() => {
-            expect(app.state.connectionCheckResult.response.gatewayVersion).to.equal('8.8.0');
+            expect(warning).to.exist;
+            expect(warning.message).to.include('8.9');
           });
 
           expect(lintTabSpy).to.not.have.been.called;
-
-          lintTabSpy.restore();
-        });
-
-
-        it('should NOT re-lint on periodic poll with same failure', async function() {
-
-          // given
-          const { app } = createApp();
-
-          await app.createDiagram('cloud-bpmn');
-
-          const { activeTab } = app.state;
-
-          setVersionState(app, activeTab, {
-            engineProfile: {
-              executionPlatform: 'Camunda Cloud',
-              executionPlatformVersion: '8.7.0'
-            },
-            connectionCheckResult: {
-              success: false,
-              reason: 'UNAVAILABLE'
-            }
-          });
-
-          const lintTabSpy = sinon.spy(app, 'lintTab');
-
-          // when - still failing (periodic poll)
-          app.emit('connectionManager.connectionStatusChanged', {
-            tab: activeTab,
-            success: false,
-            reason: 'UNAVAILABLE'
-          });
-
-          // then - wait for setState to commit, verify state updated
-          await waitFor(() => {
-            expect(app.state.connectionCheckResult.reason).to.equal('UNAVAILABLE');
-          });
-
-          expect(lintTabSpy).to.not.have.been.called;
-
-          lintTabSpy.restore();
-        });
-
-
-        it('should update state even when not re-linting', async function() {
-
-          // given
-          const { app } = createApp();
-
-          await app.createDiagram('cloud-bpmn');
-
-          const { activeTab } = app.state;
-
-          setVersionState(app, activeTab, {
-            connectionCheckResult: {
-              success: true,
-              response: { gatewayVersion: '8.8.0' }
-            }
-          });
-
-          // when - same success + same version (periodic poll)
-          app.emit('connectionManager.connectionStatusChanged', {
-            tab: activeTab,
-            success: true,
-            response: { gatewayVersion: '8.8.0' }
-          });
-
-          // then
-          await waitFor(() => {
-            expect(app.state.connectionCheckResult).to.eql({
-              success: true,
-              response: { gatewayVersion: '8.8.0' }
-            });
-          });
-        });
-
-
-        it('should re-lint with current editor contents, not stale file contents', async function() {
-
-          // given
-          const { app } = createApp();
-
-          await app.openFiles([
-            createFile('1.cloud-bpmn', {
-              contents: 'linting-errors'
-            })
-          ]);
-
-          const { activeTab } = app.state;
-
-          setVersionState(app, activeTab, {
-            engineProfile: {
-              executionPlatform: 'Camunda Cloud',
-              executionPlatformVersion: '8.7.0'
-            },
-            connectionCheckResult: {
-              success: false,
-              reason: 'UNAVAILABLE'
-            }
-          });
-
-          // lint with saved file contents — error should exist
-          await app.lintTab(activeTab, 'linting-errors');
-
-          await waitFor(() => {
-            const errors = app.getLintingState(activeTab);
-
-            expect(errors.some(e => e.id === 'Task_1')).to.be.true;
-          });
-
-          // simulate user removing the task in the editor (unsaved)
-          const tabComponent = app.tabRef.current;
-          tabComponent.currentContents = 'no-errors';
-
-          // when - connection status changes, triggering re-lint
-          app.emit('connectionManager.connectionStatusChanged', {
-            tab: activeTab,
-            success: true,
-            response: { gatewayVersion: '8.8.0' }
-          });
-
-          // then - lint should use current editor contents (task removed),
-          // not stale file contents (task still present)
-          await waitFor(() => {
-            const errors = app.getLintingState(activeTab);
-
-            expect(errors.some(e => e.id === 'Task_1')).to.be.false;
-          });
-        });
-
-
-        it('should re-lint RPA tab with current editor contents', async function() {
-
-          // given
-          const { app } = createApp();
-
-          await app.openFiles([
-            createFile('1.rpa', {
-              contents: 'linting-errors'
-            })
-          ]);
-
-          const { activeTab } = app.state;
-
-          setVersionState(app, activeTab, {
-            engineProfile: {
-              executionPlatform: 'Camunda Cloud',
-              executionPlatformVersion: '8.7.0'
-            },
-            connectionCheckResult: {
-              success: false,
-              reason: 'UNAVAILABLE'
-            }
-          });
-
-          await app.lintTab(activeTab, 'linting-errors');
-
-          await waitFor(() => {
-            const errors = app.getLintingState(activeTab);
-
-            expect(errors.some(e => e.id === 'Script_1')).to.be.true;
-          });
-
-          // simulate user editing in the editor (unsaved)
-          const tabComponent = app.tabRef.current;
-          tabComponent.currentContents = 'no-errors';
-
-          // when
-          app.emit('connectionManager.connectionStatusChanged', {
-            tab: activeTab,
-            success: true,
-            response: { gatewayVersion: '8.8.0' }
-          });
-
-          // then
-          await waitFor(() => {
-            const errors = app.getLintingState(activeTab);
-
-            expect(errors.some(e => e.id === 'Script_1')).to.be.false;
-          });
-        });
-
-
-        it('should re-lint Form (C7) tab with current editor contents', async function() {
-
-          // given
-          const { app } = createApp();
-
-          await app.openFiles([
-            createFile('1.form', {
-              contents: 'linting-errors'
-            })
-          ]);
-
-          const { activeTab } = app.state;
-
-          setVersionState(app, activeTab, {
-            engineProfile: {
-              executionPlatform: 'Camunda Platform',
-              executionPlatformVersion: '7.15'
-            },
-            connectionCheckResult: {
-              success: false,
-              reason: 'UNAVAILABLE'
-            }
-          });
-
-          await app.lintTab(activeTab, 'linting-errors');
-
-          await waitFor(() => {
-            const errors = app.getLintingState(activeTab);
-
-            expect(errors.some(e => e.id === 'Field_1')).to.be.true;
-          });
-
-          // simulate user editing in the editor (unsaved)
-          const tabComponent = app.tabRef.current;
-          tabComponent.currentContents = 'no-errors';
-
-          // when
-          app.emit('connectionManager.connectionStatusChanged', {
-            tab: activeTab,
-            success: true,
-            response: { gatewayVersion: '8.8.0' }
-          });
-
-          // then
-          await waitFor(() => {
-            const errors = app.getLintingState(activeTab);
-
-            expect(errors.some(e => e.id === 'Field_1')).to.be.false;
-          });
-        });
-
-
-        it('should re-lint BPMN (C7) tab with current editor contents', async function() {
-
-          // given
-          const { app } = createApp();
-
-          await app.openFiles([
-            createFile('1.bpmn', {
-              contents: 'linting-errors'
-            })
-          ]);
-
-          const { activeTab } = app.state;
-
-          setVersionState(app, activeTab, {
-            engineProfile: {
-              executionPlatform: 'Camunda Platform',
-              executionPlatformVersion: '7.15'
-            },
-            connectionCheckResult: {
-              success: false,
-              reason: 'UNAVAILABLE'
-            }
-          });
-
-          await app.lintTab(activeTab, 'linting-errors');
-
-          await waitFor(() => {
-            const errors = app.getLintingState(activeTab);
-
-            expect(errors.some(e => e.id === 'Task_1')).to.be.true;
-          });
-
-          // simulate user editing in the editor (unsaved)
-          const tabComponent = app.tabRef.current;
-          tabComponent.currentContents = 'no-errors';
-
-          // when
-          app.emit('connectionManager.connectionStatusChanged', {
-            tab: activeTab,
-            success: true,
-            response: { gatewayVersion: '8.8.0' }
-          });
-
-          // then
-          await waitFor(() => {
-            const errors = app.getLintingState(activeTab);
-
-            expect(errors.some(e => e.id === 'Task_1')).to.be.false;
-          });
         });
 
       });
 
 
-      describe('engine profile changed re-lint', function() {
+      describe('engine profile changed', function() {
 
-        it('should re-lint active cloud-bpmn tab with current editor contents', async function() {
-
-          // given
-          const { app } = createApp();
-
-          // create dummy tab to advance uuid past 0
-          // (_handleEngineProfileChanged guards on !tab.id)
-          await app.createDiagram('cloud-bpmn');
-
-          await app.openFiles([
-            createFile('1.cloud-bpmn', {
-              contents: 'linting-errors'
-            })
-          ]);
-
-          const { activeTab } = app.state;
-
-          await app.lintTab(activeTab, 'linting-errors');
-
-          await waitFor(() => {
-            const errors = app.getLintingState(activeTab);
-
-            expect(errors.some(e => e.id === 'Task_1')).to.be.true;
-          });
-
-          // simulate user editing in the editor (unsaved)
-          const tabComponent = app.tabRef.current;
-          tabComponent.currentContents = 'no-errors';
-
-          // when - engine profile changes on active tab
-          app.emit('tab.engineProfileChanged', {
-            tab: activeTab,
-            executionPlatform: 'Camunda Cloud',
-            executionPlatformVersion: '8.8.0'
-          });
-
-          // then - should use current editor contents
-          await waitFor(() => {
-            const errors = app.getLintingState(activeTab);
-
-            expect(errors.some(e => e.id === 'Task_1')).to.be.false;
-          });
-        });
-
-
-        it('should re-lint active RPA tab with current editor contents', async function() {
-
-          // given
-          const { app } = createApp();
-
-          await app.createDiagram('rpa');
-
-          await app.openFiles([
-            createFile('1.rpa', {
-              contents: 'linting-errors'
-            })
-          ]);
-
-          const { activeTab } = app.state;
-
-          await app.lintTab(activeTab, 'linting-errors');
-
-          await waitFor(() => {
-            const errors = app.getLintingState(activeTab);
-
-            expect(errors.some(e => e.id === 'Script_1')).to.be.true;
-          });
-
-          const tabComponent = app.tabRef.current;
-          tabComponent.currentContents = 'no-errors';
-
-          // when
-          app.emit('tab.engineProfileChanged', {
-            tab: activeTab,
-            executionPlatform: 'Camunda Cloud',
-            executionPlatformVersion: '8.8.0'
-          });
-
-          // then
-          await waitFor(() => {
-            const errors = app.getLintingState(activeTab);
-
-            expect(errors.some(e => e.id === 'Script_1')).to.be.false;
-          });
-        });
-
-
-        it('should re-lint active Form (C7) tab with current editor contents', async function() {
-
-          // given
-          const { app } = createApp();
-
-          await app.createDiagram('form');
-
-          await app.openFiles([
-            createFile('1.form', {
-              contents: 'linting-errors'
-            })
-          ]);
-
-          const { activeTab } = app.state;
-
-          await app.lintTab(activeTab, 'linting-errors');
-
-          await waitFor(() => {
-            const errors = app.getLintingState(activeTab);
-
-            expect(errors.some(e => e.id === 'Field_1')).to.be.true;
-          });
-
-          const tabComponent = app.tabRef.current;
-          tabComponent.currentContents = 'no-errors';
-
-          // when
-          app.emit('tab.engineProfileChanged', {
-            tab: activeTab,
-            executionPlatform: 'Camunda Platform',
-            executionPlatformVersion: '7.16'
-          });
-
-          // then
-          await waitFor(() => {
-            const errors = app.getLintingState(activeTab);
-
-            expect(errors.some(e => e.id === 'Field_1')).to.be.false;
-          });
-        });
-
-
-        it('should re-lint active BPMN (C7) tab with current editor contents', async function() {
-
-          // given
-          const { app } = createApp();
-
-          await app.createDiagram('bpmn');
-
-          await app.openFiles([
-            createFile('1.bpmn', {
-              contents: 'linting-errors'
-            })
-          ]);
-
-          const { activeTab } = app.state;
-
-          await app.lintTab(activeTab, 'linting-errors');
-
-          await waitFor(() => {
-            const errors = app.getLintingState(activeTab);
-
-            expect(errors.some(e => e.id === 'Task_1')).to.be.true;
-          });
-
-          const tabComponent = app.tabRef.current;
-          tabComponent.currentContents = 'no-errors';
-
-          // when
-          app.emit('tab.engineProfileChanged', {
-            tab: activeTab,
-            executionPlatform: 'Camunda Platform',
-            executionPlatformVersion: '7.16'
-          });
-
-          // then
-          await waitFor(() => {
-            const errors = app.getLintingState(activeTab);
-
-            expect(errors.some(e => e.id === 'Task_1')).to.be.false;
-          });
-        });
-
-
-        it('should re-lint non-active tab with file contents', async function() {
+        it('should record the selected engine profile in state', async function() {
 
           // given
           const { app } = createApp();
 
           await app.createDiagram('cloud-bpmn');
 
-          await app.openFiles([
-            createFile('1.cloud-bpmn', {
-              contents: 'linting-errors'
-            }),
-            createFile('2.cloud-bpmn', {
-              contents: 'no-errors'
-            })
-          ]);
-
-          // last opened tab is active, '1.cloud-bpmn' is background
-          const backgroundTab = app.state.tabs.find(t => t.file && t.file.path === '1.cloud-bpmn');
           const { activeTab } = app.state;
 
-          expect(activeTab).to.not.eql(backgroundTab);
-
-          await app.lintTab(backgroundTab, 'linting-errors');
-
-          await waitFor(() => {
-            const errors = app.getLintingState(backgroundTab);
-
-            expect(errors.some(e => e.id === 'Task_1')).to.be.true;
-          });
-
-          // when - engine profile changes on background tab
+          // when
           app.emit('tab.engineProfileChanged', {
-            tab: backgroundTab,
+            tab: activeTab,
             executionPlatform: 'Camunda Cloud',
             executionPlatformVersion: '8.8.0'
           });
 
-          // then - should use file contents (linting-errors), not editor contents,
-          // because the tab is not active
+          // then
           await waitFor(() => {
-            const errors = app.getLintingState(backgroundTab);
-
-            expect(errors.some(e => e.id === 'Task_1')).to.be.true;
+            expect(app.state.engineProfiles[ activeTab.id ]).to.eql({
+              executionPlatform: 'Camunda Cloud',
+              executionPlatformVersion: '8.8.0'
+            });
           });
+        });
+
+
+        it('should not re-lint content (the editor re-lints on the document change)', async function() {
+
+          // given
+          const { app } = createApp();
+
+          await app.createDiagram('cloud-bpmn');
+
+          const { activeTab } = app.state;
+
+          const lintTabSpy = sinon.spy(app, 'lintTab');
+
+          // when
+          app.emit('tab.engineProfileChanged', {
+            tab: activeTab,
+            executionPlatform: 'Camunda Cloud',
+            executionPlatformVersion: '8.8.0'
+          });
+
+          // then
+          await waitFor(() => {
+            expect(app.state.engineProfiles[ activeTab.id ].executionPlatformVersion).to.equal('8.8.0');
+          });
+
+          expect(lintTabSpy).to.not.have.been.called;
+        });
+
+
+        it('should recompose version warning from updated engine profile', async function() {
+
+          // given
+          const { app } = createApp();
+
+          await app.createDiagram('cloud-bpmn');
+
+          const { activeTab } = app.state;
+
+          app.emit('tab.engineProfileChanged', {
+            tab: activeTab,
+            executionPlatform: 'Camunda Cloud',
+            executionPlatformVersion: '8.7.0'
+          });
+
+          await waitFor(() => {
+            expect(app.state.engineProfiles[ activeTab.id ].executionPlatformVersion).to.equal('8.7.0');
+          });
+
+          app.emit('connectionManager.connectionStatusChanged', {
+            tab: activeTab,
+            success: true,
+            response: { gatewayVersion: '8.7.0' }
+          });
+
+          await waitFor(() => {
+            expect(app.state.connectionCheckResult.response.gatewayVersion).to.equal('8.7.0');
+            expect(app.state.engineProfiles[ activeTab.id ].executionPlatformVersion).to.equal('8.7.0');
+          });
+
+          const lintTabSpy = sinon.spy(app, 'lintTab');
+
+          // when
+          app.emit('tab.engineProfileChanged', {
+            tab: activeTab,
+            executionPlatform: 'Camunda Cloud',
+            executionPlatformVersion: '8.9.0'
+          });
+
+          // then
+          await waitFor(() => {
+            const warning = app.getLintingState(activeTab)
+              .find(r => r.rule === 'camunda/version-mismatch');
+
+            expect(warning).to.exist;
+            expect(warning.message).to.include('8.9');
+          });
+
+          expect(lintTabSpy).to.not.have.been.called;
+        });
+
+
+        it('should ignore events for a tab without an id', async function() {
+
+          // given
+          const { app } = createApp();
+
+          await app.createDiagram('cloud-bpmn');
+
+          const before = app.state.engineProfiles;
+
+          // when
+          app.emit('tab.engineProfileChanged', {
+            tab: { id: undefined },
+            executionPlatform: 'Camunda Cloud',
+            executionPlatformVersion: '8.8.0'
+          });
+
+          // then
+          expect(app.state.engineProfiles).to.equal(before);
         });
 
       });

--- a/client/src/app/tabs/LintingHelper.js
+++ b/client/src/app/tabs/LintingHelper.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { debounce } from 'min-dash';
+
+export const LINTING_DEBOUNCE_WAIT = 300;
+
+
+/**
+ * Schedules (debounced) linting for an editor and manages it across the
+ * editor's mount lifecycle.
+ *
+ * Linting is a follow-up computation that only makes sense for the tab the
+ * user is looking at: it is always scheduled (never run synchronously, e.g. on
+ * import) and coalesces bursts of triggers - a fresh import, element templates
+ * loading, engine profile changes - into a single run. Deferring the lint also
+ * lets the editor state (e.g. the imported document and its engine profile)
+ * settle before it runs.
+ *
+ * A lint scheduled while the tab is shown is cancelled when the tab is hidden
+ * (the editor unmounts) and resumed when it is shown again, so linting never
+ * runs for a hidden tab yet an owed lint is not lost.
+ *
+ * The pending marker lives in the (tab-scoped) editor cache so it survives the
+ * editor remounting when switching away and back to the tab.
+ */
+export default class LintingHelper {
+  constructor({ lint, getCached, setCached, timeout = LINTING_DEBOUNCE_WAIT }) {
+    this._getCached = getCached;
+    this._setCached = setCached;
+
+    this._scheduled = false;
+
+    this._debounced = debounce(() => {
+      this._scheduled = false;
+
+      lint();
+    }, timeout);
+
+    this.schedule = this.schedule.bind(this);
+    this.cancel = this.cancel.bind(this);
+    this.resume = this.resume.bind(this);
+    this.flush = this.flush.bind(this);
+  }
+
+  /**
+   * Schedule a (debounced) lint.
+   */
+  schedule() {
+    this._scheduled = true;
+
+    this._debounced();
+  }
+
+  /**
+   * Cancel a pending lint, remembering it so it can be resumed once the tab is
+   * shown again. Call on unmount.
+   */
+  cancel() {
+    if (!this._scheduled) {
+      return;
+    }
+
+    this._debounced.cancel();
+
+    this._scheduled = false;
+
+    this._setCached({ lintingPending: true });
+  }
+
+  /**
+   * Resume a lint that was pending when the tab was last hidden. Call on mount.
+   */
+  resume() {
+    if (!this._getCached().lintingPending) {
+      return;
+    }
+
+    this._setCached({ lintingPending: false });
+
+    this.schedule();
+  }
+
+  /**
+   * Immediately run a scheduled lint (if any). Primarily useful in tests.
+   */
+  flush() {
+    this._debounced.flush();
+  }
+}

--- a/client/src/app/tabs/__tests__/LintingHelperSpec.js
+++ b/client/src/app/tabs/__tests__/LintingHelperSpec.js
@@ -1,0 +1,204 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import LintingHelper from '../LintingHelper';
+
+
+describe('LintingHelper', function() {
+
+  let clock;
+
+  beforeEach(function() {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(function() {
+    clock.restore();
+  });
+
+
+  function createHelper(overrides = {}) {
+    let cached = {};
+
+    const lint = sinon.spy();
+
+    const defaults = {
+      lint,
+      timeout: 100,
+      getCached: () => cached,
+      setCached: (state) => {
+        cached = { ...cached, ...state };
+      }
+    };
+
+    const helper = new LintingHelper({ ...defaults, ...overrides });
+
+    return { helper, lint, getCached: () => cached };
+  }
+
+
+  describe('#schedule', function() {
+
+    it('should NOT lint synchronously', function() {
+
+      // given
+      const { helper, lint } = createHelper();
+
+      // when
+      helper.schedule();
+
+      // then
+      expect(lint).not.to.have.been.called;
+    });
+
+
+    it('should lint after debounce', function() {
+
+      // given
+      const { helper, lint } = createHelper();
+
+      helper.schedule();
+
+      // when
+      clock.tick(100);
+
+      // then
+      expect(lint).to.have.been.calledOnce;
+    });
+
+
+    it('should coalesce bursts into a single lint', function() {
+
+      // given
+      const { helper, lint } = createHelper();
+
+      // when
+      helper.schedule();
+      helper.schedule();
+      helper.schedule();
+
+      clock.tick(100);
+
+      // then
+      expect(lint).to.have.been.calledOnce;
+    });
+
+  });
+
+
+  describe('#flush', function() {
+
+    it('should run a scheduled lint immediately', function() {
+
+      // given
+      const { helper, lint } = createHelper();
+
+      helper.schedule();
+
+      // when
+      helper.flush();
+
+      // then
+      expect(lint).to.have.been.calledOnce;
+    });
+
+  });
+
+
+  describe('#cancel', function() {
+
+    it('should cancel a pending lint and persist it', function() {
+
+      // given
+      const { helper, lint, getCached } = createHelper();
+
+      helper.schedule();
+
+      // when
+      helper.cancel();
+
+      clock.tick(100);
+
+      // then
+      expect(lint).not.to.have.been.called;
+      expect(getCached().lintingPending).to.be.true;
+    });
+
+
+    it('should NOT persist when nothing is pending', function() {
+
+      // given
+      const { helper, getCached } = createHelper();
+
+      // when
+      helper.cancel();
+
+      // then
+      expect(getCached().lintingPending).not.to.be.true;
+    });
+
+  });
+
+
+  describe('#resume', function() {
+
+    it('should clear pending lint on resume', function() {
+
+      // given
+      const { helper, getCached } = createHelper();
+
+      helper.schedule();
+      helper.cancel();
+
+      // when
+      helper.resume();
+
+      // then
+      expect(getCached().lintingPending).to.be.false;
+    });
+
+
+    it('should lint after resumed debounce', function() {
+
+      // given
+      const { helper, lint } = createHelper();
+
+      helper.schedule();
+      helper.cancel();
+      helper.resume();
+
+      // when
+      clock.tick(100);
+
+      // then
+      expect(lint).to.have.been.calledOnce;
+    });
+
+
+    it('should NOT resume when nothing is pending', function() {
+
+      // given
+      const { helper, lint } = createHelper();
+
+      // when
+      helper.resume();
+
+      clock.tick(100);
+
+      // then
+      expect(lint).not.to.have.been.called;
+    });
+
+  });
+
+});

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -70,6 +70,8 @@ import {
 
 import EngineProfileHelper from '../EngineProfileHelper';
 
+import LintingHelper from '../LintingHelper';
+
 import {
   ENGINES
 } from '../../../util/Engines';
@@ -142,7 +144,11 @@ export class BpmnEditor extends CachedComponent {
 
     this.handleResize = debounce(this.handleResize);
 
-    this.handleLintingDebounced = debounce(this.handleLinting.bind(this));
+    this.linting = new LintingHelper({
+      lint: () => this.handleLinting(),
+      getCached: () => this.getCached(),
+      setCached: (state) => this.setCached(state)
+    });
     this.handlePropertiesPanelLayoutChange = this.handlePropertiesPanelLayoutChange.bind(this);
     this.handleLayoutChange = this.handleLayoutChange.bind(this);
   }
@@ -176,10 +182,14 @@ export class BpmnEditor extends CachedComponent {
 
 
     this.checkImport();
+
+    this.linting.resume();
   }
 
   componentWillUnmount() {
     this._isMounted = false;
+
+    this.linting.cancel();
 
     const modeler = this.getModeler();
 
@@ -270,9 +280,9 @@ export class BpmnEditor extends CachedComponent {
     modeler[fn]('propertiesPanel.layoutChanged', this.handlePropertiesPanelLayoutChange);
 
     if (fn === 'on') {
-      modeler[ fn ]('commandStack.changed', LOW_PRIORITY, this.handleLintingDebounced);
+      modeler[ fn ]('commandStack.changed', LOW_PRIORITY, this.linting.schedule);
     } else if (fn === 'off') {
-      modeler[ fn ]('commandStack.changed', this.handleLintingDebounced);
+      modeler[ fn ]('commandStack.changed', this.linting.schedule);
     }
 
     // reload templates on focus to pick up external edits to local template
@@ -380,7 +390,7 @@ export class BpmnEditor extends CachedComponent {
 
     this.props.onAction('element-templates-changed');
 
-    this.handleLintingDebounced();
+    this.linting.schedule();
   };
 
   handleAttach = (event) => {
@@ -496,11 +506,7 @@ export class BpmnEditor extends CachedComponent {
     }
 
     if (!error) {
-      try {
-        this.handleLinting(engineProfile);
-      } catch (err) {
-        error = err;
-      }
+      this.linting.schedule();
     }
 
     this.setState({

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -147,7 +147,7 @@ export class BpmnEditor extends CachedComponent {
     this.handleLayoutChange = this.handleLayoutChange.bind(this);
   }
 
-  async componentDidMount() {
+  componentDidMount() {
     this._isMounted = true;
 
     const {
@@ -174,12 +174,6 @@ export class BpmnEditor extends CachedComponent {
 
     propertiesPanel.attachTo(this.propertiesPanelRef.current);
 
-
-    try {
-      await this.loadTemplates();
-    } catch (error) {
-      this.handleError({ error });
-    }
 
     this.checkImport();
   }
@@ -437,7 +431,7 @@ export class BpmnEditor extends CachedComponent {
     return button === 'yes';
   }
 
-  handleImport = (error, warnings) => {
+  handleImport = async (error, warnings) => {
     const {
       isNew,
       onImport,
@@ -459,6 +453,18 @@ export class BpmnEditor extends CachedComponent {
     if (!error) {
       try {
         engineProfile = this.engineProfile.get(true);
+      } catch (err) {
+        error = err;
+      }
+    }
+
+    if (!error) {
+      try {
+
+        // load the element templates now that the diagram is imported, so they
+        // are validated once - against the imported diagram - rather than on
+        // mount (before the document is known)
+        await this.loadTemplates();
       } catch (err) {
         error = err;
       }

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -383,7 +383,8 @@ describe('<BpmnEditor>', function() {
 
     describe('behavior', function() {
 
-      let modeler,
+      let instance,
+          modeler,
           onActionSpy,
           rerender;
 
@@ -402,7 +403,7 @@ describe('<BpmnEditor>', function() {
         });
 
 
-        ({ rerender } = await renderEditor(diagramXML, {
+        ({ instance, rerender } = await renderEditor(diagramXML, {
           id: 'editor',
           cache,
           onAction: onActionSpy
@@ -412,8 +413,15 @@ describe('<BpmnEditor>', function() {
 
       it('should lint on import', async function() {
 
-        expect(onActionSpy).to.have.been.calledOnce;
-        expect(onActionSpy).to.have.been.calledWithMatch('lint-tab');
+        // then
+        await waitFor(() => {
+
+          // flush the pending lint instead of waiting out the debounce
+          instance.linting.flush();
+
+          const matchingCalls = onActionSpy.getCalls().filter(call => call.calledWithMatch('lint-tab'));
+          expect(matchingCalls).to.have.lengthOf(1);
+        });
       });
 
 
@@ -423,6 +431,8 @@ describe('<BpmnEditor>', function() {
 
         // when
         modeler._emit('commandStack.changed');
+
+        instance.linting.flush();
 
         // then
         expect(onActionSpy).to.have.been.calledOnce;
@@ -439,6 +449,8 @@ describe('<BpmnEditor>', function() {
           rerender();
 
           modeler._emit('commandStack.changed');
+
+          instance.linting.flush();
 
           // then
           expect(onActionSpy).to.have.been.calledOnce;
@@ -2045,6 +2057,8 @@ describe('<BpmnEditor>', function() {
 
       // when
       instance.getModeler()._emit('elementTemplates.changed');
+
+      instance.linting.flush();
 
       // then
       // the app is asked to invalidate the cached linter for this tab ...

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -1801,6 +1801,36 @@ describe('<BpmnEditor>', function() {
     });
 
 
+    it('should load element templates on import', async function() {
+
+      // given
+      const setTemplatesSpy = sinon.spy();
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: { setTemplates: setTemplatesSpy }
+            }
+          })
+        }
+      });
+
+      // when
+      await renderEditor(diagramXML, {
+        cache,
+        isNew: false,
+        getConfig: () => Promise.resolve([ { 'id': 'template-1' } ])
+      });
+
+      // then
+      // templates are loaded once, on import
+      expect(setTemplatesSpy).to.be.calledOnce;
+    });
+
+
     it('should not reload templates on save (unchanged path)', async function() {
 
       // given

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -500,13 +500,12 @@ export class BpmnEditor extends CachedComponent {
     } else {
       this.setCached({
         defaultTemplatesApplied,
-        engineProfile,
         lastXML: xml,
         stackIdx
       });
 
       if (engineProfile) {
-        this.emitEngineProfileChanged(engineProfile);
+        this.engineProfile.setCached(engineProfile);
       }
     }
 

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -75,6 +75,8 @@ import {
 
 import EngineProfileHelper from '../EngineProfileHelper';
 
+import LintingHelper from '../LintingHelper';
+
 import {
   ENGINES
 } from '../../../util/Engines';
@@ -150,7 +152,11 @@ export class BpmnEditor extends CachedComponent {
 
     this.handleResize = debounce(this.handleResize);
 
-    this.handleLintingDebounced = debounce(this.handleLinting.bind(this));
+    this.linting = new LintingHelper({
+      lint: () => this.handleLinting(),
+      getCached: () => this.getCached(),
+      setCached: (state) => this.setCached(state)
+    });
 
     this.handlePropertiesPanelLayoutChange = this.handlePropertiesPanelLayoutChange.bind(this);
     this.handleLayoutChange = this.handleLayoutChange.bind(this);
@@ -184,10 +190,14 @@ export class BpmnEditor extends CachedComponent {
     propertiesPanel.attachTo(this.propertiesPanelRef.current, this.propertiesPanelHeaderRef.current);
 
     this.checkImport();
+
+    this.linting.resume();
   }
 
   componentWillUnmount() {
     this._isMounted = false;
+
+    this.linting.cancel();
 
     const modeler = this.getModeler();
 
@@ -282,9 +292,9 @@ export class BpmnEditor extends CachedComponent {
     modeler[fn]('propertiesPanel.layoutChanged', this.handlePropertiesPanelLayoutChange);
 
     if (fn === 'on') {
-      modeler[ fn ]('commandStack.changed', LOW_PRIORITY, this.handleLintingDebounced);
+      modeler[ fn ]('commandStack.changed', LOW_PRIORITY, this.linting.schedule);
     } else if (fn === 'off') {
-      modeler[ fn ]('commandStack.changed', this.handleLintingDebounced);
+      modeler[ fn ]('commandStack.changed', this.linting.schedule);
     }
 
     // reload templates on focus to pick up external edits to local template
@@ -421,7 +431,7 @@ export class BpmnEditor extends CachedComponent {
 
     this.props.onAction('element-templates-changed');
 
-    this.handleLintingDebounced();
+    this.linting.schedule();
   };
 
   handleAttach = (event) => {
@@ -510,11 +520,7 @@ export class BpmnEditor extends CachedComponent {
     }
 
     if (!error) {
-      try {
-        this.handleLinting(engineProfile);
-      } catch (err) {
-        error = err;
-      }
+      this.linting.schedule();
     }
 
     this.setState({

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -156,7 +156,7 @@ export class BpmnEditor extends CachedComponent {
     this.handleLayoutChange = this.handleLayoutChange.bind(this);
   }
 
-  async componentDidMount() {
+  componentDidMount() {
     this._isMounted = true;
 
     const {
@@ -182,12 +182,6 @@ export class BpmnEditor extends CachedComponent {
     }
 
     propertiesPanel.attachTo(this.propertiesPanelRef.current, this.propertiesPanelHeaderRef.current);
-
-    try {
-      await this.loadTemplates();
-    } catch (error) {
-      this.handleError({ error });
-    }
 
     this.checkImport();
   }
@@ -448,7 +442,7 @@ export class BpmnEditor extends CachedComponent {
     onError(error);
   };
 
-  handleImport = (error, warnings) => {
+  handleImport = async (error, warnings) => {
     const {
       isNew,
       onImport,
@@ -470,6 +464,18 @@ export class BpmnEditor extends CachedComponent {
     if (!error) {
       try {
         engineProfile = this.engineProfile.get(true);
+      } catch (err) {
+        error = err;
+      }
+    }
+
+    if (!error) {
+      try {
+
+        // load the element templates now that the diagram is imported, so they
+        // are validated once - against the imported diagram - rather than on
+        // mount (before the document, and its execution platform, are known)
+        await this.loadTemplates();
       } catch (err) {
         error = err;
       }

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -375,16 +375,19 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
 
     describe('behavior', function() {
 
-      let modeler,
+      let cache,
+          instance,
+          modeler,
           onActionSpy,
-          rerender;
+          rerender,
+          unmount;
 
       beforeEach(async function() {
         modeler = new BpmnModeler();
 
         onActionSpy = spy();
 
-        const cache = new Cache();
+        cache = new Cache();
 
         cache.add('editor', {
           cached: {
@@ -399,7 +402,9 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
           onAction: onActionSpy
         });
 
+        instance = render.instance;
         rerender = render.rerender;
+        unmount = render.unmount;
       });
 
 
@@ -407,6 +412,10 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
 
         // then
         await waitFor(() => {
+
+          // flush the pending lint instead of waiting out the debounce
+          instance.linting.flush();
+
           const matchingCalls = onActionSpy.getCalls().filter(call => call.calledWithMatch('lint-tab'));
           expect(matchingCalls).to.have.lengthOf(1);
         });
@@ -419,6 +428,8 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
 
         // when
         modeler._emit('commandStack.changed');
+
+        instance.linting.flush();
 
         // then
         expect(onActionSpy).to.have.been.calledOnce;
@@ -436,11 +447,40 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
 
           modeler._emit('commandStack.changed');
 
+          instance.linting.flush();
+
           // then
           expect(onActionSpy).to.have.been.calledOnce;
           expect(onActionSpy).to.have.been.calledWithMatch('lint-tab');
         }
       );
+
+
+      it('should resume pending lint on remount', async function() {
+
+        // given
+        instance.linting.flush();
+        onActionSpy.resetHistory();
+
+        modeler._emit('commandStack.changed');
+        unmount();
+
+        // when
+        const { instance: remountedInstance } = await renderEditor(diagramXML, {
+          id: 'editor',
+          cache,
+          onAction: onActionSpy,
+          waitForImport: false
+        });
+
+        remountedInstance.linting.flush();
+
+        // then
+        const matchingCalls = onActionSpy.getCalls()
+          .filter(call => call.calledWithMatch('lint-tab'));
+
+        expect(matchingCalls).to.have.lengthOf(1);
+      });
 
     });
 
@@ -2176,6 +2216,8 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
 
       // when
       instance.getModeler()._emit('elementTemplates.changed');
+
+      instance.linting.flush();
 
       // then
       // the app is asked to invalidate the cached linter for this tab ...

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -2951,6 +2951,39 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
       });
     });
 
+
+    it('should NOT emit tab.engineProfileChanged event when engine profile unchanged', async function() {
+
+      // given
+      const emitSpy = sinon.spy();
+      const cache = new Cache();
+
+      const { unmount } = await renderEditor(engineProfileXML, {
+        cache,
+        emit: emitSpy,
+        id: 'editor'
+      });
+
+      emitSpy.resetHistory();
+      unmount();
+
+      const { instance } = await renderEditor(engineProfileXML, {
+        cache,
+        emit: emitSpy,
+        id: 'editor',
+        waitForImport: false
+      });
+
+      // when
+      instance.engineProfile.setCached({
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '1.1.0'
+      });
+
+      // then
+      expect(emitSpy).not.to.have.been.calledWith('tab.engineProfileChanged');
+    });
+
   });
 
 

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -2304,6 +2304,41 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
     });
 
 
+    it('should load element templates for existing diagram', async function() {
+
+      // given
+      const setTemplatesSpy = sinon.spy();
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new BpmnModeler({
+            modules: {
+              elementTemplatesLoader: { setTemplates: setTemplatesSpy }
+            }
+          })
+        }
+      });
+
+      // when
+      await renderEditor(engineProfileXML, {
+        cache,
+        isNew: false,
+        getConfig: () => Promise.resolve([
+          {
+            '$schema': 'https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json',
+            'id': 'template-1'
+          }
+        ])
+      });
+
+      // then
+      // templates are loaded once, on import
+      expect(setTemplatesSpy).to.be.calledOnce;
+    });
+
+
     it('should apply default templates to unsaved diagram', async function() {
 
       // given

--- a/client/src/app/tabs/cloud-dmn/DmnEditor.js
+++ b/client/src/app/tabs/cloud-dmn/DmnEditor.js
@@ -286,13 +286,12 @@ export class DmnEditor extends CachedComponent {
     } else {
       this.setCached({
         dirty: false,
-        engineProfile,
         lastXML: xml,
         stackIdx
       });
 
       if (engineProfile) {
-        this.emitEngineProfileChanged(engineProfile);
+        this.engineProfile.setCached(engineProfile);
       }
 
       this.setState({

--- a/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
@@ -2507,6 +2507,28 @@ describe('<DmnEditor>', function() {
       });
     });
 
+
+    it('should NOT emit tab.engineProfileChanged event when engine profile unchanged', async function() {
+
+      // given
+      const emitSpy = sinon.spy();
+
+      const { instance } = await renderEditor(engineProfileXML, {
+        emit: emitSpy
+      });
+
+      emitSpy.resetHistory();
+
+      // when
+      instance.engineProfile.setCached({
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '8.0.0'
+      });
+
+      // then
+      expect(emitSpy).not.to.have.been.calledWith('tab.engineProfileChanged');
+    });
+
   });
 
 });

--- a/client/src/app/tabs/form/FormEditor.js
+++ b/client/src/app/tabs/form/FormEditor.js
@@ -12,8 +12,6 @@ import React, { createRef } from 'react';
 
 import { isFunction, keys } from 'min-dash';
 
-import debounce from '../../../util/debounce';
-
 import {
   WithCache,
   WithCachedState,
@@ -40,6 +38,8 @@ import {
 } from '../EngineProfile';
 
 import EngineProfileHelper from '../EngineProfileHelper';
+
+import LintingHelper from '../LintingHelper';
 
 import { ENGINES } from '../../../util/Engines';
 
@@ -109,7 +109,11 @@ export class FormEditor extends CachedComponent {
       onChanged: (engineProfile) => this.emitEngineProfileChanged(engineProfile)
     });
 
-    this.handleLintingDebounced = debounce(() => this.handleLinting());
+    this.linting = new LintingHelper({
+      lint: () => this.handleLinting(),
+      getCached: () => this.getCached(),
+      setCached: (state) => this.setCached(state)
+    });
   }
 
   componentDidMount() {
@@ -127,10 +131,14 @@ export class FormEditor extends CachedComponent {
       // wait for proper instantiation
       form.on('formPlayground.rendered', this.handlePlaygroundRendered);
     }
+
+    this.linting.resume();
   }
 
   componentWillUnmount() {
     this._isMounted = false;
+
+    this.linting.cancel();
 
     const { form, lastSchema } = this.getCached();
 
@@ -257,7 +265,7 @@ export class FormEditor extends CachedComponent {
         this.engineProfile.setCached(engineProfile);
       }
 
-      this.handleLinting(engineProfile);
+      this.linting.schedule();
     }
 
     this.setState({
@@ -285,10 +293,10 @@ export class FormEditor extends CachedComponent {
     this.handleFormPreviewInteraction(fn);
 
     if (fn === 'on') {
-      editor.on('commandStack.changed', LOW_PRIORITY, this.handleLintingDebounced);
+      editor.on('commandStack.changed', LOW_PRIORITY, this.linting.schedule);
       form.on('formPlayground.layoutChanged', this.handlePlaygroundLayoutChanged);
     } else if (fn === 'off') {
-      editor.off('commandStack.changed', this.handleLintingDebounced);
+      editor.off('commandStack.changed', this.linting.schedule);
       form.off('formPlayground.layoutChanged', this.handlePlaygroundLayoutChanged);
     }
   }

--- a/client/src/app/tabs/form/FormEditor.js
+++ b/client/src/app/tabs/form/FormEditor.js
@@ -249,13 +249,12 @@ export class FormEditor extends CachedComponent {
       });
     } else {
       this.setCached({
-        engineProfile,
         lastSchema: schema,
         stackIdx
       });
 
       if (engineProfile) {
-        this.emitEngineProfileChanged(engineProfile);
+        this.engineProfile.setCached(engineProfile);
       }
 
       this.handleLinting(engineProfile);

--- a/client/src/app/tabs/form/__tests__/FormEditorSpec.js
+++ b/client/src/app/tabs/form/__tests__/FormEditorSpec.js
@@ -745,6 +745,32 @@ describe('<FormEditor>', function() {
     });
 
 
+    it('should NOT emit tab.engineProfileChanged event when engine profile unchanged', async function() {
+
+      // given
+      const emitSpy = spy();
+
+      const { instance } = await renderEditor(engineProfileSchema, {
+        emit: emitSpy
+      });
+
+      await waitFor(() => {
+        expect(emitSpy).to.have.been.calledWith('tab.engineProfileChanged');
+      });
+
+      emitSpy.resetHistory();
+
+      // when
+      instance.engineProfile.setCached({
+        executionPlatform: 'Camunda Platform',
+        executionPlatformVersion: '7.16.0'
+      });
+
+      // then
+      expect(emitSpy).not.to.have.been.calledWith('tab.engineProfileChanged');
+    });
+
+
   });
 
 

--- a/client/src/app/tabs/rpa/RPAEditor.js
+++ b/client/src/app/tabs/rpa/RPAEditor.js
@@ -20,7 +20,6 @@ import {
 import * as css from './RPAEditor.css';
 
 import {
-  debounce,
   isString
 } from 'min-dash';
 
@@ -42,13 +41,14 @@ import {
 } from '../EngineProfile';
 
 import EngineProfileHelper from '../EngineProfileHelper';
+
+import LintingHelper from '../LintingHelper';
+
 import { ENGINES } from '../../../util/Engines';
 
 export const DEFAULT_ENGINE_PROFILE = {
   executionPlatform: ENGINES.CLOUD
 };
-
-export const LINTING_DEBOUNCE_WAIT = 500;
 
 
 export class RPAEditor extends CachedComponent {
@@ -64,7 +64,12 @@ export class RPAEditor extends CachedComponent {
     this.propertiesPanelRef = React.createRef();
 
     this.handleLayoutChange = this.handleLayoutChange.bind(this);
-    this.handleLinting = debounce(this.handleLinting.bind(this), LINTING_DEBOUNCE_WAIT);
+
+    this.linting = new LintingHelper({
+      lint: () => this.handleLinting(),
+      getCached: () => this.getCached(),
+      setCached: (state) => this.setCached(state)
+    });
 
     this.engineProfile = new EngineProfileHelper({
       get: () => {
@@ -163,7 +168,7 @@ export class RPAEditor extends CachedComponent {
     this.setState({
       loading: false
     });
-    this.handleLinting();
+    this.linting.resume();
     this.props.onImport();
   }
 
@@ -238,6 +243,8 @@ export class RPAEditor extends CachedComponent {
   }
 
   componentWillUnmount() {
+    this.linting.cancel();
+
     const {
       editorContainer,
       propertiesContainer,
@@ -407,7 +414,7 @@ export class RPAEditor extends CachedComponent {
 
     this.handleEngineProfile();
 
-    this.handleLinting();
+    this.linting.schedule();
   };
 
   handleLayoutChange(newLayout) {

--- a/client/src/app/tabs/rpa/__tests__/RPAEditorSpec.js
+++ b/client/src/app/tabs/rpa/__tests__/RPAEditorSpec.js
@@ -238,7 +238,7 @@ describe('<RPAEditor>', function() {
           expect(onImportSpy).to.have.been.calledOnce;
         });
 
-        instance.handleLinting.flush();
+        instance.linting.flush();
 
         // then
         const calls = onActionSpy.getCalls()
@@ -263,7 +263,7 @@ describe('<RPAEditor>', function() {
           expect(onImportSpy).to.have.been.calledOnce;
         });
 
-        instance.handleLinting.flush();
+        instance.linting.flush();
 
         // when
         const { editor } = instance.getCached();
@@ -272,7 +272,7 @@ describe('<RPAEditor>', function() {
           editor.eventBus.fire('model.changed');
         });
 
-        instance.handleLinting.flush();
+        instance.linting.flush();
 
         // then
         const calls = onActionSpy.getCalls()
@@ -300,7 +300,7 @@ describe('<RPAEditor>', function() {
           expect(onImportSpy).to.have.been.calledOnce;
         });
 
-        instance.handleLinting.flush();
+        instance.linting.flush();
 
         const { editor } = instance.getCached();
 

--- a/client/src/app/tabs/rpa/__tests__/RPAEditorSpec.js
+++ b/client/src/app/tabs/rpa/__tests__/RPAEditorSpec.js
@@ -392,6 +392,32 @@ describe('<RPAEditor>', function() {
       });
     });
 
+
+    it('should NOT emit tab.engineProfileChanged event when engine profile unchanged', async function() {
+
+      // given
+      const emitSpy = sinon.spy();
+
+      const { instance } = renderEditor(RPA, {
+        emit: emitSpy
+      });
+
+      await waitFor(() => {
+        expect(emitSpy).to.have.been.calledWith('tab.engineProfileChanged');
+      });
+
+      emitSpy.resetHistory();
+
+      // when
+      instance.engineProfile.setCached({
+        executionPlatform: 'Camunda Cloud',
+        executionPlatformVersion: '8.8.0'
+      });
+
+      // then
+      expect(emitSpy).not.to.have.been.calledWith('tab.engineProfileChanged');
+    });
+
   });
 
 });


### PR DESCRIPTION
### Proposed Changes

> [!NOTE]
> Found in the process of reviewing #6099 - follow-up to https://github.com/camunda/camunda-modeler/issues/5557.

The desktop modeler re-lints and reloads element templates far more often than necessary, especially around tab open, element template loading, and cluster connection polling. This reworks linting so it is always a debounced, editor-owned follow-up instead of synchronous, App-orchestrated work.

Structured as a semantic stack:

- **`load element templates on import, not on mount`** — templates are loaded (and validated) once, against the imported document, rather than on every editor mount before the document is known.
- **`only emit engineProfileChanged on actual change`** — editors detect their engine profile on every import; the event now fires only when the profile really changed, so consumers no longer compensate for redundant events.
- **`schedule linting through a debounced, lifecycle-aware helper`** — a shared `LintingHelper` debounces and coalesces lint triggers (import, templates, engine profile), never runs synchronously, and cancels a pending lint when a tab is hidden / resumes it when shown again. Wired into all four linting editors.
- **`compose version warnings as an additional lint source`** — version-mismatch warnings are derived from app state (cluster version, engine profile) and composed with the content lint results on read, rather than merged into the linter's output. This removes all App-side re-lint orchestration: both the connection- and engine-profile handlers become pure state setters, and the warning can never drift or be dropped by an interleaving content re-lint.

The last change (`refactor`) aligns with `EngineProfileHelper` - extracting the core of the linting behavior into a helper (instead of duplicating it across many tabs).

### Steps to try out

```
npm run dev
```

In the Modeler:

* Open `DEV` console, then
* open different tabs (form, bpmn)
* observe DEV console (linting)
  * for tab open
  * for file change
  * for refocus
  * for file reload

:arrow_right: see that there is no superficial linting happening 

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)