### PR TITLE
fix(dmn): ignore unsupported lint error actions

### DIFF
--- a/client/src/app/tabs/cloud-dmn/DmnEditor.js
+++ b/client/src/app/tabs/cloud-dmn/DmnEditor.js
@@ -795,6 +795,10 @@ export class DmnEditor extends CachedComponent {
       });
     }
 
+    if (action === 'showLintError') {
+      return;
+    }
+
     return modeler.getActiveViewer()
       .get('editorActions')
       .trigger(action, context);

--- a/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
@@ -1407,6 +1407,35 @@ describe('<DmnEditor>', function() {
 
   describe('#triggerAction', function() {
 
+    it('should NOT trigger editor action for lint error', async function() {
+
+      // given
+      const triggerSpy = sinon.spy();
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new DmnModeler({
+            editorActions: {
+              trigger: triggerSpy
+            }
+          })
+        }
+      });
+
+      const { instance } = await renderEditor(diagramXML, { cache });
+
+      triggerSpy.resetHistory();
+
+      // when
+      instance.triggerAction('showLintError', { id: 'foo' });
+
+      // then
+      expect(triggerSpy).not.to.have.been.called;
+    });
+
+
     it('should return value of editor action', async function() {
 
       // given

--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -771,6 +771,10 @@ export class DmnEditor extends CachedComponent {
       return this.resetOverview();
     }
 
+    if (action === 'showLintError') {
+      return;
+    }
+
     return modeler.getActiveViewer()
       .get('editorActions')
       .trigger(action, context);

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -1405,6 +1405,35 @@ describe('<DmnEditor>', function() {
 
   describe('#triggerAction', function() {
 
+    it('should NOT trigger editor action for lint error', async function() {
+
+      // given
+      const triggerSpy = sinon.spy();
+
+      const cache = new Cache();
+
+      cache.add('editor', {
+        cached: {
+          modeler: new DmnModeler({
+            editorActions: {
+              trigger: triggerSpy
+            }
+          })
+        }
+      });
+
+      const { instance } = await renderEditor(diagramXML, { cache });
+
+      triggerSpy.resetHistory();
+
+      // when
+      instance.triggerAction('showLintError', { id: 'foo' });
+
+      // then
+      expect(triggerSpy).not.to.have.been.called;
+    });
+
+
     it('should return value of editor action', async function() {
 
       // given


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/6124

### Proposed Changes

Prevent DMN editors from forwarding unsupported `showLintError` actions, avoiding errors when linting entries are clicked. 

Adds regression tests for both DMN variants.

### Steps to try out

1. Open new DMN tab.
2. Connect to any cluster and change engine profile to something that doesn't match cluster version.
3. Click on the mismatch error.

https://github.com/user-attachments/assets/12581d21-7862-4b9b-958c-60771f77f926

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
