### PR TITLE
fix(credential-manager): do not allow modifying credential id

### DIFF
--- a/.github/workflows/CHECK_PENDING_RELEASES.yml
+++ b/.github/workflows/CHECK_PENDING_RELEASES.yml
@@ -1,0 +1,85 @@
+name: CHECK_PENDING_RELEASES
+
+on:
+  workflow_dispatch:
+    inputs:
+      concurrency:
+        description: 'Number of dependencies to check in parallel'
+        default: '10'
+  schedule:
+    # noon UTC, daily
+    - cron: '0 12 * * *'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check:
+    name: Check for pending upstream releases
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Vault OIDC/JWT auth (Slack reminder, scheduled runs only)
+    timeout-minutes: 15
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+    - name: Use Node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version: 24
+        cache: 'npm'
+    - name: Install dependencies
+      run: npm ci
+    - name: Compile tracked dependency list
+      run: node tasks/list-tracked-dependencies.js
+    # Only the daily reminder needs a Slack channel - manual runs are
+    # already watched live via the job summary, so skip importing/posting
+    # to avoid double notifications when someone triggers this by hand.
+    - name: Import Secrets
+      if: ${{ github.event_name == 'schedule' }}
+      id: secrets
+      uses: hashicorp/vault-action@v4.0.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: jwt
+        role: ${{ secrets.VAULT_JWT_ROLE }}
+        path: ${{ secrets.VAULT_JWT_PATH }}
+        jwtGithubAudience: ${{ secrets.VAULT_JWT_AUDIENCE }}
+        exportEnv: false
+        secrets: |
+          secret/data/products/desktop-modeler/ci/slack_integration SLACK_CHANNEL_ID;
+          secret/data/products/desktop-modeler/ci/slack_integration SLACK_BOT_TOKEN;
+    - name: Check pending releases
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SLACK_CHANNEL_ID: ${{ steps.secrets.outputs.SLACK_CHANNEL_ID }}
+        # Routed through env rather than interpolated directly into the
+        # script - a workflow_dispatch input is user-controlled, and
+        # splicing it into the run block as `${{ }}` would let a value
+        # like `"; rm -rf . #` break out of the quoted argument and run
+        # arbitrary shell (with GH_TOKEN in scope).
+        CONCURRENCY_INPUT: ${{ github.event.inputs.concurrency }}
+      run: |
+        node tasks/check-pending-releases.js \
+          --concurrency="${CONCURRENCY_INPUT:-10}" \
+          --json \
+          --markdown="$GITHUB_STEP_SUMMARY" \
+          --slack=pending-releases-slack.json \
+          > pending-releases.json
+    - name: Upload results
+      uses: actions/upload-artifact@v7
+      with:
+        name: pending-releases
+        path: pending-releases.json
+    # pending-releases-slack.json only exists when the check found pending
+    # releases - a quiet day sends no message, rather than a daily "all good".
+    - name: Post reminder to Slack
+      if: ${{ github.event_name == 'schedule' && hashFiles('pending-releases-slack.json') != '' }}
+      uses: slackapi/slack-github-action@v4
+      with:
+        method: chat.postMessage
+        token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+        payload-file-path: pending-releases-slack.json

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage
 tmp
 test/e2e/test-results
 test/e2e/playwright-report
+tasks/tracked-dependencies.json

--- a/client/src/app/modals/credentials/CredentialModal.css
+++ b/client/src/app/modals/credentials/CredentialModal.css
@@ -33,10 +33,6 @@
     align-items: stretch;
     margin-bottom: 16px;
 
