### PR TITLE
chore: link changelog agentDefinition entry to camunda-modeler issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: support configuration templates via `zeebe:configuration` binding ([bpmn-io/bpmn-js-element-templates#263](https://github.com/bpmn-io/bpmn-js-element-templates/pull/263))
 * `FEAT`: manage credentials for configuration templates ([#6099](https://github.com/camunda/camunda-modeler/pull/6099))
 * `FEAT`: support credential management for clusters with disabled authentication ([#6130](https://github.com/camunda/camunda-modeler/pull/6130))
-* `FEAT`: support `zeebe:agentDefinition` extension element and element template binding for service tasks and ad-hoc sub-processes ([camunda/zeebe-bpmn-moddle#94](https://github.com/camunda/zeebe-bpmn-moddle/pull/94), [bpmn-io/bpmn-js-element-templates#286](https://github.com/bpmn-io/bpmn-js-element-templates/pull/286))
+* `FEAT`: support `zeebe:agentDefinition` extension element and element template binding for service tasks and ad-hoc sub-processes ([#6094](https://github.com/camunda/camunda-modeler/issues/6094))
 * `FEAT`: surface element template configuration state via warnings and descriptions ([bpmn-io/bpmn-js-element-templates#287](https://github.com/bpmn-io/bpmn-js-element-templates/pull/287))
 * `FEAT`: add semantic warning tokens and `.has-warning` entry modifier ([bpmn-io/properties-panel#544](https://github.com/bpmn-io/properties-panel/pull/544))
 * `FEAT`: use CSS for textarea auto-resize ([bpmn-io/properties-panel#540](https://github.com/bpmn-io/properties-panel/pull/540))


### PR DESCRIPTION
### Proposed Changes

Updates the `CHANGELOG.md` entry for the `zeebe:agentDefinition` feature to link to the camunda-modeler issue instead of the upstream `zeebe-bpmn-moddle` and `bpmn-js-element-templates` PR links, which aren't the primary reference for this change from a camunda-modeler consumer's perspective.

Related to https://github.com/camunda/camunda-modeler/issues/6094

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes (not applicable, changelog-only change)
  * [ ] __Steps to try out__ (not applicable, changelog-only change)