### PR TITLE
docs: document element-template index format and updater semantics

### DIFF
--- a/docs/template-updater/README.md
+++ b/docs/template-updater/README.md
@@ -1,0 +1,37 @@
+# Template updating — developer guide
+
+Camunda Modeler has the ability to do background fetching of element templates 
+from remote sources. Today, the mechanism is used for [automatic OOTB connector template
+fetching](https://docs.camunda.io/docs/components/modeler/desktop-modeler/use-connectors/#automatic-connector-template-fetching) where the Camunda Marketplace serves the 
+reference index:
+
+```text
+GET https://marketplace.cloud.camunda.io/api/v1/ootb-connectors
+```
+
+The index maps each element-template identifier to its available versions, and
+each version points to a template document through `ref`:
+
+```json
+{
+  "io.camunda.example.v1": [
+    {
+      "version": 2,
+      "ref": "https://example.com/element-template.json",
+      "engine": {
+        "camunda": "^8.10"
+      }
+    }
+  ]
+}
+```
+
+[The mechanism](../../app/lib/template-updater/template-updater.js) can be extended to serve / fetch element templates from any endpoint.
+
+## Further resources
+
+| Resource | Purpose |
+| --- | --- |
+| [`index-format.md`](./index-format.md) | The index format: fields and well-formedness rules |
+| [`index-schema.json`](./index-schema.json) | Normative JSON Schema (Draft 2020-12) of the index format |
+| [`update-semantics.md`](./update-semantics.md) | How Camunda Modeler fetches, caches, filters, persists, and handles failures |

--- a/docs/template-updater/index-format.md
+++ b/docs/template-updater/index-format.md
@@ -1,0 +1,47 @@
+# Index format
+
+The index is a JSON object. Each property name identifies an element template
+and maps to an array of all published metadata versions for that template. The
+index does not contain the templates themselves; each metadata entry points to
+a template document through `ref`.
+
+```json
+{
+  "io.camunda.example.v1": [
+    {
+      "version": 2,
+      "ref": "https://example.com/element-template.json",
+      "engine": {
+        "camunda": "^8.10"
+      }
+    }
+  ],
+  ...
+}
+```
+
+## Metadata fields
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| Template identifier | Non-empty object property name | Groups the available versions of one template |
+| `version` | Integer, 0 or greater | Element-template version |
+| `ref` | URI string | Location of the element-template JSON document |
+| `engine` | Object | Execution-platform compatibility constraints; it may be empty |
+| `engine.camunda` | Optional string | Semver range of compatible Camunda execution-platform versions |
+
+`engine` may carry multiple constraints keyed by platform. `version` and `ref` must
+be provided.
+
+## Well-formed index
+
+Beyond matching the schema, an index MUST be consistent with the referenced
+documents:
+
+* Index key equals the referenced template's own `id`;
+* `version` equals the referenced template's own `version`;
+* `ref` resolves to a valid element-template JSON document; and
+* `engine` describes the referenced template's actual compatibility.
+
+[`index-schema.json`](./index-schema.json) is the normative definition of the
+format.

--- a/docs/template-updater/index-schema.json
+++ b/docs/template-updater/index-schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://camunda.org/schema/element-templates/index.json",
+  "title": "Element-template index",
+  "description": "Index mapping element-template identifiers to their available versions, each pointing to a template document.",
+  "type": "object",
+  "propertyNames": {
+    "minLength": 1
+  },
+  "additionalProperties": {
+    "type": "array",
+    "items": {
+      "$ref": "#/$defs/templateMetadata"
+    }
+  },
+  "$defs": {
+    "templateMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version",
+        "ref",
+        "engine"
+      ],
+      "properties": {
+        "version": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "ref": {
+          "type": "string",
+          "format": "uri"
+        },
+        "engine": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "properties": {
+            "camunda": {
+              "type": "string",
+              "description": "A semver range for the compatible Camunda execution-platform versions."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/template-updater/update-semantics.md
+++ b/docs/template-updater/update-semantics.md
@@ -1,0 +1,49 @@
+# Template updater semantics
+
+How the application updates element templates, and caches them over time.
+
+## Index processing
+
+The updater reads the index as an object whose keys are template identifiers
+and whose values are arrays of version metadata. It evaluates every metadata
+entry; it does not select only the latest version.
+
+The updater matches files found in the index against templates found in the 
+local template file, i.e. `resources/element-templates/.camunda-connector-templates.json` 
+for OOTB connector templates. 
+
+Templates that don't exist in the local cache or have `ref` changed are re-fetched.
+
+## Determining compatibility
+
+An entry is compatible when either:
+
+* its `engine` property is absent; or
+* `engine.camunda` is absent; or
+* the configured execution-platform version, after semver coercion, satisfies
+  the `engine.camunda` semver range.
+
+`engine` may carry constraints for other platforms, but the updater evaluates
+only `engine.camunda` and ignores any other keys.
+
+## Fetching and caching templates
+
+Compatible, uncached entries are fetched from `ref`, with at most six
+concurrent fetches. The response must be successful and parse as JSON.
+
+Fetched templates replace an existing local template when the fetched
+template's own `id` and `version` match. Otherwise, they are appended. Existing
+templates not present in the index are retained. Consequently, the local file
+is additive rather than a mirror of the index, and its existing ordering is
+preserved while newly fetched templates are appended in index iteration order.
+
+The updater writes the resulting array after a successful index response,
+including when no templates were fetched. 
+
+## Failures
+
+Fetch failures are indicated as warnings to the users:
+
+* A failed template fetch or template JSON parse leaves the corresponding local
+  template unchanged while other entries continue to be processed.
+* A failed index update leaves local templates unchanged


### PR DESCRIPTION
### Proposed Changes

Add a developer guide under `docs/template-updater/` for the Modeler's template updating mechanism:

- **`README.md`** — big-picture overview with an index example
- **`index-format.md`** — the remote index format (fields, well-formedness)
- **`index-schema.json`** — normative JSON Schema (Draft 2020-12), validated against the live Marketplace index
- **`update-semantics.md`** — how the updater fetches, caches, filters, persists, and handles failures

Docs only; no code changes.

Related to https://github.com/camunda/camunda-modeler/issues/5100

### Checklist

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
