### PR TITLE
chore: add changelog entry for agent tool configuration autofix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: manage credentials for configuration templates ([#6099](https://github.com/camunda/camunda-modeler/pull/6099))
 * `FEAT`: support credential management for clusters with disabled authentication ([#6130](https://github.com/camunda/camunda-modeler/pull/6130))
 * `FEAT`: support `zeebe:agentDefinition` extension element and element template binding for service tasks and ad-hoc sub-processes ([#6094](https://github.com/camunda/camunda-modeler/issues/6094))
+* `FEAT`: fix agent tool configuration mistakes from the properties panel ([#6115](https://github.com/camunda/camunda-modeler/issues/6115))
 * `FEAT`: surface element template configuration state via warnings and descriptions ([bpmn-io/bpmn-js-element-templates#287](https://github.com/bpmn-io/bpmn-js-element-templates/pull/287))
 * `FEAT`: add semantic warning tokens and `.has-warning` entry modifier ([bpmn-io/properties-panel#544](https://github.com/bpmn-io/properties-panel/pull/544))
 * `FEAT`: use CSS for textarea auto-resize ([bpmn-io/properties-panel#540](https://github.com/bpmn-io/properties-panel/pull/540))


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/camunda/camunda-modeler/issues/6115

Adds the missing `5.51.0` changelog entry for #6102, which registers `@camunda/linting-autofix`'s `agentConfigAutofillModule` so malformed agent tool input mappings can be fixed from the properties panel. The change shipped in `5.51.0` but was never reflected in `CHANGELOG.md`.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)