### PR TITLE
FEEL playground persistent context

### DIFF
--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -231,6 +231,8 @@ export class BpmnEditor extends CachedComponent {
 
     if (prevProps.file?.path !== this.props.file?.path) {
       this.loadTemplates();
+
+      this.getCached().feelPlayground.setFile(this.props.file);
     }
 
     const { layout = {} } = this.props;
@@ -1153,7 +1155,7 @@ export class BpmnEditor extends CachedComponent {
       );
     }
 
-    const feelPlayground = new FeelPlayground();
+    const feelPlayground = new FeelPlayground(props.config);
 
     const modeler = new BpmnModeler({
       ...options,
@@ -1186,6 +1188,8 @@ export class BpmnEditor extends CachedComponent {
       getFeelPlaygroundConfig(connectionCheckResult, zeebeApi)
     );
 
+    feelPlayground.setFile(props.file);
+
     modeler.on('elementTemplates.errors', (event) => {
       console.warn('Element templates errors', event.errors);
     });
@@ -1201,6 +1205,7 @@ export class BpmnEditor extends CachedComponent {
 
     return {
       __destroy: () => {
+        feelPlayground.saveContexts();
         modeler.destroy();
       },
       engineProfile: null,

--- a/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/__tests__/BpmnEditorSpec.js
@@ -35,6 +35,8 @@ import namespaceEngineProfileXML from '../../__tests__/EngineProfile.namespace.c
 
 import applyDefaultTemplates from '../../bpmn-shared/modeler/features/apply-default-templates/applyDefaultTemplates';
 
+import FeelPlayground from '../modeler/features/feel-playground/FeelPlayground';
+
 import {
   getCanvasEntries,
   getCopyCutPasteEntries,
@@ -2050,6 +2052,7 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
 
       cache.add('editor', {
         cached: {
+          feelPlayground: new FeelPlayground(),
           modeler: new BpmnModeler({
             modules: {
               elementTemplatesLoader: elementTemplatesLoaderMock
@@ -3120,6 +3123,28 @@ describe('cloud-bpmn - <BpmnEditor>', function() {
       // then
       expect(setConfigSpy).to.have.been.calledOnce;
       expect(setConfigSpy.firstCall.args[0].onEvaluate).to.be.a('function');
+    });
+
+
+    it('should update playground file when the path changes', async function() {
+
+      // given
+      const { instance, rerender } = await renderEditor(diagramXML, {
+        file: { path: '/tmp/source.bpmn' }
+      });
+      const { feelPlayground } = instance.getCached();
+      const setFileSpy = sinon.spy(feelPlayground, 'setFile');
+
+      // when
+      rerender(diagramXML, {
+        file: { path: '/tmp/copy.bpmn' }
+      });
+
+      // then
+      await waitFor(() => {
+        expect(setFileSpy).to.have.been.calledOnce;
+      });
+      expect(setFileSpy.firstCall.args[0]).to.eql({ path: '/tmp/copy.bpmn' });
     });
 
   });

--- a/client/src/app/tabs/cloud-bpmn/modeler/features/feel-playground/FeelPlayground.js
+++ b/client/src/app/tabs/cloud-bpmn/modeler/features/feel-playground/FeelPlayground.js
@@ -10,6 +10,13 @@
 
 const EMPTY_CONFIG = {};
 
+const ENCODER = new TextEncoder();
+
+const PERSISTENCE_KEY = 'feelPlayground';
+const PERSISTENCE_VERSION = 1;
+
+export const MAX_CONTEXT_SIZE = 16 * 1024;
+
 /**
  * Holds the FEEL playground configuration and the evaluation contexts entered
  * by the user.
@@ -17,15 +24,29 @@ const EMPTY_CONFIG = {};
  * The configuration depends on the cluster connection and therefore changes
  * independently of the popup lifecycle. The popup subscribes to it instead of
  * receiving it as a prop.
+ *
+ * Contexts are persisted per file so they survive restarts. They are a
+ * convenience cache: the expression itself lives in the diagram, so losing a
+ * context is never fatal.
  */
 export default class FeelPlayground {
-  constructor() {
+
+  /**
+   * @param {import('../../../../../../remote/Config').default} [config] omitted
+   * in tests, in which case contexts are kept in memory only
+   */
+  constructor(config = null) {
     this._config = EMPTY_CONFIG;
     this._contexts = new Map();
     this._listeners = new Set();
+    this._contextListeners = new Set();
+    this._file = null;
+    this._appConfig = config;
+    this._dirty = false;
 
     this.getConfig = this.getConfig.bind(this);
     this.subscribe = this.subscribe.bind(this);
+    this.subscribeContext = this.subscribeContext.bind(this);
   }
 
   /**
@@ -51,6 +72,54 @@ export default class FeelPlayground {
 
   setContext(key, context) {
     this._contexts.set(key, context);
+    this._dirty = true;
+
+    this._contextListeners.forEach(listener => listener());
+  }
+
+  /**
+   * @param {File} file
+   */
+  async setFile(file) {
+    this._file = file;
+
+    const path = file?.path;
+
+    if (!path || !this._appConfig) {
+      return;
+    }
+
+    try {
+      const persisted = await this._appConfig.getForFile(file, PERSISTENCE_KEY);
+
+      // the file changed while we were loading
+      if (this._file?.path !== path) {
+        return;
+      }
+
+      const contexts = isPersistedContexts(persisted) ? persisted.contexts : {};
+
+      let restored = false;
+
+      Object.entries(contexts).forEach(([ key, value ]) => {
+
+        // a context entered while loading wins over the persisted one
+        if (typeof value === 'string' && !this._contexts.has(key)) {
+          this._contexts.set(key, value);
+
+          restored = true;
+        }
+      });
+
+      if (restored) {
+        this._contextListeners.forEach(listener => listener());
+      }
+    } catch (error) {
+      console.error('Failed to load FEEL playground contexts:', error);
+    }
+
+    // contexts entered before the file had a path
+    await this.saveContexts();
   }
 
   subscribe(listener) {
@@ -58,4 +127,52 @@ export default class FeelPlayground {
 
     return () => this._listeners.delete(listener);
   }
+
+  subscribeContext(listener) {
+    this._contextListeners.add(listener);
+
+    return () => this._contextListeners.delete(listener);
+  }
+
+  /**
+   * Persist the contexts entered since the last save. Called when the popup
+   * closes; saving per keystroke would rewrite the whole configuration file.
+   */
+  async saveContexts() {
+    if (!this._dirty || !this._file?.path || !this._appConfig) {
+      return;
+    }
+
+    const contexts = {};
+
+    this._contexts.forEach((value, key) => {
+
+      // oversized contexts stay usable in memory, but out of the config file
+      if (ENCODER.encode(value).byteLength <= MAX_CONTEXT_SIZE) {
+        contexts[key] = value;
+      }
+    });
+
+    this._dirty = false;
+
+    try {
+      await this._appConfig.setForFile(this._file, PERSISTENCE_KEY, {
+        version: PERSISTENCE_VERSION,
+        contexts
+      });
+    } catch (error) {
+      this._dirty = true;
+      console.error('Failed to save FEEL playground contexts:', error);
+    }
+  }
+}
+
+
+// helpers //////////
+
+function isPersistedContexts(value) {
+  return value?.version === PERSISTENCE_VERSION
+    && value.contexts
+    && typeof value.contexts === 'object'
+    && !Array.isArray(value.contexts);
 }

--- a/client/src/app/tabs/cloud-bpmn/modeler/features/feel-playground/FeelPlaygroundEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/modeler/features/feel-playground/FeelPlaygroundEditor.js
@@ -8,7 +8,7 @@
  * except in compliance with the MIT License.
  */
 
-import React, { useState, useSyncExternalStore } from 'react';
+import React, { useEffect, useRef, useState, useSyncExternalStore } from 'react';
 
 import { FeelPlayground } from '@camunda/feel-playground';
 
@@ -21,8 +21,8 @@ const EMPTY_CONTEXT = '{}';
  * The React side of the FEEL playground popup.
  *
  * The expression is owned by the properties panel entry and passed through as a
- * prop; the evaluation context is owned by the playground service so it
- * survives closing and re-opening the popup.
+ * prop; contexts changed by the user are owned by the playground service so
+ * they survive closing and re-opening the popup.
  */
 export default function FeelPlaygroundEditor(props) {
   const {
@@ -34,27 +34,50 @@ export default function FeelPlaygroundEditor(props) {
     variables
   } = props;
 
+  const [ expression, setExpression ] = useState(value);
+  const initializingContext = useRef(true);
   const config = useSyncExternalStore(feelPlayground.subscribe, feelPlayground.getConfig);
-
-  const cachedContext = feelPlayground.getContext(contextKey);
-  const [ context, setContext ] = useState(
-    () => cachedContext || EMPTY_CONTEXT
+  const storedContext = useSyncExternalStore(
+    feelPlayground.subscribeContext,
+    () => feelPlayground.getContext(contextKey)
   );
+  const [ context, setContext ] = useState(storedContext ?? EMPTY_CONTEXT);
+
+  useEffect(() => {
+    setExpression(value);
+  }, [ value ]);
+
+  useEffect(() => {
+    setContext(storedContext ?? EMPTY_CONTEXT);
+  }, [ contextKey, storedContext ]);
+
+  useEffect(() => {
+    initializingContext.current = false;
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      feelPlayground.saveContexts();
+    };
+  }, [ feelPlayground ]);
 
   const handleExpressionChange = (nextExpression) => {
+    setExpression(nextExpression);
     onInput(nextExpression);
   };
 
   const handleContextChange = (nextContext) => {
     setContext(nextContext);
 
-    feelPlayground.setContext(contextKey, nextContext);
+    if (!initializingContext.current) {
+      feelPlayground.setContext(contextKey, nextContext);
+    }
   };
 
   return (
     <div className="feel-playground-popup__editor">
       <FeelPlayground
-        expression={ value }
+        expression={ expression }
         onExpressionChange={ handleExpressionChange }
         context={ context }
         onContextChange={ handleContextChange }

--- a/client/src/app/tabs/cloud-bpmn/modeler/features/feel-playground/__tests__/FeelPlaygroundEditorSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/modeler/features/feel-playground/__tests__/FeelPlaygroundEditorSpec.js
@@ -12,12 +12,17 @@ import React from 'react';
 
 import { expect } from 'chai';
 
+import sinon from 'sinon';
+
 import {
   act,
+  fireEvent,
   render,
   screen,
   waitFor
 } from '@testing-library/react';
+
+import { EditorView } from '@codemirror/view';
 
 import FeelPlayground from '../FeelPlayground';
 
@@ -67,6 +72,187 @@ describe('<FeelPlaygroundEditor>', function() {
     // then
     await waitFor(() => {
       expect(screen.getByText('Cluster unavailable.')).to.exist;
+    });
+  });
+
+
+  it('should update context while open', async function() {
+
+    // given
+    const feelPlayground = new FeelPlayground();
+
+    render(
+      <FeelPlaygroundEditor
+        contextKey="Task_1#expression"
+        feelPlayground={ feelPlayground }
+        onInput={ () => {} }
+        value="1 + 1"
+        variables={ [] }
+      />
+    );
+
+    // when
+    act(() => feelPlayground.setContext('Task_1#expression', '{ "amount": 42 }'));
+
+    // then
+    await waitFor(() => {
+      expect(screen.getByLabelText('Evaluation context').textContent).to.equal('{ "amount": 42 }');
+    });
+  });
+
+
+  it('should reset context from the current expression', async function() {
+
+    // given
+    const feelPlayground = new FeelPlayground();
+
+    render(
+      <FeelPlaygroundEditor
+        contextKey="Task_1#expression"
+        feelPlayground={ feelPlayground }
+        onInput={ () => {} }
+        value="1 + 1"
+        variables={ [] }
+      />
+    );
+
+    const expression = screen.getByLabelText('FEEL expression');
+    const editor = EditorView.findFromDOM(expression);
+
+    // when
+    act(() => editor.dispatch({
+      changes: {
+        from: 0,
+        to: editor.state.doc.length,
+        insert: 'foo'
+      }
+    }));
+    fireEvent.click(screen.getByRole('button', { name: 'Reset to prefilled context' }));
+
+    // then
+    await waitFor(() => {
+      expect(screen.getByLabelText('Evaluation context').textContent).to.contain('"foo": null');
+    });
+  });
+
+
+  it('should save contexts when closed', function() {
+
+    // given
+    const feelPlayground = new FeelPlayground();
+    const saveContextsSpy = sinon.spy(feelPlayground, 'saveContexts');
+
+    const { unmount } = render(
+      <FeelPlaygroundEditor
+        contextKey="Task_1#expression"
+        feelPlayground={ feelPlayground }
+        onInput={ () => {} }
+        value="1 + 1"
+        variables={ [] }
+      />
+    );
+
+    // when
+    unmount();
+
+    // then
+    expect(saveContextsSpy).to.have.been.calledOnce;
+  });
+
+
+  it('should regenerate untouched prefilled context when reopened', async function() {
+
+    // given
+    const config = {
+      getForFile: sinon.stub().resolves(null),
+      setForFile: sinon.stub().resolves()
+    };
+    const feelPlayground = new FeelPlayground(config);
+
+    await feelPlayground.setFile({ path: '/tmp/diagram.bpmn' });
+
+    const { unmount } = render(
+      <FeelPlaygroundEditor
+        contextKey="Task_1#expression"
+        feelPlayground={ feelPlayground }
+        onInput={ () => {} }
+        value="foo"
+        variables={ [] }
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Evaluation context').textContent).to.contain('"foo": null');
+    });
+
+    // when
+    unmount();
+
+    render(
+      <FeelPlaygroundEditor
+        contextKey="Task_1#expression"
+        feelPlayground={ feelPlayground }
+        onInput={ () => {} }
+        value="bar"
+        variables={ [] }
+      />
+    );
+
+    // then
+    await waitFor(() => {
+      expect(screen.getByLabelText('Evaluation context').textContent).to.contain('"bar": null');
+    });
+
+    expect(screen.getByLabelText('Evaluation context').textContent).not.to.contain('"foo": null');
+    expect(feelPlayground.getContext('Task_1#expression')).not.to.exist;
+    expect(config.setForFile).not.to.have.been.called;
+  });
+
+
+  it('should persist prefilled context after user changes it', async function() {
+
+    // given
+    const config = {
+      getForFile: sinon.stub().resolves(null),
+      setForFile: sinon.stub().resolves()
+    };
+    const feelPlayground = new FeelPlayground(config);
+
+    await feelPlayground.setFile({ path: '/tmp/diagram.bpmn' });
+
+    const { unmount } = render(
+      <FeelPlaygroundEditor
+        contextKey="Task_1#expression"
+        feelPlayground={ feelPlayground }
+        onInput={ () => {} }
+        value="foo"
+        variables={ [] }
+      />
+    );
+
+    const context = await screen.findByLabelText('Evaluation context');
+
+    await waitFor(() => {
+      expect(context.textContent).to.contain('"foo": null');
+    });
+
+    const editor = EditorView.findFromDOM(context);
+
+    act(() => editor.dispatch({
+      changes: {
+        from: 0,
+        to: editor.state.doc.length,
+        insert: '{ "foo": 42 }'
+      }
+    }));
+
+    // when
+    unmount();
+
+    // then
+    expect(config.setForFile).to.have.been.calledOnce;
+    expect(config.setForFile.firstCall.args[2].contexts).to.eql({
+      'Task_1#expression': '{ "foo": 42 }'
     });
   });
 

--- a/client/src/app/tabs/cloud-bpmn/modeler/features/feel-playground/__tests__/FeelPlaygroundPopupSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/modeler/features/feel-playground/__tests__/FeelPlaygroundPopupSpec.js
@@ -73,6 +73,32 @@ describe('<FeelPlaygroundPopup>', function() {
   });
 
 
+  it('should regenerate untouched context when reopened', async function() {
+
+    // given
+    const feelPlayground = new FeelPlayground();
+    const Popup = createFeelPlaygroundPopup(feelPlayground);
+
+    renderPopup(container, { value: 'foo' }, Popup);
+
+    await waitFor(() => {
+      expect(container.querySelector('[aria-label="Evaluation context"]').textContent).to.contain('"foo": null');
+    });
+
+    // when
+    act(() => render(null, container));
+    renderPopup(container, { value: 'bar' }, Popup);
+
+    // then
+    await waitFor(() => {
+      expect(container.querySelector('[aria-label="Evaluation context"]').textContent).to.contain('"bar": null');
+    });
+
+    expect(container.querySelector('[aria-label="Evaluation context"]').textContent).not.to.contain('"foo": null');
+    expect(feelPlayground.getContext('#expression')).not.to.exist;
+  });
+
+
   it('should close on Escape', async function() {
 
     // given
@@ -130,8 +156,7 @@ describe('<FeelPlaygroundPopup>', function() {
 
 // helpers //////////
 
-function renderPopup(container, props = {}) {
-  const Popup = createFeelPlaygroundPopup(new FeelPlayground());
+function renderPopup(container, props = {}, Popup = createFeelPlaygroundPopup(new FeelPlayground())) {
 
   act(() => render(
     <Popup

--- a/client/src/app/tabs/cloud-bpmn/modeler/features/feel-playground/__tests__/FeelPlaygroundSpec.js
+++ b/client/src/app/tabs/cloud-bpmn/modeler/features/feel-playground/__tests__/FeelPlaygroundSpec.js
@@ -1,0 +1,298 @@
+/**
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.
+ *
+ * Camunda licenses this file to you under the MIT; you may not use this file
+ * except in compliance with the MIT License.
+ */
+
+import { expect } from 'chai';
+
+import sinon from 'sinon';
+
+import FeelPlayground, { MAX_CONTEXT_SIZE } from '../FeelPlayground';
+
+
+const FILE = { path: '/tmp/diagram.bpmn' };
+
+
+describe('FeelPlayground', function() {
+
+  it('should restore context for file', async function() {
+
+    // given
+    const config = createConfig({
+      version: 1,
+      contexts: {
+        'Task_1#expression': '{ "amount": 42 }'
+      }
+    });
+    const feelPlayground = new FeelPlayground(config);
+
+    // when
+    await feelPlayground.setFile(FILE);
+
+    // then
+    expect(feelPlayground.getContext('Task_1#expression')).to.equal('{ "amount": 42 }');
+  });
+
+
+  it('should not write back restored contexts', async function() {
+
+    // given
+    const config = createConfig({
+      version: 1,
+      contexts: {
+        'Task_1#expression': '{ "amount": 42 }'
+      }
+    });
+    const feelPlayground = new FeelPlayground(config);
+
+    // when
+    await feelPlayground.setFile(FILE);
+
+    // then
+    expect(config.setForFile).not.to.have.been.called;
+  });
+
+
+  it('should ignore persisted contexts of unsupported version', async function() {
+
+    // given
+    const config = createConfig({
+      version: 2,
+      contexts: {
+        'Task_1#expression': '{ "amount": 42 }'
+      }
+    });
+    const feelPlayground = new FeelPlayground(config);
+
+    // when
+    await feelPlayground.setFile(FILE);
+
+    // then
+    expect(feelPlayground.getContext('Task_1#expression')).not.to.exist;
+  });
+
+
+  it('should persist context for file', async function() {
+
+    // given
+    const config = createConfig();
+    const feelPlayground = new FeelPlayground(config);
+    await feelPlayground.setFile(FILE);
+
+    feelPlayground.setContext('Task_1#expression', '{ "amount": 42 }');
+
+    // when
+    await feelPlayground.saveContexts();
+
+    // then
+    expect(config.setForFile).to.have.been.calledOnce;
+    expect(config.setForFile.firstCall.args[0]).to.equal(FILE);
+    expect(config.setForFile.firstCall.args[1]).to.equal('feelPlayground');
+    expect(config.setForFile.firstCall.args[2]).to.eql({
+      version: 1,
+      contexts: {
+        'Task_1#expression': '{ "amount": 42 }'
+      }
+    });
+  });
+
+
+  it('should not persist while editing', async function() {
+
+    // given
+    const config = createConfig();
+    const feelPlayground = new FeelPlayground(config);
+    await feelPlayground.setFile(FILE);
+
+    // when
+    feelPlayground.setContext('Task_1#expression', '{ "amount": 4');
+    feelPlayground.setContext('Task_1#expression', '{ "amount": 42 }');
+
+    // then
+    expect(config.setForFile).not.to.have.been.called;
+  });
+
+
+  it('should not persist unchanged contexts twice', async function() {
+
+    // given
+    const config = createConfig();
+    const feelPlayground = new FeelPlayground(config);
+    await feelPlayground.setFile(FILE);
+
+    feelPlayground.setContext('Task_1#expression', '{ "amount": 42 }');
+    await feelPlayground.saveContexts();
+
+    // when
+    await feelPlayground.saveContexts();
+
+    // then
+    expect(config.setForFile).to.have.been.calledOnce;
+  });
+
+
+  it('should prefer context changed while restoring', async function() {
+
+    // given
+    let resolveConfig;
+    const config = createConfig(new Promise(resolve => {
+      resolveConfig = resolve;
+    }));
+    const feelPlayground = new FeelPlayground(config);
+    const restoring = feelPlayground.setFile(FILE);
+
+    // when
+    feelPlayground.setContext('Task_1#expression', '{ "local": true }');
+    resolveConfig({
+      version: 1,
+      contexts: {
+        'Task_1#expression': '{ "persisted": true }'
+      }
+    });
+    await restoring;
+
+    // then
+    expect(feelPlayground.getContext('Task_1#expression')).to.equal('{ "local": true }');
+  });
+
+
+  it('should keep unsaved context in memory', async function() {
+
+    // given
+    const config = createConfig();
+    const feelPlayground = new FeelPlayground(config);
+    await feelPlayground.setFile({});
+
+    // when
+    feelPlayground.setContext('Task_1#expression', '{ "amount": 42 }');
+    await feelPlayground.saveContexts();
+
+    // then
+    expect(feelPlayground.getContext('Task_1#expression')).to.equal('{ "amount": 42 }');
+    expect(config.setForFile).not.to.have.been.called;
+  });
+
+
+  it('should persist unsaved context after first save', async function() {
+
+    // given
+    const config = createConfig();
+    const feelPlayground = new FeelPlayground(config);
+    await feelPlayground.setFile({});
+    feelPlayground.setContext('Task_1#expression', '{ "amount": 42 }');
+
+    // when
+    await feelPlayground.setFile(FILE);
+
+    // then
+    expect(config.setForFile).to.have.been.calledOnce;
+    expect(config.setForFile.firstCall.args[2].contexts).to.eql({
+      'Task_1#expression': '{ "amount": 42 }'
+    });
+  });
+
+
+  it('should not persist oversized context', async function() {
+
+    // given
+    const config = createConfig();
+    const feelPlayground = new FeelPlayground(config);
+    await feelPlayground.setFile(FILE);
+
+    feelPlayground.setContext('Task_1#expression', 'x'.repeat(MAX_CONTEXT_SIZE + 1));
+
+    // when
+    await feelPlayground.saveContexts();
+
+    // then
+    expect(feelPlayground.getContext('Task_1#expression')).to.have.length(MAX_CONTEXT_SIZE + 1);
+    expect(config.setForFile.firstCall.args[2].contexts).to.be.empty;
+  });
+
+
+  it('should persist context changed while saving', async function() {
+
+    // given
+    let finishSave;
+
+    const config = createConfig();
+
+    config.setForFile.onFirstCall().returns(new Promise(resolve => {
+      finishSave = resolve;
+    }));
+
+    const feelPlayground = new FeelPlayground(config);
+    await feelPlayground.setFile(FILE);
+
+    feelPlayground.setContext('Task_1#expression', '{ "amount": 42 }');
+
+    const saving = feelPlayground.saveContexts();
+
+    // when
+    feelPlayground.setContext('Task_1#expression', '{ "amount": 43 }');
+
+    finishSave();
+    await saving;
+
+    await feelPlayground.saveContexts();
+
+    // then
+    expect(config.setForFile).to.have.been.calledTwice;
+    expect(config.setForFile.secondCall.args[2].contexts).to.eql({
+      'Task_1#expression': '{ "amount": 43 }'
+    });
+  });
+
+
+  it('should not fail if persisting fails', async function() {
+
+    // given
+    const config = createConfig();
+    config.setForFile.rejects(new Error('nope'));
+
+    const feelPlayground = new FeelPlayground(config);
+    await feelPlayground.setFile(FILE);
+
+    feelPlayground.setContext('Task_1#expression', '{ "amount": 42 }');
+
+    // when
+    await feelPlayground.saveContexts();
+
+    // then
+    expect(feelPlayground.getContext('Task_1#expression')).to.equal('{ "amount": 42 }');
+  });
+
+
+  it('should retry persisting after failure', async function() {
+
+    // given
+    const config = createConfig();
+    config.setForFile.onFirstCall().rejects(new Error('nope'));
+
+    const feelPlayground = new FeelPlayground(config);
+    await feelPlayground.setFile(FILE);
+
+    feelPlayground.setContext('Task_1#expression', '{ "amount": 42 }');
+    await feelPlayground.saveContexts();
+
+    // when
+    await feelPlayground.saveContexts();
+
+    // then
+    expect(config.setForFile).to.have.been.calledTwice;
+  });
+
+});
+
+
+function createConfig(value = null) {
+  return {
+    getForFile: sinon.stub().resolves(value),
+    setForFile: sinon.stub().resolves()
+  };
+}

--- a/client/src/remote/Config.js
+++ b/client/src/remote/Config.js
@@ -28,6 +28,7 @@ export default class Config {
    */
   constructor(backend) {
     this.backend = backend;
+    this._filesUpdate = Promise.resolve();
   }
 
   /**
@@ -70,7 +71,7 @@ export default class Config {
   async getForFile(file, key, defaultValue = null) {
     const { path } = file;
 
-    const files = await this.get('files') || {};
+    const files = await this.updateFiles(files => files);
 
     const configForFile = files[ path ];
 
@@ -103,19 +104,54 @@ export default class Config {
   async setForFile(file, key, value) {
     const { path } = file;
 
-    const files = await this.get('files') || {};
+    const files = await this.updateFiles(files => {
+      const nextFiles = { ...files };
 
-    const configForFile = files[ path ] = files[ path ] || {};
+      if (key) {
+        nextFiles[ path ] = { ...nextFiles[ path ], [ key ]: value };
+      } else {
+        nextFiles[ path ] = value;
+      }
 
-    if (key) {
-      configForFile[ key ] = value;
-    } else {
-      files[ path ] = value;
-    }
-
-    await this.set('files', files);
+      return nextFiles;
+    });
 
     return files[ path ];
+  }
+
+  /**
+   * Read and update file configuration, serialized to avoid overlapping
+   * read/modify/write cycles.
+   *
+   * The updater must be synchronous; awaiting configuration from within it
+   * would deadlock the queue. Return the passed files to skip writing.
+   *
+   * @param {(files: Object) => Object} updater
+   *
+   * @returns {Promise<Object>}
+   */
+  updateFiles(updater) {
+    const update = async () => {
+      const files = await this.get('files') || {};
+      const nextFiles = updater(files);
+
+      // an async updater would deadlock waiting on the queue it is running in
+      if (nextFiles && typeof nextFiles.then === 'function') {
+        throw new Error('updater must be synchronous');
+      }
+
+      if (nextFiles !== files) {
+        await this.set('files', nextFiles);
+      }
+
+      return nextFiles;
+    };
+
+    const result = this._filesUpdate.then(update);
+
+    this._filesUpdate = result.catch(() => {});
+
+    return result;
   }
 
   /**

--- a/client/src/remote/__tests__/ConfigSpec.js
+++ b/client/src/remote/__tests__/ConfigSpec.js
@@ -232,6 +232,91 @@ describe('config', function() {
   });
 
 
+  describe('#updateFiles', function() {
+
+    beforeEach(function() {
+      backend = new FilesBackend();
+
+      config = new Config(backend);
+    });
+
+
+    it('should serialize updates', async function() {
+
+      // when
+      await Promise.all([
+        config.updateFiles(files => ({ ...files, first: true })),
+        config.updateFiles(files => ({ ...files, second: true }))
+      ]);
+
+      // then
+      expect(backend.files).to.eql({
+        first: true,
+        second: true
+      });
+    });
+
+
+    it('should skip write if files did not change', async function() {
+
+      // when
+      await config.updateFiles(files => files);
+
+      // then
+      expect(backend.writes).to.equal(0);
+    });
+
+
+    it('should continue after failed update', async function() {
+
+      // given
+      const failed = config.updateFiles(() => {
+        throw new Error('update failed');
+      });
+
+      // when
+      const update = config.updateFiles(files => ({ ...files, first: true }));
+
+      // then
+      expect(await getError(failed)).to.exist;
+
+      await update;
+
+      expect(backend.files).to.eql({ first: true });
+    });
+
+
+    it('should read file config after pending updates', async function() {
+
+      // given
+      const update = config.updateFiles(files => ({
+        ...files,
+        'foo.bpmn': { foo: 42 }
+      }));
+
+      // when
+      const value = await config.getForFile({ path: 'foo.bpmn' }, 'foo');
+
+      // then
+      expect(value).to.equal(42);
+
+      await update;
+    });
+
+
+    it('should reject async updater', async function() {
+
+      // when
+      const error = await getError(config.updateFiles(async files => files));
+
+      // then
+      expect(error.message).to.equal('updater must be synchronous');
+      expect(backend.writes).to.equal(0);
+    });
+
+  });
+
+
   describe('#getForPlugin', function() {
 
     it('should get', async function() {
@@ -360,3 +445,34 @@ describe('config', function() {
   });
 
 });
+
+
+// helpers //////////
+
+/**
+ * Backend that keeps the written configuration, so serialized read/modify/write
+ * cycles can be observed.
+ */
+class FilesBackend {
+  constructor() {
+    this.files = {};
+    this.writes = 0;
+  }
+
+  async send(event, key, value) {
+    if (event === 'config:get') {
+      return key === 'files' ? this.files : null;
+    }
+
+    this.files = value;
+    this.writes++;
+  }
+}
+
+async function getError(promise) {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+}


### PR DESCRIPTION
### Proposed Changes

Persists FEEL playground evaluation contexts per file, so they survive restarts. 

Builds on https://github.com/camunda/camunda-modeler/pull/6169
Related to https://github.com/bpmn-io/internal-docs/issues/1342

#### Storage

Contexts land in the existing per-file `config.json` section, keyed by `elementId#entryId`:

```json
{
  "files": {
    "/path/to/process.bpmn": {
      "feelPlayground": {
        "version": 1,
        "contexts": { "Task_1#expression": "{ \"amount\": 42 }" }
      }
    }
  }
}
```

#### Config serialization (first commit, reviewable on its own). 

`setForFile` did a read-modify-write over the whole files object across two IPC round trips, so overlapping calls each started from their own snapshot and the later write silently dropped the earlier one. That was already possible between deployment and task testing writes; adding a third writer made it likely. Reads and writes now queue through `Config#updateFiles`.


### Steps to try out 

1. Open a C8 diagram, open a FEEL playground popup on any expression entry.
2. Enter an evaluation context, close the popup.
3. Restart the Modeler, reopen the diagram and the same entry — the context is
still there.
4. Check config.json for the feelPlayground entry under the file's path.
5. Save As to a new path; confirm the context follows.

### Checklist

Ensure you provide everything we need to review your contribution:

<!--
Do not alter this checklist beyond checking items; provide context above.
-->

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