-    #credential-id[readonly] {
-      color: var(--color-grey-225-10-55);
-    }
-
     &.has-error .form-control {
       border-color: var(--color-red-360-100-45);
       background-color: var(--color-red-360-100-97);
@@ -50,10 +46,17 @@
 
   .form-text {
     max-width: var(--input-width);
-    margin: 4px 0 0;
+    margin: 6px 0 0;
     font-size: 12px;
     line-height: 1.4;
     color: var(--color-grey-225-10-45);
+
+    code {
+      padding: 1px 4px;
+      border-radius: 4px;
+      background-color: var(--color-grey-225-10-90);
+      overflow-wrap: anywhere;
+    }
 
     a {
       color: var(--color-blue-205-100-45);

--- a/client/src/app/modals/credentials/CredentialModal.js
+++ b/client/src/app/modals/credentials/CredentialModal.js
@@ -28,9 +28,10 @@ import {
 } from './config';
 
 import {
+  generateCredentialIdSuffix,
   getUniqueCredentialIdentity,
   getCredentialIdError,
-  toCredentialId
+  toRandomCredentialId
 } from './credentialId';
 
 import * as css from './CredentialModal.css';
@@ -55,8 +56,15 @@ class CredentialModal extends PureComponent {
   constructor(props) {
     super(props);
 
+    const credentialIdSuffix = props.mode === 'create'
+      ? generateCredentialIdSuffix()
+      : null;
     const identity = props.mode === 'create'
-      ? getUniqueCredentialIdentity(props.displayName || '', props.existingCredentials)
+      ? getUniqueCredentialIdentity(
+        props.displayName || '',
+        props.existingCredentials,
+        credentialIdSuffix
+      )
       : {
         displayName: props.displayName || '',
         credentialId: props.credentialName || ''
@@ -64,9 +72,8 @@ class CredentialModal extends PureComponent {
 
     this.state = {
       displayName: identity.displayName,
-      displayNameChanged: false,
       credentialName: identity.credentialId,
-      credentialNameChanged: false,
+      credentialIdSuffix,
       initialValues: props.initialValues,
       values: props.initialValues || {},
       checkedValues: props.initialValues || {},
@@ -177,20 +184,12 @@ class CredentialModal extends PureComponent {
   handleDisplayNameChange = (event) => {
     const displayName = event.target.value;
 
-    this.setState(state => ({
+    this.setState(({ credentialIdSuffix, credentialName }) => ({
       displayName,
-      displayNameChanged: true,
-      credentialName: this.props.mode === 'create' && !state.credentialNameChanged
-        ? toCredentialId(displayName)
-        : state.credentialName
+      credentialName: this.props.mode === 'create'
+        ? toRandomCredentialId(displayName, credentialIdSuffix)
+        : credentialName
     }));
-  };
-
-  handleCredentialNameChange = (event) => {
-    this.setState({
-      credentialName: event.target.value,
-      credentialNameChanged: true
-    });
   };
 
   handleFieldChange(id, value) {
@@ -300,19 +299,12 @@ class CredentialModal extends PureComponent {
     const { loading, mode, onClose } = this.props;
     const {
       credentialName,
-      credentialNameChanged,
       displayName,
-      displayNameChanged,
       submitting,
       error
     } = this.state;
 
     const displayNameError = this.getDuplicateDisplayNameError();
-    const credentialNameError = getCredentialIdError(credentialName) || this.getDuplicateCredentialNameError();
-    const showCredentialNameError = credentialNameError
-      && (credentialNameChanged || displayNameChanged || credentialName);
-
-    const isCreate = mode === 'create';
 
     return (
       <Modal onClose={ submitting ? null : onClose }>
@@ -344,25 +336,6 @@ class CredentialModal extends PureComponent {
                   >
                     { displayNameError }
                   </p>
-                ) }
-              </div>
-
-              <div className={ showCredentialNameError ? 'form-group has-error' : 'form-group' }>
-                <label htmlFor="credential-id">Credential ID *</label>
-                <input
-                  id="credential-id"
-                  className={ showCredentialNameError ? 'form-control is-invalid' : 'form-control' }
-                  type="text"
-                  value={ credentialName }
-                  readOnly={ !isCreate }
-                  aria-invalid={ showCredentialNameError ? 'true' : undefined }
-                  aria-describedby={ showCredentialNameError
-                    ? 'credential-id-error credential-id-help'
-                    : credentialName ? 'credential-id-help' : undefined }
-                  onChange={ isCreate ? this.handleCredentialNameChange : undefined }
-                />
-                { showCredentialNameError && (
-                  <p className="credential-modal-error" id="credential-id-error">{ credentialNameError }</p>
                 ) }
                 { credentialName && (
                   <p className="form-text" id="credential-id-help">

--- a/client/src/app/modals/credentials/CredentialModal.js
+++ b/client/src/app/modals/credentials/CredentialModal.js
@@ -28,6 +28,7 @@ import {
 } from './config';
 
 import {
+  getUniqueCredentialIdentity,
   getCredentialIdError,
   toCredentialId
 } from './credentialId';
@@ -54,12 +55,17 @@ class CredentialModal extends PureComponent {
   constructor(props) {
     super(props);
 
+    const identity = props.mode === 'create'
+      ? getUniqueCredentialIdentity(props.displayName || '', props.existingCredentials)
+      : {
+        displayName: props.displayName || '',
+        credentialId: props.credentialName || ''
+      };
+
     this.state = {
-      displayName: props.displayName || '',
+      displayName: identity.displayName,
       displayNameChanged: false,
-      credentialName: props.mode === 'create'
-        ? toCredentialId(props.displayName || '')
-        : props.credentialName || '',
+      credentialName: identity.credentialId,
       credentialNameChanged: false,
       initialValues: props.initialValues,
       values: props.initialValues || {},

--- a/client/src/app/modals/credentials/__tests__/CredentialModalSpec.js
+++ b/client/src/app/modals/credentials/__tests__/CredentialModalSpec.js
@@ -467,6 +467,30 @@ describe('<CredentialModal>', function() {
   });
 
 
+  it('should suggest a unique credential name and ID', function() {
+
+    // when
+    const { getByLabelText } = renderModal({
+      mode: 'create',
+      displayName: 'Name ',
+      existingCredentials: [
+        {
+          name: 'NAME',
+          metadata: { displayName: 'Name' }
+        },
+        {
+          name: 'NAME_1',
+          metadata: { displayName: 'Name 1' }
+        }
+      ]
+    });
+
+    // then
+    expect(getByLabelText('Credential name').value).to.equal('Name 2');
+    expect(getByLabelText('Credential ID *').value).to.equal('NAME_2');
+  });
+
+
   it('should show a required ID error when the display name is cleared', function() {
 
     // given
@@ -560,7 +584,7 @@ describe('<CredentialModal>', function() {
 
   it('should disable submit when the credential name already exists', function() {
 
-    // when
+    // given
     const { getByLabelText, getByRole, getByText } = renderModal({
       mode: 'create',
       displayName: 'My cred',
@@ -569,6 +593,9 @@ describe('<CredentialModal>', function() {
         metadata: { displayName: 'My cred' }
       } ]
     });
+
+    // when
+    fireEvent.change(getByLabelText('Credential name'), { target: { value: 'My cred' } });
 
     // then
     const input = getByLabelText('Credential name');
@@ -583,7 +610,7 @@ describe('<CredentialModal>', function() {
 
   it('should disable submit when the credential ID already exists', function() {
 
-    // when
+    // given
     const { getByLabelText, getByRole, getByText } = renderModal({
       mode: 'create',
       displayName: 'My cred',
@@ -592,6 +619,9 @@ describe('<CredentialModal>', function() {
         metadata: { displayName: 'Other credential' }
       } ]
     });
+
+    // when
+    fireEvent.change(getByLabelText('Credential ID *'), { target: { value: 'MY_CRED' } });
 
     // then
     const input = getByLabelText('Credential ID *');

--- a/client/src/app/modals/credentials/__tests__/CredentialModalSpec.js
+++ b/client/src/app/modals/credentials/__tests__/CredentialModalSpec.js
@@ -104,16 +104,14 @@ describe('<CredentialModal>', function() {
   });
 
 
-  it('should allow submit when the credential name is empty', function() {
-
-    // given
-    const { getByLabelText, getByRole } = renderModal({ mode: 'create', displayName: '' });
+  it('should disable submit when the credential name is empty', function() {
 
     // when
-    fireEvent.change(getByLabelText('Credential ID *'), { target: { value: 'MY_CRED' } });
+    const { getByRole, queryByText } = renderModal({ mode: 'create', displayName: '' });
 
     // then
-    expect(getByRole('button', { name: 'Create and select' }).disabled).to.be.false;
+    expect(queryByText(/=camunda\.vars\.env\./)).not.to.exist;
+    expect(getByRole('button', { name: 'Create and select' }).disabled).to.be.true;
   });
 
 
@@ -424,9 +422,9 @@ describe('<CredentialModal>', function() {
     });
 
     expect(onSubmit.firstCall.args[0]).to.include({
-      displayName: 'My cred',
-      name: 'MY_CRED'
+      displayName: 'My cred'
     });
+    expect(onSubmit.firstCall.args[0].name).to.match(/^my_cred_[a-z0-9]{6}$/);
   });
 
 
@@ -454,47 +452,24 @@ describe('<CredentialModal>', function() {
   });
 
 
-  it('should suggest the credential ID from the display name', function() {
+  it('should generate the credential reference from the display name', function() {
 
     // when
-    const { getByLabelText } = renderModal({
+    const { getByText, queryByLabelText } = renderModal({
       mode: 'create',
       displayName: 'My Slack workspace'
     });
 
     // then
-    expect(getByLabelText('Credential ID *').value).to.equal('MY_SLACK_WORKSPACE');
+    expect(queryByLabelText('Credential ID *')).not.to.exist;
+    expect(getByText(/^=camunda\.vars\.env\.my_slack_workspace_[a-z0-9]{6}$/)).to.exist;
   });
 
 
-  it('should suggest a unique credential name and ID', function() {
-
-    // when
-    const { getByLabelText } = renderModal({
-      mode: 'create',
-      displayName: 'Name ',
-      existingCredentials: [
-        {
-          name: 'NAME',
-          metadata: { displayName: 'Name' }
-        },
-        {
-          name: 'NAME_1',
-          metadata: { displayName: 'Name 1' }
-        }
-      ]
-    });
-
-    // then
-    expect(getByLabelText('Credential name').value).to.equal('Name 2');
-    expect(getByLabelText('Credential ID *').value).to.equal('NAME_2');
-  });
-
-
-  it('should show a required ID error when the display name is cleared', function() {
+  it('should hide the credential reference when the display name is cleared', function() {
 
     // given
-    const { getByLabelText, getByRole, getByText } = renderModal({
+    const { getByLabelText, getByRole, queryByText } = renderModal({
       mode: 'create',
       displayName: 'My Slack workspace'
     });
@@ -503,89 +478,50 @@ describe('<CredentialModal>', function() {
     fireEvent.change(getByLabelText('Credential name'), { target: { value: '' } });
 
     // then
-    const input = getByLabelText('Credential ID *');
-
-    expect(input.value).to.equal('');
-    expect(input.classList.contains('is-invalid')).to.be.true;
-    expect(getByText('Credential ID is required.')).to.exist;
+    expect(queryByText(/=camunda\.vars\.env\./)).not.to.exist;
     expect(getByRole('button', { name: 'Create and select' }).disabled).to.be.true;
   });
 
 
-  it('should submit an overridden credential ID', async function() {
+  it('should preserve the generated suffix when the display name changes', function() {
 
     // given
-    const onSubmit = sinon.spy();
-    const { getByLabelText, getByRole } = renderModal({
-      mode: 'create',
-      displayName: 'My Slack workspace',
-      onSubmit
-    });
-
-    // when
-    fireEvent.change(getByLabelText('Credential ID *'), { target: { value: 'SLACK_PROD' } });
-    fireEvent.click(getByRole('button', { name: 'Create and select' }));
-
-    // then
-    await waitFor(() => {
-      expect(onSubmit).to.have.been.calledWithMatch({ name: 'SLACK_PROD' });
-    });
-  });
-
-
-  it('should not replace an overridden credential ID when the display name changes', function() {
-
-    // given
-    const { getByLabelText } = renderModal({
+    const { getByLabelText, getByText } = renderModal({
       mode: 'create',
       displayName: 'My Slack workspace'
     });
-
-    fireEvent.change(getByLabelText('Credential ID *'), { target: { value: 'SLACK_PROD' } });
+    const suffix = getByText(/^=camunda\.vars\.env\.my_slack_workspace_[a-z0-9]{6}$/)
+      .textContent.slice(-6);
 
     // when
     fireEvent.change(getByLabelText('Credential name'), { target: { value: 'Renamed credential' } });
 
     // then
-    expect(getByLabelText('Credential ID *').value).to.equal('SLACK_PROD');
+    expect(getByText(`=camunda.vars.env.renamed_credential_${ suffix }`)).to.exist;
   });
 
 
-  it('should render the credential ID as read-only in edit mode', function() {
+  it('should preserve the credential reference when the display name changes in edit mode', function() {
 
-    // when
-    const { getByLabelText } = renderModal({
+    // given
+    const { getByLabelText, getByText } = renderModal({
       mode: 'edit',
-      displayName: 'My cred',
-      credentialName: 'MY_CRED'
-    });
-
-    // then
-    expect(getByLabelText('Credential ID *').readOnly).to.be.true;
-  });
-
-
-  it('should disable submit when the credential ID is invalid', function() {
-
-    // given
-    const { getByLabelText, getByRole, getByText } = renderModal({
-      mode: 'create',
-      displayName: 'My cred'
+      displayName: 'My Slack workspace',
+      credentialName: 'my_slack_workspace_abcdef'
     });
 
     // when
-    fireEvent.change(getByLabelText('Credential ID *'), { target: { value: '123-invalid' } });
+    fireEvent.change(getByLabelText('Credential name'), { target: { value: 'Renamed credential' } });
 
     // then
-    expect(getByRole('button', { name: 'Create and select' }).disabled).to.be.true;
-    expect(getByText(/must contain only letters, numbers, and underscores/)).to.exist;
+    expect(getByText('=camunda.vars.env.my_slack_workspace_abcdef')).to.exist;
   });
 
 
-  it('should disable submit when the credential name already exists', function() {
+  it('should suggest a unique credential name and reference', function() {
 
-    // given
-    const { getByLabelText, getByRole, getByText } = renderModal({
+    // when
+    const { getByLabelText, getByRole, getByText, queryByText } = renderModal({
       mode: 'create',
       displayName: 'My cred',
       existingCredentials: [ {
@@ -594,43 +530,13 @@ describe('<CredentialModal>', function() {
       } ]
     });
 
-    // when
-    fireEvent.change(getByLabelText('Credential name'), { target: { value: 'My cred' } });
-
     // then
     const input = getByLabelText('Credential name');
 
-    expect(getByRole('button', { name: 'Create and select' }).disabled).to.be.true;
-    expect(getByText('A credential with this name already exists. Choose a different name.')).to.exist;
-    expect(input.classList.contains('is-invalid')).to.be.true;
-    expect(input.closest('.form-group').classList.contains('has-error')).to.be.true;
-    expect(input.getAttribute('aria-invalid')).to.equal('true');
-  });
-
-
-  it('should disable submit when the credential ID already exists', function() {
-
-    // given
-    const { getByLabelText, getByRole, getByText } = renderModal({
-      mode: 'create',
-      displayName: 'My cred',
-      existingCredentials: [ {
-        name: 'MY_CRED',
-        metadata: { displayName: 'Other credential' }
-      } ]
-    });
-
-    // when
-    fireEvent.change(getByLabelText('Credential ID *'), { target: { value: 'MY_CRED' } });
-
-    // then
-    const input = getByLabelText('Credential ID *');
-
-    expect(getByRole('button', { name: 'Create and select' }).disabled).to.be.true;
-    expect(getByText('A credential with this ID already exists. Choose a different ID.')).to.exist;
-    expect(input.classList.contains('is-invalid')).to.be.true;
-    expect(input.closest('.form-group').classList.contains('has-error')).to.be.true;
-    expect(input.getAttribute('aria-invalid')).to.equal('true');
+    expect(input.value).to.equal('My cred 2');
+    expect(getByText(/^=camunda\.vars\.env\.my_cred_2_[a-z0-9]{6}$/)).to.exist;
+    expect(getByRole('button', { name: 'Create and select' }).disabled).to.be.false;
+    expect(queryByText(/already exists/)).not.to.exist;
   });
 
 
@@ -669,7 +575,7 @@ describe('<CredentialModal>', function() {
     const { getByText } = renderModal({ mode: 'create', displayName: 'My cred' });
 
     // then
-    expect(getByText(/=camunda\.vars\.env\.MY_CRED/)).to.exist;
+    expect(getByText(/^=camunda\.vars\.env\.my_cred_[a-z0-9]{6}$/)).to.exist;
   });
 
 

--- a/client/src/app/modals/credentials/credentialId.js
+++ b/client/src/app/modals/credentials/credentialId.js
@@ -73,7 +73,12 @@ export function getUniqueCredentialIdentity(displayName, existingCredentials = [
     }
   }
 
-  throw new Error('Unable to generate a unique credential identity.');
+  console.error('Unable to generate a unique credential identity.');
+
+  return {
+    displayName: normalizedDisplayName,
+    credentialId: toCredentialId(normalizedDisplayName)
+  };
 }
 
 /**

--- a/client/src/app/modals/credentials/credentialId.js
+++ b/client/src/app/modals/credentials/credentialId.js
@@ -50,6 +50,32 @@ export function toCredentialId(displayName) {
   return /^[A-Z_]/.test(slug) ? slug : `${ FALLBACK }_${ slug }`;
 }
 
+export function getUniqueCredentialIdentity(displayName, existingCredentials = []) {
+  const normalizedDisplayName = displayName.trim();
+  const displayNames = new Set(
+    existingCredentials.map(credential => credential.metadata?.displayName?.trim())
+  );
+  const credentialIds = new Set(
+    existingCredentials.map(credential => credential.name)
+  );
+
+  for (let suffix = 0; suffix <= existingCredentials.length * 2; suffix++) {
+    const uniqueDisplayName = suffix
+      ? `${ normalizedDisplayName } ${ suffix }`
+      : normalizedDisplayName;
+    const credentialId = toCredentialId(uniqueDisplayName);
+
+    if (!displayNames.has(uniqueDisplayName) && !credentialIds.has(credentialId)) {
+      return {
+        displayName: uniqueDisplayName,
+        credentialId
+      };
+    }
+  }
+
+  throw new Error('Unable to generate a unique credential identity.');
+}
+
 /**
  * Validate a credential ID against cluster-variable naming rules.
  *

--- a/client/src/app/modals/credentials/credentialId.js
+++ b/client/src/app/modals/credentials/credentialId.js
@@ -8,6 +8,8 @@
  * except in compliance with the MIT License.
  */
 
+import { generateId } from '../../../util';
+
 const FALLBACK = 'CREDENTIAL';
 
 const RESERVED_NAMES = new Set([
@@ -32,53 +34,54 @@ const MAX_NAME_LENGTH = 256;
 /**
  * Derive the cluster-variable name a credential is stored under. It becomes the
  * FEEL handle (`=camunda.vars.env.<id>`) and is fixed once created, so it must
- * satisfy the `^[a-z_][a-z0-9_]*$` shape.
+ * use lowercase snake case and satisfy the `^[a-z_][a-z0-9_]*$` shape.
  *
  * @param {string} displayName
  * @returns {string}
  */
 export function toCredentialId(displayName) {
   const slug = displayName
-    .toUpperCase()
-    .replace(/[^A-Z0-9]+/g, '_')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
     .replace(/^_+|_+$/g, '');
 
   if (!slug) {
     return '';
   }
 
-  return /^[A-Z_]/.test(slug) ? slug : `${ FALLBACK }_${ slug }`;
+  return /^[a-z_]/.test(slug) ? slug : `${ FALLBACK.toLowerCase() }_${ slug }`;
 }
 
-export function getUniqueCredentialIdentity(displayName, existingCredentials = []) {
+export function generateCredentialIdSuffix() {
+  return generateId().slice(-6);
+}
+
+export function getUniqueCredentialIdentity(displayName, existingCredentials = [], suffix) {
   const normalizedDisplayName = displayName.trim();
   const displayNames = new Set(
     existingCredentials.map(credential => credential.metadata?.displayName?.trim())
   );
-  const credentialIds = new Set(
-    existingCredentials.map(credential => credential.name)
-  );
 
-  for (let suffix = 0; suffix <= existingCredentials.length * 2; suffix++) {
-    const uniqueDisplayName = suffix
-      ? `${ normalizedDisplayName } ${ suffix }`
+  for (let index = 0; index <= existingCredentials.length; index++) {
+    const uniqueDisplayName = index
+      ? `${ normalizedDisplayName } ${ index + 1 }`
       : normalizedDisplayName;
-    const credentialId = toCredentialId(uniqueDisplayName);
 
-    if (!displayNames.has(uniqueDisplayName) && !credentialIds.has(credentialId)) {
+    if (!displayNames.has(uniqueDisplayName)) {
       return {
         displayName: uniqueDisplayName,
-        credentialId
+        credentialId: toRandomCredentialId(uniqueDisplayName, suffix)
       };
     }
   }
 
   console.error('Unable to generate a unique credential identity.');
+}
 
-  return {
-    displayName: normalizedDisplayName,
-    credentialId: toCredentialId(normalizedDisplayName)
-  };
+export function toRandomCredentialId(displayName, suffix) {
+  const credentialId = toCredentialId(displayName);
+
+  return credentialId ? `${ credentialId }_${ suffix }` : '';
 }
 
 /**

--- a/client/src/app/tabs/cloud-bpmn/credential-manager/__tests__/CredentialManagerSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/credential-manager/__tests__/CredentialManagerSpec.js
@@ -491,10 +491,13 @@ describe('<CredentialManager>', function() {
         metadata: INSTANCE_METADATA
       } ]
     });
-    const { eventBus, getByRole, getByText } = renderManager({ configurationInstances });
+    const { eventBus, findByLabelText, getByRole, getByText } = renderManager({ configurationInstances });
+
+    eventBus.fire('configuration.create', createEvent());
+    const displayNameInput = await findByLabelText('Credential name');
 
     // when
-    eventBus.fire('configuration.create', createEvent());
+    fireEvent.change(displayNameInput, { target: { value: 'My Cred' } });
 
     // then
     await waitFor(() => {

--- a/client/src/app/tabs/cloud-bpmn/credential-manager/__tests__/CredentialManagerSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/credential-manager/__tests__/CredentialManagerSpec.js
@@ -464,10 +464,10 @@ describe('<CredentialManager>', function() {
   });
 
 
-  it('should suggest a display name and credential ID from the element name', async function() {
+  it('should suggest a display name and credential reference from the element name', async function() {
 
     // given
-    const { eventBus, getByLabelText } = renderManager();
+    const { eventBus, getByLabelText, getByText } = renderManager();
 
     // when
     eventBus.fire('configuration.create', createEvent({
@@ -477,12 +477,12 @@ describe('<CredentialManager>', function() {
     // then
     await waitFor(() => {
       expect(getByLabelText('Credential name').value).to.equal('My credential');
-      expect(getByLabelText('Credential ID *').value).to.equal('MY_CREDENTIAL');
+      expect(getByText(/^=camunda\.vars\.env\.my_credential_[a-z0-9]{6}$/)).to.exist;
     });
   });
 
 
-  it('should prevent creating a duplicate credential', async function() {
+  it('should suggest a unique name when a credential already exists', async function() {
 
     // given
     const configurationInstances = createConfigurationInstances({
@@ -493,17 +493,15 @@ describe('<CredentialManager>', function() {
     });
     const { eventBus, findByLabelText, getByRole, getByText } = renderManager({ configurationInstances });
 
+    // when
     eventBus.fire('configuration.create', createEvent());
     const displayNameInput = await findByLabelText('Credential name');
 
-    // when
-    fireEvent.change(displayNameInput, { target: { value: 'My Cred' } });
-
     // then
     await waitFor(() => {
-      expect(getByRole('button', { name: 'Create and select' }).disabled).to.be.true;
-      expect(getByText(/A credential with this name already exists/)).to.exist;
-      expect(getByText(/A credential with this ID already exists/)).to.exist;
+      expect(displayNameInput.value).to.equal('My Cred 2');
+      expect(getByText(/^=camunda\.vars\.env\.my_cred_2_[a-z0-9]{6}$/)).to.exist;
+      expect(getByRole('button', { name: 'Create and select' }).disabled).to.be.false;
     });
   });
 

--- a/tasks/check-pending-releases.js
+++ b/tasks/check-pending-releases.js
@@ -1,0 +1,606 @@
+#!/usr/bin/env node
+
+/**
+ * Checks bpmn.io / Camunda dependencies of this project for "pending
+ * releases": commits landed on the dependency's default branch, after its
+ * latest git tag, that look like they should ship (feat / fix / deps
+ * commits) but haven't been released yet.
+ *
+ * This is deliberately based on the latest git tag, not the version this
+ * project currently consumes - a feature already released upstream (just
+ * not yet bumped here) is an available update, not a pending release.
+ *
+ * Reads the package list from tracked-dependencies.json (direct AND
+ * transitive dependencies - a transitive one can carry pending fixes just
+ * as much as a direct one). Run `node tasks/list-tracked-dependencies.js`
+ * first to (re)generate it from the root package-lock.json.
+ *
+ * Requires the GitHub CLI (`gh`) to be installed and authenticated. npm is
+ * only used once per package, to resolve its GitHub repo.
+ *
+ * Packages are checked concurrently (each check is a handful of sequential
+ * `gh api` / npm calls, so wall-clock time is dominated by network latency,
+ * not CPU - concurrency is a straightforward win).
+ *
+ * Usage:
+ *   node tasks/check-pending-releases.js [--json] [--concurrency=10] [--markdown=<path>] [--slack=<path>]
+ *
+ * --markdown appends a Markdown report to <path> (e.g. $GITHUB_STEP_SUMMARY
+ * when run from a GitHub Actions job).
+ *
+ * --slack writes a ready-to-post Slack `chat.postMessage` JSON payload to
+ * <path> (e.g. for slackapi/slack-github-action's `payload-file-path`),
+ * using the channel from the SLACK_CHANNEL_ID env var - but only when
+ * there's something pending; the file is left unwritten on a quiet day so
+ * a caller can skip posting via e.g. `hashFiles(path) != ''`.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFile } = require('node:child_process');
+const { promisify } = require('node:util');
+const semver = require('semver');
+
+const execFileAsync = promisify(execFile);
+
+const ROOT = path.join(__dirname, '..');
+const TRACKED_DEPENDENCIES_FILE = path.join(__dirname, 'tracked-dependencies.json');
+
+const CONVENTIONAL_TYPES = [ 'feat', 'fix', 'deps' ];
+const DEFAULT_CONCURRENCY = 10;
+
+function loadTrackedDependencies() {
+  if (!fs.existsSync(TRACKED_DEPENDENCIES_FILE)) {
+    console.error(
+      `${path.relative(ROOT, TRACKED_DEPENDENCIES_FILE)} not found.\n` +
+      'Run `node tasks/list-tracked-dependencies.js` first.'
+    );
+    process.exit(1);
+  }
+
+  return JSON.parse(fs.readFileSync(TRACKED_DEPENDENCIES_FILE, 'utf8'));
+}
+
+async function ghApi(endpoint) {
+  const { stdout } = await execFileAsync('gh', [ 'api', endpoint ], {
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024 * 20
+  });
+  return JSON.parse(stdout);
+}
+
+async function ghApiSafe(endpoint) {
+  try {
+    return await ghApi(endpoint);
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * Looks up a package's repository URL on npm. Returns `{ ok: true, url }`
+ * on a completed lookup (`url` is null if there's no repo field, or the
+ * package/version wasn't found) and `{ ok: false }` if the lookup itself
+ * failed (network/DNS error) - distinct from "no repo declared", so a
+ * transient failure surfaces as unresolved rather than as a confident
+ * "this package has no repository".
+ */
+async function fetchNpmRepoUrl(name) {
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${encodeURIComponent(name).replace(/%40/g, '@')}/latest`);
+
+    if (!res.ok) {
+      return { ok: true, url: null };
+    }
+
+    const doc = await res.json();
+
+    return { ok: true, url: doc.repository && doc.repository.url };
+  } catch (error) {
+    return { ok: false, url: null };
+  }
+}
+
+function parseGithubRepo(repositoryUrl) {
+  if (!repositoryUrl) return null;
+
+  const match = repositoryUrl.match(/github\.com[:/]([^/]+)\/([^/.]+?)(\.git)?(\/|$)/);
+
+  if (!match) return null;
+
+  return { owner: match[1], repo: match[2] };
+}
+
+/**
+ * Strips an optional `v` prefix or `<package-name>@` scope prefix (used by
+ * monorepos with independently-versioned packages) so the remainder can be
+ * parsed as semver.
+ */
+function versionFromTag(tagName, name) {
+  let rest = tagName;
+
+  if (name && rest.startsWith(`${name}@`)) {
+    rest = rest.slice(name.length + 1);
+  } else if (rest.startsWith('v')) {
+    rest = rest.slice(1);
+  }
+
+  return semver.valid(rest) ? rest : null;
+}
+
+const TAGS_PER_PAGE = 100;
+const MAX_TAG_PAGES = 5; // up to 500 tags - well beyond any repo we track
+
+/**
+ * Fetches up to MAX_TAG_PAGES pages of tags. Stops early once a page comes
+ * back short (the last page). A prior version only fetched the first page,
+ * silently missing the closest reachable tag on repos with a long history.
+ */
+async function fetchAllTags(owner, repo) {
+  const all = [];
+
+  for (let page = 1; page <= MAX_TAG_PAGES; page++) {
+    const pageTags = await ghApiSafe(`repos/${owner}/${repo}/tags?per_page=${TAGS_PER_PAGE}&page=${page}`);
+
+    if (!pageTags || pageTags.length === 0) break;
+
+    all.push(...pageTags);
+
+    if (pageTags.length < TAGS_PER_PAGE) break;
+  }
+
+  return all;
+}
+
+/**
+ * The latest git tag for a package: the tag on the default branch's own
+ * history that sits closest to its tip (`git describe --tags` semantics).
+ *
+ * Neither "highest semver tag" nor GitHub's "latest release" work here:
+ * repos can carry old tags with deceptively high numbers from before a
+ * version reset/rename (e.g. bpmn-io/bpmn-js-properties-panel has a
+ * `v6.0.1` tag from February sitting on an abandoned line, while `v5.64.0`
+ * - lower semver - is literally the current tip of `main`), and some repos
+ * stop publishing GitHub Releases while still tagging every version.
+ *
+ * Tags not reachable from the default branch (prereleases cut on a separate
+ * next-major branch, e.g. diagram-js's `v16.0.0-esm.2`) are excluded by the
+ * ancestry check itself.
+ */
+async function getLatestTag(owner, repo, name, branch) {
+  const tags = await fetchAllTags(owner, repo);
+
+  if (!tags.length) return null;
+
+  const candidates = tags
+    .map(t => ({ tag: t.name, version: versionFromTag(t.name, name) }))
+    .filter(c => c.version);
+
+  let best = null;
+
+  // Ancestry has to be probed one candidate at a time (each probe can
+  // short-circuit the search), so this loop stays sequential - it's the
+  // per-package concurrency in runPool() that gives the real speedup. Every
+  // fetched candidate is probed (no arbitrary early cutoff) - a repo can
+  // carry many non-ancestor tags (abandoned lines, sibling monorepo
+  // packages) before reaching the actually-closest one; the early `break`
+  // below still keeps the common case cheap.
+  for (const candidate of candidates) {
+    const compare = await ghApiSafe(`repos/${owner}/${repo}/compare/${encodeURIComponent(branch)}...${encodeURIComponent(candidate.tag)}`);
+
+    if (!compare || compare.ahead_by > 0) continue; // not an ancestor of the default branch
+
+    const distance = compare.behind_by;
+
+    if (!best || distance < best.distance) {
+      best = { ...candidate, distance };
+    }
+
+    if (distance === 0) break; // can't beat being the branch tip itself
+  }
+
+  return best;
+}
+
+async function getDefaultBranch(owner, repo) {
+  const info = await ghApiSafe(`repos/${owner}/${repo}`);
+  return info ? info.default_branch : null;
+}
+
+const packageDirectoryCache = new Map();
+
+/**
+ * In an independently-versioned monorepo (tags like `<name>@<version>`), a
+ * commit ahead of one package's tag is only actually relevant to that
+ * package if it touches that package's own directory - otherwise it's a
+ * sibling package's change (e.g. camunda/element-templates-json-schema has
+ * 4 independently-tagged packages under packages/*, and a commit scoped to
+ * one of them shows up as "ahead" for all of them without this check).
+ *
+ * Convention across these monorepos is packages/<unscoped-name>; verified
+ * by finding a package.json there whose own `name` matches. Cached per repo
+ * since sibling packages share one lookup.
+ */
+async function findPackageDirectory(owner, repo, branch, name) {
+  const cacheKey = `${owner}/${repo}`;
+
+  if (!packageDirectoryCache.has(cacheKey)) {
+    packageDirectoryCache.set(cacheKey, (async () => {
+      const tree = await ghApiSafe(`repos/${owner}/${repo}/git/trees/${encodeURIComponent(branch)}?recursive=1`);
+
+      if (!tree || tree.truncated) return null;
+
+      return (tree.tree || [])
+        .filter(entry => entry.type === 'blob' && entry.path.endsWith('/package.json'))
+        .map(entry => entry.path.slice(0, -'/package.json'.length));
+    })());
+  }
+
+  const candidateDirs = await packageDirectoryCache.get(cacheKey);
+
+  if (!candidateDirs) return null;
+
+  const unscopedName = name.replace(/^@[^/]+\//, '');
+  const byBasename = candidateDirs.filter(dir => dir.split('/').pop() === unscopedName);
+
+  for (const dir of byBasename) {
+    const pkg = await ghApiSafe(`repos/${owner}/${repo}/contents/${dir}/package.json?ref=${encodeURIComponent(branch)}`);
+    const content = pkg && pkg.content && JSON.parse(Buffer.from(pkg.content, 'base64').toString('utf8'));
+
+    if (content && content.name === name) return dir;
+  }
+
+  return null;
+}
+
+/**
+ * Whether a commit touches a given directory. Returns `null` (unknown,
+ * distinct from `false`) if the per-commit lookup itself fails - a
+ * rate-limit or transient API error must not be silently read as "doesn't
+ * touch the directory", or a genuinely-pending commit could be dropped and
+ * the package wrongly reported as up-to-date.
+ */
+async function commitTouchesDirectory(owner, repo, sha, dir) {
+  const commit = await ghApiSafe(`repos/${owner}/${repo}/commits/${sha}`);
+
+  if (!commit) return null;
+
+  const files = commit.files || [];
+
+  return files.some(f => f.filename === dir || f.filename.startsWith(`${dir}/`));
+}
+
+async function getPendingCommits(owner, repo, tag, branch, packageDir) {
+  const compare = await ghApiSafe(`repos/${owner}/${repo}/compare/${encodeURIComponent(tag)}...${encodeURIComponent(branch)}`);
+
+  if (!compare) return null;
+
+  const commits = compare.commits || [];
+
+  // GitHub's compare endpoint caps at 250 commits with no further
+  // pagination for this range; beyond that, silently reading only what
+  // came back risks missing a feat/fix/deps commit and wrongly reporting
+  // up-to-date. Surface it as unresolved instead of guessing.
+  if (compare.total_commits > commits.length) {
+    return { truncated: true };
+  }
+
+  let matching = commits.filter(c => CONVENTIONAL_TYPES.some(
+    type => new RegExp(`^${type}(\\(.+\\))?!?:`).test(c.commit.message.split('\n')[0])
+  ));
+
+  // Narrow to commits that actually touch this package's own directory -
+  // a monorepo sibling's changes aren't pending for this package.
+  if (packageDir) {
+    const touches = await Promise.all(matching.map(c => commitTouchesDirectory(owner, repo, c.sha, packageDir)));
+
+    if (touches.some(t => t === null)) {
+      return { directoryCheckFailed: true };
+    }
+
+    matching = matching.filter((c, i) => touches[i]);
+  }
+
+  return {
+    totalCommitsAhead: commits.length,
+    matchingCommits: matching.map(c => c.commit.message.split('\n')[0]),
+    compareUrl: `https://github.com/${owner}/${repo}/compare/${tag}...${branch}`
+  };
+}
+
+/**
+ * One-line summary of a single checked package, for progress reporting.
+ */
+function describe(result) {
+  switch (result.status) {
+  case 'pending-release': return `${result.matchingCommits.length} pending commit(s) past ${result.latestTag}`;
+  case 'up-to-date': return `up to date (${result.latestTag})`;
+  case 'npm-lookup-failed': return 'npm lookup failed (network error)';
+  case 'no-repo-found': return 'no GitHub repo found on npm';
+  case 'repo-inaccessible': return `repo ${result.owner}/${result.repo} inaccessible`;
+  case 'tag-not-found': return `no matching tag found in ${result.owner}/${result.repo}`;
+  case 'directory-not-found': return `couldn't locate package directory in ${result.owner}/${result.repo}`;
+  case 'compare-failed': return `GitHub compare failed for ${result.owner}/${result.repo}`;
+  case 'compare-truncated': return `compare range too large to check reliably for ${result.owner}/${result.repo}`;
+  case 'directory-check-failed': return `commit lookup failed while scoping to package directory in ${result.owner}/${result.repo}`;
+  case 'check-failed': return `unexpected error: ${result.error}`;
+  default: return result.status;
+  }
+}
+
+async function checkPackage({ name, version, direct }) {
+  const base = { name, version, direct };
+
+  const npmLookup = await fetchNpmRepoUrl(name);
+
+  if (!npmLookup.ok) {
+    return { ...base, status: 'npm-lookup-failed' };
+  }
+
+  const repoInfo = parseGithubRepo(npmLookup.url);
+
+  if (!repoInfo) {
+    return { ...base, status: 'no-repo-found' };
+  }
+
+  const { owner, repo } = repoInfo;
+  const branch = await getDefaultBranch(owner, repo);
+
+  if (!branch) {
+    return { ...base, owner, repo, status: 'repo-inaccessible' };
+  }
+
+  const latest = await getLatestTag(owner, repo, name, branch);
+
+  if (!latest) {
+    return { ...base, owner, repo, status: 'tag-not-found' };
+  }
+
+  const withTag = { ...base, owner, repo, latestVersion: latest.version, latestTag: latest.tag };
+
+  // A `<name>@<version>` tag means this package is independently versioned
+  // within a monorepo - scope the pending-commit check to its own
+  // directory, or a sibling package's changes would count as pending here.
+  // If that directory can't be found, fail closed (report unresolved)
+  // rather than silently falling back to an unscoped, false-positive-prone
+  // check - the exact bug this guard exists to prevent.
+  let packageDir = null;
+
+  if (latest.tag.startsWith(`${name}@`)) {
+    packageDir = await findPackageDirectory(owner, repo, branch, name);
+
+    if (!packageDir) {
+      return { ...withTag, status: 'directory-not-found' };
+    }
+  }
+
+  const pending = await getPendingCommits(owner, repo, latest.tag, branch, packageDir);
+
+  if (!pending) {
+    return { ...withTag, status: 'compare-failed' };
+  }
+
+  if (pending.truncated) {
+    return { ...withTag, status: 'compare-truncated' };
+  }
+
+  if (pending.directoryCheckFailed) {
+    return { ...withTag, status: 'directory-check-failed' };
+  }
+
+  return {
+    ...withTag,
+    updateAvailable: version !== latest.version,
+    status: pending.matchingCommits.length > 0 ? 'pending-release' : 'up-to-date',
+    ...pending
+  };
+}
+
+/**
+ * Runs `worker` over `items` with at most `limit` in flight at once.
+ * Preserves input order in the returned array; `onResult` fires as each
+ * item finishes (out of order), for live progress reporting.
+ *
+ * A `worker` rejection is caught per-item rather than propagating - an
+ * unexpected error (a transient network failure, a bug) on one package
+ * must not abort the whole run and lose the report for every other
+ * package already checked or in flight.
+ */
+async function runPool(items, limit, worker, onResult) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+  let completed = 0;
+
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+
+  async function runNext() {
+    while (nextIndex < items.length) {
+      const current = nextIndex++;
+      let result;
+
+      try {
+        result = await worker(items[current]);
+      } catch (error) {
+        result = { ...items[current], status: 'check-failed', error: error.message };
+      }
+
+      results[current] = result;
+      completed++;
+      onResult(result, completed, items.length);
+    }
+  }
+
+  const workers = Array.from({ length: workerCount }, runNext);
+  await Promise.all(workers);
+
+  return results;
+}
+
+async function main(concurrency, onResult) {
+  const tracked = loadTrackedDependencies();
+
+  return runPool(tracked, concurrency, checkPackage, onResult);
+}
+
+function printPendingDetail(r) {
+  console.log(`- ${r.name} [${r.direct ? 'direct' : 'transitive'}] (currently ${r.version}, latest published ${r.latestVersion}, ${r.owner}/${r.repo})`);
+  console.log(`  ${r.matchingCommits.length} relevant / ${r.totalCommitsAhead} commits ahead of ${r.latestTag}`);
+
+  for (const subject of r.matchingCommits) {
+    console.log(`    * ${subject}`);
+  }
+
+  console.log(`  ${r.compareUrl}\n`);
+}
+
+function buildMarkdownReport(results) {
+  const pending = results.filter(r => r.status === 'pending-release');
+  const upToDate = results.filter(r => r.status === 'up-to-date');
+  const issues = results.filter(r => ![ 'pending-release', 'up-to-date' ].includes(r.status));
+
+  const lines = [ '## bpmn.io / Camunda pending releases', '' ];
+
+  // Headline: packages with commits upstream that have NOT been released
+  // yet. This is the crucial signal this report exists for. Whether a
+  // dependency also needs bumping here (an ordinary update) is out of
+  // scope - only unreleased upstream work belongs in this summary.
+  lines.push(pending.length
+    ? `### ⚠️ ${pending.length} package(s) have unreleased feat/fix/deps commits upstream`
+    : '### ✅ No packages have unreleased feat/fix/deps commits upstream', '');
+
+  if (pending.length) {
+    for (const r of pending) {
+      lines.push(`#### ${r.name} \`${r.version}\` [${r.direct ? 'direct' : 'transitive'}]`, '');
+      lines.push(`[${r.owner}/${r.repo}](https://github.com/${r.owner}/${r.repo}) - ` +
+        `${r.matchingCommits.length} relevant / ${r.totalCommitsAhead} commits ahead of \`${r.latestTag}\` ` +
+        `([compare](${r.compareUrl}))`, '');
+
+      for (const subject of r.matchingCommits) {
+        lines.push(`- ${subject}`);
+      }
+
+      lines.push('');
+    }
+  }
+
+  lines.push(`Checked ${results.length} dependencies (direct + transitive): ` +
+    `${pending.length} pending release, ${upToDate.length} up to date, ${issues.length} unresolved.`, '');
+
+  if (issues.length) {
+    lines.push('<details><summary>Could not check</summary>', '');
+
+    for (const r of issues) {
+      lines.push(`- ${r.name}${r.version ? '@' + r.version : ''}: ${r.status}`);
+    }
+
+    lines.push('', '</details>', '');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * A Slack `chat.postMessage` payload reminding about pending releases, or
+ * null if there's nothing to report - a daily reminder should stay silent
+ * on a quiet day rather than posting "nothing pending" every morning.
+ */
+function buildSlackPayload(results, channel) {
+  const pending = results.filter(r => r.status === 'pending-release');
+
+  if (!pending.length) return null;
+
+  const lines = [ `:warning: *${pending.length} bpmn.io/Camunda package(s) have unreleased upstream changes*` ];
+
+  for (const r of pending) {
+    lines.push(`• <${r.compareUrl}|${r.name}> - ${r.matchingCommits.length} commit(s) past \`${r.latestTag}\``);
+  }
+
+  return { channel, text: lines.join('\n') };
+}
+
+const jsonMode = process.argv.includes('--json');
+
+const concurrencyArg = process.argv.find(a => a.startsWith('--concurrency='));
+const requestedConcurrency = concurrencyArg ? Number(concurrencyArg.split('=')[1]) : DEFAULT_CONCURRENCY;
+
+// An invalid value (0, negative, NaN) would make the pool spin up zero
+// workers, silently "checking" nothing while still reporting the full
+// dependency count as checked - fall back to the default instead.
+const concurrency = Number.isInteger(requestedConcurrency) && requestedConcurrency > 0
+  ? requestedConcurrency
+  : DEFAULT_CONCURRENCY;
+
+if (concurrencyArg && concurrency !== requestedConcurrency) {
+  console.error(`Invalid --concurrency value (${concurrencyArg.split('=')[1]}), falling back to ${DEFAULT_CONCURRENCY}`);
+}
+
+const markdownArg = process.argv.find(a => a.startsWith('--markdown='));
+const markdownPath = markdownArg ? markdownArg.split('=').slice(1).join('=') : null;
+
+const slackArg = process.argv.find(a => a.startsWith('--slack='));
+const slackPath = slackArg ? slackArg.split('=').slice(1).join('=') : null;
+
+main(concurrency, (result, completed, total) => {
+  const progress = `[${completed}/${total}] ${result.name} - ${describe(result)}`;
+
+  // Progress always goes to stderr, so --json's stdout stays clean and
+  // pipeable while still showing live progress in a terminal. Pending-release
+  // details are reported together in the final summary instead of here, so
+  // they aren't scattered across out-of-order concurrent progress lines.
+  console.error(progress);
+}).then(results => {
+  if (markdownPath) {
+    fs.appendFileSync(markdownPath, buildMarkdownReport(results) + '\n');
+  }
+
+  if (slackPath) {
+    if (!process.env.SLACK_CHANNEL_ID) {
+      console.error('--slack given but SLACK_CHANNEL_ID is not set - skipping Slack payload');
+    } else {
+      const payload = buildSlackPayload(results, process.env.SLACK_CHANNEL_ID);
+
+      // Only write the file when there's something to report, so a
+      // workflow can skip the Slack post entirely (via hashFiles) on a
+      // quiet day instead of sending an empty reminder.
+      if (payload) {
+        fs.writeFileSync(slackPath, JSON.stringify(payload, null, 2) + '\n');
+      }
+    }
+  }
+
+  if (jsonMode) {
+    console.log(JSON.stringify(results, null, 2));
+    return;
+  }
+
+  const pending = results.filter(r => r.status === 'pending-release');
+  const upToDate = results.filter(r => r.status === 'up-to-date');
+  const issues = results.filter(r => ![ 'pending-release', 'up-to-date' ].includes(r.status));
+
+  // Headline first: packages with commits upstream that have NOT been
+  // released yet. That's the only thing this summary reports on - whether
+  // a dependency also needs bumping here is a separate, unrelated concern.
+  console.log(pending.length
+    ? `\n⚠️  ${pending.length} package(s) have unreleased feat/fix/deps commits upstream\n`
+    : '\n✅ No packages have unreleased feat/fix/deps commits upstream\n');
+
+  for (const r of pending) {
+    printPendingDetail(r);
+  }
+
+  console.log(`Checked ${results.length} bpmn.io / Camunda dependencies: ` +
+    `${pending.length} pending release, ${upToDate.length} up to date, ${issues.length} unresolved.`);
+
+  if (issues.length) {
+    console.log(`\nCould not check ${issues.length}:`);
+
+    for (const r of issues) {
+      console.log(`- ${r.name}${r.version ? '@' + r.version : ''}: ${r.status}`);
+    }
+  }
+}).catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tasks/list-tracked-dependencies.js
+++ b/tasks/list-tracked-dependencies.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+/**
+ * Compiles the list of bpmn.io / Camunda packages this project depends on -
+ * directly or transitively - by scanning the root package-lock.json. A
+ * transitive dependency can carry pending upstream fixes just as much as a
+ * direct one, so this deliberately isn't limited to what's declared in the
+ * workspaces' package.json files.
+ *
+ * Writes tasks/tracked-dependencies.json, consumed by
+ * check-pending-releases.js. Re-run this after `npm install` changes the
+ * lockfile.
+ *
+ * Usage:
+ *   node tasks/list-tracked-dependencies.js
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const semver = require('semver');
+
+const ROOT = path.join(__dirname, '..');
+const OUTPUT_FILE = path.join(__dirname, 'tracked-dependencies.json');
+
+const SCOPE_PREFIXES = [
+  '@bpmn-io/',
+  '@camunda/',
+  'bpmn-js',
+  'bpmn-moddle',
+  'camunda-',
+  'diagram-js',
+  'dmn-js',
+  'zeebe-',
+  'modeler-moddle',
+  'eslint-plugin-bpmn-io',
+  'eslint-plugin-camunda-licensed',
+  'remark-preset-bpmn-io'
+];
+
+function isTrackedPackage(name) {
+  return SCOPE_PREFIXES.some(prefix => name.startsWith(prefix));
+}
+
+/**
+ * Extracts the installed package name from a package-lock `packages` key,
+ * e.g. "app/node_modules/foo/node_modules/@bpmn-io/bar" -> "@bpmn-io/bar".
+ */
+function nameFromLockKey(key) {
+  const marker = 'node_modules/';
+  const idx = key.lastIndexOf(marker);
+
+  return idx === -1 ? null : key.slice(idx + marker.length);
+}
+
+/**
+ * The root project and every npm workspace get their own entry in
+ * `packages` (keyed by their path, e.g. "" for the root or "app"/"client"
+ * for workspaces - the only keys that don't contain "node_modules/"), each
+ * carrying its own `dependencies`/`devDependencies` - i.e. exactly what's
+ * declared in that workspace's package.json. No need to read the
+ * package.json files separately; the lockfile already has this.
+ */
+function collectDirectDependencyNames(lock) {
+  const names = new Set();
+
+  for (const [ key, entry ] of Object.entries(lock.packages)) {
+    if (key.includes('node_modules/')) continue;
+
+    for (const section of [ 'dependencies', 'devDependencies' ]) {
+      for (const name of Object.keys(entry[section] || {})) {
+        names.add(name);
+      }
+    }
+  }
+
+  return names;
+}
+
+function main() {
+  const lock = JSON.parse(fs.readFileSync(path.join(ROOT, 'package-lock.json'), 'utf8'));
+  const directNames = collectDirectDependencyNames(lock);
+
+  const byName = new Map();
+
+  for (const [ key, entry ] of Object.entries(lock.packages)) {
+    const name = nameFromLockKey(key);
+
+    if (!name || !isTrackedPackage(name) || !entry.version) continue;
+
+    const existing = byName.get(name);
+
+    if (!existing || semver.gt(entry.version, existing.version)) {
+      byName.set(name, { version: entry.version, versions: existing ? existing.versions : [] });
+    }
+
+    if (!byName.get(name).versions.includes(entry.version)) {
+      byName.get(name).versions.push(entry.version);
+    }
+  }
+
+  const list = [ ...byName.entries() ]
+    .map(([ name, info ]) => ({
+      name,
+      version: info.version,
+      versions: info.versions.sort(semver.compare),
+      direct: directNames.has(name)
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(list, null, 2) + '\n');
+
+  const direct = list.filter(p => p.direct).length;
+  const multiVersion = list.filter(p => p.versions.length > 1);
+
+  console.log(`Wrote ${list.length} tracked packages to ${path.relative(ROOT, OUTPUT_FILE)}`);
+  console.log(`  ${direct} direct, ${list.length - direct} transitive-only`);
+
+  if (multiVersion.length) {
+    console.log(`  ${multiVersion.length} installed at multiple versions (using the highest for each):`);
+
+    for (const p of multiVersion) {
+      console.log(`    - ${p.name}: ${p.versions.join(', ')}`);
+    }
+  }
+}
+
+main();


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-modeler/issues/6137

### Proposed Changes

In credential modal, do not let user manually set the ID - generate it instead.

ID stays fixed even when user re-names the credential later.

<img width="638" height="600" alt="image" src="https://github.com/user-attachments/assets/27784548-1d2f-4bf9-a5e5-5928dc748d34" />

<img width="641" height="597" alt="image" src="https://github.com/user-attachments/assets/73b7dbc1-5c09-4d40-8186-19e7359fab5c" />

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
