### PR TITLE
fix(process-applications): forward emit to deployment and start-instance overlays

### DIFF
--- a/client/src/plugins/process-applications/ProcessApplicationsDeploymentPlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsDeploymentPlugin.js
@@ -27,6 +27,7 @@ export default function ProcessApplicationsDeploymentPlugin(props) {
     _getGlobal,
     activeTab,
     displayNotification,
+    emit,
     log,
     processApplication,
     processApplicationItems,
@@ -113,6 +114,7 @@ export default function ProcessApplicationsDeploymentPlugin(props) {
         anchor={ anchorRef.current }
         connectionCheckResult={ connectionCheckResult }
         deployment={ deployment }
+        emit={ emit }
         getSuccessNotification={ (...args) => getSuccessNotification(...args, resourceConfigs) }
         log={ log }
         onClose={ () => setOverlayOpen(false) }

--- a/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsPlugin.js
@@ -229,6 +229,7 @@ export default function ProcessApplicationsPlugin(props) {
       _getGlobal={ _getGlobal }
       activeTab={ activeTab }
       displayNotification={ displayNotification }
+      emit={ emit }
       log={ log }
       processApplication={ processApplication }
       processApplicationItems={ processApplicationItems }
@@ -239,6 +240,7 @@ export default function ProcessApplicationsPlugin(props) {
       _getGlobal={ _getGlobal }
       activeTab={ activeTab }
       displayNotification={ displayNotification }
+      emit={ emit }
       log={ log }
       processApplication={ processApplication }
       processApplicationItems={ processApplicationItems }

--- a/client/src/plugins/process-applications/ProcessApplicationsStartInstancePlugin.js
+++ b/client/src/plugins/process-applications/ProcessApplicationsStartInstancePlugin.js
@@ -29,6 +29,7 @@ export default function ProcessApplicationsStartInstancePlugin(props) {
     _getGlobal,
     activeTab,
     displayNotification,
+    emit,
     log,
     processApplication,
     processApplicationItems,
@@ -99,6 +100,7 @@ export default function ProcessApplicationsStartInstancePlugin(props) {
         anchor={ anchorRef.current }
         connectionCheckResult={ connectionCheckResult }
         deployment={ deployment }
+        emit={ emit }
         getResourceConfigs={ () => resourceConfigs }
         getSuccessNotification={ (...args) => getSuccessNotification(...args, resourceConfigs) }
         log={ log }

--- a/client/src/plugins/process-applications/__tests__/ProcessApplicationsDeploymentPluginSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ProcessApplicationsDeploymentPluginSpec.js
@@ -196,6 +196,56 @@ describe('ProcessApplicationsDeploymentPlugin', function() {
   });
 
 
+  it('should forward <emit> to overlay (deployment event)', async function() {
+
+    // given
+    const triggerAction = sinon.spy(function(action) {
+      if (action === 'save-tab') {
+        return Promise.resolve(true);
+      }
+    });
+
+    const deployment = new Deployment({
+      async getConnectionForTab() {
+        return DEFAULT_ENDPOINT;
+      },
+      on: sinon.spy(),
+      registerResourcesProvider() {},
+      unregisterResourcesProvider() {}
+    });
+
+    const emit = sinon.spy();
+
+    const { container } = createProcessApplicationsDeploymentPlugin({
+      _getGlobal: (name) => name === 'deployment' ? deployment : new ZeebeAPI(),
+      emit,
+      processApplication: DEFAULT_PROCESS_APPLICATION,
+      triggerAction
+    });
+
+    // when
+    fireEvent.click(container.querySelector('.btn'));
+
+    await waitFor(() => {
+      const overlay = document.querySelector('[role="dialog"]');
+
+      expect(overlay).to.exist;
+    });
+
+    expect(deployment.on).to.have.been.calledWith('deployed', sinon.match.func);
+
+    // simulating <deployed> event as emitted by the deployment
+    deployment.on.getCall(0).args[1]({
+      deploymentResult: { success: true, response: {} },
+      endpoint: { targetType: 'camundaCloud' },
+      gatewayVersion: '8.0.0'
+    });
+
+    // then
+    expect(emit).to.have.been.calledWith('deployment.done', sinon.match.object);
+  });
+
+
   it('should register resources provider', async function() {
 
     // given
@@ -304,6 +354,7 @@ function createProcessApplicationsDeploymentPlugin(props = {}) {
     },
     activeTab = DEFAULT_ACTIVE_TAB,
     displayNotification = () => {},
+    emit = () => {},
     log = () => {},
     processApplication = null,
     processApplicationItems = DEFAULT_ITEMS,
@@ -316,6 +367,7 @@ function createProcessApplicationsDeploymentPlugin(props = {}) {
       _getGlobal={ _getGlobal }
       activeTab={ activeTab }
       displayNotification={ displayNotification }
+      emit={ emit }
       log={ log }
       processApplication={ processApplication }
       processApplicationItems={ processApplicationItems }

--- a/client/src/plugins/process-applications/__tests__/ProcessApplicationsDeploymentPluginSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ProcessApplicationsDeploymentPluginSpec.js
@@ -235,7 +235,7 @@ describe('ProcessApplicationsDeploymentPlugin', function() {
     expect(deployment.on).to.have.been.calledWith('deployed', sinon.match.func);
 
     // simulating <deployed> event as emitted by the deployment
-    deployment.on.getCall(0).args[1]({
+    deployment.on.getCalls().find(call => call.args[0] === 'deployed').args[1]({
       deploymentResult: { success: true, response: {} },
       endpoint: { targetType: 'camundaCloud' },
       gatewayVersion: '8.0.0'

--- a/client/src/plugins/process-applications/__tests__/ProcessApplicationsPluginSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ProcessApplicationsPluginSpec.js
@@ -181,7 +181,7 @@ describe('<ProcessApplicationsPlugin>', function() {
       expect(deployment.on).to.have.been.calledWith('deployed', sinon.match.func);
 
       // simulating <deployed> event as emitted by the deployment
-      deployment.on.getCall(0).args[1]({
+      deployment.on.getCalls().find(call => call.args[0] === 'deployed').args[1]({
         deploymentResult: { success: true, response: {} },
         endpoint: { targetType: 'camundaCloud' },
         gatewayVersion: '8.0.0'

--- a/client/src/plugins/process-applications/__tests__/ProcessApplicationsPluginSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ProcessApplicationsPluginSpec.js
@@ -13,7 +13,7 @@ import * as sinon from 'sinon';
 
 import React from 'react';
 
-import { act, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
 
 import ProcessApplicationsPlugin from '../ProcessApplicationsPlugin';
 
@@ -21,8 +21,30 @@ import { Slot, SlotFillRoot } from '../../../app/slot-fill';
 
 import { Deployment, ZeebeAPI } from '../../../app/__tests__/mocks';
 
-const CLOUD_TAB = { id: 'cloud', type: 'cloud-bpmn', file: {} };
+const PROCESS_APPLICATION_FILE = {
+  name: '.process-application',
+  uri: 'file:///C:/process-application/.process-application',
+  path: 'C://process-application/.process-application',
+  dirname: 'C://process-application',
+  contents: '{}'
+};
+
+const DIAGRAM_FILE = {
+  name: 'foo.bpmn',
+  uri: 'file:///C:/process-application/foo.bpmn',
+  path: 'C://process-application/foo.bpmn',
+  dirname: 'C://process-application',
+  contents: '<?xml version="1.0" encoding="UTF-8"?>'
+};
+
+const PROCESS_APPLICATION_ITEMS = [
+  { file: PROCESS_APPLICATION_FILE, metadata: { type: 'processApplication' } },
+  { file: DIAGRAM_FILE, metadata: { type: 'bpmn' } }
+];
+
+const CLOUD_TAB = { id: 'cloud', type: 'cloud-bpmn', file: DIAGRAM_FILE };
 const PLATFORM_TAB = { id: 'platform', type: 'bpmn', file: {} };
+const EMPTY_TAB = { id: 'empty', type: 'cloud-bpmn', file: null };
 
 
 describe('<ProcessApplicationsPlugin>', function() {
@@ -85,6 +107,95 @@ describe('<ProcessApplicationsPlugin>', function() {
       });
     });
   });
+
+
+  describe('<emit> forwarding to child plugins', function() {
+
+    it('should forward <emit> to deployment overlay (deployment event)', async function() {
+
+      // given
+      const triggerAction = sinon.spy(function(action) {
+        if (action === 'save-tab') {
+          return Promise.resolve(true);
+        }
+      });
+
+      const deployment = new Deployment({
+        async getConnectionForTab() {
+          return {};
+        },
+        on: sinon.spy(),
+        registerResourcesProvider() {},
+        unregisterResourcesProvider() {}
+      });
+
+      const emit = sinon.spy();
+
+      let onItemsChanged;
+
+      const { emit: internalEmit } = createProcessApplicationsPlugin({
+        triggerAction,
+        emit,
+        _getGlobal: (name) => {
+          if (name === 'backend') {
+            return {
+              on(event, callback) {
+                if (event === 'file-context:changed') {
+                  onItemsChanged = callback;
+                }
+
+                return { cancel() {} };
+              },
+              send() {}
+            };
+          } else if (name === 'deployment') {
+            return deployment;
+          } else if (name === 'zeebeAPI') {
+            return new ZeebeAPI();
+          } else if (name === 'startInstance') {
+            return {};
+          }
+        }
+      });
+
+      // when
+      // simulate a process application being opened for the active tab
+      act(() => internalEmit('app.tabsChanged', { tabs: [ CLOUD_TAB ] }));
+      act(() => internalEmit('app.activeTabChanged', { activeTab: CLOUD_TAB }));
+      act(() => onItemsChanged(null, PROCESS_APPLICATION_ITEMS));
+
+      const statusBarItem = await waitFor(() => {
+        const button = document.querySelector('[title="Open process application deployment"]');
+
+        expect(button).to.exist;
+
+        return button;
+      });
+
+      fireEvent.click(statusBarItem);
+
+      await waitFor(() => {
+        expect(document.querySelector('[role="dialog"]')).to.exist;
+      });
+
+      expect(deployment.on).to.have.been.calledWith('deployed', sinon.match.func);
+
+      // simulating <deployed> event as emitted by the deployment
+      deployment.on.getCall(0).args[1]({
+        deploymentResult: { success: true, response: {} },
+        endpoint: { targetType: 'camundaCloud' },
+        gatewayVersion: '8.0.0'
+      });
+
+      // then
+      expect(emit).to.have.been.calledWith('deployment.done', sinon.match.object);
+
+      // close the process application so module-level state does
+      // not leak into subsequent tests
+      act(() => internalEmit('app.activeTabChanged', { activeTab: EMPTY_TAB }));
+    });
+
+  });
 });
 
 
@@ -94,7 +205,30 @@ function createProcessApplicationsPlugin(props = {}) {
   const {
     triggerAction = () => {},
     displayNotification = () => {},
-    log = () => {}
+    log = () => {},
+    emit: emitProp = () => {},
+    _getGlobal = (name) => {
+      if (name === 'backend') {
+        return {
+          on() {
+            return { cancel() {} };
+          },
+          send() {}
+        };
+      } else if (name === 'deployment') {
+        return new Deployment({
+          async getConnectionForTab() {
+            return {};
+          },
+          registerResourcesProvider() {},
+          unregisterResourcesProvider() {}
+        });
+      } else if (name === 'zeebeAPI') {
+        return new ZeebeAPI();
+      } else if (name === 'startInstance') {
+        return {};
+      }
+    }
   } = props;
 
   const subscribers = {};
@@ -114,29 +248,6 @@ function createProcessApplicationsPlugin(props = {}) {
     (subscribers[ event ] || []).forEach(cb => cb(payload));
   };
 
-  const _getGlobal = (name) => {
-    if (name === 'backend') {
-      return {
-        on() {
-          return { cancel() {} };
-        },
-        send() {}
-      };
-    } else if (name === 'deployment') {
-      return new Deployment({
-        async getConnectionForTab() {
-          return {};
-        },
-        registerResourcesProvider() {},
-        unregisterResourcesProvider() {}
-      });
-    } else if (name === 'zeebeAPI') {
-      return new ZeebeAPI();
-    } else if (name === 'startInstance') {
-      return {};
-    }
-  };
-
   const _getFromApp = (prop) => {
     if (prop === 'props') {
       return { tabsProvider: {} };
@@ -149,6 +260,7 @@ function createProcessApplicationsPlugin(props = {}) {
       _getFromApp={ _getFromApp }
       _getGlobal={ _getGlobal }
       displayNotification={ displayNotification }
+      emit={ emitProp }
       log={ log }
       subscribe={ subscribe }
       triggerAction={ triggerAction } />

--- a/client/src/plugins/process-applications/__tests__/ProcessApplicationsStartInstancePluginSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ProcessApplicationsStartInstancePluginSpec.js
@@ -128,6 +128,66 @@ describe('ProcessApplicationsStartInstancePlugin', function() {
     });
   });
 
+
+  it('should forward <emit> to overlay (deployment event)', async function() {
+
+    // given
+    const triggerAction = sinon.spy(function(action) {
+      if (action === 'save-tab') {
+        return Promise.resolve(true);
+      }
+    });
+
+    const deployment = new Deployment({
+      async getConnectionForTab() {
+        return DEFAULT_ENDPOINT;
+      },
+      on: sinon.spy()
+    });
+
+    const emit = sinon.spy();
+
+    const { container } = createProcessApplicationsStartInstancePlugin({
+      _getGlobal: (name) => {
+        if (name === 'deployment') {
+          return deployment;
+        } else if (name === 'startInstance') {
+          return new StartInstance({
+            async getConnectionForTab() {
+              return {};
+            }
+          });
+        } else if (name === 'zeebeAPI') {
+          return new ZeebeAPI();
+        }
+      },
+      emit,
+      processApplication: DEFAULT_PROCESS_APPLICATION,
+      triggerAction
+    });
+
+    // when
+    fireEvent.click(container.querySelector('.btn'));
+
+    await waitFor(() => {
+      const overlay = document.querySelector('[role="dialog"]');
+
+      expect(overlay).to.exist;
+    });
+
+    expect(deployment.on).to.have.been.calledWith('deployed', sinon.match.func);
+
+    // simulating <deployed> event as emitted by the deployment
+    deployment.on.getCall(0).args[1]({
+      deploymentResult: { success: true, response: {} },
+      endpoint: { targetType: 'camundaCloud' },
+      gatewayVersion: '8.0.0'
+    });
+
+    // then
+    expect(emit).to.have.been.calledWith('deployment.done', sinon.match.object);
+  });
+
 });
 
 const DEFAULT_PROCESS_APPLICATION = {
@@ -161,6 +221,7 @@ function createProcessApplicationsStartInstancePlugin(props = {}) {
     },
     activeTab = DEFAULT_ACTIVE_TAB,
     displayNotification = () => {},
+    emit = () => {},
     log = () => {},
     processApplication = null,
     processApplicationItems = [],
@@ -173,6 +234,7 @@ function createProcessApplicationsStartInstancePlugin(props = {}) {
       _getGlobal={ _getGlobal }
       activeTab={ activeTab }
       displayNotification={ displayNotification }
+      emit={ emit }
       log={ log }
       processApplication={ processApplication }
       processApplicationItems={ processApplicationItems }

--- a/client/src/plugins/process-applications/__tests__/ProcessApplicationsStartInstancePluginSpec.js
+++ b/client/src/plugins/process-applications/__tests__/ProcessApplicationsStartInstancePluginSpec.js
@@ -178,7 +178,7 @@ describe('ProcessApplicationsStartInstancePlugin', function() {
     expect(deployment.on).to.have.been.calledWith('deployed', sinon.match.func);
 
     // simulating <deployed> event as emitted by the deployment
-    deployment.on.getCall(0).args[1]({
+    deployment.on.getCalls().find(call => call.args[0] === 'deployed').args[1]({
       deploymentResult: { success: true, response: {} },
       endpoint: { targetType: 'camundaCloud' },
       gatewayVersion: '8.0.0'


### PR DESCRIPTION
https://github.com/user-attachments/assets/eef9d199-aba2-4bbc-a14b-d50dae2dd8ac



### Proposed Changes

Issue [#6151](https://github.com/camunda/camunda-modeler/issues/6151) was originally fixed by [#6152](https://github.com/camunda/camunda-modeler/pull/6152), which forwarded the `emit` prop from `DeploymentPlugin`/`StartInstancePlugin` to their overlays. It was reopened because the same `TypeError: emit is not a function` still happens for **process applications**: they render the same overlays through a separate wrapper chain (`ProcessApplicationsPlugin` → `ProcessApplicationsDeploymentPlugin` / `ProcessApplicationsStartInstancePlugin` → the overlays) that never forwarded `emit` either.

This PR threads `emit` through all three process-applications components, mirroring the pattern from #6152, and adds regression tests at each level, including an end-to-end test in `ProcessApplicationsPluginSpec.js` that opens a process application, deploys, and asserts `emit('deployment.done', …)` fires.

I verified the fix is load-bearing by reverting it locally and re-running the new end-to-end test, which reproduced the exact reported error (`TypeError: emit is not a function`) before the fix was restored.

Closes https://github.com/camunda/camunda-modeler/issues/6151

### Steps to try out

1. Create a process application (start → end BPMN inside a `.process-application` folder).
2. Trigger the deployment tool from the process application status bar → deploys and shows a success notification instead of throwing.
3. Trigger the run tool → starts an instance.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
