### PR TITLE
fix(zeebe-plugin): forward emit to deploy and start-instance overlays

### DIFF
--- a/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/DeploymentPlugin.js
@@ -26,7 +26,8 @@ export default function DeploymentPlugin(props) {
     log,
     subscribe,
     triggerAction,
-    connectionCheckResult
+    connectionCheckResult,
+    emit
   } = props;
 
   const [ activeTab, setActiveTab ] = useState(null);
@@ -102,6 +103,7 @@ export default function DeploymentPlugin(props) {
         renderHeader={ <><TabIcon width="16" height="16" />Deploy { tabName }</> }
         renderSubmit={ `Deploy ${ tabName }` }
         triggerAction={ triggerAction }
+        emit={ emit }
       />
     ) }
   </>;

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/__tests__/DeploymentPluginSpec.js
@@ -124,6 +124,60 @@ describe('DeploymentPlugin', function() {
     });
   });
 
+
+  it('should forward <emit> to overlay (deployment event)', async function() {
+
+    // given
+    const subscribe = sinon.spy(function(event, callback) {
+      if (event === 'app.activeTabChanged') {
+        callback({
+          activeTab: DEFAULT_ACTIVE_TAB
+        });
+      }
+    });
+
+    const triggerAction = sinon.spy(function(action) {
+      if (action === 'save-tab') {
+        return Promise.resolve(true);
+      }
+    });
+
+    const deployment = new Deployment({
+      async getConnectionForTab() {
+        return { deployment: {}, endpoint: DEFAULT_ENDPOINT };
+      },
+      on: sinon.spy()
+    });
+
+    const emit = sinon.spy();
+
+    const { getByTitle, getByRole } = createDeploymentPlugin({
+      subscribe,
+      triggerAction,
+      emit,
+      _getGlobal: (name) => name === 'deployment' ? deployment : undefined
+    });
+
+    fireEvent.click(getByTitle('Open file deployment'));
+
+    await waitFor(() => {
+      expect(getByRole('dialog')).to.exist;
+    });
+
+    expect(deployment.on).to.have.been.calledWith('deployed', sinon.match.func);
+
+    // when
+    // simulating <deployed> event as emitted by the deployment
+    deployment.on.getCall(0).args[1]({
+      deploymentResult: { success: true, response: {} },
+      endpoint: { targetType: 'camundaCloud' },
+      gatewayVersion: '8.0.0'
+    });
+
+    // then
+    expect(emit).to.have.been.calledWith('deployment.done', sinon.match.object);
+  });
+
 });
 
 const DEFAULT_ACTIVE_TAB = {
@@ -163,7 +217,8 @@ function createDeploymentPlugin(props = {}) {
     displayNotification = () => {},
     log = () => {},
     subscribe = () => {},
-    triggerAction = () => {}
+    triggerAction = () => {},
+    emit = () => {}
   } = props;
 
   return render(<SlotFillRoot>
@@ -174,6 +229,7 @@ function createDeploymentPlugin(props = {}) {
       displayNotification={ displayNotification }
       log={ log }
       subscribe={ subscribe }
-      triggerAction={ triggerAction } />
+      triggerAction={ triggerAction }
+      emit={ emit } />
   </SlotFillRoot>);
 }

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/StartInstancePlugin.js
@@ -30,7 +30,8 @@ export default function StartInstancePlugin(props) {
     log,
     subscribe,
     triggerAction,
-    connectionCheckResult
+    connectionCheckResult,
+    emit
   } = props;
 
   const [ activeTab, setActiveTab ] = useState(null);
@@ -105,6 +106,7 @@ export default function StartInstancePlugin(props) {
         startInstanceConfigValidator={ StartInstanceConfigValidator }
         triggerAction={ triggerAction }
         connectionCheckResult={ connectionCheckResult }
+        emit={ emit }
       />
     ) }
   </>;

--- a/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/start-instance-plugin/__tests__/StartInstancePluginSpec.js
@@ -151,6 +151,72 @@ describe('StartInstancePlugin', function() {
     });
   });
 
