### PR TITLE
fix(drop-zone): do not intercept non-file drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
-* `FIX`: do not block drag and drop inside nested editors (e.g. reordering DMN decision table rows/columns) ([#6168](https://github.com/camunda/camunda-modeler/pull/6168))
+* `FIX`: do not block drag and drop inside nested editors (e.g. reordering DMN decision table rows/columns) ([#6166](https://github.com/camunda/camunda-modeler/issue/6166))
 
 ## 5.51.0
 
@@ -144,7 +144,7 @@ ___Note:__ Yet to be released changes appear here._
 * `FEAT`: enable popup editor for text areas ([bpmn-io/properties-panel#523](https://github.com/bpmn-io/properties-panel/pull/523))
 * `FEAT`: enhance FEEL syntax highlighting ([bpmn-io/feel-editor#100](https://github.com/bpmn-io/feel-editor/pull/100))
 * `FEAT`: recognize additional Camunda built-ins and improve expression analysis accuracy in variable outline ([bpmn-io/variable-resolver#121](https://github.com/bpmn-io/variable-resolver/pull/121))
-* `FEAT`: improve minimap performance ([#5215](https://github.com/camunda/camunda-modeler/issues/5215), [bpmn-io/diagram-js-minimap#115](https://github.com/bpmn-io/diagram-js-minimap/pull/115)) 
+* `FEAT`: improve minimap performance ([#5215](https://github.com/camunda/camunda-modeler/issues/5215), [bpmn-io/diagram-js-minimap#115](https://github.com/bpmn-io/diagram-js-minimap/pull/115))
 * `FIX`: assign `$parent` property in all cases for I/O mapping in element templates ([bpmn-io/bpmn-js-element-templates#265](https://github.com/bpmn-io/bpmn-js-element-templates/pull/265))
 * `FIX`: support snippet placeholder navigation in FEEL popup ([bpmn-io/properties-panel#524](https://github.com/bpmn-io/properties-panel/pull/524))
 * `FIX`: compare popup input against live value ([bpmn-io/properties-panel#530](https://github.com/bpmn-io/properties-panel/pull/530))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the [Camunda Modeler](https://github.com/camunda/camunda-
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: do not block drag and drop inside nested editors (e.g. reordering DMN decision table rows/columns) ([#6168](https://github.com/camunda/camunda-modeler/pull/6168))
+
 ## 5.51.0
 
 * `FEAT`: cache linter creation / prevent unnecessary element template reloading ([#6092](https://github.com/camunda/camunda-modeler/pull/6092))

--- a/client/src/app/drop-zone/DropHandler.js
+++ b/client/src/app/drop-zone/DropHandler.js
@@ -49,6 +49,10 @@ export class DropHandler {
   }
 
   async handleDrop(event) {
+    if (!this.isDragAllowed(event)) {
+      return DropHandler.STATES.NOT_DRAGGING;
+    }
+
     event.preventDefault();
     event.stopPropagation();
 

--- a/client/src/app/drop-zone/__tests__/DropZoneSpec.js
+++ b/client/src/app/drop-zone/__tests__/DropZoneSpec.js
@@ -165,15 +165,8 @@ describe('<DropZone>', function() {
       // `document`; this drop zone wraps that tree and must let such events
       // bubble on past it rather than swallowing them
       // (https://github.com/camunda/camunda-modeler/issues/6166)
-      //
-      // `fireEvent.drop` builds a real native DragEvent from `MockDragEvent`
-      // (used only as a property bag — its own no-op `stopPropagation` is
-      // never actually invoked), so this spies on the real `Event.prototype`
-      // method rather than on the mock, and independently confirms the event
-      // still reaches a `document`-level listener, i.e. it truly bubbles
 
-      // given — a listener above the zone's own React root, mirroring where
-      // dmn-js's own drag-and-drop handling lives in the real app
+      // given
       const { dropzone } = renderDropZone();
 
       const stopPropagationSpy = sinon.spy(window.Event.prototype, 'stopPropagation');

--- a/client/src/app/drop-zone/__tests__/DropZoneSpec.js
+++ b/client/src/app/drop-zone/__tests__/DropZoneSpec.js
@@ -158,6 +158,45 @@ describe('<DropZone>', function() {
     });
 
 
+    it('should let a drop that carries no file bubble past the zone (e.g. an internal drag-and-drop)', function() {
+
+      // a non-file drop (e.g. reordering rows in a nested dmn-js decision
+      // table) relies on its own `drop` handler further up the DOM tree, on
+      // `document`; this drop zone wraps that tree and must let such events
+      // bubble on past it rather than swallowing them
+      // (https://github.com/camunda/camunda-modeler/issues/6166)
+      //
+      // `fireEvent.drop` builds a real native DragEvent from `MockDragEvent`
+      // (used only as a property bag — its own no-op `stopPropagation` is
+      // never actually invoked), so this spies on the real `Event.prototype`
+      // method rather than on the mock, and independently confirms the event
+      // still reaches a `document`-level listener, i.e. it truly bubbles
+
+      // given — a listener above the zone's own React root, mirroring where
+      // dmn-js's own drag-and-drop handling lives in the real app
+      const { dropzone } = renderDropZone();
+
+      const stopPropagationSpy = sinon.spy(window.Event.prototype, 'stopPropagation');
+      const outerDropSpy = sinon.spy();
+
+      document.addEventListener('drop', outerDropSpy);
+
+      try {
+
+        // when
+        fireEvent.drop(dropzone, new MockDragEvent());
+
+        // then
+        expect(stopPropagationSpy).to.have.not.been.called;
+        expect(outerDropSpy).to.have.been.calledOnce;
+      } finally {
+        document.removeEventListener('drop', outerDropSpy);
+        stopPropagationSpy.restore();
+      }
+
+    });
+
+
     it('should call passed onDrop prop with filepaths from file', async function() {
 
       // given

--- a/test/e2e/fixtures/decision-table-rows.dmn
+++ b/test/e2e/fixtures/decision-table-rows.dmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <decision id="Decision_1" name="Decide">
+    <decisionTable id="DecisionTable_1">
+      <input id="Input_1">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text></text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" typeRef="string" />
+      <rule id="Rule_1">
+        <inputEntry id="InputEntry_1">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="OutputEntry_1">
+          <text></text>
+        </outputEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="InputEntry_2">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="OutputEntry_2">
+          <text></text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="DMNDiagram_1">
+      <dmndi:DMNShape id="DMNShape_Decision_1" dmnElementRef="Decision_1">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/test/e2e/pages/DmnEditorPage.js
+++ b/test/e2e/pages/DmnEditorPage.js
@@ -83,6 +83,87 @@ class DmnEditorPage extends DiagramEditorPage {
   decisionTable() {
     return this.page.locator('.dmn-decision-table-container');
   }
+
+  /**
+   * @param {string} ruleId
+   *
+   * @return {import('@playwright/test').Locator} the rule's (row's) input cell
+   */
+  ruleInputCell(ruleId) {
+    return this.page.locator(`[data-row-id="${ ruleId }"].input-cell`).first();
+  }
+
+  /**
+   * Type a FEEL value into a rule's input cell — the FEEL editor is a
+   * `contenteditable` widget, not an `<input>`, so it is clicked and typed
+   * into rather than filled.
+   *
+   * @param {string} ruleId
+   * @param {string} value
+   *
+   * @return {Promise<void>}
+   */
+  async setRuleInputValue(ruleId, value) {
+    const cell = this.ruleInputCell(ruleId);
+
+    await cell.click();
+    await cell.locator('.content-editable').pressSequentially(value);
+  }
+
+  /**
+   * Drag a rule via its rule-index drag handle and drop it above/below
+   * another rule's row — the same gesture as dragging the "Move rule" icon.
+   *
+   * The handle is only visually revealed on hover (`color: transparent`
+   * otherwise), but keeps its layout box, so its position can be read without
+   * hovering first. A real HTML5 drag only starts once the browser sees the
+   * pointer move past its drag threshold, so the move to the target is split
+   * into steps rather than jumping there in one go.
+   *
+   * @param {string} ruleId the rule to drag
+   * @param {string} targetRuleId the rule whose row to drop onto
+   * @param {'top'|'bottom'} position drop above or below the target row
+   *
+   * @return {Promise<void>}
+   */
+  async dragRule(ruleId, targetRuleId, position) {
+    const handle = this.page.locator(`[data-row-id="${ ruleId }"] .dmn-icon-drag.vertical`);
+    const targetRow = this.page.locator(`[data-row-id="${ targetRuleId }"]`).first();
+
+    await handle.waitFor();
+    await targetRow.waitFor();
+
+    const handleBox = await handle.boundingBox();
+    const targetBox = await targetRow.boundingBox();
+
+    if (!handleBox) {
+      throw new Error(`could not determine the drag handle position for rule "${ ruleId }"`);
+    }
+
+    if (!targetBox) {
+      throw new Error(`could not determine the row position for rule "${ targetRuleId }"`);
+    }
+
+    const startX = handleBox.x + handleBox.width / 2;
+    const startY = handleBox.y + handleBox.height / 2;
+
+    const endX = targetBox.x + targetBox.width / 2;
+    const endY = targetBox.y + (position === 'bottom' ? targetBox.height - 2 : 2);
+
+    await this.page.mouse.move(startX, startY);
+    await this.page.mouse.down();
+
+    const steps = 8;
+
+    for (let i = 1; i <= steps; i++) {
+      await this.page.mouse.move(
+        startX + (endX - startX) * i / steps,
+        startY + (endY - startY) * i / steps
+      );
+    }
+
+    await this.page.mouse.up();
+  }
 }
 
 module.exports = DmnEditorPage;

--- a/test/e2e/specs/dmn-modeling.spec.js
+++ b/test/e2e/specs/dmn-modeling.spec.js
@@ -332,4 +332,41 @@ test.describe('DMN modeling', function() {
     });
   });
 
+
+  test('should reorder decision table rules via drag and drop after editing a cell', async function({ launch, tmp }) {
+
+    // given a decision table with two rules, having just typed a value into
+    // the first rule's input cell (https://github.com/camunda/camunda-modeler/issues/6166)
+    const app = await launch({ openFile: await copyFixture('decision-table-rows.dmn', tmp) });
+
+    const editor = new Modeler(app).dmnEditor;
+
+    await editor.openDecisionTable('Decision_1');
+    await expect(editor.decisionTable()).toBeVisible();
+
+    await editor.setRuleInputValue('Rule_1', '"a"');
+
+    // when dragging the first rule below the second one
+    await editor.dragRule('Rule_1', 'Rule_2', 'bottom');
+
+    const output = path.join(tmp, 'reordered.dmn');
+
+    // then the saved file reflects the new rule order
+    await app.step('save and verify the rule order', async () => {
+      await app.expectSaveDialog(output);
+      await app.shortcut('CommandOrControl+Shift+S');
+
+      await expectFileExists(output);
+
+      const xml = await readFile(output);
+
+      const rule1Index = xml.indexOf('id="Rule_1"');
+      const rule2Index = xml.indexOf('id="Rule_2"');
+
+      expect(rule1Index).toBeGreaterThan(-1);
+      expect(rule2Index).toBeGreaterThan(-1);
+      expect(rule2Index).toBeLessThan(rule1Index);
+    });
+  });
+
 });


### PR DESCRIPTION
> 🤖 **This pull request was opened autonomously by an AI agent (Claude), based on human-reviewed analysis.** Please review it with that in mind.

### Proposed Changes

The app-wide drop zone (used to open a diagram by dragging a file onto the window, `client/src/app/drop-zone/`) wraps the whole editor area, so every native `drop` event happening inside it — including inside a nested dmn-js decision table — reaches it first.

`DropHandler#handleDragOver` and `#handleDragLeave` already skip non-file drags by checking `isDragAllowed(event)` before touching the event. `#handleDrop` was missing that same guard and always called `event.stopPropagation()`, regardless of what was being dragged. That silently killed dmn-js's own `document`-level `drop` listener for any internal (non-file) drag, so dragging a decision table row or column to reorder it never actually applied the move — even though the drag-over highlight looked correct the whole time, which made the bug easy to miss.

The fix mirrors the existing guard from `handleDragOver`/`handleDragLeave` onto `handleDrop`.

Closes https://github.com/camunda/camunda-modeler/issues/6166

#### Why this surfaced now, between 5.44 and 5.45

The defect itself is old — introduced in [`2f320ff8`](https://github.com/camunda/camunda-modeler/commit/2f320ff831fdfc7c41ecdbb89c17244a6f8d6724) ("chore: move drop handling to a separate component", Sep 2024, first released in v5.29.0) — but it was harmless until [`7b284466c`](https://github.com/camunda/camunda-modeler/commit/7b284466cd625356d95009f0fcde82111a5b3037) ("deps: update to `react@18`", first released in **v5.45.0**, matching the reporter's bisect exactly).

That commit switched `client/src/index.js` from React 16's `ReactDOM.render(<App/>, rootElement)` to React 18's `createRoot(rootElement).render(<App/>)`:

* **React 16** (through 5.44.0) attaches its own delegated native event listener to `document` — the same node `table-js` binds its decision-table drag-and-drop `drop` listener to. Multiple listeners on the same node all fire regardless of order, so `DropHandler`'s buggy unconditional `stopPropagation()` never actually blocked `table-js`'s sibling listener from also running. Dragging worked despite the latent bug.
* **React 18 with `createRoot`** (from 5.45.0) moves that listener to the app's own root container, below `document`. Now the `drop` event hits React's listener — and `DropHandler`'s `stopPropagation()` — before it can reach `document`, so `table-js`'s listener never fires and the reorder command never applies.

The fix in this PR is unaffected by any of this — `handleDrop` should have had the same guard as its siblings all along, and fixing that is correct and sufficient regardless of which React root API is in use.

Full analysis history (including an earlier, since-corrected hypothesis) is on the issue: [comment 1](https://github.com/camunda/camunda-modeler/issues/6166#issuecomment-5526384307), [correction](https://github.com/camunda/camunda-modeler/issues/6166#issuecomment-5526669288), [timeline](https://github.com/camunda/camunda-modeler/issues/6166#issuecomment-5527037912).

### Steps to try out

1. Open or create a DMN diagram with a decision table containing at least two rules.
2. Drag a rule's row-index handle (or a column header) to reorder it.
3. Before this fix: the drag-over highlight shows, but releasing the mouse does not reorder the row/column. After this fix: the reorder is applied.

The included e2e test (`test/e2e/specs/dmn-modeling.spec.js`) automates this exact repro with a real (non-synthetic) Playwright-driven drag.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes (behavioral fix only, no UI change — covered instead by the new e2e test)
  * [x] __Steps to try out__
