### PR TITLE
fix(app): do not auto-save discarded tab on close

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -463,11 +463,23 @@ export class App extends PureComponent {
   /**
    * Show the tab.
    *
+   * Showing a tab is treated as switching to it: the previously active tab is
+   * auto-saved. Pass `autoSavePreviousTab: false` when the previous tab must
+   * not be saved, e.g. while closing it (its unsaved changes may have been
+   * discarded on purpose).
+   *
    * @param {Tab} tab
+   * @param {Object} [options]
+   * @param {boolean} [options.autoSavePreviousTab=true] auto-save the previously
+   * active tab
    *
    * @return {Promise<Void>} tab shown promise
    */
-  async showTab(tab) {
+  async showTab(tab, options = {}) {
+
+    const {
+      autoSavePreviousTab = true
+    } = options;
 
     const {
       activeTab,
@@ -479,7 +491,7 @@ export class App extends PureComponent {
     }
 
     // auto-save the previously active tab when switching (async, non-blocking)
-    if (activeTab !== tab && this.shouldAutoSave(activeTab)) {
+    if (autoSavePreviousTab && activeTab !== tab && this.shouldAutoSave(activeTab)) {
 
       const contents = await this.getActiveTabContents();
 
@@ -682,7 +694,8 @@ export class App extends PureComponent {
         EMPTY_TAB
       );
 
-      await this.showTab(nextActive);
+      // discarded changes must not be auto-saved back to the closing tab
+      await this.showTab(nextActive, { autoSavePreviousTab: false });
     }
 
     return new Promise((resolve) => {

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -1635,6 +1635,27 @@ describe('<App>', function() {
     });
 
 
+    it('should NOT auto-save discarded tab on close', async function() {
+
+      // given
+      const file = createFile('diagram_1.bpmn');
+      const [ tab ] = await app.openFiles([ file ]);
+
+      // mark as dirty
+      app.setState(app.setDirty(tab));
+      await waitFor(() => expect(app.isDirty(tab)).to.be.true);
+
+      // user chooses to discard the unsaved changes when closing
+      dialog.setShowCloseFileDialogResponse({ button: 'discard' });
+
+      // when
+      await app.closeTab(tab);
+
+      // then: the discarded changes must NOT be written back to the file
+      expect(writeFileSpy).not.to.have.been.called;
+    });
+
+
     it('should handle auto-save on window blur', async function() {
 
       // given


### PR DESCRIPTION
### Proposed Changes

Closing a dirty, saved tab and choosing __Don't Save__ still wrote the changes to disk, then popped a "file changed externally" dialog:

<img width="1332" height="884" alt="capture DMwxcE_optimized" src="https://github.com/user-attachments/assets/46e41b1d-e9de-4ed3-a097-d8f92f23f3fa" />


#### Root cause

`closeTab` → `_removeTab` switches to the next tab via `showTab`, which auto-saves the previously active tab. The tab being closed was still the active tab, so its discarded changes got written back.

#### Fix

Skip auto-save of the previous tab while closing (new `autoSavePreviousTab` option on `showTab`, off for the close path). Normal tab-switch auto-save is unchanged:

<img width="1332" height="884" alt="capture t96vDJ_optimized" src="https://github.com/user-attachments/assets/6193a37c-4b27-40f0-bad2-4ad30dc07671" />

### Steps to try out

1. Open a saved BPMN diagram and edit it (tab is dirty).
2. Close it (`CTRL+W`) and pick __Don't Save__.
3. The file on disk stays unchanged and no external-change dialog appears.

Closes https://github.com/camunda/camunda-modeler/issues/5571

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)