### PR TITLE
feat(empty-tab): link to documentation instead of dead version details

### DIFF
--- a/client/src/app/EmptyTab.js
+++ b/client/src/app/EmptyTab.js
@@ -75,7 +75,7 @@ export default class EmptyTab extends PureComponent {
             <CloudIcon className="engine-icon cloud-icon" />
             <h3>Camunda 8</h3>
           </div>
-          <a href={ utmTag('https://camunda.com/products/cloud/') }>See version details</a>
+          <a href={ utmTag('https://docs.camunda.io/') }>See documentation</a>
         </div>
 
         <p>Create a new file</p>
@@ -96,7 +96,7 @@ export default class EmptyTab extends PureComponent {
             <PlatformIcon className="engine-icon platform-icon" />
             <h3>Camunda 7</h3>
           </div>
-          <a href={ utmTag('https://camunda.com/products/camunda-platform/') }>See version details</a>
+          <a href={ utmTag('https://docs.camunda.org/') }>See documentation</a>
         </div>
 
         <p>Create a new file</p>


### PR DESCRIPTION
### Proposed Changes

This PR changes the empty tab to display links to documentation on the Camunda versions instead of outdated links about "version details" (which don't give you version details). Alternatively we could remove the links entirely.

<img width="1208" height="1018" alt="image" src="https://github.com/user-attachments/assets/bb8861b3-2227-4c1f-a58f-565fea5035f8" />

Related thread on Slack: https://camunda.slack.com/archives/C0BR2LSRB1S/p1789041585281169

### Checklist

Ensure you provide everything we need to review your contribution:

<!--
Do not alter this checklist beyond checking items; provide context above.
-->

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
