### PR TITLE
feat: navigate tab history via mouse back and forward buttons

### DIFF
--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -83,6 +83,10 @@ export const EMPTY_TAB = {
 
 const ENCODING_UTF8 = 'utf8';
 
+// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+const BACK_MOUSE_BUTTON = 3;
+const FORWARD_MOUSE_BUTTON = 4;
+
 const FILTER_ALL_EXTENSIONS = {
   name: 'All Files',
   extensions: [ '*' ]
@@ -1443,7 +1447,39 @@ export class App extends PureComponent {
     this.on('tab.activeSheetChanged', () => {
       this.closeNotifications();
     });
+
+    window.addEventListener('mousedown', this.handleMouseDown);
   }
+
+  componentWillUnmount() {
+    window.removeEventListener('mousedown', this.handleMouseDown);
+  }
+
+  /**
+   * Navigate the tab history via the pointer device's back / forward buttons.
+   *
+   * @param {MouseEvent} event
+   */
+  handleMouseDown = (event) => {
+    const { button } = event;
+
+    if (button !== BACK_MOUSE_BUTTON && button !== FORWARD_MOUSE_BUTTON) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const { tabs } = this.state;
+
+    if (!tabs.length) {
+      return;
+    }
+
+    this.triggerAction(
+      'select-tab',
+      button === BACK_MOUSE_BUTTON ? 'previous' : 'next'
+    );
+  };
 
   componentDidUpdate(prevProps, prevState) {
 

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -2043,6 +2043,100 @@ describe('<App>', function() {
     });
 
 
+    describe('mouse history buttons', function() {
+
+      function dispatchMouseDown(button) {
+        return act(() => {
+          window.dispatchEvent(new MouseEvent('mousedown', {
+            button,
+            bubbles: true,
+            cancelable: true
+          }));
+        });
+      }
+
+
+      it('should navigate back on back button', async function() {
+
+        // when
+        await dispatchMouseDown(3);
+
+        // then
+        await waitFor(() => {
+          expect(app.state.activeTab).to.eql(openedTabs[2]);
+        });
+      });
+
+
+      it('should navigate forward on forward button', async function() {
+
+        // given
+        await app.navigate(-1);
+
+        // when
+        await dispatchMouseDown(4);
+
+        // then
+        await waitFor(() => {
+          expect(app.state.activeTab).to.eql(openedTabs[3]);
+        });
+      });
+
+
+      it('should ignore other buttons', async function() {
+
+        // given
+        const triggerActionSpy = spy(app, 'triggerAction');
+
+        // when
+        await dispatchMouseDown(0);
+        await dispatchMouseDown(1);
+        await dispatchMouseDown(2);
+
+        // then
+        expect(triggerActionSpy).not.to.have.been.called;
+        expect(app.state.activeTab).to.eql(openedTabs[3]);
+      });
+
+
+      it('should not navigate without tabs', async function() {
+
+        // given
+        await app.triggerAction('close-all-tabs');
+
+        const triggerActionSpy = spy(app, 'triggerAction');
+
+        // assume
+        expect(app.state.tabs).to.be.empty;
+
+        // when
+        await dispatchMouseDown(3);
+
+        // then
+        expect(triggerActionSpy).not.to.have.been.called;
+        expect(app.navigationHistory.idx).to.eql(-1);
+      });
+
+
+      it('should not navigate once unmounted', async function() {
+
+        // given
+        const { app: unmountedApp, unmount } = createApp();
+
+        const triggerActionSpy = spy(unmountedApp, 'triggerAction');
+
+        unmount();
+
+        // when
+        await dispatchMouseDown(3);
+
+        // then
+        expect(triggerActionSpy).not.to.have.been.called;
+      });
+
+    });
+
+
     describe('tab moving', function() {
 
       let app, openedTabs;


### PR DESCRIPTION
### Proposed Changes

Implements tab history navigation via the mouse forward / back buttons.

The pointer device's back button (`MouseEvent.button === 3`) navigates backward and its forward button (`MouseEvent.button === 4`) forward through the tab history.

`App` listens for `mousedown` on the window and dispatches the existing `select-tab` action with `previous` / `next`, so the mouse takes the same path as the menu. The event's default is prevented, so the embedding browsing context never navigates as well. While no tab is open the buttons are claimed but do nothing.

Closes #6159.

**Steps to try out**

```sh
npx @bpmn-io/sr minchingtonak/camunda-modeler#feat/mouse-button-history-navigation
```

1. Open three or more diagrams and switch between them a few times.
2. Press the mouse back button. The previously visited tab is shown.
3. Press the mouse forward button. You move forward again through the same history.
4. Close all tabs and press either button on the welcome screen. Nothing happens.

### Checklist

Ensure you provide everything we need to review your contribution:

<!--
Do not alter this checklist beyond checking items; provide context above.
-->

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
