### PR TITLE
fix(connection-manager): don't report an error while resolving connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: do not report a connection error while the tab's connection is still being resolved
+
 ## 5.51.0
 
 * `FEAT`: cache linter creation / prevent unnecessary element template reloading ([#6092](https://github.com/camunda/camunda-modeler/pull/6092))

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerPlugin.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerPlugin.js
@@ -185,13 +185,22 @@ export default function ConnectionManagerPlugin(props) {
       if (activeConnection && activeConnection.id !== NO_CONNECTION.id && !paused) {
         globalConnectionChecker.current.updateConfig({ endpoint: activeConnection });
       }
-      else {
+      else if (activeConnection) {
         globalConnectionChecker.current.stopChecking();
         globalConnectionChecker.current.updateConfig(null, false);
         setConnectionCheckResult({
           success: false,
           reason: CONNECTION_CHECK_ERROR_REASONS.NO_CONFIG,
         });
+      }
+      else {
+
+        // `activeConnection` is `null` while there is no active tab, or while
+        // the active tab's connection is still being resolved. Neither means
+        // "no connection configured", so we must not report that status - doing
+        // so surfaced a spurious connection error whenever resolving the
+        // connection took longer than `DELAYS.SHORT`.
+        globalConnectionChecker.current.stopChecking();
       }
     })();
 

--- a/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionManagerPluginSpec.js
+++ b/client/src/plugins/zeebe-plugin/connection-manager-plugin/__tests__/ConnectionManagerPluginSpec.js
@@ -418,11 +418,8 @@ describe('ConnectionManagerPlugin', function() {
           connectionCheckResult: { success: true }
         });
 
-        // make React state settle
-        await waitForNextCycle(3);
-
-        // advance past ConnectionChecker SHORT delay (1000ms)
-        await clock.tickAsync(2000);
+        // wait for the connection to resolve and the first check to run
+        await waitForStatusChanges(clock, emit, 1);
 
         // then
         expect(emit).to.have.been.calledWith(
@@ -512,9 +509,9 @@ describe('ConnectionManagerPlugin', function() {
             emit,
           });
 
-          // make React state settle and let the connection resolve
-          await waitForNextCycle(3);
-          await clock.tickAsync(2000);
+          // wait for the active tab's connection to resolve
+          await waitForClock(clock, () => getEmits(emit, 'connectionManager.connectionCheckStarted')
+            .some(call => call.args[1].connectionId === DEFAULT_CONNECTIONS[0].id));
 
           // then
           expect(emit).to.have.been.calledWith(
@@ -556,9 +553,8 @@ describe('ConnectionManagerPlugin', function() {
               connectionCheckResult: { success }
             });
 
-            // make React state settle and let initial checks run
-            await waitForNextCycle(3);
-            await clock.tickAsync(2000);
+            // let the connection resolve and the initial check run
+            await waitForStatusChanges(clock, emit, 1);
 
             // isolate: reset history so assertions only cover the next check cycle
             emit.resetHistory();
@@ -612,9 +608,8 @@ describe('ConnectionManagerPlugin', function() {
             connectionCheckResult: { success: true }
           });
 
-          // make React state settle and let initial checks run
-          await waitForNextCycle(3);
-          await clock.tickAsync(2000);
+          // let the connection resolve and the initial check run
+          await waitForStatusChanges(clock, emit, 1);
 
           // cancel the in-progress check by opening settings (triggers stopChecking)
           openSettings();
@@ -641,11 +636,11 @@ describe('ConnectionManagerPlugin', function() {
 
       describe('connectionManager.connectionStatusChanged de-duplication', function() {
 
-        function createGetGlobal(checkConnection, settings) {
+        function createGetGlobal(checkConnection, settings, getConnectionForTab = () => Promise.resolve(DEFAULT_CONNECTIONS[0])) {
           return (name) => {
             if (name === 'deployment') {
               return new Deployment({
-                getConnectionForTab: () => Promise.resolve(DEFAULT_CONNECTIONS[0]),
+                getConnectionForTab,
                 async setConnectionForFile() {},
                 getEndpoints() {
                   return settings.get('connectionManagerPlugin.c8connections') || [];
@@ -688,15 +683,13 @@ describe('ConnectionManagerPlugin', function() {
           });
 
           // when - initial check + several periodic checks all return the same result
-          await waitForNextCycle(3);
-          await clock.tickAsync(2000);
+          await waitForStatusChanges(clock, emit, 1);
           await clock.tickAsync(5000);
           await clock.tickAsync(5000);
 
           // then - status change is emitted exactly once
-          const statusChangedCalls = emit.getCalls().filter(
-            call => call.args[0] === 'connectionManager.connectionStatusChanged'
-          );
+          const statusChangedCalls = getStatusChanges(emit);
+
           expect(statusChangedCalls).to.have.lengthOf(1);
           expect(statusChangedCalls[0].args[1]).to.include({ success: true });
         });
@@ -722,22 +715,53 @@ describe('ConnectionManagerPlugin', function() {
           });
 
           // when - first check succeeds
-          await waitForNextCycle(3);
-          await clock.tickAsync(2000);
+          await waitForStatusChanges(clock, emit, 1);
 
           // ...then the connection starts failing
           currentResult = { success: false, reason: 'CONTACT_POINT_UNAVAILABLE' };
-          await clock.tickAsync(5000);
+          await waitForStatusChanges(clock, emit, 2);
 
           // then - status change emitted for both the success and the error
-          const statusChangedCalls = emit.getCalls().filter(
-            call => call.args[0] === 'connectionManager.connectionStatusChanged'
+          const statusChangedCalls = getStatusChanges(emit);
+
+          expect(statusChangedCalls).to.have.lengthOf(2);
+          expect(statusChangedCalls[0].args[1]).to.include({ success: true });
+          expect(statusChangedCalls[1].args[1])
+            .to.include({ success: false, reason: 'CONTACT_POINT_UNAVAILABLE' });
+        });
+
+
+        it('should not report a connection error while the connection is still being resolved', async function() {
+
+          // given
+          const settings = createMockSettings({
+            'connectionManagerPlugin.c8connections': DEFAULT_CONNECTIONS
+          });
+
+          const checkConnection = () => ({ success: true, response: { gatewayVersion: '8.8.0' } });
+
+          // resolving the active tab's connection takes longer than `DELAYS.SHORT`
+          const getConnectionForTab = () => new Promise(
+            resolve => setTimeout(() => resolve(DEFAULT_CONNECTIONS[0]), 2000)
           );
 
-          expect(statusChangedCalls.length).to.be.at.least(2);
+          const emit = sinon.spy();
+
+          createConnectionManagerPlugin({
+            subscribe: createSubscribe(),
+            settings,
+            emit,
+            _getGlobal: createGetGlobal(checkConnection, settings, getConnectionForTab)
+          });
+
+          // when
+          await waitForStatusChanges(clock, emit, 1);
+
+          // then - only the actual check result is reported, no `NO_CONFIG` error
+          const statusChangedCalls = getStatusChanges(emit);
+
+          expect(statusChangedCalls).to.have.lengthOf(1);
           expect(statusChangedCalls[0].args[1]).to.include({ success: true });
-          expect(statusChangedCalls[statusChangedCalls.length - 1].args[1])
-            .to.include({ success: false, reason: 'CONTACT_POINT_UNAVAILABLE' });
         });
 
       });
@@ -1417,6 +1441,37 @@ function createPluginProps(props = {}, globals = {}) {
     connectionCheckResult,
     setConnectionCheckResult
   };
+}
+
+function getEmits(emit, event) {
+  return emit.getCalls().filter(call => call.args[0] === event);
+}
+
+function getStatusChanges(emit) {
+  return getEmits(emit, 'connectionManager.connectionStatusChanged');
+}
+
+/**
+ * Advance the fake clock until `condition` holds.
+ *
+ * Waiting for the actual condition instead of a fixed number of event loop
+ * turns keeps these assertions independent of how React schedules the
+ * intermediate re-renders, which differs between platforms.
+ */
+async function waitForClock(clock, condition, timeout = 30000) {
+  for (let elapsed = 0; elapsed <= timeout; elapsed += 100) {
+    if (condition()) {
+      return;
+    }
+
+    await clock.tickAsync(100);
+  }
+
+  throw new Error('timeout waiting for condition');
+}
+
+async function waitForStatusChanges(clock, emit, count) {
+  return waitForClock(clock, () => getStatusChanges(emit).length >= count);
 }
 
 async function waitForNextCycle(n = 1) {


### PR DESCRIPTION
This PR aims to fix the macOS CI failure. Some tests hardening is included. The old tests continue to pass after the source code change is applied.

🤖 input below:

### Proposed Changes

Fixes the intermittent `build (macos-latest)` CI failures, which turned out to be a real product race rather than infrastructure flakiness.

**Symptom.** `build (macos-latest)` was regularly the only failing job, always in the same block of unit tests, with two different-looking assertions:

| Run | Failing test | Assertion |
|---|---|---|
| [33071107696](https://github.com/camunda/camunda-modeler/actions/runs/33071107696) | `should emit only once for repeated identical results` | expected length 1, got 2 |
| [33075550034](https://github.com/camunda/camunda-modeler/actions/runs/33075550034) | `should emit again when the result changes` | expected `success` true, but got false |
| [33159187711](https://github.com/camunda/camunda-modeler/actions/runs/33159187711) | `should emit again when the result changes` | same |
| [33167496438](https://github.com/camunda/camunda-modeler/actions/runs/33167496438) | `should emit again when the result changes` | same |

Both are the same defect — one extra `success: false` emit arriving first. Reproduced deterministically by delaying `getConnectionForTab` past `DELAYS.SHORT`:

```
REPRO emits: [{"success":false,"reason":"NO_CONFIG"},{"success":false,"reason":"CONTACT_POINT_UNAVAILABLE"}]
```

**Root cause.** `activeConnection` is `null` both when there is no active tab *and* while the active tab's connection is still being resolved. `ConnectionManagerPlugin` treated that as "no connection configured" and called `updateConfig(null, false)`, arming a 1s timer whose only possible outcome is a `NO_CONFIG` failure emit. Normally the effect cleanup cancels that timer once the connection lands; on macOS the React re-render that triggers the cleanup is scheduled via `MessageChannel`, which sinon's fake timers do not control, so it regularly landed after the timer had already fired.

**This is user-facing, not just a test problem.** On a slow tab-connection resolve the app emits `connectionManager.connectionStatusChanged` with a connection error for a connection that is actually fine. `CredentialManager`, `useConnectionStatus` and the connection telemetry handler all consume that event. `git blame` dates the conflation to `1253a4e5ed` (2025-12-05), so it shipped; `ca0e8b0f1` did not cause it, it added the first tests that count emits and thereby made it observable.

**The change.**

1. Only report `NO_CONFIG` once we actually know there is no connection — an explicitly selected *No connection*, or while checking is paused. The `null` case now just stops checking. Explicit-no-connection behaviour is unchanged.
2. New regression test covering a connection that resolves slower than `DELAYS.SHORT`.
3. Test hardening: replaced the fixed `waitForNextCycle(3)` + `tickAsync(2000)` settling with `waitForStatusChanges()` / `waitForClock()`, which advance the fake clock until the awaited event is actually observed. Applied to all 6 timing-sensitive tests in that block, not only the 2 that failed — 4 siblings had the same latent dependency. The one negative-assertion test was already timing-tolerant and is left alone.
4. `CHANGELOG.md` entry under `Unreleased`.

There is no tracking issue; the CI runs linked above are the context.

### Steps to try out

The fix is behavioural and only observable through timing, so it is best checked via the tests:

```
npm ci && cd client && npx karma start karma.config.js -- --grep "ConnectionManagerPlugin"
```

To confirm the new test actually guards the fix, revert `ConnectionManagerPlugin.js` and re-run — `should not report a connection error while the connection is still being resolved` fails.

### Verification

* Repro interleaving (1500ms resolve delay) — **2/2 failed before, 34/34 pass after**
* New regression test — **fails without the product fix, passes with it**
* Full client suite — **2582 tests, 0 failures**
* `eslint .` — clean

### Reviewer notes

* Dropping the delayed `NO_CONFIG` emit for the `null` case does not leave stale state: `App` clears `connectionCheckResult` on `connectionManager.connectionCheckStarted`, which is still emitted on every `activeConnection` change.
* `ConnectionChecker#getLastResult()` is never called outside the class, so no longer resetting `_config` on that path has no consumer.
* Out of scope, noticed in passing: `ConnectionManagerPlugin.js:136` passes an argument to the zero-arg `stopChecking(null)` (harmless), and the `getPluginsDirectory()` deprecation plus React `checked`-without-`onChange` warnings in the CI logs are pre-existing and unrelated.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
