### PR TITLE
fix(credential-manager): ensure unique name and id when creating credentials

### DIFF
--- a/client/src/app/modals/credentials/CredentialModal.js
+++ b/client/src/app/modals/credentials/CredentialModal.js
@@ -28,6 +28,7 @@ import {
 } from './config';
 
 import {
+  getUniqueCredentialIdentity,
   getCredentialIdError,
   toCredentialId
 } from './credentialId';
@@ -54,12 +55,17 @@ class CredentialModal extends PureComponent {
   constructor(props) {
     super(props);
 
+    const identity = props.mode === 'create'
+      ? getUniqueCredentialIdentity(props.displayName || '', props.existingCredentials)
+      : {
+        displayName: props.displayName || '',
+        credentialId: props.credentialName || ''
+      };
+
     this.state = {
-      displayName: props.displayName || '',
+      displayName: identity.displayName,
       displayNameChanged: false,
-      credentialName: props.mode === 'create'
-        ? toCredentialId(props.displayName || '')
-        : props.credentialName || '',
+      credentialName: identity.credentialId,
       credentialNameChanged: false,
       initialValues: props.initialValues,
       values: props.initialValues || {},

--- a/client/src/app/modals/credentials/__tests__/CredentialModalSpec.js
+++ b/client/src/app/modals/credentials/__tests__/CredentialModalSpec.js
@@ -467,6 +467,30 @@ describe('<CredentialModal>', function() {
   });
 
 
+  it('should suggest a unique credential name and ID', function() {
+
+    // when
+    const { getByLabelText } = renderModal({
+      mode: 'create',
+      displayName: 'Name ',
+      existingCredentials: [
+        {
+          name: 'NAME',
+          metadata: { displayName: 'Name' }
+        },
+        {
+          name: 'NAME_1',
+          metadata: { displayName: 'Name 1' }
+        }
+      ]
+    });
+
+    // then
+    expect(getByLabelText('Credential name').value).to.equal('Name 2');
+    expect(getByLabelText('Credential ID *').value).to.equal('NAME_2');
+  });
+
+
   it('should show a required ID error when the display name is cleared', function() {
 
     // given
@@ -560,7 +584,7 @@ describe('<CredentialModal>', function() {
 
   it('should disable submit when the credential name already exists', function() {
 
-    // when
+    // given
     const { getByLabelText, getByRole, getByText } = renderModal({
       mode: 'create',
       displayName: 'My cred',
@@ -569,6 +593,9 @@ describe('<CredentialModal>', function() {
         metadata: { displayName: 'My cred' }
       } ]
     });
+
+    // when
+    fireEvent.change(getByLabelText('Credential name'), { target: { value: 'My cred' } });
 
     // then
     const input = getByLabelText('Credential name');
@@ -583,7 +610,7 @@ describe('<CredentialModal>', function() {
 
   it('should disable submit when the credential ID already exists', function() {
 
-    // when
+    // given
     const { getByLabelText, getByRole, getByText } = renderModal({
       mode: 'create',
       displayName: 'My cred',
@@ -592,6 +619,9 @@ describe('<CredentialModal>', function() {
         metadata: { displayName: 'Other credential' }
       } ]
     });
+
+    // when
+    fireEvent.change(getByLabelText('Credential ID *'), { target: { value: 'MY_CRED' } });
 
     // then
     const input = getByLabelText('Credential ID *');

--- a/client/src/app/modals/credentials/credentialId.js
+++ b/client/src/app/modals/credentials/credentialId.js
@@ -73,7 +73,12 @@ export function getUniqueCredentialIdentity(displayName, existingCredentials = [
     }
   }
 
-  throw new Error('Unable to generate a unique credential identity.');
+  console.error('Unable to generate a unique credential identity.');
+
+  return {
+    displayName: normalizedDisplayName,
+    credentialId: toCredentialId(normalizedDisplayName)
+  };
 }
 
 /**

--- a/client/src/app/modals/credentials/credentialId.js
+++ b/client/src/app/modals/credentials/credentialId.js
@@ -50,6 +50,32 @@ export function toCredentialId(displayName) {
   return /^[A-Z_]/.test(slug) ? slug : `${ FALLBACK }_${ slug }`;
 }
 
+export function getUniqueCredentialIdentity(displayName, existingCredentials = []) {
+  const normalizedDisplayName = displayName.trim();
+  const displayNames = new Set(
+    existingCredentials.map(credential => credential.metadata?.displayName?.trim())
+  );
+  const credentialIds = new Set(
+    existingCredentials.map(credential => credential.name)
+  );
+
+  for (let suffix = 0; suffix <= existingCredentials.length * 2; suffix++) {
+    const uniqueDisplayName = suffix
+      ? `${ normalizedDisplayName } ${ suffix }`
+      : normalizedDisplayName;
+    const credentialId = toCredentialId(uniqueDisplayName);
+
+    if (!displayNames.has(uniqueDisplayName) && !credentialIds.has(credentialId)) {
+      return {
+        displayName: uniqueDisplayName,
+        credentialId
+      };
+    }
+  }
+
+  throw new Error('Unable to generate a unique credential identity.');
+}
+
 /**
  * Validate a credential ID against cluster-variable naming rules.
  *

--- a/client/src/app/tabs/cloud-bpmn/credential-manager/__tests__/CredentialManagerSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/credential-manager/__tests__/CredentialManagerSpec.js
@@ -491,10 +491,13 @@ describe('<CredentialManager>', function() {
         metadata: INSTANCE_METADATA
       } ]
     });
-    const { eventBus, getByRole, getByText } = renderManager({ configurationInstances });
+    const { eventBus, findByLabelText, getByRole, getByText } = renderManager({ configurationInstances });
+
+    eventBus.fire('configuration.create', createEvent());
+    const displayNameInput = await findByLabelText('Credential name');
 
     // when
-    eventBus.fire('configuration.create', createEvent());
+    fireEvent.change(displayNameInput, { target: { value: 'My Cred' } });
 
     // then
     await waitFor(() => {


### PR DESCRIPTION
### Problem

If credentials are created with the default name and ID combo, the next time I open the create modal, I see errors, cause the defaults are the same.

Not a great UX.

https://github.com/user-attachments/assets/a119acaf-9686-4b63-a1ed-aa2a31e5398f

### Proposed Changes

Ensure the default values for name and ID are unique, by adding a number incrementally:

https://github.com/user-attachments/assets/a4d9369a-09f1-4414-8bec-6ad2966450d1

### Steps to try out

1. Create credentials with the default name and ID.
2. Open Create modal again.
3. Before, you see errors on name and ID.
4. After, you see no errors.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
