### PR TITLE
fix(panel): fall back to first available tab

### DIFF
--- a/client/src/app/panel/Panel.js
+++ b/client/src/app/panel/Panel.js
@@ -70,7 +70,8 @@ export default function Panel({ children, layout = {}, onLayoutChanged, onUpdate
   const [ tabs, setTabs ] = useState([]);
 
   const { tab: activeTabId } = panel;
-  const activeTab = tabs.find(t => t.id === activeTabId) || {};
+  const sortedTabs = [ ...tabs ].sort((a, b) => b.priority - a.priority);
+  const activeTab = sortedTabs.find(t => t.id === activeTabId) || sortedTabs[ 0 ] || {};
 
   const contextValue = {
     tabs,
@@ -95,7 +96,7 @@ export default function Panel({ children, layout = {}, onLayoutChanged, onUpdate
     <div className={ css.Panel }>
       <div className="panel__header">
         <div className="panel__links">
-          {tabs.sort((a, b) => b.priority - a.priority).map(tab => (
+          {sortedTabs.map(tab => (
             <button
               key={ tab.id }
               className={ classnames('panel__link', { 'panel__link--active': tab === activeTab }) }

--- a/client/src/app/panel/__tests__/PanelSpec.js
+++ b/client/src/app/panel/__tests__/PanelSpec.js
@@ -137,6 +137,50 @@ describe('<Panel>', function() {
     });
 
 
+    it('should activate first available tab when active tab is removed', function() {
+
+      // given
+      const onLayoutChangedSpy = spy();
+
+      const tab = createTab({
+        id: 'foo',
+        label: 'Foo',
+        children: <div data-testid="foo" />
+      });
+
+      const testingTab = createTab({
+        id: 'RPA-output',
+        label: 'Testing',
+        priority: 2,
+        children: <div data-testid="testing" />
+      });
+
+      const options = {
+        children: [ tab, testingTab ],
+        layout: {
+          panel: {
+            open: true,
+            tab: 'RPA-output'
+          }
+        },
+        onLayoutChanged: onLayoutChangedSpy
+      };
+
+      const { getByTestId, queryByTestId, rerender } = renderPanel(options);
+
+      // when
+      rerender(createPanel({
+        ...options,
+        children: tab
+      }));
+
+      // then
+      expect(getByTestId('foo')).to.exist;
+      expect(queryByTestId('testing')).not.to.exist;
+      expect(onLayoutChangedSpy).not.to.have.been.called;
+    });
+
+
     it('should render number', function() {
 
       // when
@@ -262,6 +306,10 @@ function createTab(options = {}) {
 }
 
 function renderPanel(options = {}) {
+  return render(createPanel(options));
+}
+
+function createPanel(options = {}) {
   const {
     children,
     layout = defaultLayout,
@@ -269,7 +317,7 @@ function renderPanel(options = {}) {
     onUpdateMenu = noop
   } = options;
 
-  return render(
+  return (
     <SlotFillRoot>
       <Panel
         layout={ layout }


### PR DESCRIPTION
### Proposed Changes

When switching between tabs, if a bottom panel tab is not available in the newly open tab, the bottom panel stays empty.

With this change, we open the first available tab by default.

### Steps to try

1. Open BPMN and RPA tabs.
2. Open "Testing" tab in RPA bottom panel.
3. Switch to BPMN tab.
4. You now see empty bottom panel.

https://github.com/user-attachments/assets/21d02f51-ce08-449a-b478-f8f3fbf0353a




### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