+
+  it('should forward <emit> to overlay (deployment event)', async function() {
+
+    // given
+    const subscribe = sinon.spy(function(event, callback) {
+      if (event === 'app.activeTabChanged') {
+        callback({
+          activeTab: DEFAULT_ACTIVE_TAB
+        });
+      }
+    });
+
+    const triggerAction = sinon.spy(function(action) {
+      if (action === 'save-tab') {
+        return Promise.resolve(true);
+      }
+    });
+
+    const deployment = new Deployment({
+      async getConnectionForTab() {
+        return { deployment: {}, endpoint: DEFAULT_ENDPOINT };
+      },
+      on: sinon.spy()
+    });
+
+    const emit = sinon.spy();
+
+    const { container } = createStartInstancePlugin({
+      subscribe,
+      triggerAction,
+      emit,
+      _getGlobal: (name) => {
+        if (name === 'deployment') {
+          return deployment;
+        } else if (name === 'startInstance') {
+          return new StartInstance({
+            async getConfigForFile() {
+              return {};
+            }
+          });
+        } else if (name === 'zeebeAPI') {
+          return new ZeebeAPI();
+        }
+      }
+    });
+
+    fireEvent.click(container.querySelector('.btn'));
+
+    await waitFor(() => {
+      expect(document.querySelector('[role="dialog"]')).to.exist;
+    });
+
+    expect(deployment.on).to.have.been.calledWith('deployed', sinon.match.func);
+
+    // when
+    // simulating <deployed> event as emitted by the deployment
+    deployment.on.getCall(0).args[1]({
+      deploymentResult: { success: true, response: {} },
+      endpoint: { targetType: 'camundaCloud' },
+      gatewayVersion: '8.0.0'
+    });
+
+    // then
+    expect(emit).to.have.been.calledWith('deployment.done', sinon.match.object);
+  });
+
 });
 
 const DEFAULT_ACTIVE_TAB = {
@@ -185,7 +251,7 @@ function createStartInstancePlugin(props = {}) {
         });
       } else if (name === 'startInstance') {
         return new StartInstance({
-          async getConnectionForTab(file) {
+          async getConfigForFile(file) {
             return {};
           }
         });
@@ -196,7 +262,8 @@ function createStartInstancePlugin(props = {}) {
     displayNotification = () => {},
     log = () => {},
     subscribe = () => {},
-    triggerAction = () => {}
+    triggerAction = () => {},
+    emit = () => {}
   } = props;
 
   return render(<SlotFillRoot>
@@ -207,6 +274,7 @@ function createStartInstancePlugin(props = {}) {
       displayNotification={ displayNotification }
       log={ log }
       subscribe={ subscribe }
-      triggerAction={ triggerAction } />
+      triggerAction={ triggerAction }
+      emit={ emit } />
   </SlotFillRoot>);
 }


### PR DESCRIPTION
### Proposed Changes

Fixes the broken Camunda 8 **deploy** and **run** tools reported in #6151.

The `DeploymentPluginOverlay` and `StartInstancePluginOverlay` were migrated in [#6106](https://github.com/camunda/camunda-modeler/pull/6106) to emit application events through a new `emit(type, payload)` prop (threaded to plug-ins by `PluginsRoot`). However, the two wrapper plug-ins (`DeploymentPlugin`, `StartInstancePlugin`) were never updated to forward `emit` down to their overlays.

As a result, `emit` was `undefined` inside the overlays. On a successful deploy the `deployment.on('deployed', …)` handler called `emit('deployment.done', …)`, throwing:

```
TypeError: A is not a function
    at DeploymentPluginOverlay.js:139
    at Deployment.deploy (Deployment.js:151)
    at async onSubmit (DeploymentPluginOverlay.js:117)
```

The deploy itself succeeded on the backend, but the post-deploy event emission crashed — so the UI appeared to do nothing. Task testing was unaffected because it lives in a tab that receives `emit` directly.

**Changes**
* Forward `emit` from `DeploymentPlugin` → `DeploymentPluginOverlay`.
* Forward `emit` from `StartInstancePlugin` → `StartInstancePluginOverlay`.
* Add wrapper-level regression tests exercising the deploy → `emit` path (the existing overlay specs passed `emit` directly, so the wrapper gap was uncovered).

### Steps to try out

1. Create a simple C8 process (start → end).
2. Trigger the deployment tool → deploys and shows a success notification.
3. Trigger the run tool → starts an instance.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

Closes #6151
