### PR TITLE
refactor: centralize engine profile change detection

### DIFF
--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -70,7 +70,6 @@ import { GridBehavior } from '../util/grid';
 
 import {
   EngineProfile,
-  engineProfilesEqual,
   getEngineProfileFromBpmn
 } from '../EngineProfile';
 
@@ -315,17 +314,6 @@ export class BpmnEditor extends CachedComponent {
   }
 
   emitEngineProfileChanged = (engineProfile) => {
-
-    // editors detect their engine profile on every import (e.g. tab open),
-    // not only on an actual change. Emit `tab.engineProfileChanged` only when
-    // the profile really changed so no consumer has to compensate for
-    // redundant events.
-    if (engineProfilesEqual(engineProfile, this._emittedEngineProfile)) {
-      return;
-    }
-
-    this._emittedEngineProfile = engineProfile;
-
     const {
       executionPlatform,
       executionPlatformVersion
@@ -522,13 +510,12 @@ export class BpmnEditor extends CachedComponent {
     } else {
       this.setCached({
         defaultTemplatesApplied,
-        engineProfile,
         lastXML: xml,
         stackIdx
       });
 
       if (engineProfile) {
-        this.emitEngineProfileChanged(engineProfile);
+        this.engineProfile.setCached(engineProfile);
       }
     }
 

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -2998,15 +2998,26 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
 
       // given
       const emitSpy = sinon.spy();
+      const cache = new Cache();
 
-      const { instance } = await renderEditor(engineProfileXML, {
-        emit: emitSpy
+      const { unmount } = await renderEditor(engineProfileXML, {
+        cache,
+        emit: emitSpy,
+        id: 'editor'
       });
 
       emitSpy.resetHistory();
+      unmount();
+
+      const { instance } = await renderEditor(engineProfileXML, {
+        cache,
+        emit: emitSpy,
+        id: 'editor',
+        waitForImport: false
+      });
 
       // when
-      instance.emitEngineProfileChanged({
+      instance.engineProfile.setCached({
         executionPlatform: 'Camunda Cloud',
         executionPlatformVersion: '1.1.0'
       });

--- a/client/src/app/tabs/cloud-dmn/DmnEditor.js
+++ b/client/src/app/tabs/cloud-dmn/DmnEditor.js
@@ -66,7 +66,7 @@ import { migrateDiagram } from '@bpmn-io/dmn-migrate';
 
 import { DEFAULT_LAYOUT as overviewDefaultLayout } from '../dmn/OverviewContainer';
 
-import { EngineProfile, engineProfilesEqual, toSemver } from '../EngineProfile';
+import { EngineProfile, toSemver } from '../EngineProfile';
 
 import EngineProfileHelper from '../EngineProfileHelper';
 
@@ -286,13 +286,12 @@ export class DmnEditor extends CachedComponent {
     } else {
       this.setCached({
         dirty: false,
-        engineProfile,
         lastXML: xml,
         stackIdx
       });
 
       if (engineProfile) {
-        this.emitEngineProfileChanged(engineProfile);
+        this.engineProfile.setCached(engineProfile);
       }
 
       this.setState({
@@ -376,17 +375,6 @@ export class DmnEditor extends CachedComponent {
   };
 
   emitEngineProfileChanged = (engineProfile) => {
-
-    // editors detect their engine profile on every import (e.g. tab open),
-    // not only on an actual change. Emit `tab.engineProfileChanged` only when
-    // the profile really changed so no consumer has to compensate for
-    // redundant events.
-    if (engineProfilesEqual(engineProfile, this._emittedEngineProfile)) {
-      return;
-    }
-
-    this._emittedEngineProfile = engineProfile;
-
     const {
       executionPlatform,
       executionPlatformVersion

--- a/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
@@ -2520,7 +2520,7 @@ describe('<DmnEditor>', function() {
       emitSpy.resetHistory();
 
       // when
-      instance.emitEngineProfileChanged({
+      instance.engineProfile.setCached({
         executionPlatform: 'Camunda Cloud',
         executionPlatformVersion: '8.0.0'
       });

--- a/client/src/app/tabs/form/FormEditor.js
+++ b/client/src/app/tabs/form/FormEditor.js
@@ -34,7 +34,6 @@ import Metadata from '../../../util/Metadata';
 
 import {
   EngineProfile,
-  engineProfilesEqual,
   getEngineProfileFromForm
 } from '../EngineProfile';
 
@@ -258,13 +257,12 @@ export class FormEditor extends CachedComponent {
       });
     } else {
       this.setCached({
-        engineProfile,
         lastSchema: schema,
         stackIdx
       });
 
       if (engineProfile) {
-        this.emitEngineProfileChanged(engineProfile);
+        this.engineProfile.setCached(engineProfile);
       }
 
       this.linting.schedule();
@@ -382,17 +380,6 @@ export class FormEditor extends CachedComponent {
   }
 
   emitEngineProfileChanged = (engineProfile) => {
-
-    // editors detect their engine profile on every import (e.g. tab open),
-    // not only on an actual change. Emit `tab.engineProfileChanged` only when
-    // the profile really changed so no consumer has to compensate for
-    // redundant events.
-    if (engineProfilesEqual(engineProfile, this._emittedEngineProfile)) {
-      return;
-    }
-
-    this._emittedEngineProfile = engineProfile;
-
     const {
       executionPlatform,
       executionPlatformVersion

--- a/client/src/app/tabs/form/__tests__/FormEditorSpec.js
+++ b/client/src/app/tabs/form/__tests__/FormEditorSpec.js
@@ -761,7 +761,7 @@ describe('<FormEditor>', function() {
       emitSpy.resetHistory();
 
       // when
-      instance.emitEngineProfileChanged({
+      instance.engineProfile.setCached({
         executionPlatform: 'Camunda Platform',
         executionPlatformVersion: '7.16.0'
       });

--- a/client/src/app/tabs/rpa/RPAEditor.js
+++ b/client/src/app/tabs/rpa/RPAEditor.js
@@ -37,7 +37,6 @@ import { Loader } from '../../primitives';
 
 import {
   EngineProfile,
-  engineProfilesEqual,
   getEngineProfileFromForm
 } from '../EngineProfile';
 
@@ -348,17 +347,6 @@ export class RPAEditor extends CachedComponent {
   }
 
   emitEngineProfileChanged = (engineProfile) => {
-
-    // editors detect their engine profile on every import (e.g. tab open),
-    // not only on an actual change. Emit `tab.engineProfileChanged` only when
-    // the profile really changed so no consumer has to compensate for
-    // redundant events.
-    if (engineProfilesEqual(engineProfile, this._emittedEngineProfile)) {
-      return;
-    }
-
-    this._emittedEngineProfile = engineProfile;
-
     const {
       executionPlatform,
       executionPlatformVersion

--- a/client/src/app/tabs/rpa/__tests__/RPAEditorSpec.js
+++ b/client/src/app/tabs/rpa/__tests__/RPAEditorSpec.js
@@ -409,7 +409,7 @@ describe('<RPAEditor>', function() {
       emitSpy.resetHistory();
 
       // when
-      instance.emitEngineProfileChanged({
+      instance.engineProfile.setCached({
         executionPlatform: 'Camunda Cloud',
         executionPlatformVersion: '8.8.0'
       });


### PR DESCRIPTION
### Proposed Changes

Centralize engine-profile change detection in EngineProfileHelper.

Editors previously bypassed the helper during import and duplicated their own change guards. Imports now use `EngineProfileHelper#setCached`, which deduplicates events using the tab-scoped cache and continues working across editor remounts.

This removes duplicate logic from the BPMN, DMN, Form, and RPA editors and ensures `tab.engineProfileChanged` is emitted only when the profile actually changes.

Related to https://github.com/camunda/camunda-modeler/pull/6117

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
