### PR TITLE
feat(client): consume linting autofix 0.2.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "@camunda/form-playground": "^0.26.0",
     "@camunda/improved-canvas": "^1.11.0",
     "@camunda/linting": "^3.54.1",
-    "@camunda/linting-autofix": "^0.1.1",
+    "@camunda/linting-autofix": "^0.2.0",
     "@camunda/rpa-integration": "^1.3.4",
     "@camunda/task-testing": "^6.0.1",
     "@carbon/icons-react": "^11.53.0",

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -90,6 +90,11 @@ const FILTER_ALL_EXTENSIONS = {
 
 const EMPTY_LINTING_STATE = [];
 
+const LINTING_FIX_TAB_TYPES = [
+  'bpmn',
+  'cloud-bpmn'
+];
+
 /**
  * Additional lint sources contribute warnings on top of the content linter's
  * results. Unlike content linting - which is expensive and cached per tab -
@@ -1197,7 +1202,11 @@ export class App extends PureComponent {
   };
 
   resolveLintingFix = (tab, report) => {
-    if (tab !== this.state.activeTab || !this.tabRef.current) {
+    if (
+      tab !== this.state.activeTab ||
+      !LINTING_FIX_TAB_TYPES.includes(tab.type) ||
+      !this.tabRef.current
+    ) {
       return null;
     }
 

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1174,7 +1174,34 @@ export class App extends PureComponent {
       log('linted tab', { tabId: tab.id });
     }
 
+    results = await Promise.all(results.map(async report => {
+      const resolvedFix = await this.resolveLintingFix(tab, report);
+
+      if (!resolvedFix) {
+        return report;
+      }
+
+      return {
+        ...report,
+        action: {
+          handler: 'apply-linting-fix',
+          label: resolvedFix.label,
+          ariaLabel: resolvedFix.ariaLabel,
+          title: resolvedFix.tooltip,
+          options: { report }
+        }
+      };
+    }));
+
     this.setLintingState(tab, results);
+  };
+
+  resolveLintingFix = (tab, report) => {
+    if (tab !== this.state.activeTab || !this.tabRef.current) {
+      return null;
+    }
+
+    return this.tabRef.current.triggerAction('resolve-linting-fix', { report });
   };
 
   /**

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1101,6 +1101,10 @@ export class App extends PureComponent {
       },
       tabLoadingState: 'shown'
     });
+
+    this.resolveStoredLintingFixes(tab).catch(error => {
+      this.handleError(error, tab);
+    });
   };
 
   /**
@@ -1179,26 +1183,56 @@ export class App extends PureComponent {
       log('linted tab', { tabId: tab.id });
     }
 
-    results = await Promise.all(results.map(async report => {
-      const resolvedFix = await this.resolveLintingFix(tab, report);
+    if (tab !== this.state.activeTab) {
+      this.setLintingState(tab, results);
+
+      return;
+    }
+
+    results = await this.resolveLintingFixes(tab, results);
+
+    this.setLintingState(tab, results);
+  };
+
+  resolveLintingFixes = (tab, reports) => {
+    return Promise.all(reports.map(async report => {
+      const unresolvedReport = removeLintingFixAction(report);
+      const resolvedFix = await this.resolveLintingFix(tab, unresolvedReport);
 
       if (!resolvedFix) {
-        return report;
+        return unresolvedReport;
       }
 
       return {
-        ...report,
+        ...unresolvedReport,
         action: {
           handler: 'apply-linting-fix',
           label: resolvedFix.label,
           ariaLabel: resolvedFix.ariaLabel,
           title: resolvedFix.tooltip,
-          options: { report }
+          options: { report: unresolvedReport }
         }
       };
     }));
+  };
 
-    this.setLintingState(tab, results);
+  resolveStoredLintingFixes = async (tab) => {
+    const results = this.state.lintingState[ tab.id ];
+
+    if (!results || !LINTING_FIX_TAB_TYPES.includes(tab.type)) {
+      return;
+    }
+
+    const resolvedResults = await this.resolveLintingFixes(tab, results);
+
+    if (
+      tab !== this.state.activeTab ||
+      results !== this.state.lintingState[ tab.id ]
+    ) {
+      return;
+    }
+
+    this.setLintingState(tab, resolvedResults);
   };
 
   resolveLintingFix = (tab, report) => {
@@ -2924,6 +2958,18 @@ function getNextTab(tabs, activeTab, direction) {
   }
 
   return tabs[nextIdx];
+}
+
+function removeLintingFixAction(report) {
+  if (report.action?.handler !== 'apply-linting-fix') {
+    return report;
+  }
+
+  const unresolvedReport = { ...report };
+
+  delete unresolvedReport.action;
+
+  return unresolvedReport;
 }
 
 export default WithCache(App);

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -4559,6 +4559,94 @@ describe('<App>', function() {
     });
 
 
+    it('should expose shared lint fixes as Problems actions', async function() {
+
+      // given
+      const { app } = createApp();
+
+      const [ currentTab ] = await app.openFiles([
+        createFile('1.form', {
+          contents: 'foo'
+        })
+      ]);
+
+      const report = {
+        id: 'Task_1',
+        message: 'Fixable finding'
+      };
+
+      sinon.stub(app, 'getTabLinter').resolves({
+        lint: async () => [ report ]
+      });
+
+      const resolvedFix = {
+        label: 'Input from agent',
+        ariaLabel: 'Input from agent: fill in the key as count',
+        tooltip: 'Fill in the key as count.'
+      };
+
+      const triggerAction = sinon.stub().resolves(resolvedFix);
+
+      app.tabRef.current = { triggerAction };
+
+      // when
+      await app.lintTab(currentTab);
+
+      // then
+      await waitFor(() => {
+        expect(app.getLintingState(currentTab)).to.have.length(1);
+      });
+
+      const [ result ] = app.getLintingState(currentTab);
+
+      expect(triggerAction).to.have.been.calledOnceWith(
+        'resolve-linting-fix',
+        { report }
+      );
+      expect(result.action).to.deep.equal({
+        handler: 'apply-linting-fix',
+        label: resolvedFix.label,
+        ariaLabel: resolvedFix.ariaLabel,
+        title: resolvedFix.tooltip,
+        options: { report }
+      });
+    });
+
+
+    it('should not expose a Problems action without a shared resolved fix', async function() {
+
+      // given
+      const { app } = createApp();
+
+      const [ currentTab ] = await app.openFiles([
+        createFile('1.form', {
+          contents: 'foo'
+        })
+      ]);
+
+      const report = {
+        id: 'Task_1',
+        message: 'Stale finding'
+      };
+
+      sinon.stub(app, 'getTabLinter').resolves({
+        lint: async () => [ report ]
+      });
+
+      app.tabRef.current = {
+        triggerAction: sinon.stub().resolves(null)
+      };
+
+      // when
+      await app.lintTab(currentTab);
+
+      // then
+      await waitFor(() => {
+        expect(app.getLintingState(currentTab)).to.deep.equal([ report ]);
+      });
+    });
+
+
     it('should lint tab (custom contents)', async function() {
 
       // given

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -4565,7 +4565,7 @@ describe('<App>', function() {
       const { app } = createApp();
 
       const [ currentTab ] = await app.openFiles([
-        createFile('1.form', {
+        createFile('1.bpmn', {
           contents: 'foo'
         })
       ]);
@@ -4613,13 +4613,49 @@ describe('<App>', function() {
     });
 
 
+    it('should not resolve BPMN fixes for DMN reports', async function() {
+
+      // given
+      const { app } = createApp();
+
+      const [ currentTab ] = await app.openFiles([
+        createFile('1.dmn', {
+          contents: 'foo'
+        })
+      ]);
+
+      const report = {
+        id: 'Decision_1',
+        message: 'DMN finding'
+      };
+
+      sinon.stub(app, 'getTabLinter').resolves({
+        lint: async () => [ report ]
+      });
+
+      const triggerAction = sinon.stub().throws(new Error('unknown action'));
+
+      app.tabRef.current = { triggerAction };
+
+      // when
+      await app.lintTab(currentTab);
+
+      // then
+      await waitFor(() => {
+        expect(app.getLintingState(currentTab)).to.deep.equal([ report ]);
+      });
+
+      expect(triggerAction).not.to.have.been.called;
+    });
+
+
     it('should not expose a Problems action without a shared resolved fix', async function() {
 
       // given
       const { app } = createApp();
 
       const [ currentTab ] = await app.openFiles([
-        createFile('1.form', {
+        createFile('1.bpmn', {
           contents: 'foo'
         })
       ]);

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -4613,6 +4613,114 @@ describe('<App>', function() {
     });
 
 
+    it('should resolve shared lint fixes after returning to a tab', async function() {
+
+      // given
+      const { app } = createApp();
+
+      const [ currentTab ] = await app.openFiles([
+        createFile('1.bpmn', {
+          contents: 'foo'
+        })
+      ]);
+
+      const report = {
+        id: 'Task_1',
+        message: 'Fixable finding'
+      };
+
+      const linting = pDefer();
+
+      sinon.stub(app, 'getTabLinter').resolves({
+        lint: () => linting.promise
+      });
+
+      sinon.stub(app, 'setLintingState').callsFake((tab, results) => {
+        app.state.lintingState = {
+          ...app.state.lintingState,
+          [ tab.id ]: results
+        };
+      });
+
+      const resolvedFix = {
+        label: 'Input from agent',
+        ariaLabel: 'Input from agent: fill in the key as count',
+        tooltip: 'Fill in the key as count.'
+      };
+
+      const resolveLintingFix = sinon.stub(app, 'resolveLintingFix').resolves(resolvedFix);
+
+      const lintTab = app.lintTab(currentTab);
+
+      app.state.activeTab = { id: 'other-tab' };
+      linting.resolve([ report ]);
+
+      await lintTab;
+
+      expect(app.getLintingState(currentTab)).to.deep.equal([ report ]);
+      expect(resolveLintingFix).not.to.have.been.called;
+
+      // when
+      app.state.activeTab = currentTab;
+      await app.resolveStoredLintingFixes(currentTab);
+
+      // then
+      expect(app.getLintingState(currentTab)[0].action).to.deep.equal({
+        handler: 'apply-linting-fix',
+        label: resolvedFix.label,
+        ariaLabel: resolvedFix.ariaLabel,
+        title: resolvedFix.tooltip,
+        options: { report }
+      });
+
+      expect(resolveLintingFix).to.have.been.calledWith(currentTab, report);
+    });
+
+
+    it('should remove a stale shared lint fix after returning to a tab', async function() {
+
+      // given
+      const { app } = createApp();
+
+      const [ currentTab ] = await app.openFiles([
+        createFile('1.bpmn', {
+          contents: 'foo'
+        })
+      ]);
+
+      const report = {
+        id: 'Task_1',
+        message: 'Stale finding'
+      };
+
+      sinon.stub(app, 'setLintingState').callsFake((tab, results) => {
+        app.state.lintingState = {
+          ...app.state.lintingState,
+          [ tab.id ]: results
+        };
+      });
+
+      app.state.lintingState = {
+        [ currentTab.id ]: [ {
+          ...report,
+          action: {
+            handler: 'apply-linting-fix',
+            label: 'Fix',
+            options: { report }
+          }
+        } ]
+      };
+
+      sinon.stub(app, 'resolveLintingFix').resolves(null);
+
+      // when
+      await app.resolveStoredLintingFixes(currentTab);
+
+      // then
+      expect(app.getLintingState(currentTab)).to.deep.equal([ report ]);
+    });
+
+
     it('should not resolve BPMN fixes for DMN reports', async function() {
 
       // given

--- a/client/src/app/panel/tabs/linting/LintingTab.css
+++ b/client/src/app/panel/tabs/linting/LintingTab.css
@@ -65,25 +65,34 @@
     }
 
     .linting-tab-item__button {
-      margin-left: 4px;
-      margin-right: 4px;
+      &:not(.agent-config-autofill-button) {
+        margin-left: 4px;
+        margin-right: 4px;
 
-      background: none;
-      border: none;
-      padding: 0;
-      cursor: pointer;
-      text-decoration: underline;
-      font: inherit;
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        text-decoration: underline;
+        font: inherit;
 
-      color: var(--color-blue-205-100-50);
+        color: var(--color-blue-205-100-50);
 
-      &:hover {
-        color: var(--color-blue-205-100-45);
+        &:hover {
+          color: var(--color-blue-205-100-45);
+        }
+
+        &:focus {
+          outline: 2px solid #0066cc;
+          outline-offset: 2px;
+        }
       }
 
-      &:focus {
-        outline: 2px solid #0066cc;
-        outline-offset: 2px;
+      &.agent-config-autofill-button {
+        margin-left: 8px;
+        margin-right: 4px;
+        font-size: 11px;
+        vertical-align: middle;
       }
     }
 

--- a/client/src/app/panel/tabs/linting/LintingTab.js
+++ b/client/src/app/panel/tabs/linting/LintingTab.js
@@ -150,7 +150,8 @@ function LintingTabItem(props) {
               stopPropagation(event);
               onAction(report.action.handler, report.action.options);
             } }
-            title={ report.action.label }>
+            aria-label={ report.action.ariaLabel }
+            title={ report.action.title || report.action.label }>
             { report.action.label }
           </button>
         )

--- a/client/src/app/panel/tabs/linting/LintingTab.js
+++ b/client/src/app/panel/tabs/linting/LintingTab.js
@@ -144,7 +144,9 @@ function LintingTabItem(props) {
       {
         report.action && (
           <button
-            className="linting-tab-item__button"
+            className={ classnames('linting-tab-item__button', {
+              'agent-config-autofill-button': report.action.handler === 'apply-linting-fix'
+            }) }
             onClick={ (event) => {
               event.preventDefault();
               stopPropagation(event);

--- a/client/src/app/panel/tabs/linting/__tests__/LintingTabSpec.js
+++ b/client/src/app/panel/tabs/linting/__tests__/LintingTabSpec.js
@@ -234,20 +234,21 @@ describe('<LintingTab>', function() {
           message: 'This file targets Camunda 8.7, but the connected cluster runs Camunda 8.8.',
           rule: 'camunda/version-mismatch',
           action: {
-            label: 'Update engine profile to 8.8',
-            handler: 'set-engine-profile',
-            options: {
-              executionPlatformVersion: '8.8.0'
-            }
+            label: 'Input from agent',
+            ariaLabel: 'Input from agent: fill in the key as count',
+            title: 'Fill in the key as count.',
+            handler: 'apply-linting-fix',
+            options: { report: {} }
           }
         }
       ]
     });
 
     // then
-    const link = getByRole('button', { name: 'Update engine profile to 8.8' });
+    const link = getByRole('button', { name: 'Input from agent: fill in the key as count' });
     expect(link).to.exist;
-    expect(link.textContent).to.equal('Update engine profile to 8.8');
+    expect(link.textContent).to.equal('Input from agent');
+    expect(link.title).to.equal('Fill in the key as count.');
   });
 
 

--- a/client/src/app/panel/tabs/linting/__tests__/LintingTabSpec.js
+++ b/client/src/app/panel/tabs/linting/__tests__/LintingTabSpec.js
@@ -249,6 +249,7 @@ describe('<LintingTab>', function() {
     expect(link).to.exist;
     expect(link.textContent).to.equal('Input from agent');
     expect(link.title).to.equal('Fill in the key as count.');
+    expect(link.classList.contains('agent-config-autofill-button')).to.be.true;
   });
 
 

--- a/client/src/app/tabs/bpmn-shared/LintingFix.js
+++ b/client/src/app/tabs/bpmn-shared/LintingFix.js
@@ -32,8 +32,7 @@ export function resolveLintingFix(modeler, report) {
 }
 
 export function applyLintingFix(modeler, report) {
-  const element = getReportElement(modeler, report);
-  const resolvedFix = resolveFix(report, element);
+  const resolvedFix = resolveLintingFix(modeler, report);
 
   if (!resolvedFix) {
     return;

--- a/client/src/app/tabs/bpmn-shared/LintingFix.js
+++ b/client/src/app/tabs/bpmn-shared/LintingFix.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import {
+  resolveFix,
+  shouldOfferFix
+} from '@camunda/linting-autofix';
+
+function getReportElement(modeler, report) {
+  if (!report) {
+    return null;
+  }
+
+  return modeler.get('elementRegistry').get(report.id);
+}
+
+export function resolveLintingFix(modeler, report) {
+  const element = getReportElement(modeler, report);
+
+  if (!shouldOfferFix(report, element)) {
+    return null;
+  }
+
+  return resolveFix(report, element);
+}
+
+export function applyLintingFix(modeler, report) {
+  const element = getReportElement(modeler, report);
+  const resolvedFix = resolveFix(report, element);
+
+  if (!resolvedFix) {
+    return;
+  }
+
+  const commands = resolvedFix.apply();
+
+  if (!commands.length) {
+    return;
+  }
+
+  modeler.get('linting').showError(report);
+  modeler.get('commandStack').execute('properties-panel.multi-command-executor', commands);
+}

--- a/client/src/app/tabs/bpmn-shared/__tests__/LintingFixSpec.js
+++ b/client/src/app/tabs/bpmn-shared/__tests__/LintingFixSpec.js
@@ -71,9 +71,23 @@ describe('LintingFix', function() {
     expect(commandStack.execute).not.to.have.been.called;
   });
 
+
+  it('should do nothing when the reported element was removed', function() {
+
+    // given
+    const { commandStack, linting, modeler, report } = createScenario('=fromAi(url)', false);
+
+    // when
+    applyLintingFix(modeler, report);
+
+    // then
+    expect(linting.showError).not.to.have.been.called;
+    expect(commandStack.execute).not.to.have.been.called;
+  });
+
 });
 
-function createScenario(source) {
+function createScenario(source, elementExists = true) {
   const moddleElement = {
     source,
     target: 'url',
@@ -107,7 +121,7 @@ function createScenario(source) {
   const services = {
     commandStack,
     elementRegistry: {
-      get: () => element
+      get: () => elementExists ? element : null
     },
     linting
   };

--- a/client/src/app/tabs/bpmn-shared/__tests__/LintingFixSpec.js
+++ b/client/src/app/tabs/bpmn-shared/__tests__/LintingFixSpec.js
@@ -1,0 +1,125 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+import {
+  applyLintingFix,
+  resolveLintingFix
+} from '../LintingFix';
+
+describe('LintingFix', function() {
+
+  it('should expose shared fix presentation metadata', function() {
+
+    // given
+    const { modeler, report } = createScenario('=fromAi(42)');
+
+    // when
+    const resolvedFix = resolveLintingFix(modeler, report);
+
+    // then
+    expect(resolvedFix).to.include({
+      label: 'Input from agent',
+      kind: 'autofill'
+    });
+    expect(resolvedFix.ariaLabel).to.match(/^Input from agent: /);
+    expect(resolvedFix.tooltip).to.be.a('string').and.not.be.empty;
+  });
+
+
+  it('should apply shared commands as one undo unit', function() {
+
+    // given
+    const { commandStack, linting, modeler, report } = createScenario('=fromAi(url)');
+
+    // when
+    applyLintingFix(modeler, report);
+
+    // then
+    expect(linting.showError).to.have.been.calledOnceWith(report);
+    expect(commandStack.execute).to.have.been.calledOnce;
+
+    const [ command, commands ] = commandStack.execute.firstCall.args;
+
+    expect(command).to.equal('properties-panel.multi-command-executor');
+    expect(commands).to.have.length(1);
+    expect(commands[ 0 ]).to.deep.include({
+      cmd: 'element.updateModdleProperties'
+    });
+  });
+
+
+  it('should do nothing when a report has become stale', function() {
+
+    // given
+    const { commandStack, linting, modeler, report } = createScenario('=fromAi(toolCall.url)');
+
+    // when
+    applyLintingFix(modeler, report);
+
+    // then
+    expect(linting.showError).not.to.have.been.called;
+    expect(commandStack.execute).not.to.have.been.called;
+  });
+
+});
+
+function createScenario(source) {
+  const moddleElement = {
+    source,
+    target: 'url',
+    get(property) {
+      return this[ property ];
+    }
+  };
+
+  const element = {
+    businessObject: moddleElement
+  };
+
+  const report = {
+    id: 'Task_1',
+    path: [ 'source' ],
+    data: {
+      fix: {
+        kind: 'fix'
+      }
+    }
+  };
+
+  const commandStack = {
+    execute: spy()
+  };
+
+  const linting = {
+    showError: spy()
+  };
+
+  const services = {
+    commandStack,
+    elementRegistry: {
+      get: () => element
+    },
+    linting
+  };
+
+  const modeler = {
+    get: service => services[ service ]
+  };
+
+  return {
+    commandStack,
+    linting,
+    modeler,
+    report
+  };
+}

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -19,6 +19,11 @@ import {
 } from '../../primitives';
 
 import {
+  applyLintingFix,
+  resolveLintingFix
+} from '../bpmn-shared/LintingFix';
+
+import {
   debounce
 } from '../../../util';
 
@@ -839,6 +844,14 @@ export class BpmnEditor extends CachedComponent {
       this.getModeler().get('linting').showError(context);
 
       return;
+    }
+
+    if (action === 'resolve-linting-fix') {
+      return resolveLintingFix(modeler, context.report);
+    }
+
+    if (action === 'apply-linting-fix') {
+      return applyLintingFix(modeler, context.report);
     }
 
     if (action === 'elementTemplates.reload') {

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -1248,6 +1248,26 @@ describe('<BpmnEditor>', function() {
       expect(showErrorSpy).to.have.been.calledWithMatch(lintError);
     });
 
+
+    it('should route linting fix actions', async function() {
+
+      // given
+      const { instance } = await renderEditor(diagramXML);
+      const context = {
+        report: {
+          id: 'missing'
+        }
+      };
+
+      // when
+      const resolvedFix = instance.triggerAction('resolve-linting-fix', context);
+      const applyResult = instance.triggerAction('apply-linting-fix', context);
+
+      // then
+      expect(resolvedFix).to.be.null;
+      expect(applyResult).to.be.undefined;
+    });
+
   });
 
 

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -19,6 +19,11 @@ import {
 } from '../../primitives';
 
 import {
+  applyLintingFix,
+  resolveLintingFix
+} from '../bpmn-shared/LintingFix';
+
+import {
   debounce
 } from '../../../util';
 
@@ -873,6 +878,14 @@ export class BpmnEditor extends CachedComponent {
       this.getModeler().get('linting').showError(context);
 
       return;
+    }
+
+    if (action === 'resolve-linting-fix') {
+      return resolveLintingFix(modeler, context.report);
+    }
+
+    if (action === 'apply-linting-fix') {
+      return applyLintingFix(modeler, context.report);
     }
 
     if (action === 'set-engine-profile') {

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -1196,6 +1196,26 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
       expect(showErrorSpy).to.have.been.calledWithMatch(lintError);
     });
 
+
+    it('should route linting fix actions', async function() {
+
+      // given
+      const { instance } = await renderEditor(diagramXML);
+      const context = {
+        report: {
+          id: 'missing'
+        }
+      };
+
+      // when
+      const resolvedFix = instance.triggerAction('resolve-linting-fix', context);
+      const applyResult = instance.triggerAction('apply-linting-fix', context);
+
+      // then
+      expect(resolvedFix).to.be.null;
+      expect(applyResult).to.be.undefined;
+    });
+
   });
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -174,7 +174,7 @@
         "@camunda/form-playground": "^0.26.0",
         "@camunda/improved-canvas": "^1.11.0",
         "@camunda/linting": "^3.54.1",
-        "@camunda/linting-autofix": "^0.1.1",
+        "@camunda/linting-autofix": "^0.2.0",
         "@camunda/rpa-integration": "^1.3.4",
         "@camunda/task-testing": "^6.0.1",
         "@carbon/icons-react": "^11.53.0",
@@ -2737,9 +2737,9 @@
       }
     },
     "node_modules/@camunda/linting-autofix": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@camunda/linting-autofix/-/linting-autofix-0.1.1.tgz",
-      "integrity": "sha512-qsJsG5mDNFD+6QaOSCtLuDGl40IZKJpPJ8iNDk1zQTSmkSD7v3NZPmd8jZynkck8DPBSW5Fw+s5AAYJ+By5Cwg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@camunda/linting-autofix/-/linting-autofix-0.2.0.tgz",
+      "integrity": "sha512-8nSNiw0uQz7XtafdDC5UT69b+W3Bz/vMCKuuJcfqUPOwn9M+O3ARIGGnR06kMZGb3nOSzpmrRWkyKHuNhmqzsA==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/feelin": "^6.1.0",


### PR DESCRIPTION
### Proposed Changes

Closes https://github.com/camunda/camunda-modeler/issues/6145.

Adopt `@camunda/linting-autofix@0.2.0` in Desktop Modeler to provide three user-facing agent-tool configuration features:

1. **Goal-oriented assistance in the Properties panel.** Invalid or incomplete agent input/output mappings offer the shared action that describes the builder's goal: `Fix`, `Input from agent`, `Output to agent`, or `Move to "<entry element>"`. The generic visible `Autofill` label is removed.
2. **The same one-click assistance in the Problems panel.** Action label, tooltip, eligibility, and commands come from the shared live-model resolver, so both surfaces apply the same correction as one undoable change. Stale, ambiguous, or unsafe findings keep their guidance without exposing an action.
3. **Warning visibility in the Properties.** Warnings now appear with a highlighted field and orange badge. Errors still take precedence

This lets builders repair deterministic agent-tool configuration issues where they discover them, without Desktop duplicating correction policy from the shared package.

Shared implementation: https://github.com/camunda/linting-autofix/pull/21  
Canonical Epic 35 contract: https://github.com/camunda/agentic-orchestration-pod/pull/21 at [`d055a303`](https://github.com/camunda/agentic-orchestration-pod/commit/d055a303b6666c8dd536fa501afdc950f5b5405f)

**Actions offered and warnings available in Properties and Problems**

https://github.com/user-attachments/assets/dfa4c394-db47-42df-a563-acecc77653a2

![Desktop Modeler showing a Fix action beside the Properties-panel validation and Fix/Input from agent actions in Problems](https://github.com/user-attachments/assets/fd46f5e7-6fac-4472-a6b2-4b0bcf3d9f4c)

**After applying `Input from agent`** — the generated `fromAi(toolCall…)` value is visible and that Problems item is gone.

![Desktop Modeler after applying Input from agent, with the generated value in Properties and the corresponding Problems item removed](https://github.com/user-attachments/assets/6bfae855-0833-400d-964b-ecebfb8448ce)

**Steps to try out**

1. Run `cd /Users/eric.lundberg/GitHub/copilot-worktrees/camunda-modeler/pr-6118-feat-agent-config-autofix-0.2.0 && npm install && npm run dev -- test/e2e/fixtures/agentic-tool.bpmn`.
2. Select **Fetch URL**, open **Input mapping**, and expand the `url` mapping.
4. Observe the `Fix` action beside the Properties validation and on the matching Problems row; activate it and undo once to restore the original value.
5. Change the source to `=fromAi(42)` and observe `Input from agent` on both surfaces; activate it to generate the safe mapping in one undoable change.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)