### PR TITLE
feat: rename cluster connection terminology to plain connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: rename cluster connection terminology to plain connection ([#6158](https://github.com/camunda/camunda-modeler/pull/6158))
 * `FIX`: do not report a connection error while the tab's connection is still being resolved
 
 ## 5.51.0

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -1245,7 +1245,7 @@ export class App extends PureComponent {
 
   _handleConnectionStatusChanged = ({ tab, ...connectionCheckResult }) => {
 
-    // The cluster connection feeds the additional lint sources, not the content
+    // The connection feeds the additional lint sources, not the content
     // linter, so updating state is enough - the warning is recomposed on read.
     this.setState({ connectionCheckResult });
   };

--- a/client/src/app/linting/VersionMismatchChecker.js
+++ b/client/src/app/linting/VersionMismatchChecker.js
@@ -78,7 +78,7 @@ export function getVersionMismatchWarning(selectedVersion, clusterVersion) {
   return {
     category: 'warn',
     name: 'Engine profile',
-    message: `This file targets Camunda ${ selectedMinorVersion }, but the connected cluster runs Camunda ${ clusterMinorVersion }.`,
+    message: `This file targets Camunda ${ selectedMinorVersion }, but you are connected to Camunda ${ clusterMinorVersion }.`,
     rule: 'camunda/version-mismatch',
     action: {
       label: `Update engine profile to ${ clusterMinorVersion }`,

--- a/client/src/app/modals/credentials/CredentialModal.js
+++ b/client/src/app/modals/credentials/CredentialModal.js
@@ -241,8 +241,8 @@ class CredentialModal extends PureComponent {
     const fieldError = validationError || (missingSecret
       ? (
         <>
-          Secret <code>{ missingSecret }</code> was not found on this cluster.
-          { ' Add it to the cluster\'s secret store before deploying.' }
+          Secret <code>{ missingSecret }</code> was not found.
+          { ' Add it to the secret store before deploying.' }
         </>
       )
       : null);

--- a/client/src/app/modals/credentials/__tests__/CredentialModalSpec.js
+++ b/client/src/app/modals/credentials/__tests__/CredentialModalSpec.js
@@ -606,7 +606,7 @@ describe('<CredentialModal>', function() {
     // then
     const input = getByLabelText('API key');
 
-    expect(getByText(/was not found on this cluster/)).to.exist;
+    expect(getByText(/was not found/)).to.exist;
     expect(input.classList.contains('is-invalid')).to.be.true;
     expect(input.closest('.form-group').classList.contains('has-error')).to.be.true;
     expect(input.getAttribute('aria-invalid')).to.equal('true');
@@ -625,7 +625,7 @@ describe('<CredentialModal>', function() {
     });
 
     // then
-    expect(queryByText(/was not found on this cluster/)).not.to.exist;
+    expect(queryByText(/was not found/)).not.to.exist;
   });
 
 

--- a/client/src/app/panel/tabs/linting/__tests__/LintingTabSpec.js
+++ b/client/src/app/panel/tabs/linting/__tests__/LintingTabSpec.js
@@ -231,7 +231,7 @@ describe('<LintingTab>', function() {
           category: 'warn',
           id: 'foo',
           name: 'Engine profile',
-          message: 'This file targets Camunda 8.7, but the connected cluster runs Camunda 8.8.',
+          message: 'This file targets Camunda 8.7, but you are connected to Camunda 8.8.',
           rule: 'camunda/version-mismatch',
           action: {
             label: 'Update engine profile to 8.8',

--- a/client/src/app/tabs/cloud-bpmn/credential-manager/CredentialManager.js
+++ b/client/src/app/tabs/cloud-bpmn/credential-manager/CredentialManager.js
@@ -58,9 +58,9 @@ const log = debug('CredentialManager');
  */
 
 const CONFIGURATION_UNAVAILABLE_MESSAGES = {
-  noConnection: 'Connect to a Camunda 8 cluster to manage credentials.',
-  offline: 'Cannot reach the cluster. Reconnect to manage credentials.',
-  unsupported: 'The connected cluster does not support credentials. Camunda 8.10 or later is required.'
+  noConnection: 'Connect to Camunda 8 to manage credentials.',
+  offline: 'Cannot reach Camunda 8. Reconnect to manage credentials.',
+  unsupported: 'Your connection does not support credentials. Camunda 8.10 or later is required.'
 };
 
 const SEARCH_PAGE_SIZE = 100;
@@ -70,10 +70,10 @@ const CREDENTIAL_REFERENCE_PREFIX = '=camunda.vars.env.';
 const CREDENTIAL_VARIABLE_KIND = 'SECRET_REFERENCE';
 
 const CREDENTIAL_CREATE_FORBIDDEN_MESSAGE =
-  'You do not have permission to create credentials on this cluster. Contact your cluster administrator.';
+  'You do not have permission to create credentials. Contact your administrator.';
 
 const CREDENTIAL_UPDATE_FORBIDDEN_MESSAGE =
-  'You do not have permission to update credentials on this cluster. Contact your cluster administrator.';
+  'You do not have permission to update credentials. Contact your administrator.';
 
 /**
  * Hosts the element-template credential chooser for a cloud BPMN tab: feeds the
@@ -522,7 +522,7 @@ export default class CredentialManager extends PureComponent {
     const endpoint = await this.getEndpoint();
 
     if (!endpoint) {
-      throw new Error('No connection to the cluster.');
+      throw new Error('No connection to Camunda 8.');
     }
 
     const value = buildCredentialValue(configurationTemplate, values);

--- a/client/src/app/tabs/cloud-bpmn/credential-manager/__tests__/CredentialManagerSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/credential-manager/__tests__/CredentialManagerSpec.js
@@ -305,7 +305,7 @@ describe('<CredentialManager>', function() {
       const call = unavailableCall(configurationInstances);
 
       expect(call).to.exist;
-      expect(call.unavailableMessage).to.match(/Connect to a Camunda 8 cluster/);
+      expect(call.unavailableMessage).to.match(/Connect to Camunda 8/);
     });
   });
 
@@ -313,7 +313,7 @@ describe('<CredentialManager>', function() {
   [
     [ 400, /Camunda 8\.10 or later/ ],
     [ 404, /Camunda 8\.10 or later/ ],
-    [ undefined, /Cannot reach the cluster/ ]
+    [ undefined, /Cannot reach Camunda 8/ ]
   ].forEach(([ status, unavailableMessage ]) => {
 
     it(`should mark the chooser unavailable for a failed credential search (${ status || 'offline' })`,
@@ -726,7 +726,7 @@ describe('<CredentialManager>', function() {
     // then
     await waitFor(() => {
       expect(getByRole('alert').textContent).to.equal(
-        'You do not have permission to create credentials on this cluster. Contact your cluster administrator.'
+        'You do not have permission to create credentials. Contact your administrator.'
       );
     });
   });
@@ -752,7 +752,7 @@ describe('<CredentialManager>', function() {
     // then
     await waitFor(() => {
       expect(getByRole('alert').textContent).to.equal(
-        'You do not have permission to update credentials on this cluster. Contact your cluster administrator.'
+        'You do not have permission to update credentials. Contact your administrator.'
       );
     });
   });

--- a/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/TaskTestingTab.js
+++ b/client/src/app/tabs/cloud-bpmn/side-panel/tabs/task-testing/TaskTestingTab.js
@@ -38,11 +38,11 @@ export const DEFAULT_CONFIG = {
 export const MIN_SUPPORTED_EXECUTION_PLATFORM_VERSION = '8.8.0';
 export const SUPPORTED_PROTOCOL = 'rest';
 
-export const CANNOT_CONNECT_TITLE = 'Couldn\'t connect to Camunda';
-export const CANNOT_CONNECT_DESCRIPTION = 'Configure a REST connection to a Camunda 8 cluster.';
+export const CANNOT_CONNECT_TITLE = 'Couldn\'t connect to Camunda 8';
+export const CANNOT_CONNECT_DESCRIPTION = 'Configure a REST connection to Camunda 8.';
 
 export const UNSUPPORTED_PROTOCOL_TITLE = 'REST connection required';
-export const UNSUPPORTED_PROTOCOL_DESCRIPTION = 'Task testing requires a REST connection to a Camunda 8 cluster. The current connection uses gRPC.';
+export const UNSUPPORTED_PROTOCOL_DESCRIPTION = 'Task testing requires a REST connection. The current connection uses gRPC.';
 
 export const UNSUPPORTED_EXECUTION_PLATFORM_VERSION_TITLE = 'Execution platform version not supported';
 export const UNSUPPORTED_EXECUTION_PLATFORM_VERSION_DESCRIPTION = `Task testing requires Camunda ${MIN_SUPPORTED_EXECUTION_PLATFORM_VERSION} or higher`;
@@ -50,7 +50,7 @@ export const UNSUPPORTED_EXECUTION_PLATFORM_VERSION_DESCRIPTION = `Task testing 
 export const LINTING_ERRORS_TITLE = 'Diagram has errors';
 export const LINTING_ERRORS_DESCRIPTION = 'Task testing requires a diagram without errors.';
 
-export const DEFAULT_CONFIGURE_DESCRIPTION = 'Configure cluster connection.';
+export const DEFAULT_CONFIGURE_DESCRIPTION = 'Configure connection.';
 
 const DOCUMENTATION_URL = utmTag('https://docs.camunda.io/docs/components/modeler/desktop-modeler/task-testing/');
 

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerOverlay.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerOverlay.js
@@ -121,7 +121,7 @@ export function ConnectionManagerOverlay({
           </div>
 
           <div className={ classNames('form-group form-description') }>
-            A connection to a running <a href={ utmTag('https://docs.camunda.io/docs/components/modeler/desktop-modeler/connect-to-camunda-8/') }>orchestration cluster</a> lets you test tasks, deploy resources, and run processes.
+            A connection to <a href={ utmTag('https://docs.camunda.io/docs/components/modeler/desktop-modeler/connect-to-camunda-8/') }>Camunda 8</a> lets you test tasks, deploy resources, and run processes.
           </div>
         </form>
       </Section.Body>

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettings.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettings.js
@@ -21,13 +21,13 @@ export async function initializeSettings({ settings, connectionChecker }) {
   /** @type import("../../../app/Settings").SettingsGroup */
   const pluginSettings = {
     id: CONNECTION_MANAGER_PLUGIN_ID,
-    title: 'Camunda 8 cluster connections',
+    title: 'Camunda 8 connections',
     order: 1,
     properties: {
       [SETTINGS_KEY_CONNECTIONS]: {
         type: 'custom',
         component: (props) => ConnectionManagerSettingsComponent({ ...props, connectionChecker }),
-        description: 'Manage Camunda 8 Orchestration Cluster connections.'
+        description: 'Manage your Camunda 8 connections.'
       },
 
     }

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettingsComponent.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettingsComponent.js
@@ -160,7 +160,7 @@ export function ConnectionManagerSettingsComponent({ name: fieldName, targetElem
       if (isC8RunConnection(connection)) {
         return (
           <>
-            Cannot connect to your local Orchestration Cluster. <a data-testid="c8run-download-link" href={ C8RUN_DOWNLOAD_URL }>Download</a> or start Camunda 8 Run to connect. See troubleshooting information about C8 Run <a data-testid="c8run-troubleshoot-link" href={ C8RUN_TROUBLESHOOTING_URL }>here</a>.
+            Cannot connect to your local Camunda 8 instance. <a data-testid="c8run-download-link" href={ C8RUN_DOWNLOAD_URL }>Download</a> or start Camunda 8 Run to connect. See troubleshooting information about C8 Run <a data-testid="c8run-troubleshoot-link" href={ C8RUN_TROUBLESHOOTING_URL }>here</a>.
           </>
         );
       }
@@ -184,14 +184,14 @@ export function ConnectionManagerSettingsComponent({ name: fieldName, targetElem
 
       return <div className={ css.ConnectionManagerSettings } data-testid="connection-manager-settings" id={ fieldName }>
         <div className="custom-control">
-          <div className="custom-control-description">Deploy and run your processes on Camunda 8 Orchestration Clusters, including <a href="https://docs.camunda.io/docs/self-managed/quickstart/developer-quickstart/c8run/">Camunda 8 Run</a>.</div>
+          <div className="custom-control-description">Deploy and run your processes on Camunda 8, including <a href="https://docs.camunda.io/docs/self-managed/quickstart/developer-quickstart/c8run/">Camunda 8 Run</a>.</div>
         </div>
         {(!fieldValue || fieldValue.length === 0) && (
           <div className="empty-placeholder">
             <ErrorFilled size={ 20 } />
             <div className="placeholder-content">
               <h1>No connections configured</h1>
-              <p>Add a cluster connection to deploy and run processes</p>
+              <p>Add a connection to deploy and run processes</p>
             </div>
           </div>
         )}

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettingsProperties.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettingsProperties.js
@@ -21,7 +21,7 @@ const LABELS = {
   CAMUNDA_CLOUD: 'Camunda 8 SaaS',
   CLIENT_ID: 'Client ID',
   CLIENT_SECRET: 'Client secret',
-  CLUSTER_URL: 'Cluster URL',
+  CONNECTION_URL: 'Connection URL',
   OAUTH_AUDIENCE: 'OAuth audience',
   OAUTH_SCOPE: 'OAuth scope',
   OAUTH_URL: 'OAuth token URL',
@@ -33,7 +33,7 @@ const LABELS = {
 };
 
 const HINTS = {
-  CLUSTER_URL: 'http://localhost:8080/v2',
+  CONNECTION_URL: 'http://localhost:8080/v2',
   TENANT_ID: 'Optional',
   OPERATE_URL: 'Optional',
   TASKLIST_URL: 'Optional'
@@ -45,13 +45,13 @@ const VALIDATION_ERROR_MESSAGES = {
   BASIC_AUTH_USERNAME_MUST_NOT_BE_EMPTY: 'Username must not be empty.',
   CLIENT_ID_MUST_NOT_BE_EMPTY: 'Client ID must not be empty.',
   CLIENT_SECRET_MUST_NOT_BE_EMPTY: 'Client secret must not be empty.',
-  CLUSTER_URL_MUST_BE_VALID_CLOUD_URL: 'Must be a valid Camunda 8 SaaS URL.',
-  CONTACT_POINT_MUST_BE_URL: 'Cluster URL must be a valid URL.',
+  CONNECTION_URL_MUST_BE_VALID_CLOUD_URL: 'Must be a valid Camunda 8 SaaS URL.',
+  CONTACT_POINT_MUST_BE_URL: 'Connection URL must be a valid URL.',
   OPERATE_URL_MUST_BE_URL: 'Operate URL must be a valid URL starting with "http://" or "https://".',
   TASKLIST_URL_MUST_BE_URL: 'Tasklist URL must be a valid URL starting with "http://" or "https://".',
-  CONTACT_POINT_MUST_NOT_BE_EMPTY: 'Cluster URL must not be empty.',
-  CLUSTER_URL_MUST_NOT_BE_EMPTY: 'Cluster URL must not be empty.',
-  CLUSTER_URL_MUST_START_WITH_PROTOCOL: 'Cluster URL must start with "http://", "grpc://", "https://", or "grpcs://".',
+  CONTACT_POINT_MUST_NOT_BE_EMPTY: 'URL must not be empty.',
+  CONNECTION_URL_MUST_NOT_BE_EMPTY: 'URL must not be empty.',
+  CONNECTION_URL_MUST_START_WITH_PROTOCOL: 'Connection URL must start with "http://", "grpc://", "https://", or "grpcs://".',
   MUST_PROVIDE_A_VALUE: 'Must provide a value.',
   OAUTH_URL_MUST_NOT_BE_EMPTY: 'OAuth URL must not be empty.',
   TENANT_ID_INVALID: 'Logical Tenant ID must be 31 characters or fewer and contain only alphanumeric characters, dots (.), dashes (-), or underscores (_).'
@@ -82,13 +82,13 @@ export const properties = [
 
   { key: 'camundaCloudClusterUrl',
     type: 'text',
-    label: LABELS.CLUSTER_URL,
+    label: LABELS.CONNECTION_URL,
     condition: { property: 'targetType', equals: TARGET_TYPES.CAMUNDA_CLOUD },
     constraints: {
-      notEmpty: VALIDATION_ERROR_MESSAGES.CLUSTER_URL_MUST_NOT_BE_EMPTY,
+      notEmpty: VALIDATION_ERROR_MESSAGES.CONNECTION_URL_MUST_NOT_BE_EMPTY,
       pattern: {
         value: REGEXES.CAMUNDA_CLOUD_URL,
-        message: VALIDATION_ERROR_MESSAGES.CLUSTER_URL_MUST_BE_VALID_CLOUD_URL
+        message: VALIDATION_ERROR_MESSAGES.CONNECTION_URL_MUST_BE_VALID_CLOUD_URL
       }
     }
   },
@@ -111,7 +111,7 @@ export const properties = [
 
   { key: 'contactPoint',
     type: 'text',
-    label: LABELS.CLUSTER_URL,
+    label: LABELS.CONNECTION_URL,
     condition: { property: 'targetType', equals: TARGET_TYPES.SELF_HOSTED },
     constraints: {
       notEmpty: VALIDATION_ERROR_MESSAGES.CONTACT_POINT_MUST_NOT_BE_EMPTY,

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionManagerOverlaySpec.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionManagerOverlaySpec.js
@@ -186,7 +186,7 @@ describe('ConnectionManagerOverlay', function() {
       // then
       const errorMessage = container.querySelector('.invalid-feedback');
       expect(errorMessage).to.exist;
-      expect(errorMessage.textContent).to.equal('Cannot connect to Orchestration Cluster.');
+      expect(errorMessage.textContent).to.equal('Cannot connect to Camunda 8.');
       expect(errorMessage.textContent).to.not.contain('Could not establish connection:');
     });
 
@@ -207,7 +207,7 @@ describe('ConnectionManagerOverlay', function() {
       // then
       const errorMessage = container.querySelector('.invalid-feedback');
       expect(errorMessage).to.exist;
-      expect(errorMessage.textContent).to.equal('Cannot connect to Orchestration Cluster.');
+      expect(errorMessage.textContent).to.equal('Cannot connect to Camunda 8.');
       expect(errorMessage.textContent).to.not.contain('Could not establish connection:');
     });
 
@@ -228,7 +228,7 @@ describe('ConnectionManagerOverlay', function() {
       // then
       const errorMessage = container.querySelector('.invalid-feedback');
       expect(errorMessage).to.exist;
-      expect(errorMessage.textContent).to.equal('Unknown error. Please check Orchestration Cluster status.');
+      expect(errorMessage.textContent).to.equal('Unknown error. Please check Camunda 8 status.');
       expect(errorMessage.textContent).to.not.contain('Could not establish connection:');
     });
 

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionManagerSettingsComponentSpec.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionManagerSettingsComponentSpec.js
@@ -626,7 +626,7 @@ describe('ConnectionManagerSettingsComponent', function() {
         expect(getByLabelText('Error')).to.exist;
 
         // Verify full message text content
-        expect(container.textContent).to.contain('Cannot connect to your local Orchestration Cluster');
+        expect(container.textContent).to.contain('Cannot connect to your local Camunda 8 instance');
         expect(container.textContent).to.contain('Download');
         expect(container.textContent).to.contain('or start Camunda 8 Run to connect');
         expect(container.textContent).to.contain('See troubleshooting information about C8 Run');
@@ -781,7 +781,7 @@ describe('ConnectionManagerSettingsComponent', function() {
     // then
     const description = container.querySelector('.custom-control-description');
     expect(description).to.exist;
-    expect(description.textContent).to.equal('Deploy and run your processes on Camunda 8 Orchestration Clusters, including Camunda 8 Run.');
+    expect(description.textContent).to.equal('Deploy and run your processes on Camunda 8, including Camunda 8 Run.');
   });
 
 

--- a/client/src/plugins/zeebe-plugin/deployment-plugin/ConnectionCheckErrors.js
+++ b/client/src/plugins/zeebe-plugin/deployment-plugin/ConnectionCheckErrors.js
@@ -33,13 +33,13 @@ export const CONNECTION_CHECK_ERROR_REASONS = {
 };
 
 export const CONNECTION_CHECK_ERROR_MESSAGES = {
-  [ CONNECTION_CHECK_ERROR_REASONS.CONTACT_POINT_UNAVAILABLE ]: 'Cannot connect to Orchestration Cluster.',
-  [ CONNECTION_CHECK_ERROR_REASONS.CLUSTER_UNAVAILABLE ]: 'Cannot connect to Orchestration Cluster.',
+  [ CONNECTION_CHECK_ERROR_REASONS.CONTACT_POINT_UNAVAILABLE ]: 'Cannot connect to Camunda 8.',
+  [ CONNECTION_CHECK_ERROR_REASONS.CLUSTER_UNAVAILABLE ]: 'Cannot connect to Camunda 8.',
   [ CONNECTION_CHECK_ERROR_REASONS.UNAUTHORIZED ]: 'Credentials rejected by server.',
   [ CONNECTION_CHECK_ERROR_REASONS.FORBIDDEN ]: 'This user is not permitted to deploy. Please use different credentials or get this user enabled to deploy.',
   [ CONNECTION_CHECK_ERROR_REASONS.OAUTH_URL ]: 'Cannot connect to OAuth token endpoint.',
-  [ CONNECTION_CHECK_ERROR_REASONS.UNKNOWN ]: 'Unknown error. Please check Orchestration Cluster status.',
-  [ CONNECTION_CHECK_ERROR_REASONS.UNSUPPORTED_ENGINE ]: 'Unsupported Orchestration Cluster version.',
+  [ CONNECTION_CHECK_ERROR_REASONS.UNKNOWN ]: 'Unknown error. Please check Camunda 8 status.',
+  [ CONNECTION_CHECK_ERROR_REASONS.UNSUPPORTED_ENGINE ]: 'Unsupported Camunda 8 version.',
   [ CONNECTION_CHECK_ERROR_REASONS.INVALID_CLIENT_ID ]: 'Invalid Client ID.',
   [ CONNECTION_CHECK_ERROR_REASONS.INVALID_CREDENTIALS ]: 'The client secret is not valid for the client ID provided.',
   [ CONNECTION_CHECK_ERROR_REASONS.NO_CONFIG ]: 'No connection configured.',

--- a/test/e2e/specs/bpmn-credentials.spec.js
+++ b/test/e2e/specs/bpmn-credentials.spec.js
@@ -18,10 +18,10 @@ const { copyFixture } = require('../harness/files');
 
 const Modeler = require('../pages/Modeler');
 
-// The credential create / edit flow is gated on a live Camunda 8 cluster, which
+// The credential create / edit flow is gated on a live Camunda 8 connection, which
 // the offline e2e harness has none of. These specs therefore cover the offline
 // contract: the chooser renders for a credential-enabled template and prompts to
-// connect a cluster instead of offering the (unusable) create action.
+// connect instead of offering the (unusable) create action.
 test.describe('BPMN credentials chooser (Camunda 8)', function() {
 
   test('should render the credential chooser for a templated element', async function({ launch, tmp }) {
@@ -50,7 +50,7 @@ test.describe('BPMN credentials chooser (Camunda 8)', function() {
   });
 
 
-  test('should prompt to connect a cluster when offline', async function({ launch, tmp }) {
+  test('should prompt to connect when offline', async function({ launch, tmp }) {
 
     // given
     const app = await launchWithTemplate(launch, tmp);
@@ -59,7 +59,7 @@ test.describe('BPMN credentials chooser (Camunda 8)', function() {
     await revealChooser(app);
 
     // then
-    await expect(unavailable(app)).toHaveText(/Connect to a Camunda 8 cluster/);
+    await expect(unavailable(app)).toHaveText(/Connect to Camunda 8/);
   });
 
 


### PR DESCRIPTION

<img width="1324" height="1042" alt="Screenshot 2026-09-02 at 11 46 59" src="https://github.com/user-attachments/assets/d4857110-3f02-49ae-aede-8e49d19cb87c" />
<img width="1324" height="1042" alt="Screenshot 2026-09-02 at 11 47 03" src="https://github.com/user-attachments/assets/eed43fe0-e941-4e16-be93-9c134cb708ee" />
<img width="1324" height="1042" alt="Screenshot 2026-09-02 at 11 47 06" src="https://github.com/user-attachments/assets/011d28a2-4aad-480e-9e88-4c8511bf9725" />
<img width="1324" height="1042" alt="Screenshot 2026-09-02 at 11 47 10" src="https://github.com/user-attachments/assets/67bc1bff-2666-4a3a-8b13-ec4b5ff10c8a" />
<img width="1324" height="1042" alt="Screenshot 2026-09-02 at 11 47 12" src="https://github.com/user-attachments/assets/e1544690-cdf4-4a1d-ac32-d62e40fe7ed0" />


### Proposed Changes

Related to https://github.com/camunda/camunda-modeler/issues/6161

Renames Camunda 8 connection-related UI text and error messages from "cluster connection" / "Cluster URL" / "Orchestration Cluster" phrasing to plain "connection" wording, ahead of the upcoming release.

Per the linked issue, a Camunda 8 connection isn't always literally to a cluster (it can also be to a physical or logical tenant) — which resource sits behind it is a technical detail that shouldn't leak into user-facing language.

- **Scope**: Camunda 8 only (Camunda 7 doesn't use "cluster" wording), user-visible text only (no internal identifiers, state, or persisted config keys renamed, to avoid migration risk). Checked `camunda/task-testing` (the other repo called out in the issue) — its published library source has no user-facing "cluster" wording (only a local, unshipped demo app and the external `@camunda8/orchestration-cluster-api` package name), so no changes were needed there.
- **Kept as-is**: `camundaCloudClusterUrl`/`clusterId`/`clusterRegion` internals and the entire "cluster variable" API/IPC surface, since those name real Camunda 8 wire contracts and backend resources, not user-facing connection phrasing.
- **Renamed**:
  - `Cluster URL` → `Connection URL` (also fixes an existing inconsistency where the Self-Managed `contactPoint` field was mislabeled "Cluster URL"); its "must not be empty" validation message was further trimmed to just `URL must not be empty.`
  - "Camunda 8 cluster connections" (Settings title) → "Camunda 8 connections"
  - "Manage Camunda 8 Orchestration Cluster connections." (Settings description) → "Manage your Camunda 8 connections."
  - "Add a cluster connection to deploy and run processes" → "Add a connection to deploy and run processes"
  - "Configure cluster connection." / "a REST connection to a Camunda 8 cluster" (Task Testing) → drop "cluster"; the gRPC/REST mismatch message also dropped the redundant "to Camunda 8"
  - "Couldn't connect to Camunda" (Task Testing error title) → "Couldn't connect to Camunda 8", matching the description right below it
  - "Orchestration Cluster" in connection-check errors and Connection Manager copy (e.g. "Cannot connect to Orchestration Cluster.", "Unsupported Orchestration Cluster version.", "Deploy and run your processes on Camunda 8 Orchestration Clusters...") → "Camunda 8"
  - "A connection to a running Camunda 8 instance..." (Connection Manager overlay) → "A connection to Camunda 8..." — "instance" read as self-managed/single-instance specific, but this text applies to any connection including SaaS
  - Credential Manager unavailable-state and permission-denied messages ("Connect to a Camunda 8 cluster...", "Cannot reach the cluster...", "The connected cluster does not support credentials...", "...on this cluster. Contact your cluster administrator.") → reworded around "connection"/"Camunda 8", dropping the trailing "on Camunda 8" where redundant (e.g. "You do not have permission to create credentials. Contact your administrator.")
  - Missing-secret message in the Credential modal ("...was not found on this cluster" / "the cluster's secret store") → "...was not found." / "the secret store" (dropped "on Camunda 8"/"the cluster's" as redundant)
  - Version-mismatch lint warning ("the connected cluster runs Camunda Y") → "you are connected to Camunda Y"
- Historical release notes (`ReleaseInfo.js`) were deliberately left untouched — they describe a shipped version's changelog copy and editing them would misrepresent past releases.

**Verification**: Full client test suite passes (`npm run client:test` — 2564 passed, 0 failed). Updated the test assertions pinned to old copy across the affected spec files, and the offline-chooser e2e spec (`test/e2e/specs/bpmn-credentials.spec.js`).

**Steps to try out**: open Settings → Camunda 8 connections; open a `.bpmn` cloud diagram's Task Testing / Credential Manager panels without a connection configured.

Screenshots not attached — this is a text-only rename with no layout/UX change; happy to add if requested.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
