### PR TITLE
feat(credential-manager): connection-scoped credential cache + lifecycle refactor

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -2736,6 +2736,7 @@ export class App extends PureComponent {
                         deployment={ this.getGlobal('deployment') }
                         startInstance={ this.getGlobal('startInstance') }
                         zeebeApi={ this.getGlobal('zeebeAPI') }
+                        credentialCache={ this.getGlobal('credentialCache') }
                       />
                     }
                   </TabContainer>

--- a/client/src/app/__tests__/AppParentSpec.js
+++ b/client/src/app/__tests__/AppParentSpec.js
@@ -32,7 +32,8 @@ import {
   SystemClipboard,
   TabsProvider,
   Workspace,
-  ZeebeAPI
+  ZeebeAPI,
+  CredentialCache
 } from './mocks';
 
 const { spy } = sinon;
@@ -1253,7 +1254,8 @@ function createAppParent(options = {}) {
     startInstance: new StartInstance(),
     systemClipboard: new SystemClipboard(),
     workspace: new Workspace(),
-    zeebeAPI: new ZeebeAPI()
+    zeebeAPI: new ZeebeAPI(),
+    credentialCache: new CredentialCache()
   };
 
   const globals = {

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -36,7 +36,8 @@ import {
   TabsProvider,
   TabStorage,
   Workspace,
-  ZeebeAPI
+  ZeebeAPI,
+  CredentialCache
 } from './mocks';
 
 import pDefer from 'p-defer';
@@ -5536,7 +5537,8 @@ function createApp(options = {}) {
     systemClipboard: new SystemClipboard(),
     tabStorage: new TabStorage(),
     workspace: new Workspace(),
-    zeebeAPI: new ZeebeAPI()
+    zeebeAPI: new ZeebeAPI(),
+    credentialCache: new CredentialCache()
   };
 
   const globals = {

--- a/client/src/app/__tests__/IntegrationSpec.js
+++ b/client/src/app/__tests__/IntegrationSpec.js
@@ -29,7 +29,8 @@ import {
   StartInstance,
   SystemClipboard,
   Workspace,
-  ZeebeAPI
+  ZeebeAPI,
+  CredentialCache
 } from './mocks';
 
 import { TabsProvider } from '../';
@@ -150,7 +151,8 @@ function createApp(options = {}) {
     startInstance: new StartInstance(),
     systemClipboard: new SystemClipboard(),
     workspace: new Workspace(),
-    zeebeAPI: new ZeebeAPI()
+    zeebeAPI: new ZeebeAPI(),
+    credentialCache: new CredentialCache()
   };
 
   if (options.globals) {

--- a/client/src/app/__tests__/MigrateConnectionsSpec.js
+++ b/client/src/app/__tests__/MigrateConnectionsSpec.js
@@ -31,7 +31,8 @@ import {
   Deployment,
   StartInstance,
   SystemClipboard,
-  ZeebeAPI
+  ZeebeAPI,
+  CredentialCache
 } from './mocks';
 
 
@@ -254,7 +255,8 @@ function createAppParent(options = {}) {
     startInstance: new StartInstance(),
     systemClipboard: new SystemClipboard(),
     workspace: new Workspace(),
-    zeebeAPI: new ZeebeAPI()
+    zeebeAPI: new ZeebeAPI(),
+    credentialCache: new CredentialCache()
   };
 
   const onStarted = () => {

--- a/client/src/app/__tests__/mocks/index.js
+++ b/client/src/app/__tests__/mocks/index.js
@@ -493,6 +493,26 @@ export class ZeebeAPI extends Mock {
   checkConnection() {}
 }
 
+export class CredentialCache extends Mock {
+  getPermissions() {
+    return Promise.resolve({ create: false, update: false });
+  }
+
+  getCredentials() {
+    return Promise.resolve({ success: true, response: { items: [] } });
+  }
+
+  upsertCredential() {
+    return Promise.resolve();
+  }
+
+  invalidate() {}
+
+  invalidateAll() {}
+
+  revalidate() {}
+}
+
 export class Backend extends Mock {
 
   constructor(overrides) {

--- a/client/src/app/tabs/MultiSheetTab.js
+++ b/client/src/app/tabs/MultiSheetTab.js
@@ -429,6 +429,7 @@ export class MultiSheetTab extends CachedComponent {
             deployment={ this.props.deployment }
             startInstance={ this.props.startInstance }
             zeebeApi={ this.props.zeebeApi }
+            credentialCache={ this.props.credentialCache }
           />
         </TabContainer>
 

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -971,7 +971,8 @@ export class BpmnEditor extends CachedComponent {
       linting,
       onAction,
       startInstance,
-      zeebeApi
+      zeebeApi,
+      credentialCache
     } = this.props;
 
     const modeler = this.getModeler();
@@ -1077,8 +1078,7 @@ export class BpmnEditor extends CachedComponent {
         <CredentialManager
           injector={ injector }
           zeebeApi={ zeebeApi }
-          deployment={ deployment }
-          file={ file }
+          credentialCache={ credentialCache }
           onError={ this.handleError }
         />
       </div>

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -47,7 +47,7 @@ import {
 import Metadata from '../../../../util/Metadata';
 
 import renderEditorHelper from '../../../__tests__/helpers/renderEditor';
-import { Deployment, StartInstance, ZeebeAPI } from '../../../__tests__/mocks';
+import { CredentialCache, Deployment, StartInstance, ZeebeAPI } from '../../../__tests__/mocks';
 
 const { spy } = sinon;
 
@@ -3084,6 +3084,7 @@ async function renderEditor(xml, options = {}) {
     deployment: new Deployment(),
     startInstance: new StartInstance(),
     zeebeApi: new ZeebeAPI(),
+    credentialCache: new CredentialCache(),
     ...options
   });
 }

--- a/client/src/app/tabs/cloud-bpmn/credential-manager/CredentialManager.js
+++ b/client/src/app/tabs/cloud-bpmn/credential-manager/CredentialManager.js
@@ -263,16 +263,15 @@ export default class CredentialManager extends PureComponent {
       return;
     }
 
-    this.setConfigurationInstancesState(configurationInstances, { available: true, loading: true, error: false });
-
-    // The connection is configured but its check has not succeeded yet: show
-    // loading and wait for `connectionStatusChanged`. Fetching now (on an early
-    // import.done / elementTemplates.changed) would only be invalidated and
-    // re-fetched by the establishing status change.
     if (!this.isConnectionEstablished()) {
       log('skip load - connection not established');
 
       return;
+    }
+
+    // keep current list during re-validation - no spinner wipe.
+    if (!configurationInstances.isAvailable()) {
+      this.setConfigurationInstancesState(configurationInstances, { available: true, loading: true, error: false });
     }
 
     try {

--- a/client/src/app/tabs/cloud-bpmn/credential-manager/CredentialManager.js
+++ b/client/src/app/tabs/cloud-bpmn/credential-manager/CredentialManager.js
@@ -63,8 +63,6 @@ const CONFIGURATION_UNAVAILABLE_MESSAGES = {
   unsupported: 'The connected cluster does not support credentials. Camunda 8.10 or later is required.'
 };
 
-const SEARCH_PAGE_SIZE = 100;
-
 const CREDENTIAL_REFERENCE_PREFIX = '=camunda.vars.env.';
 
 const CREDENTIAL_VARIABLE_KIND = 'SECRET_REFERENCE';
@@ -90,9 +88,21 @@ export default class CredentialManager extends PureComponent {
     this.state = { modal: null };
 
     this.updateConfigurationInstancesDebounced = debounce(() => this.updateConfigurationInstances());
+    this.refreshReferencedInstancesDebounced = debounce(() => this.refreshReferencedInstances());
     this._configurationUpdatePromise = null;
     this._configurationUpdatePending = false;
-    this._pendingConnectionStatus = undefined;
+
+    // the tab's cluster connection and its latest check result, both pushed in
+    // by the connection events (never resolved from the tab/endpoint here).
+    // A successful status is what gates credential loading, so early triggers
+    // (import.done, elementTemplates.changed) don't fetch before the connection
+    // is confirmed and then get thrown away by the establishing status change.
+    this._connection = null;
+    this._connectionStatus = undefined;
+
+    // signature of the referenced-credential name set last fed to the chooser,
+    // so model changes that don't touch it can be skipped
+    this._referencedNamesSignature = null;
   }
 
   componentDidMount() {
@@ -103,13 +113,34 @@ export default class CredentialManager extends PureComponent {
     eventBus.on('configuration.upgrade', this.handleConfigurationUpgrade);
     eventBus.on('import.done', this.updateConfigurationInstancesDebounced);
     eventBus.on('elementTemplates.changed', this.updateConfigurationInstancesDebounced);
+    eventBus.on('commandStack.changed', this.refreshReferencedInstancesDebounced);
+
+    // The connection is pushed in by the connection lifecycle: `checkStarted`
+    // gives us the tab's connection (or none), `statusChanged` its check result.
+    // Credentials load on a successful status, never on mount, so we don't race
+    // the connection check and get invalidated by it (redundant double fetch).
+    //
+    // This relies on ConnectionManagerPlugin re-emitting these events on every
+    // tab activation (its effect re-runs because `activeConnection` is a fresh
+    // object each time — see getEndpoints().map(sanitizeEndpoint)). That is what
+    // drives the reload for a re-activated tab in place of a mount-time load. If
+    // the plugin is ever changed to reuse connection objects across activations,
+    // a re-activated tab would receive no event and this manager must load on
+    // mount (or another activation signal) instead.
+    this._checkStartedSubscription = this.context.subscribe(
+      'connectionManager.connectionCheckStarted',
+      this.handleConnectionCheckStarted
+    );
 
     this._connectionSubscription = this.context.subscribe(
       'connectionManager.connectionStatusChanged',
       this.handleConnectionStatusChanged
     );
 
-    this.updateConfigurationInstances();
+    this._appFocusedSubscription = this.context.subscribe(
+      'app.focused',
+      this.handleAppFocused
+    );
   }
 
   componentWillUnmount() {
@@ -120,22 +151,56 @@ export default class CredentialManager extends PureComponent {
     eventBus.off('configuration.upgrade', this.handleConfigurationUpgrade);
     eventBus.off('import.done', this.updateConfigurationInstancesDebounced);
     eventBus.off('elementTemplates.changed', this.updateConfigurationInstancesDebounced);
+    eventBus.off('commandStack.changed', this.refreshReferencedInstancesDebounced);
 
     this.updateConfigurationInstancesDebounced.cancel();
+    this.refreshReferencedInstancesDebounced.cancel();
+
+    if (this._checkStartedSubscription) {
+      this._checkStartedSubscription.cancel();
+    }
 
     if (this._connectionSubscription) {
       this._connectionSubscription.cancel();
     }
-  }
 
-  componentDidUpdate(prevProps) {
-    if (prevProps.file !== this.props.file) {
-      this.updateConfigurationInstances();
+    if (this._appFocusedSubscription) {
+      this._appFocusedSubscription.cancel();
     }
   }
 
   getService(name, strict = true) {
     return this.props.injector.get(name, strict);
+  }
+
+  /**
+   * The connection-scoped credential cache, shared across tabs on the same
+   * connection so they fetch the credential source once.
+   *
+   * @returns {CredentialCache}
+   */
+  getCredentialCache() {
+    return this.props.credentialCache;
+  }
+
+  /**
+   * The cluster endpoint the tab is connected to, as pushed in by the
+   * connection events; null when there is no usable connection.
+   *
+   * @returns {Object|null}
+   */
+  getConnection() {
+    return this._connection;
+  }
+
+  /**
+   * Whether the connection check has completed successfully — the point at
+   * which credentials can be loaded. Earlier triggers only render loading.
+   *
+   * @returns {boolean}
+   */
+  isConnectionEstablished() {
+    return Boolean(this._connection && this._connectionStatus && this._connectionStatus.success);
   }
 
   /**
@@ -153,31 +218,10 @@ export default class CredentialManager extends PureComponent {
   }
 
   /**
-   * Resolve the cluster endpoint the tab is connected to.
-   *
-   * @returns {Promise<Object|null>} the endpoint, or null when there is no usable connection
-   */
-  async getEndpoint() {
-    const { deployment, file } = this.props;
-
-    const endpoint = await deployment.getConnectionForTab({ file });
-
-    if (!endpoint || endpoint.id === NO_CONNECTION_ID) {
-      return null;
-    }
-
-    return endpoint;
-  }
-
-  /**
    * Feed the credential chooser's `configurationInstances` registry from the
    * connected cluster, or mark it unavailable when there is no usable connection.
-   *
-   * @param {Object} [connectionStatus] - latest status from the connection check
    */
-  async updateConfigurationInstances(connectionStatus) {
-    this._pendingConnectionStatus = connectionStatus;
-
+  async updateConfigurationInstances() {
     if (this._configurationUpdatePromise) {
       this._configurationUpdatePending = true;
 
@@ -197,20 +241,21 @@ export default class CredentialManager extends PureComponent {
     do {
       this._configurationUpdatePending = false;
 
-      await this.updateConfigurationInstancesOnce(this._pendingConnectionStatus);
+      await this.updateConfigurationInstancesOnce();
     } while (this._configurationUpdatePending);
   }
 
-  async updateConfigurationInstancesOnce(connectionStatus) {
+  async updateConfigurationInstancesOnce() {
     const configurationInstances = this.getService('configurationInstances', false);
 
     if (!configurationInstances) {
       return;
     }
 
-    const endpoint = await this.getEndpoint();
+    const connection = this._connection;
+    const status = this._connectionStatus;
 
-    const unavailableState = getUnavailableState(endpoint, connectionStatus);
+    const unavailableState = getUnavailableState(connection, status);
 
     if (unavailableState) {
       this.setConfigurationInstancesState(configurationInstances, unavailableState);
@@ -220,16 +265,27 @@ export default class CredentialManager extends PureComponent {
 
     this.setConfigurationInstancesState(configurationInstances, { available: true, loading: true, error: false });
 
+    // The connection is configured but its check has not succeeded yet: show
+    // loading and wait for `connectionStatusChanged`. Fetching now (on an early
+    // import.done / elementTemplates.changed) would only be invalidated and
+    // re-fetched by the establishing status change.
+    if (!this.isConnectionEstablished()) {
+      log('skip load - connection not established');
+
+      return;
+    }
+
     try {
-      await this.loadConfigurationInstances(configurationInstances, endpoint);
+      await this.loadConfigurationInstances(configurationInstances, connection);
     } catch (error) {
       this.setConfigurationInstancesState(configurationInstances, { loading: false, error: true });
     }
   }
 
   /**
-   * Query the cluster for credential permissions and instances and push the
-   * result into the `configurationInstances` registry.
+   * Feed the credential chooser from the connection-scoped cache: the user's
+   * permissions and the cluster's credential source, filtered client-side to
+   * the configuration templates this diagram uses.
    *
    * @param {Object} configurationInstances - the registry to feed
    * @param {Object} endpoint - the connected cluster endpoint
@@ -238,12 +294,14 @@ export default class CredentialManager extends PureComponent {
     const elementRegistry = this.getService('elementRegistry', false);
     const elementTemplates = this.getService('elementTemplates', false);
 
-    const filters = getConfigurationSearchFilters(
+    const configurationTemplates = getConfigurationTemplateIds(
       elementRegistry,
       elementTemplates
     );
 
-    if (!filters.length) {
+    if (!configurationTemplates.length) {
+      this._referencedNamesSignature = null;
+
       this.setConfigurationInstancesState(configurationInstances, {
         available: false,
         loading: false,
@@ -256,28 +314,34 @@ export default class CredentialManager extends PureComponent {
       return;
     }
 
-    const [ permissions, variablesResults ] = await Promise.all([
-      this.resolvePermissions(endpoint),
-      Promise.all(filters.map(filter => this.getAllClusterVariables(endpoint, filter)))
+    const [ permissions, credentialsResult ] = await Promise.all([
+      this.getCredentialCache().getPermissions(endpoint),
+      this.getCredentialsForTemplates(endpoint, configurationTemplates)
     ]);
 
-    const failedVariablesResult = variablesResults.find(result => !result.success);
-
-    if (failedVariablesResult) {
+    if (!credentialsResult.success) {
       this.setConfigurationInstancesState(
         configurationInstances,
-        getConfigurationUnavailableState(failedVariablesResult)
+        getConfigurationUnavailableState(credentialsResult)
       );
 
       return;
     }
 
-    const selectableInstances = toSelectableInstances(uniqueByName(
-      variablesResults.flatMap(result => result.response.items)
-    ))
+    const credentials = credentialsResult.response.items || [];
+
+    const selectableInstances = toSelectableInstances(uniqueByName(credentials))
       .map(instance => this.withInstanceIcon(instance));
 
-    const referencedInstances = await this.getReferencedInstances(endpoint, selectableInstances);
+    const names = getReferencedCredentialNames(this.getService('elementRegistry'));
+
+    this._referencedNamesSignature = toReferencedNamesSignature(names);
+
+    const referencedInstances = await this.resolveReferencedInstances(
+      endpoint,
+      names,
+      toSelectableInstances(credentials)
+    );
 
     this.setConfigurationInstancesState(configurationInstances, {
       available: true,
@@ -290,64 +354,115 @@ export default class CredentialManager extends PureComponent {
   }
 
   /**
-   * Resolve the user's create/update permissions for credentials.
-   *
-   * Authorizations are only enforced — and thus only searchable — when they are
-   * enabled on the cluster. When disabled, the authorization search returns
-   * empty even though everything is permitted, which would wrongly disable
-   * create/update. The current user's `authorizedComponents` is the only
-   * REST-visible tell: a `*` entry means full access (authorizations disabled or
-   * a wildcard admin), so we grant everything without searching. Otherwise we
-   * derive the concrete grants from the authorization search.
+   * Fetch the credential source for every configuration template the diagram
+   * uses — each server-filtered by template and cached per (connection,
+   * template) — and merge into a single search result. If any template's fetch
+   * failed, that failing result is returned so the caller renders the
+   * unavailable state.
    *
    * @param {Object} endpoint
+   * @param {string[]} configurationTemplates
    *
-   * @returns {Promise<{ create: boolean, update: boolean }>}
+   * @returns {Promise<Object>}
    */
-  async resolvePermissions(endpoint) {
-    const currentUserResult = await this.props.zeebeApi.getCurrentUser({ endpoint });
+  async getCredentialsForTemplates(endpoint, configurationTemplates) {
+    const cache = this.getCredentialCache();
 
-    if (hasFullAccess(currentUserResult)) {
-      return { create: true, update: true };
+    const results = await Promise.all(
+      configurationTemplates.map(template => cache.getCredentials(endpoint, template))
+    );
+
+    const failed = results.find(result => !result || !result.success);
+
+    if (failed) {
+      return failed;
     }
 
-    const authorizationsResult = await this.getAllAuthorizations(endpoint);
-
-    return getConfigurationPermissions(authorizationsResult);
-  }
-
-  getAllAuthorizations(endpoint) {
-    return getAllSearchResults(page => {
-      return this.props.zeebeApi.getAuthorizations({ endpoint }, 'CLUSTER_VARIABLE', page);
-    });
-  }
-
-  getAllClusterVariables(endpoint, filter) {
-    return getAllSearchResults(page => {
-      return this.props.zeebeApi.searchClusterVariables({ endpoint }, filter, page);
-    });
+    return {
+      success: true,
+      response: {
+        items: results.flatMap(result => result.response.items || [])
+      }
+    };
   }
 
   /**
-   * Resolve the credentials referenced by the diagram's Configuration bindings
-   * (`=camunda.vars.env.<name>`), reusing the search results where possible and
-   * fetching the rest, so the chooser can render "missing" / "incompatible type"
-   * / "version too old" states and offer the upgrade action.
+   * Re-resolve just the referenced credentials after a model change, when the
+   * referenced-name set actually changed (e.g. paste, undo/redo, delete). The
+   * cheap common case — model changes that don't touch a credential binding —
+   * is skipped. Reuses the cached credential source and the registry's current
+   * selectable list (which includes optimistic creations), fetching only names
+   * not found in either.
+   */
+  async refreshReferencedInstances() {
+    if (!this.isConnectionEstablished()) {
+      return;
+    }
+
+    const configurationInstances = this.getService('configurationInstances', false);
+
+    if (!configurationInstances) {
+      return;
+    }
+
+    const elementRegistry = this.getService('elementRegistry', false);
+
+    if (!elementRegistry) {
+      return;
+    }
+
+    // established ⇒ a connection is set
+    const endpoint = this.getConnection();
+
+    const names = getReferencedCredentialNames(elementRegistry);
+
+    const signature = toReferencedNamesSignature(names);
+
+    if (signature === this._referencedNamesSignature) {
+      return;
+    }
+
+    this._referencedNamesSignature = signature;
+
+    const configurationTemplates = getConfigurationTemplateIds(
+      elementRegistry,
+      this.getService('elementTemplates', false)
+    );
+
+    const credentialsResult = await this.getCredentialsForTemplates(endpoint, configurationTemplates);
+
+    const known = [
+      ...(credentialsResult.success ? toSelectableInstances(credentialsResult.response.items || []) : []),
+      ...configurationInstances.getSelectableInstances()
+    ];
+
+    const referencedInstances = await this.resolveReferencedInstances(endpoint, names, known);
+
+    this.setConfigurationInstancesState(configurationInstances, { referencedInstances });
+  }
+
+  /**
+   * Resolve the referenced credentials by name, reusing known instances where
+   * possible and fetching the rest, so the chooser can render "missing" /
+   * "incompatible type" / "version too old" states and offer the upgrade action.
    *
    * @param {Object} endpoint
-   * @param {ConfigurationInstance[]} selectableInstances
+   * @param {string[]} names - referenced cluster-variable names
+   * @param {ConfigurationInstance[]} knownInstances - already-resolved instances to reuse
    *
    * @returns {Promise<ConfigurationInstance[]>}
    */
-  async getReferencedInstances(endpoint, selectableInstances) {
-    const selectableByName = new Map(selectableInstances.map(instance => [ instance.name, instance ]));
+  async resolveReferencedInstances(endpoint, names, knownInstances) {
+    const knownByName = new Map(
+      knownInstances.filter(instance => instance && instance.name).map(instance => [ instance.name, instance ])
+    );
 
     const referencedInstances = [];
     const namesToFetch = [];
 
-    getReferencedCredentialNames(this.getService('elementRegistry')).forEach(name => {
-      if (selectableByName.has(name)) {
-        referencedInstances.push(selectableByName.get(name));
+    names.forEach(name => {
+      if (knownByName.has(name)) {
+        referencedInstances.push(this.withInstanceIcon(knownByName.get(name)));
       } else {
         namesToFetch.push(name);
       }
@@ -369,9 +484,57 @@ export default class CredentialManager extends PureComponent {
     return referencedInstances;
   }
 
-  /** @param {Object} [connectionStatus] */
-  handleConnectionStatusChanged = (connectionStatus = {}) => {
-    this.updateConfigurationInstances(connectionStatus);
+  /**
+   * A connection check began for the tab: record the connection (or none) the
+   * check is for. Rendered as loading (real connection) or unavailable (no
+   * connection); credentials only load once the check succeeds.
+   *
+   * @param {{ connection?: Object }} [event]
+   */
+  handleConnectionCheckStarted = ({ connection } = {}) => {
+    this._connection = toConnection(connection);
+    this._connectionStatus = undefined;
+
+    this.updateConfigurationInstances();
+  };
+
+  /**
+   * The connection check completed: record the connection and its result, then
+   * reconcile the connection-scoped cache against the connection's identity
+   * fingerprint before reloading. `revalidate` is a no-op when the fingerprint
+   * is unchanged (the common case — the plugin re-emits on every tab activation
+   * and periodic re-check), so activating a tab does not refetch; it only clears
+   * and reloads when the cluster/tenant/principal behind the connection changed.
+   *
+   * @param {{ connection?: Object, connectionId?: string, connectionFingerprint?: string }} [event]
+   */
+  handleConnectionStatusChanged = ({ connection, connectionId, connectionFingerprint, ...status } = {}) => {
+    this._connection = toConnection(connection);
+    this._connectionStatus = status;
+
+    if (connectionId) {
+      this.getCredentialCache().revalidate(connectionId, connectionFingerprint);
+    }
+
+    this.updateConfigurationInstances();
+  };
+
+  /**
+   * On app focus, refresh the connection-scoped cache so credentials created in
+   * Hub or another tab while away are picked up. Invalidation is synchronous, so
+   * every tab's manager clears the connection before any reload runs — the
+   * subsequent reloads then coalesce on a single fetch per connection.
+   */
+  handleAppFocused = () => {
+    const connection = this._connection;
+
+    if (!connection) {
+      return;
+    }
+
+    this.getCredentialCache().invalidate(connection.id);
+
+    this.updateConfigurationInstances();
   };
 
   handleConfigurationCreate = (event) => {
@@ -464,7 +627,7 @@ export default class CredentialManager extends PureComponent {
       return null;
     }
 
-    const endpoint = await this.getEndpoint();
+    const endpoint = this.getConnection();
 
     if (!endpoint) {
       return null;
@@ -516,7 +679,7 @@ export default class CredentialManager extends PureComponent {
       return initialValues;
     }
 
-    const endpoint = await this.getEndpoint();
+    const endpoint = this.getConnection();
 
     if (!endpoint) {
       return initialValues;
@@ -546,7 +709,7 @@ export default class CredentialManager extends PureComponent {
   handleSubmit = async ({ displayName, name, values }) => {
     const { mode, event, configurationTemplate } = this.state.modal;
 
-    const endpoint = await this.getEndpoint();
+    const endpoint = this.getConnection();
 
     if (!endpoint) {
       throw new Error('No connection to the cluster.');
@@ -588,6 +751,8 @@ export default class CredentialManager extends PureComponent {
 
     const instance = this.withInstanceIcon({ name, metadata });
 
+    this.getCredentialCache().upsertCredential(endpoint.id, { name, metadata });
+
     this.registerSelectableInstance(instance);
 
     this.getService('eventBus').fire('configuration.created', {
@@ -615,6 +780,8 @@ export default class CredentialManager extends PureComponent {
         ? CREDENTIAL_UPDATE_FORBIDDEN_MESSAGE
         : result.reason || 'Could not update the credential.');
     }
+
+    this.getCredentialCache().upsertCredential(endpoint.id, { name, metadata });
 
     this.refreshSavedInstance(this.withInstanceIcon({ name, metadata }));
   }
@@ -710,56 +877,14 @@ export default class CredentialManager extends PureComponent {
 // helpers //////////
 
 /**
- * Fetch every page from a search endpoint using cursor pagination.
- *
- * @param {Function} search
- * @returns {Promise<Object>}
- */
-async function getAllSearchResults(search) {
-  const items = [];
-  let after;
-  let hasNextPage = true;
-
-  while (hasNextPage) {
-    const page = {
-      limit: SEARCH_PAGE_SIZE,
-      ...(after ? { after } : {})
-    };
-    const result = await search(page);
-
-    if (!result.success) {
-      return result;
-    }
-
-    const responseItems = result.response.items || [];
-    const endCursor = result.response.page && result.response.page.endCursor;
-
-    items.push(...responseItems);
-
-    hasNextPage = responseItems.length > 0 && !!endCursor && endCursor !== after;
-    after = endCursor;
-
-    if (!hasNextPage) {
-      return {
-        ...result,
-        response: {
-          ...result.response,
-          items
-        }
-      };
-    }
-  }
-}
-
-/**
- * Build one server-side credential filter per Configuration property used by
- * an applied element template.
+ * The configuration-template ids used by the diagram's applied element
+ * templates (via their `Configuration` properties).
  *
  * @param {Object|null} elementRegistry
  * @param {Object|null} elementTemplates
- * @returns {Object[]}
+ * @returns {string[]}
  */
-function getConfigurationSearchFilters(elementRegistry, elementTemplates) {
+function getConfigurationTemplateIds(elementRegistry, elementTemplates) {
   const configurationTemplates = new Set();
 
   if (!elementRegistry || !elementTemplates) {
@@ -776,12 +901,18 @@ function getConfigurationSearchFilters(elementRegistry, elementTemplates) {
     });
   });
 
-  return [ ...configurationTemplates ].map(configurationTemplate => ({
-    metadata: {
-      kind: { '$eq': 'CREDENTIAL' },
-      configurationTemplate: { '$eq': configurationTemplate }
-    }
-  }));
+  return [ ...configurationTemplates ];
+}
+
+/**
+ * A stable signature of a referenced-credential name set, used to skip model
+ * changes that don't alter which credentials the diagram references.
+ *
+ * @param {string[]} names
+ * @returns {string}
+ */
+function toReferencedNamesSignature(names) {
+  return [ ...names ].sort().join('\n');
 }
 
 /**
@@ -792,6 +923,22 @@ function getConfigurationSearchFilters(elementRegistry, elementTemplates) {
  */
 function uniqueByName(instances) {
   return [ ...new Map(instances.map(instance => [ instance.name, instance ])).values() ];
+}
+
+/**
+ * Normalize a connection from a connection event: the "no connection"
+ * placeholder maps to null so callers can treat it uniformly as "no cluster".
+ *
+ * @param {Object} [connection]
+ *
+ * @returns {Object|null}
+ */
+function toConnection(connection) {
+  if (!connection || connection.id === NO_CONNECTION_ID) {
+    return null;
+  }
+
+  return connection;
 }
 
 /**
@@ -1025,46 +1172,6 @@ function upsertInstance(instances, instance) {
     ...instances.filter(existing => existing.name !== instance.name),
     instance
   ];
-}
-
-/**
- * Whether the current user has full access — either authorizations are disabled
- * on the cluster or the user is a wildcard admin — signalled by a `*` entry in
- * their `authorizedComponents`.
- *
- * @param {Object} currentUserResult
- *
- * @returns {boolean}
- */
-function hasFullAccess(currentUserResult) {
-  if (!currentUserResult || !currentUserResult.success || !currentUserResult.response) {
-    return false;
-  }
-
-  const { authorizedComponents } = currentUserResult.response;
-
-  return Array.isArray(authorizedComponents) && authorizedComponents.includes('*');
-}
-
-/**
- * Derive create/update permissions from an authorizations search result.
- *
- * @param {Object} authorizationsResult
- *
- * @returns {{ create: boolean, update: boolean }}
- */
-function getConfigurationPermissions(authorizationsResult) {
-  if (!authorizationsResult || !authorizationsResult.success) {
-    return { create: false, update: false };
-  }
-
-  const permissions = (authorizationsResult.response.items || [])
-    .flatMap(item => item.permissionTypes || []);
-
-  return {
-    create: permissions.includes('CREATE'),
-    update: permissions.includes('UPDATE')
-  };
 }
 
 /**

--- a/client/src/app/tabs/cloud-bpmn/credential-manager/__tests__/CredentialManagerSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/credential-manager/__tests__/CredentialManagerSpec.js
@@ -505,6 +505,34 @@ describe('<CredentialManager>', function() {
   });
 
 
+  it('should show loading only for the first population, not on revalidation', async function() {
+
+    // given
+    const { configurationInstances, establishConnection } = renderManager({ establish: false });
+
+    // when the connection is first established
+    establishConnection();
+
+    await waitFor(() => {
+      expect(fedInstancesCall(configurationInstances)).to.exist;
+    });
+
+    // then a loading state is pushed so the chooser shows a spinner
+    const loadingBefore = loadingPushCount(configurationInstances);
+
+    expect(loadingBefore).to.be.above(0);
+
+    // when the connection is revalidated (same fingerprint: re-check, activation)
+    establishConnection();
+    establishConnection();
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    // then no further loading flash is pushed — the current list stays visible
+    expect(loadingPushCount(configurationInstances)).to.equal(loadingBefore);
+  });
+
+
   it('should reload credentials when the connection identity changes', async function() {
 
     // given the connection is established, driving the first load
@@ -992,8 +1020,15 @@ function createConfigurationInstances(overrides = {}) {
   const selectableInstances = overrides.selectableInstances || [];
   const referencedInstances = overrides.referencedInstances || [];
 
+  let available = overrides.available || false;
+
   return {
-    setState: sinon.spy(),
+    setState: sinon.spy(state => {
+      if ('available' in state) {
+        available = !!state.available;
+      }
+    }),
+    isAvailable: () => available,
     getSelectableInstances: () => selectableInstances,
     getReferencedInstanceByName: name => referencedInstances.find(instance => instance.name === name) || null
   };
@@ -1132,6 +1167,11 @@ function fedInstancesCall(configurationInstances) {
   const call = configurationInstances.setState.getCalls().find(call => call.args[0].selectableInstances);
 
   return call && call.args[0];
+}
+
+function loadingPushCount(configurationInstances) {
+  return configurationInstances.setState.getCalls()
+    .filter(call => call.args[0].loading === true).length;
 }
 
 function unavailableCall(configurationInstances) {

--- a/client/src/app/tabs/cloud-bpmn/credential-manager/__tests__/CredentialManagerSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/credential-manager/__tests__/CredentialManagerSpec.js
@@ -16,6 +16,7 @@ import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import CredentialManager from '../CredentialManager';
+import CredentialCache from '../../../../zeebe/CredentialCache';
 import { EventsContext } from '../../../../EventsContext';
 
 const TEMPLATE = {
@@ -48,6 +49,14 @@ const INSTANCE_METADATA = {
   configurationTemplateVersion: 1
 };
 
+// the connection the default test harness establishes
+const DEFAULT_CONNECTION_ID = 'cluster';
+const DEFAULT_CONNECTION = { id: DEFAULT_CONNECTION_ID };
+
+// the identity fingerprint the plugin emits alongside the connection; a stable
+// default means repeated status events for the same connection are no-ops
+const DEFAULT_CONNECTION_FINGERPRINT = 'cluster-fingerprint';
+
 
 describe('<CredentialManager>', function() {
 
@@ -61,7 +70,7 @@ describe('<CredentialManager>', function() {
   });
 
 
-  it('should feed the selectable instances on mount', async function() {
+  it('should feed the selectable instances once the connection is established', async function() {
 
     // given
     const zeebeApi = createZeebeApi({
@@ -83,6 +92,33 @@ describe('<CredentialManager>', function() {
   });
 
 
+  it('should not load credentials before the connection is established', async function() {
+
+    // given
+    const zeebeApi = createZeebeApi();
+
+    // when mounted but the connection has not been established yet
+    const { eventBus, establishConnection } = renderManager({ zeebeApi, establish: false });
+
+    // then early triggers do not fetch (they would only be invalidated and
+    // re-fetched by the establishing status change)
+    eventBus.fire('import.done');
+    eventBus.fire('elementTemplates.changed');
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(zeebeApi.searchClusterVariables).not.to.have.been.called;
+
+    // when the connection is established
+    establishConnection();
+
+    // then the first (and only) load runs
+    await waitFor(() => {
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledOnce;
+    });
+  });
+
+
   it('should search credentials per configuration template', async function() {
 
     // given
@@ -94,27 +130,39 @@ describe('<CredentialManager>', function() {
         configurationTemplate: element.id === 'Task_1' ? 'template-a' : 'template-b'
       } ]
     }));
-    const zeebeApi = createZeebeApi();
 
-    renderManager({ elementRegistry, elementTemplates, zeebeApi });
+    const credentialsByTemplate = {
+      'template-a': [ { name: 'CRED_A', metadata: { configurationTemplate: 'template-a' } } ],
+      'template-b': [ { name: 'CRED_B', metadata: { configurationTemplate: 'template-b' } } ]
+    };
+
+    const zeebeApi = createZeebeApi({
+      searchClusterVariables: sinon.stub().callsFake((_, filter) => Promise.resolve({
+        success: true,
+        response: { items: credentialsByTemplate[filter.metadata.configurationTemplate['$eq']] || [] }
+      }))
+    });
+
+    const { configurationInstances } = renderManager({ elementRegistry, elementTemplates, zeebeApi });
 
     // then
     await waitFor(() => {
-      expect(zeebeApi.searchClusterVariables).to.have.been.calledTwice;
+      expect(fedInstancesCall(configurationInstances)).to.exist;
     });
 
+    // one server-filtered search per configuration template
+    expect(zeebeApi.searchClusterVariables).to.have.been.calledTwice;
     expect(zeebeApi.searchClusterVariables).to.have.been.calledWithMatch({}, {
       metadata: {
         kind: { '$eq': 'CREDENTIAL' },
         configurationTemplate: { '$eq': 'template-a' }
       }
     });
-    expect(zeebeApi.searchClusterVariables).to.have.been.calledWithMatch({}, {
-      metadata: {
-        kind: { '$eq': 'CREDENTIAL' },
-        configurationTemplate: { '$eq': 'template-b' }
-      }
-    });
+
+    // selectable merged from each template's server-filtered search
+    const call = fedInstancesCall(configurationInstances);
+
+    expect(call.selectableInstances.map(instance => instance.name)).to.eql([ 'CRED_A', 'CRED_B' ]);
   });
 
 
@@ -180,7 +228,12 @@ describe('<CredentialManager>', function() {
     // given
     const elementRegistry = { getAll: () => [] };
     const zeebeApi = createZeebeApi();
-    const { configurationInstances } = renderManager({ elementRegistry, zeebeApi });
+    const { configurationInstances, eventBus } = renderManager({ elementRegistry, zeebeApi });
+
+    // when — no configuration templates, so nothing is queried; the state is
+    // reported unavailable (both the establishing load and import.done evaluate
+    // to this)
+    eventBus.fire('import.done');
 
     // then
     await waitFor(() => {
@@ -222,8 +275,7 @@ describe('<CredentialManager>', function() {
 
     expect(zeebeApi.searchClusterVariables).to.have.been.calledWithMatch({}, {
       metadata: {
-        kind: { '$eq': 'CREDENTIAL' },
-        configurationTemplate: { '$eq': TEMPLATE.id }
+        kind: { '$eq': 'CREDENTIAL' }
       }
     });
   });
@@ -258,7 +310,7 @@ describe('<CredentialManager>', function() {
   });
 
 
-  it('should serialize concurrent credential reloads', async function() {
+  it('should coalesce concurrent credential reloads', async function() {
 
     // given
     let resolveSearch;
@@ -270,13 +322,13 @@ describe('<CredentialManager>', function() {
     searchClusterVariables.onSecondCall().resolves({ success: true, response: { items: [] } });
 
     const zeebeApi = createZeebeApi({ searchClusterVariables });
-    const { eventBus } = renderManager({ zeebeApi });
+    const { eventBus, configurationInstances } = renderManager({ zeebeApi });
 
     await waitFor(() => {
       expect(searchClusterVariables).to.have.been.calledOnce;
     });
 
-    // when
+    // when reloads are triggered while the first search is still in flight
     eventBus.fire('import.done');
     eventBus.fire('elementTemplates.changed');
 
@@ -284,19 +336,25 @@ describe('<CredentialManager>', function() {
 
     resolveSearch({ success: true, response: { items: [] } });
 
-    // then
+    // then the coalesced reload is served from the connection-scoped cache,
+    // so no additional cluster search is issued
     await waitFor(() => {
-      expect(searchClusterVariables).to.have.been.calledTwice;
+      const call = fedInstancesCall(configurationInstances);
+
+      expect(call).to.exist;
     });
+
+    expect(searchClusterVariables).to.have.been.calledOnce;
   });
 
 
   it('should mark the chooser unavailable without a connection', async function() {
 
     // given
-    const deployment = createDeployment({ getConnectionForTab: sinon.stub().resolves(null) });
+    const { configurationInstances, startConnectionCheck } = renderManager({ establish: false });
 
-    const { configurationInstances } = renderManager({ deployment });
+    // when a connection check starts for a tab without a connection
+    startConnectionCheck(null);
 
     // then
     await waitFor(() => {
@@ -420,34 +478,139 @@ describe('<CredentialManager>', function() {
   });
 
 
-  it('should reload credentials for each connection status event', async function() {
+  it('should not reload credentials while the connection is unchanged', async function() {
 
     // given
-    let connectionStatusListener;
+    const { zeebeApi, establishConnection } = renderManager({ establish: false });
 
-    const subscribe = sinon.stub().callsFake((event, listener) => {
-      if (event === 'connectionManager.connectionStatusChanged') {
-        connectionStatusListener = listener;
-      }
+    // no load before the connection is established
+    expect(zeebeApi.searchClusterVariables).not.to.have.been.called;
 
-      return { cancel: sinon.spy() };
+    // when the connection is established, credentials load once
+    establishConnection();
+
+    await waitFor(() => {
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledOnce;
     });
-    const zeebeApi = createZeebeApi();
 
-    renderManager({ subscribe, zeebeApi });
+    // when further status events fire for the SAME connection (re-check, tab
+    // activation) — same fingerprint
+    establishConnection();
+    establishConnection();
+
+    // then the cache is not refetched
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(zeebeApi.searchClusterVariables).to.have.been.calledOnce;
+  });
+
+
+  it('should reload credentials when the connection identity changes', async function() {
+
+    // given the connection is established, driving the first load
+    const { zeebeApi, establishConnection } = renderManager({ establish: false });
+
+    establishConnection();
+
+    await waitFor(() => {
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledOnce;
+    });
+
+    // when a status event carries a different fingerprint (cluster, tenant or
+    // principal changed behind the same connection)
+    establishConnection({ connectionFingerprint: 'other-fingerprint' });
+
+    // then the connection is revalidated and credentials refetched
+    await waitFor(() => {
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledTwice;
+    });
+  });
+
+
+  it('should reload credentials on app focus', async function() {
+
+    // given the connection is established, driving the first load
+    const { zeebeApi, focusApp } = renderManager();
 
     await waitFor(() => {
       expect(zeebeApi.searchClusterVariables).to.have.been.calledOnce;
     });
 
     // when
-    connectionStatusListener({ connectionId: 'cluster', success: true });
-    connectionStatusListener({ connectionId: 'cluster', success: true });
+    focusApp();
 
-    // then
+    // then — cache is invalidated on focus, so the source is re-fetched
     await waitFor(() => {
-      expect(zeebeApi.searchClusterVariables).to.have.callCount(3);
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledTwice;
     });
+  });
+
+
+  it('should refresh referenced credentials when a binding appears', async function() {
+
+    // given
+    const elements = [ { id: 'Task_1' } ];
+    const elementRegistry = { getAll: () => elements };
+    const getClusterVariable = sinon.stub().resolves({
+      success: true,
+      response: { metadata: INSTANCE_METADATA }
+    });
+    const zeebeApi = createZeebeApi({ getClusterVariable });
+
+    const { eventBus, configurationInstances } = renderManager({ elementRegistry, zeebeApi });
+
+    await waitFor(() => {
+      expect(fedInstancesCall(configurationInstances)).to.exist;
+    });
+
+    expect(getClusterVariable).not.to.have.been.called;
+
+    // when a pasted element introduces a credential binding
+    elements.push(elementWithReferences([ 'CRED_X' ]));
+    eventBus.fire('commandStack.changed');
+
+    // then only the newly-referenced name is resolved
+    await waitFor(() => {
+      expect(getClusterVariable).to.have.been.calledWithMatch({}, 'CRED_X');
+    });
+
+    const referencedCall = configurationInstances.setState.getCalls()
+      .reverse()
+      .find(call => call.args[0].referencedInstances);
+
+    expect(referencedCall.args[0].referencedInstances.map(instance => instance.name)).to.eql([ 'CRED_X' ]);
+  });
+
+
+  it('should not refresh referenced credentials when the referenced set is unchanged', async function() {
+
+    // given
+    const elementRegistry = {
+      getAll: () => [ elementWithReferences([ 'CRED_X' ]) ]
+    };
+    const getClusterVariable = sinon.stub().resolves({
+      success: true,
+      response: { metadata: INSTANCE_METADATA }
+    });
+    const zeebeApi = createZeebeApi({ getClusterVariable });
+
+    const { eventBus, configurationInstances } = renderManager({ elementRegistry, zeebeApi });
+
+    await waitFor(() => {
+      expect(getClusterVariable).to.have.been.calledOnce;
+    });
+
+    const setStateCount = configurationInstances.setState.callCount;
+
+    // when a model change does not alter the referenced set
+    eventBus.fire('commandStack.changed');
+    eventBus.fire('commandStack.changed');
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    // then no additional referenced fetch or state push
+    expect(getClusterVariable).to.have.been.calledOnce;
+    expect(configurationInstances.setState.callCount).to.equal(setStateCount);
   });
 
 
@@ -687,6 +850,39 @@ describe('<CredentialManager>', function() {
   });
 
 
+  it('should write a created credential through to the shared connection cache', async function() {
+
+    // given
+    const zeebeApi = createZeebeApi();
+    const credentialCache = new CredentialCache(zeebeApi);
+
+    const { eventBus, getByRole } = renderManager({ zeebeApi, credentialCache });
+
+    // wait for the initial source load so the cache is populated
+    await waitFor(() => {
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledOnce;
+    });
+
+    eventBus.fire('configuration.create', createEvent());
+
+    const submit = await waitFor(() => getByRole('button', { name: 'Create and select' }));
+
+    // when
+    fireEvent.click(submit);
+
+    await waitFor(() => {
+      expect(zeebeApi.createClusterVariable).to.have.been.calledOnce;
+    });
+
+    // then — the shared cache reflects the new credential without a refetch
+    const created = zeebeApi.createClusterVariable.firstCall.args[1];
+    const cached = await credentialCache.getCredentials({ id: 'cluster' }, 'io.camunda:test:1');
+
+    expect(cached.response.items.map(item => item.name)).to.include(created.name);
+    expect(zeebeApi.searchClusterVariables).to.have.been.calledOnce;
+  });
+
+
   it('should show an error when credential submission fails', async function() {
 
     // given
@@ -831,13 +1027,6 @@ function createZeebeApi(overrides = {}) {
   };
 }
 
-function createDeployment(overrides = {}) {
-  return {
-    getConnectionForTab: sinon.stub().resolves({ id: 'cluster' }),
-    ...overrides
-  };
-}
-
 function renderManager(overrides = {}) {
   const eventBus = overrides.eventBus || createEventBus();
   const configurationInstances = overrides.configurationInstances || createConfigurationInstances();
@@ -845,9 +1034,21 @@ function renderManager(overrides = {}) {
   const elementRegistry = overrides.elementRegistry || { getAll: () => [ { id: 'Task_1' } ] };
   const elementTemplates = overrides.elementTemplates || createElementTemplates();
   const zeebeApi = overrides.zeebeApi || createZeebeApi();
-  const deployment = overrides.deployment || createDeployment();
   const onError = overrides.onError || sinon.spy();
-  const subscribe = overrides.subscribe;
+  const credentialCache = overrides.credentialCache || new CredentialCache(zeebeApi);
+
+  // credentials are loaded once the connection is established, so the harness
+  // captures the connection handlers and establishes by default
+  const handlers = {};
+  const subscribe = overrides.subscribe || ((event, listener) => {
+    (handlers[event] = handlers[event] || []).push(listener);
+
+    return {
+      cancel() {
+        handlers[event] = (handlers[event] || []).filter(l => l !== listener);
+      }
+    };
+  });
 
   const services = {
     eventBus,
@@ -875,19 +1076,56 @@ function renderManager(overrides = {}) {
     <CredentialManager
       injector={ injector }
       zeebeApi={ zeebeApi }
-      deployment={ deployment }
-      file={ overrides.file || {} }
+      credentialCache={ credentialCache }
       onError={ onError }
     />
   );
 
   const result = render(
-    subscribe
-      ? <EventsContext.Provider value={ { subscribe } }>{ manager }</EventsContext.Provider>
-      : manager
+    <EventsContext.Provider value={ { subscribe } }>{ manager }</EventsContext.Provider>
   );
 
-  return { eventBus, configurationInstances, configurationTemplates, zeebeApi, deployment, onError, ...result };
+  const fire = (event, payload) => {
+    (handlers[event] || []).forEach(listener => listener(payload));
+  };
+
+  // the connection the check runs for; null renders the "no connection" message
+  const startConnectionCheck = (connection = DEFAULT_CONNECTION) => {
+    fire('connectionManager.connectionCheckStarted', { connection });
+  };
+
+  // the connection check completed with a result (success by default); the
+  // fingerprint identifies the connection so equal fingerprints are no-ops
+  const establishConnection = (status = {}) => {
+    fire('connectionManager.connectionStatusChanged', {
+      connection: DEFAULT_CONNECTION,
+      connectionId: DEFAULT_CONNECTION_ID,
+      connectionFingerprint: DEFAULT_CONNECTION_FINGERPRINT,
+      success: true,
+      ...status
+    });
+  };
+
+  const focusApp = () => fire('app.focused');
+
+  // mirror the real flow: the connection is established shortly after mount,
+  // which drives the first load. Tests providing their own `subscribe` or
+  // passing `establish: false` drive establishment themselves.
+  if (!overrides.subscribe && overrides.establish !== false) {
+    establishConnection();
+  }
+
+  return {
+    eventBus,
+    configurationInstances,
+    configurationTemplates,
+    zeebeApi,
+    onError,
+    startConnectionCheck,
+    establishConnection,
+    focusApp,
+    ...result
+  };
 }
 
 function fedInstancesCall(configurationInstances) {

--- a/client/src/app/zeebe/CredentialCache.js
+++ b/client/src/app/zeebe/CredentialCache.js
@@ -1,0 +1,459 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import debug from 'debug';
+
+const log = debug('CredentialCache');
+
+const SEARCH_PAGE_SIZE = 100;
+
+const CREDENTIAL_KIND = 'CREDENTIAL';
+
+/**
+ * Connection-scoped, session-lived cache for a cluster's credentials: the
+ * user's create/update permissions (per CONNECTION) and the credential cluster
+ * variables (`metadata.kind = CREDENTIAL`), searched server-side per
+ * configuration template and cached per (CONNECTION, configurationTemplate).
+ *
+ * Permissions are independent of any template, so they are keyed by connection
+ * alone. Credentials are keyed additionally by `configurationTemplate` and the
+ * search is server-filtered by it, so each fetch returns only that template's
+ * credentials rather than the cluster's entire credential population.
+ *
+ * All queries are memoized and coalesce concurrent in-flight requests, so two
+ * tabs on the same connection+template share a single network fetch.
+ *
+ * Staleness is driven by the connection's identity, not by wall-clock time:
+ * `revalidate(connectionId, connectionFingerprint)` compares an opaque
+ * fingerprint (emitted by the connection lifecycle) against the one the cached
+ * data was loaded under and drops the connection's data only when it changed —
+ * a different cluster, tenant or principal, or a reconnect. An unchanged
+ * fingerprint (the common case: tab activation or a periodic re-check of the
+ * same connection) is a no-op, so activating a tab does NOT trigger a refetch.
+ * Because the decision is a pure function of the fingerprint, it is idempotent
+ * across tabs. `invalidate(connectionId)` unconditionally drops a connection's
+ * cached data (keeping its identity fingerprint) and is used for the explicit
+ * app-focus force-refresh (to pick up credentials created outside the app);
+ * `invalidateAll` evicts everything, fingerprints included.
+ *
+ * In-app modifications write through to the cache via `upsertCredential`, so a
+ * credential created/edited in one tab is reflected in every other tab on the
+ * same connection when they re-activate (inactive tabs are unmounted and re-read
+ * the cache on mount). Credentials created OUTSIDE the app (Hub, another client)
+ * cannot be pushed and are picked up on the next focus/reconnect invalidation —
+ * matching the session-cached design.
+ *
+ * Every load, cache hit and invalidation is logged under the `CredentialCache`
+ * debug namespace (`localStorage.debug = 'CredentialCache'`), so it is visible
+ * when an actual network fetch happens versus a cache hit.
+ */
+export default class CredentialCache {
+
+  /**
+   * @param {Object} zeebeApi
+   */
+  constructor(zeebeApi) {
+    this._zeebeApi = zeebeApi;
+
+    /**
+     * @type {Map<string, { fingerprint: string|undefined, permissions: Promise|null, credentials: Map<string, Promise> }>}
+     */
+    this._connections = new Map();
+  }
+
+  /**
+   * Resolve the user's create/update permissions for credentials on the
+   * connected cluster, cached for the session. Only a result derived from a
+   * SUCCESSFUL query is cached; a deny derived from a failed user lookup or
+   * authorization search is returned for the current render but not cached, so
+   * a later trigger re-queries instead of sticking on a transient deny.
+   *
+   * @param {Object} endpoint
+   *
+   * @returns {Promise<{ create: boolean, update: boolean }>}
+   */
+  getPermissions(endpoint) {
+    const entry = this._getEntry(endpoint.id);
+
+    if (entry.permissions) {
+      log('permissions: cache hit', endpoint.id);
+
+      return entry.permissions;
+    }
+
+    log('permissions: load', endpoint.id);
+
+    const promise = this._loadPermissions(endpoint).then(({ permissions, cacheable }) => {
+      if (cacheable) {
+        log('permissions: loaded', endpoint.id, permissions);
+      } else {
+        log('permissions: loaded (not cacheable, clearing)', endpoint.id, permissions);
+
+        this._clearPermissions(endpoint.id, promise);
+      }
+
+      return permissions;
+    });
+
+    entry.permissions = promise;
+
+    promise.catch(error => {
+      log('permissions: load failed', endpoint.id, error);
+
+      this._clearPermissions(endpoint.id, promise);
+    });
+
+    return entry.permissions;
+  }
+
+  /**
+   * Resolve the credential cluster variables for a single configuration
+   * template on the connected cluster, server-filtered by that template and
+   * cached for the session. Only successful results are cached; a failure clears
+   * the entry so a later trigger can retry.
+   *
+   * @param {Object} endpoint
+   * @param {string} configurationTemplate
+   *
+   * @returns {Promise<Object>} the (paged) cluster-variable search result
+   */
+  getCredentials(endpoint, configurationTemplate) {
+    const entry = this._getEntry(endpoint.id);
+
+    const cached = entry.credentials.get(configurationTemplate);
+
+    if (cached) {
+      log('credentials: cache hit', endpoint.id, configurationTemplate);
+
+      return cached;
+    }
+
+    log('credentials: load', endpoint.id, configurationTemplate);
+
+    const promise = this._loadCredentials(endpoint, configurationTemplate);
+
+    entry.credentials.set(configurationTemplate, promise);
+
+    promise.then(
+      result => {
+        if (!result || !result.success) {
+          log('credentials: load failed', endpoint.id, configurationTemplate, result && result.status);
+
+          this._clearCredentials(endpoint.id, configurationTemplate, promise);
+        } else {
+          log('credentials: loaded', endpoint.id, configurationTemplate, (result.response.items || []).length);
+        }
+      },
+      error => {
+        log('credentials: load failed', endpoint.id, configurationTemplate, error);
+
+        this._clearCredentials(endpoint.id, configurationTemplate, promise);
+      }
+    );
+
+    return promise;
+  }
+
+  /**
+   * Write a created or updated credential into the connection's cached source,
+   * so other tabs on the same connection reflect it on their next (re)load
+   * without a network refetch.
+   *
+   * In-app modifications from any tab MUST call this: inactive tabs are
+   * unmounted (only the active tab is mounted), so they cannot be notified via
+   * events — the shared cache is the single source of truth they re-read when
+   * re-activated. The credential is written into the bucket for its own
+   * `metadata.configurationTemplate`; upsert is by name.
+   *
+   * No-op when that template's source is not cached yet (nothing to keep in
+   * sync; the next load fetches fresh and includes the new credential).
+   *
+   * @param {string} connectionId
+   * @param {{ name: string, metadata: Object }} credential
+   */
+  upsertCredential(connectionId, credential) {
+    const entry = this._connections.get(connectionId);
+
+    if (!entry) {
+      return;
+    }
+
+    const configurationTemplate = credential.metadata && credential.metadata.configurationTemplate;
+
+    const existing = entry.credentials.get(configurationTemplate);
+
+    if (!existing) {
+      return;
+    }
+
+    log('upserting credential', connectionId, configurationTemplate, credential.name);
+
+    const promise = existing.then(result => {
+      if (!result || !result.success) {
+        return result;
+      }
+
+      const items = result.response.items || [];
+
+      return {
+        ...result,
+        response: {
+          ...result.response,
+          items: [ ...items.filter(item => item.name !== credential.name), credential ]
+        }
+      };
+    });
+
+    entry.credentials.set(configurationTemplate, promise);
+
+    // preserve the retry-on-failure invariant: if the underlying fetch failed,
+    // don't keep the (unpatched) failure cached
+    promise.then(
+      result => {
+        if (!result || !result.success) {
+          this._clearCredentials(connectionId, configurationTemplate, promise);
+        }
+      },
+      () => this._clearCredentials(connectionId, configurationTemplate, promise)
+    );
+  }
+
+  /**
+   * Reconcile a connection's cache against its current identity fingerprint,
+   * dropping the cached permissions and credentials only when the fingerprint
+   * differs from the one the data was loaded under.
+   *
+   * The fingerprint is an opaque token emitted by the connection lifecycle
+   * (`connectionFingerprint`); it changes when the cluster, tenant, principal or
+   * connection status behind a (stable) connection id changes, and stays equal
+   * across tab activations and periodic re-checks of an unchanged connection.
+   * Callers should run this on every connection status change before reading:
+   * an unchanged fingerprint is a cheap no-op (no refetch on activation), a
+   * changed one resets the connection so the next read re-queries the cluster.
+   *
+   * Idempotent across tabs: the outcome depends only on the stored vs. given
+   * fingerprint, so concurrent tabs on the same connection converge without
+   * refetching.
+   *
+   * @param {string} connectionId
+   * @param {string} fingerprint
+   */
+  revalidate(connectionId, fingerprint) {
+    const entry = this._getEntry(connectionId);
+
+    if (entry.fingerprint === fingerprint) {
+      log('revalidate: unchanged', connectionId);
+
+      return;
+    }
+
+    if (entry.fingerprint === undefined) {
+      log('revalidate: init', connectionId);
+    } else {
+      log('revalidate: changed, clearing', connectionId);
+
+      this._clearData(entry);
+    }
+
+    entry.fingerprint = fingerprint;
+  }
+
+  /**
+   * Drop a connection's cached permissions and credentials, e.g. on app focus, so
+   * the next consumer re-queries the cluster. The identity fingerprint is left
+   * untouched: only the data axis is cleared, the connection is still the same
+   * one (identity is `revalidate`'s concern, full eviction is `invalidateAll`).
+   *
+   * @param {string} connectionId
+   */
+  invalidate(connectionId) {
+    const entry = this._connections.get(connectionId);
+
+    if (!entry) {
+      return;
+    }
+
+    log('invalidating', connectionId);
+
+    this._clearData(entry);
+  }
+
+  /** Drop every connection's cache, fingerprints included. */
+  invalidateAll() {
+    log('invalidating all');
+
+    this._connections.clear();
+  }
+
+  _getEntry(connectionId) {
+    if (!this._connections.has(connectionId)) {
+      this._connections.set(connectionId, { fingerprint: undefined, permissions: null, credentials: new Map() });
+    }
+
+    return this._connections.get(connectionId);
+  }
+
+  /** Clear the data axis (permissions + credentials) of an entry, keeping its identity. */
+  _clearData(entry) {
+    entry.permissions = null;
+    entry.credentials.clear();
+  }
+
+  _clearPermissions(connectionId, promise) {
+    const entry = this._connections.get(connectionId);
+
+    if (entry && entry.permissions === promise) {
+      entry.permissions = null;
+    }
+  }
+
+  _clearCredentials(connectionId, configurationTemplate, promise) {
+    const entry = this._connections.get(connectionId);
+
+    if (entry && entry.credentials.get(configurationTemplate) === promise) {
+      entry.credentials.delete(configurationTemplate);
+    }
+  }
+
+  _loadCredentials(endpoint, configurationTemplate) {
+    return getAllSearchResults(page => this._zeebeApi.searchClusterVariables(
+      { endpoint },
+      credentialsSearchFilter(configurationTemplate),
+      page
+    ));
+  }
+
+  async _loadPermissions(endpoint) {
+    const currentUserResult = await this._zeebeApi.getCurrentUser({ endpoint });
+
+    if (hasFullAccess(currentUserResult)) {
+      return { permissions: { create: true, update: true }, cacheable: true };
+    }
+
+    const authorizationsResult = await getAllSearchResults(page => this._zeebeApi.getAuthorizations(
+      { endpoint },
+      'CLUSTER_VARIABLE',
+      page
+    ));
+
+    // The deny/allow is derived solely from the authorization search (a non-full
+    // user lookup only tells us the user is not a wildcard admin). A SUCCESSFUL
+    // search — even an empty one on an authz-enabled cluster — is authoritative
+    // and cacheable. A FAILED search yields a bogus deny that must not stick, so
+    // mark it non-cacheable and let a later trigger re-query.
+    return {
+      permissions: getConfigurationPermissions(authorizationsResult),
+      cacheable: authorizationsResult.success
+    };
+  }
+}
+
+
+// helpers //////////
+
+/**
+ * The server-side filter matching the credential cluster variables for a single
+ * configuration template.
+ *
+ * @param {string} configurationTemplate
+ *
+ * @returns {Object}
+ */
+function credentialsSearchFilter(configurationTemplate) {
+  return {
+    metadata: {
+      kind: { '$eq': CREDENTIAL_KIND },
+      configurationTemplate: { '$eq': configurationTemplate }
+    }
+  };
+}
+
+/**
+ * Fetch every page from a search endpoint using cursor pagination.
+ *
+ * @param {Function} search
+ *
+ * @returns {Promise<Object>}
+ */
+async function getAllSearchResults(search) {
+  const items = [];
+  let after;
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    const page = {
+      limit: SEARCH_PAGE_SIZE,
+      ...(after ? { after } : {})
+    };
+    const result = await search(page);
+
+    if (!result.success) {
+      return result;
+    }
+
+    const responseItems = result.response.items || [];
+    const endCursor = result.response.page && result.response.page.endCursor;
+
+    items.push(...responseItems);
+
+    hasNextPage = responseItems.length > 0 && !!endCursor && endCursor !== after;
+    after = endCursor;
+
+    if (!hasNextPage) {
+      return {
+        ...result,
+        response: {
+          ...result.response,
+          items
+        }
+      };
+    }
+  }
+}
+
+/**
+ * Whether the current user has full access — either authorizations are disabled
+ * on the cluster or the user is a wildcard admin — signalled by a `*` entry in
+ * their `authorizedComponents`.
+ *
+ * @param {Object} currentUserResult
+ *
+ * @returns {boolean}
+ */
+function hasFullAccess(currentUserResult) {
+  if (!currentUserResult || !currentUserResult.success || !currentUserResult.response) {
+    return false;
+  }
+
+  const { authorizedComponents } = currentUserResult.response;
+
+  return Array.isArray(authorizedComponents) && authorizedComponents.includes('*');
+}
+
+/**
+ * Derive create/update permissions from an authorizations search result.
+ *
+ * @param {Object} authorizationsResult
+ *
+ * @returns {{ create: boolean, update: boolean }}
+ */
+function getConfigurationPermissions(authorizationsResult) {
+  if (!authorizationsResult || !authorizationsResult.success) {
+    return { create: false, update: false };
+  }
+
+  const permissions = (authorizationsResult.response.items || [])
+    .flatMap(item => item.permissionTypes || []);
+
+  return {
+    create: permissions.includes('CREATE'),
+    update: permissions.includes('UPDATE')
+  };
+}

--- a/client/src/app/zeebe/__tests__/CredentialCacheSpec.js
+++ b/client/src/app/zeebe/__tests__/CredentialCacheSpec.js
@@ -1,0 +1,519 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import CredentialCache from '../CredentialCache';
+
+const ENDPOINT = { id: 'cluster-a' };
+
+const OTHER_ENDPOINT = { id: 'cluster-b' };
+
+const TEMPLATE = 't1';
+
+
+describe('CredentialCache', function() {
+
+  describe('#getCredentials', function() {
+
+    it('should fetch the credential source once per connection + template', async function() {
+
+      // given
+      const zeebeApi = createZeebeApi();
+      const cache = new CredentialCache(zeebeApi);
+
+      // when
+      const first = await cache.getCredentials(ENDPOINT, TEMPLATE);
+      const second = await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      // then
+      expect(first.success).to.be.true;
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledOnce;
+      expect(second).to.equal(first);
+    });
+
+
+    it('should filter by credential kind and configuration template', async function() {
+
+      // given
+      const zeebeApi = createZeebeApi();
+      const cache = new CredentialCache(zeebeApi);
+
+      // when
+      await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      // then
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledWithMatch({ endpoint: ENDPOINT }, {
+        metadata: {
+          kind: { '$eq': 'CREDENTIAL' },
+          configurationTemplate: { '$eq': TEMPLATE }
+        }
+      });
+    });
+
+
+    it('should fetch each template separately', async function() {
+
+      // given
+      const zeebeApi = createZeebeApi();
+      const cache = new CredentialCache(zeebeApi);
+
+      // when
+      await cache.getCredentials(ENDPOINT, 't1');
+      await cache.getCredentials(ENDPOINT, 't2');
+
+      // then
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledTwice;
+    });
+
+
+    it('should coalesce concurrent requests into a single fetch', async function() {
+
+      // given
+      let resolveSearch;
+      const searchClusterVariables = sinon.stub().returns(new Promise(resolve => {
+        resolveSearch = resolve;
+      }));
+      const zeebeApi = createZeebeApi({ searchClusterVariables });
+      const cache = new CredentialCache(zeebeApi);
+
+      // when
+      const first = cache.getCredentials(ENDPOINT, TEMPLATE);
+      const second = cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      resolveSearch({ success: true, response: { items: [] } });
+
+      // then
+      expect(await first).to.equal(await second);
+      expect(searchClusterVariables).to.have.been.calledOnce;
+    });
+
+
+    it('should page through all results', async function() {
+
+      // given
+      const searchClusterVariables = sinon.stub();
+      searchClusterVariables.onFirstCall().resolves({
+        success: true,
+        response: { items: [ { name: 'CRED_A' } ], page: { endCursor: 'page-2' } }
+      });
+      searchClusterVariables.onSecondCall().resolves({
+        success: true,
+        response: { items: [ { name: 'CRED_B' } ], page: {} }
+      });
+
+      const zeebeApi = createZeebeApi({ searchClusterVariables });
+      const cache = new CredentialCache(zeebeApi);
+
+      // when
+      const result = await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      // then
+      expect(result.response.items.map(item => item.name)).to.eql([ 'CRED_A', 'CRED_B' ]);
+      expect(searchClusterVariables.secondCall.args[2]).to.eql({ after: 'page-2', limit: 100 });
+    });
+
+
+    it('should not cache a failed search', async function() {
+
+      // given
+      const searchClusterVariables = sinon.stub();
+      searchClusterVariables.onFirstCall().resolves({ success: false, status: 500 });
+      searchClusterVariables.onSecondCall().resolves({ success: true, response: { items: [] } });
+
+      const zeebeApi = createZeebeApi({ searchClusterVariables });
+      const cache = new CredentialCache(zeebeApi);
+
+      // when
+      const failed = await cache.getCredentials(ENDPOINT, TEMPLATE);
+      const retried = await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      // then
+      expect(failed.success).to.be.false;
+      expect(retried.success).to.be.true;
+      expect(searchClusterVariables).to.have.been.calledTwice;
+    });
+
+  });
+
+
+  describe('#upsertCredential', function() {
+
+    it('should reflect a created credential without a refetch', async function() {
+
+      // given
+      const zeebeApi = createZeebeApi();
+      const cache = new CredentialCache(zeebeApi);
+
+      await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      // when
+      cache.upsertCredential(ENDPOINT.id, { name: 'CRED_NEW', metadata: { configurationTemplate: TEMPLATE } });
+
+      // then
+      const result = await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      expect(result.response.items.map(item => item.name)).to.include('CRED_NEW');
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledOnce;
+    });
+
+
+    it('should replace an existing credential by name', async function() {
+
+      // given
+      const searchClusterVariables = sinon.stub().resolves({
+        success: true,
+        response: { items: [ { name: 'CRED_A', metadata: { configurationTemplate: TEMPLATE, version: 1 } } ] }
+      });
+      const zeebeApi = createZeebeApi({ searchClusterVariables });
+      const cache = new CredentialCache(zeebeApi);
+
+      await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      // when
+      cache.upsertCredential(ENDPOINT.id, { name: 'CRED_A', metadata: { configurationTemplate: TEMPLATE, version: 2 } });
+
+      // then
+      const result = await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      const matches = result.response.items.filter(item => item.name === 'CRED_A');
+
+      expect(matches).to.have.length(1);
+      expect(matches[0].metadata.version).to.equal(2);
+    });
+
+
+    it('should be a no-op when the template has no cached source', async function() {
+
+      // given
+      const zeebeApi = createZeebeApi();
+      const cache = new CredentialCache(zeebeApi);
+
+      // when — nothing cached yet
+      cache.upsertCredential(ENDPOINT.id, { name: 'CRED_NEW', metadata: { configurationTemplate: TEMPLATE } });
+
+      // then — the next load fetches fresh; the phantom entry was not created
+      const result = await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      expect(result.response.items.map(item => item.name)).not.to.include('CRED_NEW');
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledOnce;
+    });
+
+  });
+
+
+  describe('#getPermissions', function() {
+
+    it('should grant full access on a wildcard component', async function() {
+
+      // given
+      const zeebeApi = createZeebeApi({
+        getCurrentUser: sinon.stub().resolves({ success: true, response: { authorizedComponents: [ '*' ] } })
+      });
+      const cache = new CredentialCache(zeebeApi);
+
+      // when
+      const permissions = await cache.getPermissions(ENDPOINT);
+
+      // then
+      expect(permissions).to.eql({ create: true, update: true });
+      expect(zeebeApi.getAuthorizations).not.to.have.been.called;
+    });
+
+
+    it('should derive permissions from the authorization search', async function() {
+
+      // given
+      const zeebeApi = createZeebeApi({
+        getCurrentUser: sinon.stub().resolves({ success: true, response: { authorizedComponents: [] } }),
+        getAuthorizations: sinon.stub().resolves({
+          success: true,
+          response: { items: [ { permissionTypes: [ 'CREATE' ] } ] }
+        })
+      });
+      const cache = new CredentialCache(zeebeApi);
+
+      // when
+      const permissions = await cache.getPermissions(ENDPOINT);
+
+      // then
+      expect(permissions).to.eql({ create: true, update: false });
+    });
+
+
+    it('should resolve permissions once per connection', async function() {
+
+      // given
+      const zeebeApi = createZeebeApi();
+      const cache = new CredentialCache(zeebeApi);
+
+      // when
+      await cache.getPermissions(ENDPOINT);
+      await cache.getPermissions(ENDPOINT);
+
+      // then
+      expect(zeebeApi.getCurrentUser).to.have.been.calledOnce;
+    });
+
+
+    it('should cache a legitimate deny from a successful empty search', async function() {
+
+      // given — authz-enabled cluster, user has no CLUSTER_VARIABLE grants
+      const zeebeApi = createZeebeApi({
+        getCurrentUser: sinon.stub().resolves({ success: true, response: { authorizedComponents: [] } }),
+        getAuthorizations: sinon.stub().resolves({ success: true, response: { items: [] } })
+      });
+      const cache = new CredentialCache(zeebeApi);
+
+      // when
+      const first = await cache.getPermissions(ENDPOINT);
+      const second = await cache.getPermissions(ENDPOINT);
+
+      // then
+      expect(first).to.eql({ create: false, update: false });
+      expect(second).to.eql({ create: false, update: false });
+      expect(zeebeApi.getAuthorizations).to.have.been.calledOnce;
+    });
+
+
+    it('should not cache a deny derived from a failed authorization search', async function() {
+
+      // given — user lookup is non-full, then the authorization search fails
+      const getAuthorizations = sinon.stub();
+      getAuthorizations.onFirstCall().resolves({ success: false, status: 500 });
+      getAuthorizations.onSecondCall().resolves({
+        success: true,
+        response: { items: [ { permissionTypes: [ 'CREATE', 'UPDATE' ] } ] }
+      });
+
+      const zeebeApi = createZeebeApi({
+        getCurrentUser: sinon.stub().resolves({ success: true, response: { authorizedComponents: [] } }),
+        getAuthorizations
+      });
+      const cache = new CredentialCache(zeebeApi);
+
+      // when
+      const denied = await cache.getPermissions(ENDPOINT);
+      const retried = await cache.getPermissions(ENDPOINT);
+
+      // then — the transient deny is not cached, so a later call re-queries
+      expect(denied).to.eql({ create: false, update: false });
+      expect(retried).to.eql({ create: true, update: true });
+      expect(getAuthorizations).to.have.been.calledTwice;
+    });
+
+
+    it('should not cache when the user lookup and authorization search both fail', async function() {
+
+      // given
+      const getCurrentUser = sinon.stub();
+      getCurrentUser.onFirstCall().resolves({ success: false, status: 500 });
+      getCurrentUser.onSecondCall().resolves({ success: true, response: { authorizedComponents: [ '*' ] } });
+
+      const getAuthorizations = sinon.stub().resolves({ success: false, status: 500 });
+
+      const zeebeApi = createZeebeApi({ getCurrentUser, getAuthorizations });
+      const cache = new CredentialCache(zeebeApi);
+
+      // when
+      const denied = await cache.getPermissions(ENDPOINT);
+      const retried = await cache.getPermissions(ENDPOINT);
+
+      // then
+      expect(denied).to.eql({ create: false, update: false });
+      expect(retried).to.eql({ create: true, update: true });
+      expect(getCurrentUser).to.have.been.calledTwice;
+    });
+
+  });
+
+
+  describe('#invalidate', function() {
+
+    it('should re-fetch after invalidation', async function() {
+
+      // given
+      const zeebeApi = createZeebeApi();
+      const cache = new CredentialCache(zeebeApi);
+
+      await cache.getCredentials(ENDPOINT);
+
+      // when
+      cache.invalidate(ENDPOINT.id);
+      await cache.getCredentials(ENDPOINT);
+
+      // then
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledTwice;
+    });
+
+
+    it('should keep other connections cached', async function() {
+
+      // given
+      const zeebeApi = createZeebeApi();
+      const cache = new CredentialCache(zeebeApi);
+
+      await cache.getCredentials(ENDPOINT);
+      await cache.getCredentials(OTHER_ENDPOINT);
+
+      // when
+      cache.invalidate(ENDPOINT.id);
+      await cache.getCredentials(OTHER_ENDPOINT);
+
+      // then — one for ENDPOINT, one for OTHER_ENDPOINT (still cached)
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledTwice;
+    });
+
+
+    it('should re-fetch all connections after invalidateAll', async function() {
+
+      // given
+      const zeebeApi = createZeebeApi();
+      const cache = new CredentialCache(zeebeApi);
+
+      await cache.getCredentials(ENDPOINT);
+      await cache.getCredentials(OTHER_ENDPOINT);
+
+      // when
+      cache.invalidateAll();
+      await cache.getCredentials(ENDPOINT);
+      await cache.getCredentials(OTHER_ENDPOINT);
+
+      // then
+      expect(zeebeApi.searchClusterVariables).to.have.callCount(4);
+    });
+
+
+    it('should keep the fingerprint so later changes are still detected', async function() {
+
+      // given a loaded, fingerprinted connection
+      const zeebeApi = createZeebeApi();
+      const cache = new CredentialCache(zeebeApi);
+
+      cache.revalidate(ENDPOINT.id, 'fp-1');
+      await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      // when force-refreshed (app focus) and reloaded
+      cache.invalidate(ENDPOINT.id);
+      await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      // then a revalidate with the same fingerprint is still a no-op
+      cache.revalidate(ENDPOINT.id, 'fp-1');
+      await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledTwice;
+    });
+
+  });
+
+
+  describe('#revalidate', function() {
+
+    it('should keep the cache while the fingerprint is unchanged', async function() {
+
+      // given
+      const zeebeApi = createZeebeApi();
+      const cache = new CredentialCache(zeebeApi);
+
+      cache.revalidate(ENDPOINT.id, 'fp-1');
+      await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      // when the same fingerprint is seen again (re-check, tab activation)
+      cache.revalidate(ENDPOINT.id, 'fp-1');
+      await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      // then no refetch
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledOnce;
+    });
+
+
+    it('should re-fetch credentials when the fingerprint changes', async function() {
+
+      // given
+      const zeebeApi = createZeebeApi();
+      const cache = new CredentialCache(zeebeApi);
+
+      cache.revalidate(ENDPOINT.id, 'fp-1');
+      await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      // when the fingerprint changes (cluster, tenant or principal changed)
+      cache.revalidate(ENDPOINT.id, 'fp-2');
+      await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      // then
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledTwice;
+    });
+
+
+    it('should drop permissions when the fingerprint changes', async function() {
+
+      // given
+      const zeebeApi = createZeebeApi();
+      const cache = new CredentialCache(zeebeApi);
+
+      cache.revalidate(ENDPOINT.id, 'fp-1');
+      await cache.getPermissions(ENDPOINT);
+
+      // when
+      cache.revalidate(ENDPOINT.id, 'fp-2');
+      await cache.getPermissions(ENDPOINT);
+
+      // then
+      expect(zeebeApi.getCurrentUser).to.have.been.calledTwice;
+    });
+
+
+    it('should not fetch when revalidating before the first load', function() {
+
+      // given
+      const zeebeApi = createZeebeApi();
+      const cache = new CredentialCache(zeebeApi);
+
+      // when revalidate only initializes the fingerprint (no data yet)
+      cache.revalidate(ENDPOINT.id, 'fp-1');
+
+      // then nothing is fetched
+      expect(zeebeApi.searchClusterVariables).not.to.have.been.called;
+      expect(zeebeApi.getCurrentUser).not.to.have.been.called;
+    });
+
+
+    it('should be idempotent across tabs on the same connection', async function() {
+
+      // given two tabs on the same connection see the same fingerprint
+      const zeebeApi = createZeebeApi();
+      const cache = new CredentialCache(zeebeApi);
+
+      // when
+      cache.revalidate(ENDPOINT.id, 'fp-1');
+      await cache.getCredentials(ENDPOINT, TEMPLATE);
+      cache.revalidate(ENDPOINT.id, 'fp-1');
+      await cache.getCredentials(ENDPOINT, TEMPLATE);
+
+      // then a single shared fetch
+      expect(zeebeApi.searchClusterVariables).to.have.been.calledOnce;
+    });
+
+  });
+
+});
+
+
+// helpers //////////
+
+function createZeebeApi(overrides = {}) {
+  return {
+    getAuthorizations: sinon.stub().resolves({ success: true, response: { items: [] } }),
+    getCurrentUser: sinon.stub().resolves({ success: true, response: { authorizedComponents: [] } }),
+    searchClusterVariables: sinon.stub().resolves({ success: true, response: { items: [] } }),
+    ...overrides
+  };
+}

--- a/client/src/globals.js
+++ b/client/src/globals.js
@@ -21,6 +21,7 @@ import Settings from './app/Settings';
 import TabStorage from './app/TabStorage';
 import StartInstance from './app/zeebe/StartInstance';
 import Deployment from './app/zeebe/Deployment';
+import CredentialCache from './app/zeebe/CredentialCache';
 
 const {
   metadata,
@@ -57,6 +58,8 @@ export const deployment = new Deployment(tabStorage, config, zeebeAPI, settings)
 
 export const startInstance = new StartInstance(config, zeebeAPI);
 
+export const credentialCache = new CredentialCache(zeebeAPI);
+
 export const isMac = backend.getPlatform() === 'darwin';
 
 export {
@@ -67,6 +70,7 @@ export {
 export const globals = {
   backend,
   config,
+  credentialCache,
   deployment,
   dialog,
   fileSystem,

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerPlugin.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerPlugin.js
@@ -19,6 +19,7 @@ import ConnectionChecker from '../deployment-plugin/ConnectionChecker';
 import { CONNECTION_MANAGER_PLUGIN_ID, SETTINGS_KEY_CONNECTIONS, initializeSettings } from './ConnectionManagerSettings';
 import { ConnectionManagerOverlay } from './ConnectionManagerOverlay';
 import { StatusIndicator } from '../shared/StatusIndicator';
+import { getConnectionFingerprint } from '../shared/util';
 import { CONNECTION_CHECK_ERROR_REASONS } from '../deployment-plugin/ConnectionCheckErrors';
 import { NO_CONNECTION_ID } from './constants';
 import { AUTH_TYPES, TARGET_TYPES } from '../../../remote/ZeebeAPI';
@@ -178,6 +179,7 @@ export default function ConnectionManagerPlugin(props) {
       emit('connectionManager.connectionCheckStarted', {
         connectionId: activeConnection?.id,
         connection: activeConnection,
+        connectionFingerprint: getConnectionFingerprint(activeConnection),
       });
 
       setConnectionCheckResult(null);
@@ -215,6 +217,7 @@ export default function ConnectionManagerPlugin(props) {
         ...connectionCheckResult,
         connectionId: activeConnection?.id,
         connection: activeConnection,
+        connectionFingerprint: getConnectionFingerprint(activeConnection),
         isLocal: endpoint ? isLocalEndpoint(endpoint) : null
       });
       setConnectionCheckResult(connectionCheckResult);

--- a/client/src/plugins/zeebe-plugin/shared/__tests__/utilSpec.js
+++ b/client/src/plugins/zeebe-plugin/shared/__tests__/utilSpec.js
@@ -10,6 +10,7 @@
 
 import { expect } from 'chai';
 import {
+  getConnectionFingerprint,
   getGRPCErrorCode,
   isC8RunConnection
 } from '../util';
@@ -182,6 +183,117 @@ describe('util', function() {
       expect(isC8RunConnection({})).to.be.false;
       expect(isC8RunConnection({ name: 'c8run' })).to.be.false;
       expect(isC8RunConnection({ contactPoint: 'http://localhost:8080' })).to.be.false;
+    });
+
+  });
+
+  describe('getConnectionFingerprint', function() {
+
+    it('should return null without a connection', function() {
+      expect(getConnectionFingerprint(null)).to.be.null;
+      expect(getConnectionFingerprint(undefined)).to.be.null;
+    });
+
+    it('should be stable for the same identity', function() {
+
+      // given
+      const connection = {
+        id: 'a',
+        contactPoint: 'http://localhost:26500',
+        authType: 'none'
+      };
+
+      // then
+      expect(getConnectionFingerprint(connection)).to.eql(
+        getConnectionFingerprint({ ...connection })
+      );
+    });
+
+    it('should ignore the connection id and non-identity fields', function() {
+
+      // given
+      const connection = {
+        id: 'a',
+        name: 'My Connection',
+        contactPoint: 'http://localhost:26500',
+        authType: 'none'
+      };
+
+      // then
+      expect(getConnectionFingerprint(connection)).to.eql(
+        getConnectionFingerprint({
+          ...connection,
+          id: 'b',
+          name: 'Renamed'
+        })
+      );
+    });
+
+    it('should ignore secrets', function() {
+
+      // given
+      const connection = {
+        contactPoint: 'http://localhost:26500',
+        authType: 'oauth',
+        clientId: 'client',
+        clientSecret: 'secret'
+      };
+
+      // then
+      expect(getConnectionFingerprint(connection)).to.eql(
+        getConnectionFingerprint({ ...connection, clientSecret: 'rotated' })
+      );
+    });
+
+    it('should change when the cluster changes', function() {
+
+      // given
+      const connection = { contactPoint: 'http://localhost:26500' };
+
+      // then
+      expect(getConnectionFingerprint(connection)).to.not.eql(
+        getConnectionFingerprint({ contactPoint: 'http://other:26500' })
+      );
+    });
+
+    it('should change when the tenant changes', function() {
+
+      // given
+      const connection = { contactPoint: 'http://localhost:26500', tenantId: 'a' };
+
+      // then
+      expect(getConnectionFingerprint(connection)).to.not.eql(
+        getConnectionFingerprint({ ...connection, tenantId: 'b' })
+      );
+    });
+
+    it('should change when the principal changes', function() {
+
+      // given
+      const connection = {
+        contactPoint: 'http://localhost:26500',
+        authType: 'oauth',
+        clientId: 'client-a'
+      };
+
+      // then
+      expect(getConnectionFingerprint(connection)).to.not.eql(
+        getConnectionFingerprint({ ...connection, clientId: 'client-b' })
+      );
+    });
+
+    it('should not log secrets in the fingerprint', function() {
+
+      // given
+      const connection = {
+        contactPoint: 'http://localhost:26500',
+        authType: 'oauth',
+        clientId: 'client',
+        clientSecret: 'super-secret'
+      };
+
+      // then
+      expect(getConnectionFingerprint(connection)).to.not.contain('super-secret');
     });
 
   });

--- a/client/src/plugins/zeebe-plugin/shared/util.js
+++ b/client/src/plugins/zeebe-plugin/shared/util.js
@@ -68,3 +68,52 @@ export function isC8RunConnection(connection) {
 
   return urlMatches && nameMatches;
 }
+
+/**
+ * Identity-bearing endpoint fields, in a stable order. Two connections that
+ * agree on all of these address the same cluster, tenant and principal, and
+ * therefore expose the same credentials and permissions. Secrets are
+ * deliberately excluded: rotating a secret for the same principal does not
+ * change the server-side data, and the fingerprint must be safe to log.
+ *
+ * @type {string[]}
+ */
+const CONNECTION_IDENTITY_FIELDS = [
+  'targetType',
+  'contactPoint',
+  'camundaCloudClusterUrl',
+  'tenantId',
+  'authType',
+  'clientId',
+  'camundaCloudClientId',
+  'basicAuthUsername',
+  'oauthURL',
+  'audience'
+];
+
+/**
+ * Compute an opaque fingerprint of a connection's identity.
+ *
+ * The connection id is a stable, persisted handle that does NOT change when a
+ * connection is edited in place, so it cannot by itself tell whether the
+ * cluster, tenant or principal behind it changed. This fingerprint fills that
+ * gap: it changes whenever an identity-bearing field changes and stays equal
+ * across tab activations and re-checks of an unchanged connection.
+ *
+ * Consumers must treat the value as opaque — compare for equality only, never
+ * parse it. It is intended as a cache/staleness token that lives alongside the
+ * connection id (see `connectionFingerprint` on the connection events).
+ *
+ * @param {Endpoint} connection
+ *
+ * @returns {string|null} the fingerprint, or null when there is no connection
+ */
+export function getConnectionFingerprint(connection) {
+  if (!connection) {
+    return null;
+  }
+
+  return CONNECTION_IDENTITY_FIELDS
+    .map(field => `${field}=${connection[field] ?? ''}`)
+    .join('|');
+}


### PR DESCRIPTION
### Proposed Changes

Builds on top of #6099 (merged). Refactors the credential load/reload lifecycle so credentials are cached and refreshed only when the connection actually changes, instead of being re-fetched per tab and per trigger.

The change is split into self-contained commits: a small, reusable connection-manager feature, the credential caching work that builds on it, and a follow-up rendering refinement.

#### 1. `feat(connection-manager)`: expose connection identity fingerprint

* The connection id is a stable, persisted handle that does **not** change when a connection is edited in place, so on its own it can't tell whether the cluster, tenant or principal behind it changed. The connection-manager plugin — the single authority on connection identity — now emits an opaque **`connectionFingerprint`** alongside `connectionId` on both connection events (`connectionCheckStarted`, `connectionStatusChanged`).
* It is derived from the connection's identity-bearing fields (target type, cluster URL / contact point, tenant, auth type and principal — **never secrets**, so it is safe to log), so it changes on any such change and stays equal across tab activations and periodic re-checks.
* Consumers treat the value as **opaque** (compare for equality only), staying decoupled from the endpoint schema. This commit only *exposes* the fingerprint; it has no consumer on its own.

#### 2. `feat(credential-manager)`: connection-scoped credential cache + lifecycle refactor

* **`CredentialCache`** (app-level): holds a cluster's credentials — the user's create/update permissions (per connection) and the credential cluster variables (`kind=CREDENTIAL`), server-filtered per configuration template and cached per `(connection, configurationTemplate)`. Queries are memoized and in-flight coalesced, so tabs sharing a connection + template fetch once, and each fetch pulls only that template's credentials rather than the cluster's whole credential population.
* **Pure-subscriber `CredentialManager`**: the manager no longer resolves the tab's endpoint or watches the file — the connection is pushed in entirely by the connection lifecycle. `connectionCheckStarted` renders availability (connection vs. "connect to a cluster"), `connectionStatusChanged` carries the check result that gates loading.
* **Establishment-gated first load**: nothing is fetched before establishment, so early triggers (`import.done`, `elementTemplates.changed`) no longer race the connection check and get invalidated by it — the redundant double fetch on tab open is gone.
* **Fingerprint-driven staleness** (consumes commit 1): on `connectionStatusChanged` the manager calls `CredentialCache.revalidate(connectionId, connectionFingerprint)`, which clears a connection's cache only when the fingerprint changed. Re-activating a tab is now a **no-op** instead of a full permissions + credentials refetch, while an edit-in-place or reconnect still resets. `app.focused` invalidation force-refreshes but keeps the fingerprint, so a later in-place edit remains detectable. Every revalidate outcome (init / unchanged / changed) is logged under the `CredentialCache` debug namespace.
* **`commandStack.changed`**: debounced, referenced-only refresh with a name-set diff — paste/undo/redo/delete stay current, unrelated edits do nothing.
* **Write-through**: in-app create/edit upserts into the cached source, so other tabs reflect it on their next load without a refetch.
* **Cache-on-failure**: a deny derived from a failed query is rendered but not cached (re-queried next trigger); a legitimate empty-grants deny from a successful query stays cached.

#### 3. `perf(credential-manager)`: show loading only on first population

* The chooser registry (`configurationInstances`) fires `changed` on every `setState` with no equality guard, so pushing `{ loading: true }` on each trigger produced a spinner flash on every tab activation and focus. The loading push is now gated on `!isAvailable()`: a real spinner on cold start, stale-while-revalidate afterwards (the already-shown list stays put while a background revalidation runs).

### Remaining caveats

These are known, accepted limitations of this slice — none are regressions, but they bound how far the refactor goes:

* **Terminal "loaded" push still fires per activation.** Only the *loading* push is guarded (caveat 3). The final loaded `setState` still runs on each trigger with fresh array references, so the chooser does one idempotent re-render per activation. Eliminating it needs a `changed`-dedupe **inside `bpmn-js-element-templates`** (equality check before emit); it can't be fixed host-side without touching `node_modules`.
* **"No mount load" leans on the plugin re-emitting on every activation.** The manager deliberately never loads on mount; a re-activated tab reloads only because `ConnectionManagerPlugin` emits fresh connection objects each activation (`getEndpoints().map(sanitizeEndpoint)`). If the plugin were ever changed to reuse connection objects across activations, a re-activated tab would receive no event and wouldn't reload. This coupling is load-bearing and documented in a code comment, but it is an implicit contract rather than an enforced one.
* **No truly lazy, on-open per-template load.** `selectableInstances` still populates when templates are present, not when the chooser popover actually opens — see Follow-ups.
* **App-level service access is still prop-drilled.** `CredentialManager` receives `credentialCache`/`zeebeApi` as props threaded through `MultiSheetTab` → `BpmnEditor`. A `ServicesContext` (didi-style `get(name)`) that lets the manager pull app singletons and subscribe to app events directly was prototyped separately and is **not** part of this PR.

### Complexity vs. architecture / performance

This is intentionally **not a code-simplicity improvement** — it is a net increase in moving parts (a new `CredentialCache`, an opaque fingerprint, explicit cache lifecycle, and event wiring). The trade is deliberate:

* **Architecture.** Responsibilities are now cleanly separated: `ConnectionManagerPlugin` is the sole authority on connection identity, `CredentialCache` is a connection-scoped memoized store with a small opaque contract (fingerprint equality), and `CredentialManager` collapses to a pure subscriber/bridge. The manager sheds its ad-hoc endpoint resolution and file watching. The added complexity is concentrated in one well-tested unit rather than spread across the manager.
* **Performance.** The refactor removes the double-fetch on tab open, makes tab re-activation a no-op, de-dups permissions + credential fetches per `(connection, template)` across tabs, narrows model-change refreshes to only newly-referenced names, and drops the per-activation spinner flash.

In short: more code, but clearer ownership and materially fewer network round-trips and re-renders on the hot paths (tab open, tab switch, refocus).

### Follow-ups

* Truly lazy per-template `selectableInstances` load (only when the chooser popover opens) needs a pull-on-open signal from `bpmn-js-element-templates`; the chooser is currently a pure subscriber with no host-visible open event.
* Host-side `configurationInstances.changed` dedupe (or a lib-side equality guard) to make an unchanged revalidation a true end-to-end no-op.
* `ServicesContext` to remove app-service prop-drilling and let the manager subscribe to app events via a well-known `eventBus` service (prototyped on a separate branch).

### Related

* Builds on top of #6099

### Checklist

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__