### PR TITLE
Mark Camunda 8.10 as latest stable engine profile

### DIFF
--- a/client/src/plugins/settings/__tests__/useBuiltInSettingsSpec.js
+++ b/client/src/plugins/settings/__tests__/useBuiltInSettingsSpec.js
@@ -17,7 +17,7 @@ describe('useBuiltInSettings', function() {
   it('should use latest stable versions', function() {
 
     // then
-    expect(schema.properties['app.defaultC8Version'].default).to.equal('8.9.0');
+    expect(schema.properties['app.defaultC8Version'].default).to.equal('8.10.0');
     expect(schema.properties['app.defaultC7Version'].default).to.equal('7.24.0');
   });
 

--- a/client/src/util/Engines.js
+++ b/client/src/util/Engines.js
@@ -22,7 +22,7 @@ export const ENGINE_PROFILES = [
   {
     executionPlatform: ENGINES.CLOUD,
     executionPlatformVersions: [ '8.10.0', '8.9.0', '8.8.0', '8.7.0', '8.6.0', '8.5.0', '8.4.0', '8.3.0', '8.2.0', '8.1.0', '8.0.0' ],
-    latestStable: '8.9.0'
+    latestStable: '8.10.0'
   }
 ];
 

--- a/client/src/util/__tests__/EnginesSpec.js
+++ b/client/src/util/__tests__/EnginesSpec.js
@@ -30,7 +30,7 @@ describe('util/Engines', function() {
 
     it('Platform', verifyLatestStable(ENGINES.PLATFORM, '7.24.0'));
 
-    it('Cloud', verifyLatestStable(ENGINES.CLOUD, '8.9.0'));
+    it('Cloud', verifyLatestStable(ENGINES.CLOUD, '8.10.0'));
 
   });
 


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

Promotes Camunda 8.10 to the latest stable engine profile by bumping `latestStable` for the Cloud engine profile in `client/src/util/Engines.js` from `8.9.0` to `8.10.0`. Versions exceeding `latestStable` are displayed with an `(alpha)` suffix — this removes the alpha tag from 8.10 without any other behavioral changes. Follows the same pattern as the previous promotion (#5741):

<img width="772" height="552" alt="image" src="https://github.com/user-attachments/assets/4973f084-f253-48b8-a19b-9eece4cb4492" />

### Steps to try out:

1. Open a Camunda 8 BPMN diagram
2. Open the engine profile chooser :arrow_right: 8.10 is provided without `(alpha)` suffix

Also

1. Create new Camunda 8 diagram
4. Verify Camunda 8.10 is the default version

### Checklist

Ensure you provide everything we need to review your contribution:

<!--
Do not alter this checklist beyond checking items; provide context above.
-->

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
